### PR TITLE
Proper strict weak ordering relation

### DIFF
--- a/components/physical_plan/collection/operators/sort/sort.hpp
+++ b/components/physical_plan/collection/operators/sort/sort.hpp
@@ -35,7 +35,7 @@ namespace services::storage::sort {
                     return false;
                 }
             }
-            return true;
+            return false;
         }
 
     private:


### PR DESCRIPTION
Previously not all of the requirements for compare object were met, specifically this one:
comp(a, a) == false

https://en.cppreference.com/w/cpp/named_req/Compare.html