### PR TITLE
Compare expression extension

### DIFF
--- a/components/expressions/compare_expression.hpp
+++ b/components/expressions/compare_expression.hpp
@@ -18,6 +18,7 @@ namespace components::expressions {
 
         compare_expression_t(std::pmr::memory_resource* resource,
                              compare_type type,
+                             side_t side,
                              const key_t& key,
                              core::parameter_id_t);
         compare_expression_t(std::pmr::memory_resource* resource,
@@ -26,6 +27,7 @@ namespace components::expressions {
                              const key_t& key_right);
 
         compare_type type() const;
+        side_t side() const;
         const key_t& key_left() const;
         const key_t& key_right() const;
         core::parameter_id_t value() const;
@@ -40,6 +42,7 @@ namespace components::expressions {
 
     private:
         compare_type type_;
+        side_t side_;
         key_t key_left_;
         key_t key_right_;
         core::parameter_id_t value_;
@@ -53,6 +56,7 @@ namespace components::expressions {
 
     compare_expression_ptr make_compare_expression(std::pmr::memory_resource* resource,
                                                    compare_type type,
+                                                   side_t side,
                                                    const key_t& key,
                                                    core::parameter_id_t id);
     compare_expression_ptr make_compare_expression(std::pmr::memory_resource* resource,

--- a/components/expressions/forward.hpp
+++ b/components/expressions/forward.hpp
@@ -70,6 +70,13 @@ namespace components::expressions {
         asc = 1
     };
 
+    enum class side_t : uint8_t
+    {
+        undefined = 0,
+        left,
+        right
+    };
+
     template<class OStream>
     OStream& operator<<(OStream& stream, const compare_type& type) {
         if (type == compare_type::union_and) {

--- a/components/expressions/test/test_compare_expression.cpp
+++ b/components/expressions/test/test_compare_expression.cpp
@@ -7,11 +7,16 @@ using key = components::expressions::key_t;
 
 TEST_CASE("expression::compare::equals") {
     auto resource = std::pmr::synchronized_pool_resource();
-    auto expr1 = make_compare_expression(&resource, compare_type::eq, key("name"), core::parameter_id_t(1));
-    auto expr2 = make_compare_expression(&resource, compare_type::eq, key("name"), core::parameter_id_t(1));
-    auto expr3 = make_compare_expression(&resource, compare_type::ne, key("name"), core::parameter_id_t(1));
-    auto expr4 = make_compare_expression(&resource, compare_type::eq, key("count"), core::parameter_id_t(1));
-    auto expr5 = make_compare_expression(&resource, compare_type::eq, key("name"), core::parameter_id_t(2));
+    auto expr1 =
+        make_compare_expression(&resource, compare_type::eq, side_t::left, key("name"), core::parameter_id_t(1));
+    auto expr2 =
+        make_compare_expression(&resource, compare_type::eq, side_t::left, key("name"), core::parameter_id_t(1));
+    auto expr3 =
+        make_compare_expression(&resource, compare_type::ne, side_t::left, key("name"), core::parameter_id_t(1));
+    auto expr4 =
+        make_compare_expression(&resource, compare_type::eq, side_t::left, key("count"), core::parameter_id_t(1));
+    auto expr5 =
+        make_compare_expression(&resource, compare_type::eq, side_t::left, key("name"), core::parameter_id_t(2));
     auto expr_union1 = make_compare_union_expression(&resource, compare_type::union_and);
     expr_union1->append_child(expr1);
     expr_union1->append_child(expr3);
@@ -35,11 +40,14 @@ TEST_CASE("expression::compare::equals") {
 
 TEST_CASE("expression::compare::to_string") {
     auto resource = std::pmr::synchronized_pool_resource();
-    auto expr = make_compare_expression(&resource, compare_type::eq, key("count"), core::parameter_id_t(1));
+    auto expr =
+        make_compare_expression(&resource, compare_type::eq, side_t::left, key("count"), core::parameter_id_t(1));
     REQUIRE(expr->to_string() == R"("count": {$eq: #1})");
 
     expr = make_compare_union_expression(&resource, compare_type::union_and);
-    expr->append_child(make_compare_expression(&resource, compare_type::eq, key("key1"), core::parameter_id_t(1)));
-    expr->append_child(make_compare_expression(&resource, compare_type::lt, key("key2"), core::parameter_id_t(2)));
+    expr->append_child(
+        make_compare_expression(&resource, compare_type::eq, side_t::left, key("key1"), core::parameter_id_t(1)));
+    expr->append_child(
+        make_compare_expression(&resource, compare_type::lt, side_t::left, key("key2"), core::parameter_id_t(2)));
     REQUIRE(expr->to_string() == R"($and: ["key1": {$eq: #1}, "key2": {$lt: #2}])");
 }

--- a/components/expressions/update_expression.hpp
+++ b/components/expressions/update_expression.hpp
@@ -138,12 +138,6 @@ namespace components::expressions {
 
     class update_expr_get_value_t final : public update_expr_t {
     public:
-        enum class side_t : uint8_t
-        {
-            to,
-            from,
-            undefined
-        };
         explicit update_expr_get_value_t(key_t key, side_t side);
 
         const key_t& key() const noexcept;

--- a/components/physical_plan/collection/operators/predicates/predicate.cpp
+++ b/components/physical_plan/collection/operators/predicates/predicate.cpp
@@ -14,6 +14,7 @@ namespace components::collection::operators::predicates {
     }
 
     predicate_ptr create_predicate(const expressions::compare_expression_ptr& expr) {
+        // TODO: use schema to deduce expr side, if it is not set, before this
         auto result = create_simple_predicate(expr);
         if (result) {
             return result;

--- a/components/physical_plan/collection/operators/predicates/simple_predicate.cpp
+++ b/components/physical_plan/collection/operators/predicates/simple_predicate.cpp
@@ -59,15 +59,7 @@ namespace components::collection::operators::predicates {
                 return {new simple_predicate([&expr](const document::document_ptr& document_left,
                                                      const document::document_ptr& document_right,
                                                      const logical_plan::storage_parameters* parameters) {
-                    if (expr->key_right().is_null()) {
-                        auto it = parameters->parameters.find(expr->value());
-                        if (it == parameters->parameters.end()) {
-                            return false;
-                        } else {
-                            return document_left->compare(expr->key_left().as_string(), it->second) ==
-                                   types::compare_t::equals;
-                        }
-                    } else {
+                    if (!expr->key_left().is_null() && !expr->key_right().is_null()) {
                         auto comp =
                             document_right
                                 ? document_left->compare(expr->key_left().as_string(),
@@ -76,20 +68,33 @@ namespace components::collection::operators::predicates {
                                                          document_left->get_value(expr->key_right().as_string()));
                         return comp == types::compare_t::equals;
                     }
+                    auto it = parameters->parameters.find(expr->value());
+                    if (it == parameters->parameters.end()) {
+                        return false;
+                    }
+                    if (expr->side() == expressions::side_t::left) {
+                        return document_left->compare(expr->key_left().as_string(), it->second) ==
+                               types::compare_t::equals;
+                    }
+                    if (expr->side() == expressions::side_t::right) {
+                        return document_right->compare(expr->key_right().as_string(), it->second) ==
+                               types::compare_t::equals;
+                    }
+                    if (document_left->is_exists(expr->key_left().as_string())) {
+                        return document_left->compare(expr->key_left().as_string(), it->second) ==
+                               types::compare_t::equals;
+                    }
+                    if (document_right->is_exists(expr->key_left().as_string())) {
+                        return document_right->compare(expr->key_left().as_string(), it->second) ==
+                               types::compare_t::equals;
+                    }
+                    return false;
                 })};
             case compare_type::ne:
                 return {new simple_predicate([&expr](const document::document_ptr& document_left,
                                                      const document::document_ptr& document_right,
                                                      const logical_plan::storage_parameters* parameters) {
-                    if (expr->key_right().is_null()) {
-                        auto it = parameters->parameters.find(expr->value());
-                        if (it == parameters->parameters.end()) {
-                            return false;
-                        } else {
-                            return document_left->compare(expr->key_left().as_string(), it->second) !=
-                                   types::compare_t::equals;
-                        }
-                    } else {
+                    if (!expr->key_left().is_null() && !expr->key_right().is_null()) {
                         auto comp =
                             document_right
                                 ? document_left->compare(expr->key_left().as_string(),
@@ -98,20 +103,33 @@ namespace components::collection::operators::predicates {
                                                          document_left->get_value(expr->key_right().as_string()));
                         return comp != types::compare_t::equals;
                     }
+                    auto it = parameters->parameters.find(expr->value());
+                    if (it == parameters->parameters.end()) {
+                        return false;
+                    }
+                    if (expr->side() == expressions::side_t::left) {
+                        return document_left->compare(expr->key_left().as_string(), it->second) !=
+                               types::compare_t::equals;
+                    }
+                    if (expr->side() == expressions::side_t::right) {
+                        return document_right->compare(expr->key_right().as_string(), it->second) !=
+                               types::compare_t::equals;
+                    }
+                    if (document_left->is_exists(expr->key_left().as_string())) {
+                        return document_left->compare(expr->key_left().as_string(), it->second) !=
+                               types::compare_t::equals;
+                    }
+                    if (document_right->is_exists(expr->key_left().as_string())) {
+                        return document_right->compare(expr->key_left().as_string(), it->second) !=
+                               types::compare_t::equals;
+                    }
+                    return false;
                 })};
             case compare_type::gt:
                 return {new simple_predicate([&expr](const document::document_ptr& document_left,
                                                      const document::document_ptr& document_right,
                                                      const logical_plan::storage_parameters* parameters) {
-                    if (expr->key_right().is_null()) {
-                        auto it = parameters->parameters.find(expr->value());
-                        if (it == parameters->parameters.end()) {
-                            return false;
-                        } else {
-                            return document_left->compare(expr->key_left().as_string(), it->second) ==
-                                   types::compare_t::more;
-                        }
-                    } else {
+                    if (!expr->key_left().is_null() && !expr->key_right().is_null()) {
                         auto comp =
                             document_right
                                 ? document_left->compare(expr->key_left().as_string(),
@@ -120,20 +138,33 @@ namespace components::collection::operators::predicates {
                                                          document_left->get_value(expr->key_right().as_string()));
                         return comp == types::compare_t::more;
                     }
+                    auto it = parameters->parameters.find(expr->value());
+                    if (it == parameters->parameters.end()) {
+                        return false;
+                    }
+                    if (expr->side() == expressions::side_t::left) {
+                        return document_left->compare(expr->key_left().as_string(), it->second) ==
+                               types::compare_t::more;
+                    }
+                    if (expr->side() == expressions::side_t::right) {
+                        return document_right->compare(expr->key_right().as_string(), it->second) ==
+                               types::compare_t::more;
+                    }
+                    if (document_left->is_exists(expr->key_left().as_string())) {
+                        return document_left->compare(expr->key_left().as_string(), it->second) ==
+                               types::compare_t::more;
+                    }
+                    if (document_right->is_exists(expr->key_left().as_string())) {
+                        return document_right->compare(expr->key_left().as_string(), it->second) ==
+                               types::compare_t::more;
+                    }
+                    return false;
                 })};
             case compare_type::gte:
                 return {new simple_predicate([&expr](const document::document_ptr& document_left,
                                                      const document::document_ptr& document_right,
                                                      const logical_plan::storage_parameters* parameters) {
-                    if (expr->key_right().is_null()) {
-                        auto it = parameters->parameters.find(expr->value());
-                        if (it == parameters->parameters.end()) {
-                            return false;
-                        } else {
-                            auto comp = document_left->compare(expr->key_left().as_string(), it->second);
-                            return comp == types::compare_t::equals || comp == types::compare_t::more;
-                        }
-                    } else {
+                    if (!expr->key_left().is_null() && !expr->key_right().is_null()) {
                         auto comp =
                             document_right
                                 ? document_left->compare(expr->key_left().as_string(),
@@ -142,20 +173,33 @@ namespace components::collection::operators::predicates {
                                                          document_left->get_value(expr->key_right().as_string()));
                         return comp == types::compare_t::equals || comp == types::compare_t::more;
                     }
+                    auto it = parameters->parameters.find(expr->value());
+                    if (it == parameters->parameters.end()) {
+                        return false;
+                    }
+                    if (expr->side() == expressions::side_t::left) {
+                        auto comp = document_left->compare(expr->key_left().as_string(), it->second);
+                        return comp == types::compare_t::equals || comp == types::compare_t::more;
+                    }
+                    if (expr->side() == expressions::side_t::right) {
+                        auto comp = document_right->compare(expr->key_right().as_string(), it->second);
+                        return comp == types::compare_t::equals || comp == types::compare_t::more;
+                    }
+                    if (document_left->is_exists(expr->key_left().as_string())) {
+                        auto comp = document_left->compare(expr->key_left().as_string(), it->second);
+                        return comp == types::compare_t::equals || comp == types::compare_t::more;
+                    }
+                    if (document_right->is_exists(expr->key_left().as_string())) {
+                        auto comp = document_right->compare(expr->key_left().as_string(), it->second);
+                        return comp == types::compare_t::equals || comp == types::compare_t::more;
+                    }
+                    return false;
                 })};
             case compare_type::lt:
                 return {new simple_predicate([&expr](const document::document_ptr& document_left,
                                                      const document::document_ptr& document_right,
                                                      const logical_plan::storage_parameters* parameters) {
-                    if (expr->key_right().is_null()) {
-                        auto it = parameters->parameters.find(expr->value());
-                        if (it == parameters->parameters.end()) {
-                            return false;
-                        } else {
-                            return document_left->compare(expr->key_left().as_string(), it->second) ==
-                                   types::compare_t::less;
-                        }
-                    } else {
+                    if (!expr->key_left().is_null() && !expr->key_right().is_null()) {
                         auto comp =
                             document_right
                                 ? document_left->compare(expr->key_left().as_string(),
@@ -164,20 +208,33 @@ namespace components::collection::operators::predicates {
                                                          document_left->get_value(expr->key_right().as_string()));
                         return comp == types::compare_t::less;
                     }
+                    auto it = parameters->parameters.find(expr->value());
+                    if (it == parameters->parameters.end()) {
+                        return false;
+                    }
+                    if (expr->side() == expressions::side_t::left) {
+                        return document_left->compare(expr->key_left().as_string(), it->second) ==
+                               types::compare_t::less;
+                    }
+                    if (expr->side() == expressions::side_t::right) {
+                        return document_right->compare(expr->key_right().as_string(), it->second) ==
+                               types::compare_t::less;
+                    }
+                    if (document_left->is_exists(expr->key_left().as_string())) {
+                        return document_left->compare(expr->key_left().as_string(), it->second) ==
+                               types::compare_t::less;
+                    }
+                    if (document_right->is_exists(expr->key_left().as_string())) {
+                        return document_right->compare(expr->key_left().as_string(), it->second) ==
+                               types::compare_t::less;
+                    }
+                    return false;
                 })};
             case compare_type::lte:
                 return {new simple_predicate([&expr](const document::document_ptr& document_left,
                                                      const document::document_ptr& document_right,
                                                      const logical_plan::storage_parameters* parameters) {
-                    if (expr->key_right().is_null()) {
-                        auto it = parameters->parameters.find(expr->value());
-                        if (it == parameters->parameters.end()) {
-                            return false;
-                        } else {
-                            auto comp = document_left->compare(expr->key_left().as_string(), it->second);
-                            return comp == types::compare_t::equals || comp == types::compare_t::less;
-                        }
-                    } else {
+                    if (!expr->key_left().is_null() && !expr->key_right().is_null()) {
                         auto comp =
                             document_right
                                 ? document_left->compare(expr->key_left().as_string(),
@@ -186,22 +243,33 @@ namespace components::collection::operators::predicates {
                                                          document_left->get_value(expr->key_right().as_string()));
                         return comp == types::compare_t::equals || comp == types::compare_t::less;
                     }
+                    auto it = parameters->parameters.find(expr->value());
+                    if (it == parameters->parameters.end()) {
+                        return false;
+                    }
+                    if (expr->side() == expressions::side_t::left) {
+                        auto comp = document_left->compare(expr->key_left().as_string(), it->second);
+                        return comp == types::compare_t::equals || comp == types::compare_t::less;
+                    }
+                    if (expr->side() == expressions::side_t::right) {
+                        auto comp = document_right->compare(expr->key_right().as_string(), it->second);
+                        return comp == types::compare_t::equals || comp == types::compare_t::less;
+                    }
+                    if (document_left->is_exists(expr->key_left().as_string())) {
+                        auto comp = document_left->compare(expr->key_left().as_string(), it->second);
+                        return comp == types::compare_t::equals || comp == types::compare_t::less;
+                    }
+                    if (document_right->is_exists(expr->key_left().as_string())) {
+                        auto comp = document_right->compare(expr->key_left().as_string(), it->second);
+                        return comp == types::compare_t::equals || comp == types::compare_t::less;
+                    }
+                    return false;
                 })};
             case compare_type::regex:
                 return {new simple_predicate([&expr](const document::document_ptr& document_left,
                                                      const document::document_ptr& document_right,
                                                      const logical_plan::storage_parameters* parameters) {
-                    if (expr->key_right().is_null()) {
-                        auto it = parameters->parameters.find(expr->value());
-                        if (it == parameters->parameters.end()) {
-                            return false;
-                        } else {
-                            return document_left->type_by_key(expr->key_left().as_string()) ==
-                                       types::logical_type::STRING_LITERAL &&
-                                   std::regex_match(document_left->get_string(expr->key_left().as_string()).data(),
-                                                    std::regex(fmt::format(".*{}.*", it->second.as_string())));
-                        }
-                    } else {
+                    if (!expr->key_left().is_null() && !expr->key_right().is_null()) {
                         return document_right
                                    ? document_left->type_by_key(expr->key_left().as_string()) ==
                                              types::logical_type::STRING_LITERAL &&
@@ -219,6 +287,35 @@ namespace components::collection::operators::predicates {
                                                              document_right->get_value(expr->key_right().as_string())
                                                                  .as_string())));
                     }
+                    auto it = parameters->parameters.find(expr->value());
+                    if (it == parameters->parameters.end()) {
+                        return false;
+                    }
+                    if (expr->side() == expressions::side_t::left) {
+                        return document_left->type_by_key(expr->key_left().as_string()) ==
+                                   types::logical_type::STRING_LITERAL &&
+                               std::regex_match(document_left->get_string(expr->key_left().as_string()).data(),
+                                                std::regex(fmt::format(".*{}.*", it->second.as_string())));
+                    }
+                    if (expr->side() == expressions::side_t::right) {
+                        return document_right->type_by_key(expr->key_right().as_string()) ==
+                                   types::logical_type::STRING_LITERAL &&
+                               std::regex_match(document_right->get_string(expr->key_right().as_string()).data(),
+                                                std::regex(fmt::format(".*{}.*", it->second.as_string())));
+                    }
+                    if (document_left->is_exists(expr->key_left().as_string())) {
+                        return document_left->type_by_key(expr->key_left().as_string()) ==
+                                   types::logical_type::STRING_LITERAL &&
+                               std::regex_match(document_left->get_string(expr->key_left().as_string()).data(),
+                                                std::regex(fmt::format(".*{}.*", it->second.as_string())));
+                    }
+                    if (document_right->is_exists(expr->key_left().as_string())) {
+                        return document_right->type_by_key(expr->key_left().as_string()) ==
+                                   types::logical_type::STRING_LITERAL &&
+                               std::regex_match(document_right->get_string(expr->key_left().as_string()).data(),
+                                                std::regex(fmt::format(".*{}.*", it->second.as_string())));
+                    }
+                    return false;
                 })};
             case compare_type::all_true:
                 return {new simple_predicate([](const document::document_ptr&,

--- a/components/physical_plan/tests/operators/test_aggregate_operators.cpp
+++ b/components/physical_plan/tests/operators/test_aggregate_operators.cpp
@@ -50,7 +50,8 @@ TEST_CASE("operator::aggregate::count") {
     }
 
     SECTION("count::match") {
-        auto cond = make_compare_expression(&resource, compare_type::lte, key("count"), core::parameter_id_t(1));
+        auto cond =
+            make_compare_expression(&resource, compare_type::lte, side_t::left, key("count"), core::parameter_id_t(1));
         logical_plan::storage_parameters parameters(&resource);
         add_parameter(parameters, core::parameter_id_t(1), new_value(10));
         pipeline::context_t pipeline_context(std::move(parameters));
@@ -103,7 +104,8 @@ TEST_CASE("operator::aggregate::min") {
     }
 
     SECTION("min::match") {
-        auto cond = make_compare_expression(&resource, compare_type::gt, key("count"), core::parameter_id_t(1));
+        auto cond =
+            make_compare_expression(&resource, compare_type::gt, side_t::left, key("count"), core::parameter_id_t(1));
         logical_plan::storage_parameters parameters(&resource);
         add_parameter(parameters, core::parameter_id_t(1), new_value(80));
         pipeline::context_t pipeline_context(std::move(parameters));
@@ -156,7 +158,8 @@ TEST_CASE("operator::aggregate::max") {
     }
 
     SECTION("max::match") {
-        auto cond = make_compare_expression(&resource, compare_type::lt, key("count"), core::parameter_id_t(1));
+        auto cond =
+            make_compare_expression(&resource, compare_type::lt, side_t::left, key("count"), core::parameter_id_t(1));
         logical_plan::storage_parameters parameters(&resource);
         add_parameter(parameters, core::parameter_id_t(1), new_value(20));
         pipeline::context_t pipeline_context(std::move(parameters));
@@ -209,7 +212,8 @@ TEST_CASE("operator::aggregate::sum") {
     }
 
     SECTION("sum::match") {
-        auto cond = make_compare_expression(&resource, compare_type::lt, key("count"), core::parameter_id_t(1));
+        auto cond =
+            make_compare_expression(&resource, compare_type::lt, side_t::left, key("count"), core::parameter_id_t(1));
         logical_plan::storage_parameters parameters(&resource);
         add_parameter(parameters, core::parameter_id_t(1), new_value(10));
         pipeline::context_t pipeline_context(std::move(parameters));
@@ -262,7 +266,8 @@ TEST_CASE("operator::aggregate::avg") {
     }
 
     SECTION("avg::match") {
-        auto cond = make_compare_expression(&resource, compare_type::lt, key("count"), core::parameter_id_t(1));
+        auto cond =
+            make_compare_expression(&resource, compare_type::lt, side_t::left, key("count"), core::parameter_id_t(1));
         logical_plan::storage_parameters parameters(&resource);
         add_parameter(parameters, core::parameter_id_t(1), new_value(10));
         pipeline::context_t pipeline_context(std::move(parameters));

--- a/components/physical_plan/tests/operators/test_merge_operators.cpp
+++ b/components/physical_plan/tests/operators/test_merge_operators.cpp
@@ -19,8 +19,10 @@ TEST_CASE("operator_merge::and") {
     auto new_value = [&](auto value) { return value_t{tape.get(), value}; };
 
     auto collection = init_collection(&resource);
-    auto cond1 = make_compare_expression(&resource, compare_type::gt, key("count"), core::parameter_id_t(1));
-    auto cond2 = make_compare_expression(&resource, compare_type::lte, key("count"), core::parameter_id_t(2));
+    auto cond1 =
+        make_compare_expression(&resource, compare_type::gt, side_t::left, key("count"), core::parameter_id_t(1));
+    auto cond2 =
+        make_compare_expression(&resource, compare_type::lte, side_t::left, key("count"), core::parameter_id_t(2));
     operator_and_t op_and(d(collection), logical_plan::limit_t::unlimit());
     op_and.set_children(
         boost::intrusive_ptr(
@@ -41,8 +43,10 @@ TEST_CASE("operator_merge::or") {
     auto new_value = [&](auto value) { return value_t{tape.get(), value}; };
 
     auto collection = init_collection(&resource);
-    auto cond1 = make_compare_expression(&resource, compare_type::lte, key("count"), core::parameter_id_t(1));
-    auto cond2 = make_compare_expression(&resource, compare_type::gt, key("count"), core::parameter_id_t(2));
+    auto cond1 =
+        make_compare_expression(&resource, compare_type::lte, side_t::left, key("count"), core::parameter_id_t(1));
+    auto cond2 =
+        make_compare_expression(&resource, compare_type::gt, side_t::left, key("count"), core::parameter_id_t(2));
     operator_or_t op_or(d(collection), logical_plan::limit_t::unlimit());
     op_or.set_children(
         boost::intrusive_ptr(
@@ -63,7 +67,8 @@ TEST_CASE("operator_merge::not") {
     auto new_value = [&](auto value) { return value_t{tape.get(), value}; };
 
     auto collection = init_collection(&resource);
-    auto cond = make_compare_expression(&resource, compare_type::gt, key("count"), core::parameter_id_t(1));
+    auto cond =
+        make_compare_expression(&resource, compare_type::gt, side_t::left, key("count"), core::parameter_id_t(1));
     operator_not_t op_not(d(collection), logical_plan::limit_t::unlimit());
     op_not.set_children(boost::intrusive_ptr(
         new full_scan(d(collection), predicates::create_predicate(cond), logical_plan::limit_t::unlimit())));
@@ -85,10 +90,14 @@ TEST_CASE("operator_merge::complex") {
     //    {"$and": [{"count": {"$gt": 5}}, {"count": {"$lte": 95}}]}
     //  ]
 
-    auto cond_or1 = make_compare_expression(&resource, compare_type::lte, key("count"), core::parameter_id_t(1));
-    auto cond_or2 = make_compare_expression(&resource, compare_type::gt, key("count"), core::parameter_id_t(2));
-    auto cond_and1 = make_compare_expression(&resource, compare_type::gt, key("count"), core::parameter_id_t(3));
-    auto cond_and2 = make_compare_expression(&resource, compare_type::lte, key("count"), core::parameter_id_t(4));
+    auto cond_or1 =
+        make_compare_expression(&resource, compare_type::lte, side_t::left, key("count"), core::parameter_id_t(1));
+    auto cond_or2 =
+        make_compare_expression(&resource, compare_type::gt, side_t::left, key("count"), core::parameter_id_t(2));
+    auto cond_and1 =
+        make_compare_expression(&resource, compare_type::gt, side_t::left, key("count"), core::parameter_id_t(3));
+    auto cond_and2 =
+        make_compare_expression(&resource, compare_type::lte, side_t::left, key("count"), core::parameter_id_t(4));
 
     auto op = create_operator_merge(d(collection), compare_type::union_and, logical_plan::limit_t::unlimit());
     auto op_or = create_operator_merge(d(collection), compare_type::union_or, logical_plan::limit_t::unlimit());

--- a/components/physical_plan/tests/operators/test_operators.cpp
+++ b/components/physical_plan/tests/operators/test_operators.cpp
@@ -42,7 +42,8 @@ TEST_CASE("operator::full_scan") {
     auto table = init_table(&resource);
 
     SECTION("find::eq") {
-        auto cond = make_compare_expression(&resource, compare_type::eq, key("count"), core::parameter_id_t(1));
+        auto cond =
+            make_compare_expression(&resource, compare_type::eq, side_t::left, key("count"), core::parameter_id_t(1));
         logical_plan::storage_parameters parameters(&resource);
         add_parameter(parameters, core::parameter_id_t(1), new_value(static_cast<int64_t>(90)));
         pipeline::context_t pipeline_context(std::move(parameters));
@@ -62,7 +63,8 @@ TEST_CASE("operator::full_scan") {
     }
 
     SECTION("find::ne") {
-        auto cond = make_compare_expression(&resource, compare_type::ne, key("count"), core::parameter_id_t(1));
+        auto cond =
+            make_compare_expression(&resource, compare_type::ne, side_t::left, key("count"), core::parameter_id_t(1));
         logical_plan::storage_parameters parameters(&resource);
         add_parameter(parameters, core::parameter_id_t(1), new_value(static_cast<int64_t>(90)));
         pipeline::context_t pipeline_context(std::move(parameters));
@@ -82,7 +84,8 @@ TEST_CASE("operator::full_scan") {
     }
 
     SECTION("find::gt") {
-        auto cond = make_compare_expression(&resource, compare_type::gt, key("count"), core::parameter_id_t(1));
+        auto cond =
+            make_compare_expression(&resource, compare_type::gt, side_t::left, key("count"), core::parameter_id_t(1));
         logical_plan::storage_parameters parameters(&resource);
         add_parameter(parameters, core::parameter_id_t(1), new_value(static_cast<int64_t>(90)));
         pipeline::context_t pipeline_context(std::move(parameters));
@@ -102,7 +105,8 @@ TEST_CASE("operator::full_scan") {
     }
 
     SECTION("find::gte") {
-        auto cond = make_compare_expression(&resource, compare_type::gte, key("count"), core::parameter_id_t(1));
+        auto cond =
+            make_compare_expression(&resource, compare_type::gte, side_t::left, key("count"), core::parameter_id_t(1));
         logical_plan::storage_parameters parameters(&resource);
         add_parameter(parameters, core::parameter_id_t(1), new_value(static_cast<int64_t>(90)));
         pipeline::context_t pipeline_context(std::move(parameters));
@@ -122,7 +126,8 @@ TEST_CASE("operator::full_scan") {
     }
 
     SECTION("find::lt") {
-        auto cond = make_compare_expression(&resource, compare_type::lt, key("count"), core::parameter_id_t(1));
+        auto cond =
+            make_compare_expression(&resource, compare_type::lt, side_t::left, key("count"), core::parameter_id_t(1));
         logical_plan::storage_parameters parameters(&resource);
         add_parameter(parameters, core::parameter_id_t(1), new_value(static_cast<int64_t>(90)));
         pipeline::context_t pipeline_context(std::move(parameters));
@@ -142,7 +147,8 @@ TEST_CASE("operator::full_scan") {
     }
 
     SECTION("find::lte") {
-        auto cond = make_compare_expression(&resource, compare_type::lte, key("count"), core::parameter_id_t(1));
+        auto cond =
+            make_compare_expression(&resource, compare_type::lte, side_t::left, key("count"), core::parameter_id_t(1));
         logical_plan::storage_parameters parameters(&resource);
         add_parameter(parameters, core::parameter_id_t(1), new_value(static_cast<int64_t>(90)));
         pipeline::context_t pipeline_context(std::move(parameters));
@@ -162,7 +168,8 @@ TEST_CASE("operator::full_scan") {
     }
 
     SECTION("find_one") {
-        auto cond = make_compare_expression(&resource, compare_type::gt, key("count"), core::parameter_id_t(1));
+        auto cond =
+            make_compare_expression(&resource, compare_type::gt, side_t::left, key("count"), core::parameter_id_t(1));
         logical_plan::storage_parameters parameters(&resource);
         add_parameter(parameters, core::parameter_id_t(1), new_value(static_cast<int64_t>(90)));
         pipeline::context_t pipeline_context(std::move(parameters));
@@ -192,7 +199,8 @@ TEST_CASE("operator::delete") {
     SECTION("find::delete") {
         REQUIRE(d(collection)->document_storage().size() == 100);
         REQUIRE(d(table)->table_storage().table().calculate_size() == 100);
-        auto cond = make_compare_expression(&resource, compare_type::gt, key("count"), core::parameter_id_t(1));
+        auto cond =
+            make_compare_expression(&resource, compare_type::gt, side_t::left, key("count"), core::parameter_id_t(1));
         logical_plan::storage_parameters parameters(&resource);
         add_parameter(parameters, core::parameter_id_t(1), new_value(static_cast<int64_t>(90)));
         pipeline::context_t pipeline_context(std::move(parameters));
@@ -218,7 +226,8 @@ TEST_CASE("operator::delete") {
     SECTION("find::delete_one") {
         REQUIRE(d(collection)->document_storage().size() == 100);
         REQUIRE(d(table)->table_storage().table().calculate_size() == 100);
-        auto cond = make_compare_expression(&resource, compare_type::gt, key("count"), core::parameter_id_t(1));
+        auto cond =
+            make_compare_expression(&resource, compare_type::gt, side_t::left, key("count"), core::parameter_id_t(1));
         logical_plan::storage_parameters parameters(&resource);
         add_parameter(parameters, core::parameter_id_t(1), new_value(static_cast<int64_t>(90)));
         pipeline::context_t pipeline_context(std::move(parameters));
@@ -244,7 +253,8 @@ TEST_CASE("operator::delete") {
     SECTION("find::delete_limit") {
         REQUIRE(d(collection)->document_storage().size() == 100);
         REQUIRE(d(table)->table_storage().table().calculate_size() == 100);
-        auto cond = make_compare_expression(&resource, compare_type::gt, key("count"), core::parameter_id_t(1));
+        auto cond =
+            make_compare_expression(&resource, compare_type::gt, side_t::left, key("count"), core::parameter_id_t(1));
         logical_plan::storage_parameters parameters(&resource);
         add_parameter(parameters, core::parameter_id_t(1), new_value(static_cast<int64_t>(90)));
         pipeline::context_t pipeline_context(std::move(parameters));
@@ -283,8 +293,10 @@ TEST_CASE("operator::update") {
         add_parameter(parameters, core::parameter_id_t(3), new_value(static_cast<int64_t>(9999)));
         pipeline::context_t pipeline_context(std::move(parameters));
 
-        auto cond = make_compare_expression(&resource, compare_type::gt, key("count"), core::parameter_id_t(1));
-        auto cond_check = make_compare_expression(&resource, compare_type::eq, key("count"), core::parameter_id_t(2));
+        auto cond =
+            make_compare_expression(&resource, compare_type::gt, side_t::left, key("count"), core::parameter_id_t(1));
+        auto cond_check =
+            make_compare_expression(&resource, compare_type::eq, side_t::left, key("count"), core::parameter_id_t(2));
 
         update_expr_ptr script_update_1 = new update_expr_set_t(expressions::key_t{"count"});
         script_update_1->left() = new update_expr_get_const_value_t(core::parameter_id_t(2));
@@ -346,8 +358,10 @@ TEST_CASE("operator::update") {
         add_parameter(parameters, core::parameter_id_t(3), new_value(static_cast<int64_t>(9999)));
         pipeline::context_t pipeline_context(std::move(parameters));
 
-        auto cond = make_compare_expression(&resource, compare_type::gt, key("count"), core::parameter_id_t(1));
-        auto cond_check = make_compare_expression(&resource, compare_type::eq, key("count"), core::parameter_id_t(2));
+        auto cond =
+            make_compare_expression(&resource, compare_type::gt, side_t::left, key("count"), core::parameter_id_t(1));
+        auto cond_check =
+            make_compare_expression(&resource, compare_type::eq, side_t::left, key("count"), core::parameter_id_t(2));
         update_expr_ptr script_update_1 = new update_expr_set_t(expressions::key_t{"count"});
         script_update_1->left() = new update_expr_get_const_value_t(core::parameter_id_t(2));
         update_expr_ptr script_update_2 = new update_expr_set_t(expressions::key_t{"countArray/0"});
@@ -408,8 +422,10 @@ TEST_CASE("operator::update") {
         add_parameter(parameters, core::parameter_id_t(3), new_value(static_cast<int64_t>(9999)));
         pipeline::context_t pipeline_context(std::move(parameters));
 
-        auto cond = make_compare_expression(&resource, compare_type::gt, key("count"), core::parameter_id_t(1));
-        auto cond_check = make_compare_expression(&resource, compare_type::eq, key("count"), core::parameter_id_t(2));
+        auto cond =
+            make_compare_expression(&resource, compare_type::gt, side_t::left, key("count"), core::parameter_id_t(1));
+        auto cond_check =
+            make_compare_expression(&resource, compare_type::eq, side_t::left, key("count"), core::parameter_id_t(2));
         update_expr_ptr script_update_1 = new update_expr_set_t(expressions::key_t{"count"});
         script_update_1->left() = new update_expr_get_const_value_t(core::parameter_id_t(2));
         update_expr_ptr script_update_2 = new update_expr_set_t(expressions::key_t{"countArray/0"});
@@ -483,7 +499,8 @@ TEST_CASE("operator::index_scan") {
     fill_table(table);
 
     SECTION("find::eq") {
-        auto cond = make_compare_expression(&resource, compare_type::eq, key("count"), core::parameter_id_t(1));
+        auto cond =
+            make_compare_expression(&resource, compare_type::eq, side_t::left, key("count"), core::parameter_id_t(1));
         logical_plan::storage_parameters parameters(&resource);
         add_parameter(parameters, core::parameter_id_t(1), new_value(static_cast<int64_t>(90)));
         pipeline::context_t pipeline_context(std::move(parameters));
@@ -501,7 +518,8 @@ TEST_CASE("operator::index_scan") {
     }
 
     SECTION("find::ne") {
-        auto cond = make_compare_expression(&resource, compare_type::ne, key("count"), core::parameter_id_t(1));
+        auto cond =
+            make_compare_expression(&resource, compare_type::ne, side_t::left, key("count"), core::parameter_id_t(1));
         logical_plan::storage_parameters parameters(&resource);
         add_parameter(parameters, core::parameter_id_t(1), new_value(static_cast<int64_t>(90)));
         pipeline::context_t pipeline_context(std::move(parameters));
@@ -519,7 +537,8 @@ TEST_CASE("operator::index_scan") {
     }
 
     SECTION("find::gt") {
-        auto cond = make_compare_expression(&resource, compare_type::gt, key("count"), core::parameter_id_t(1));
+        auto cond =
+            make_compare_expression(&resource, compare_type::gt, side_t::left, key("count"), core::parameter_id_t(1));
         logical_plan::storage_parameters parameters(&resource);
         add_parameter(parameters, core::parameter_id_t(1), new_value(static_cast<int64_t>(90)));
         pipeline::context_t pipeline_context(std::move(parameters));
@@ -537,7 +556,8 @@ TEST_CASE("operator::index_scan") {
     }
 
     SECTION("find::gte") {
-        auto cond = make_compare_expression(&resource, compare_type::gte, key("count"), core::parameter_id_t(1));
+        auto cond =
+            make_compare_expression(&resource, compare_type::gte, side_t::left, key("count"), core::parameter_id_t(1));
         logical_plan::storage_parameters parameters(&resource);
         add_parameter(parameters, core::parameter_id_t(1), new_value(static_cast<int64_t>(90)));
         pipeline::context_t pipeline_context(std::move(parameters));
@@ -555,7 +575,8 @@ TEST_CASE("operator::index_scan") {
     }
 
     SECTION("find::lt") {
-        auto cond = make_compare_expression(&resource, compare_type::lt, key("count"), core::parameter_id_t(1));
+        auto cond =
+            make_compare_expression(&resource, compare_type::lt, side_t::left, key("count"), core::parameter_id_t(1));
         logical_plan::storage_parameters parameters(&resource);
         add_parameter(parameters, core::parameter_id_t(1), new_value(static_cast<int64_t>(90)));
         pipeline::context_t pipeline_context(std::move(parameters));
@@ -573,7 +594,8 @@ TEST_CASE("operator::index_scan") {
     }
 
     SECTION("find::lte") {
-        auto cond = make_compare_expression(&resource, compare_type::lte, key("count"), core::parameter_id_t(1));
+        auto cond =
+            make_compare_expression(&resource, compare_type::lte, side_t::left, key("count"), core::parameter_id_t(1));
         logical_plan::storage_parameters parameters(&resource);
         add_parameter(parameters, core::parameter_id_t(1), new_value(static_cast<int64_t>(90)));
         pipeline::context_t pipeline_context(std::move(parameters));
@@ -591,7 +613,8 @@ TEST_CASE("operator::index_scan") {
     }
 
     SECTION("find_one") {
-        auto cond = make_compare_expression(&resource, compare_type::gt, key("count"), core::parameter_id_t(1));
+        auto cond =
+            make_compare_expression(&resource, compare_type::gt, side_t::left, key("count"), core::parameter_id_t(1));
         logical_plan::storage_parameters parameters(&resource);
         add_parameter(parameters, core::parameter_id_t(1), new_value(static_cast<int64_t>(90)));
         pipeline::context_t pipeline_context(std::move(parameters));
@@ -609,7 +632,8 @@ TEST_CASE("operator::index_scan") {
     }
 
     SECTION("find_limit") {
-        auto cond = make_compare_expression(&resource, compare_type::gt, key("count"), core::parameter_id_t(1));
+        auto cond =
+            make_compare_expression(&resource, compare_type::gt, side_t::left, key("count"), core::parameter_id_t(1));
         logical_plan::storage_parameters parameters(&resource);
         add_parameter(parameters, core::parameter_id_t(1), new_value(static_cast<int64_t>(90)));
         pipeline::context_t pipeline_context(std::move(parameters));
@@ -687,7 +711,8 @@ TEST_CASE("operator::index::delete_and_update") {
     fill_table(table);
 
     SECTION("index_scan after delete") {
-        auto cond_check = make_compare_expression(&resource, compare_type::gt, key("count"), core::parameter_id_t(1));
+        auto cond_check =
+            make_compare_expression(&resource, compare_type::gt, side_t::left, key("count"), core::parameter_id_t(1));
         logical_plan::storage_parameters parameters_check(&resource);
         add_parameter(parameters_check, core::parameter_id_t(1), new_value(static_cast<int64_t>(50)));
         pipeline::context_t pipeline_context_check(std::move(parameters_check));
@@ -699,7 +724,11 @@ TEST_CASE("operator::index::delete_and_update") {
                 REQUIRE(scan.output()->size() == 50);
             }
             {
-                auto cond = make_compare_expression(&resource, compare_type::gt, key("count"), core::parameter_id_t(1));
+                auto cond = make_compare_expression(&resource,
+                                                    compare_type::gt,
+                                                    side_t::left,
+                                                    key("count"),
+                                                    core::parameter_id_t(1));
                 logical_plan::storage_parameters parameters(&resource);
                 add_parameter(parameters, core::parameter_id_t(1), new_value(static_cast<int64_t>(60)));
                 pipeline::context_t pipeline_context(std::move(parameters));
@@ -721,7 +750,11 @@ TEST_CASE("operator::index::delete_and_update") {
                 REQUIRE(scan.output()->size() == 50);
             }
             {
-                auto cond = make_compare_expression(&resource, compare_type::gt, key("count"), core::parameter_id_t(1));
+                auto cond = make_compare_expression(&resource,
+                                                    compare_type::gt,
+                                                    side_t::left,
+                                                    key("count"),
+                                                    core::parameter_id_t(1));
                 logical_plan::storage_parameters parameters(&resource);
                 add_parameter(parameters, core::parameter_id_t(1), new_value(static_cast<int64_t>(60)));
                 pipeline::context_t pipeline_context(std::move(parameters));
@@ -739,7 +772,8 @@ TEST_CASE("operator::index::delete_and_update") {
     }
 
     SECTION("index_scan after update") {
-        auto cond_check = make_compare_expression(&resource, compare_type::eq, key("count"), core::parameter_id_t(1));
+        auto cond_check =
+            make_compare_expression(&resource, compare_type::eq, side_t::left, key("count"), core::parameter_id_t(1));
         logical_plan::storage_parameters parameters_check(&resource);
         add_parameter(parameters_check, core::parameter_id_t(1), new_value(static_cast<int64_t>(50)));
         add_parameter(parameters_check, core::parameter_id_t(2), new_value(static_cast<int64_t>(0)));

--- a/components/physical_plan_generator/tests/planner/test_create_plan_match.cpp
+++ b/components/physical_plan_generator/tests/planner/test_create_plan_match.cpp
@@ -27,10 +27,10 @@ TEST_CASE("create_plan::match") {
         REQUIRE(plan->output()->size() == 100);
     }
     {
-        auto node_match =
-            make_node_match(&resource,
-                            get_name(),
-                            make_compare_expression(&resource, compare_type::eq, key("key"), core::parameter_id_t(1)));
+        auto node_match = make_node_match(
+            &resource,
+            get_name(),
+            make_compare_expression(&resource, compare_type::eq, side_t::left, key("key"), core::parameter_id_t(1)));
         services::context_storage_t context;
         context.emplace(get_name(), d(collection));
         auto plan = create_plan(context, node_match, components::logical_plan::limit_t::unlimit());

--- a/components/planner/test/test_logical_plan.cpp
+++ b/components/planner/test/test_logical_plan.cpp
@@ -63,10 +63,10 @@ TEST_CASE("logical_plan::drop_collection") {
 
 TEST_CASE("logical_plan::match") {
     auto resource = std::pmr::synchronized_pool_resource();
-    auto node_match =
-        make_node_match(&resource,
-                        get_name(),
-                        make_compare_expression(&resource, compare_type::eq, key("key"), core::parameter_id_t(1)));
+    auto node_match = make_node_match(
+        &resource,
+        get_name(),
+        make_compare_expression(&resource, compare_type::eq, side_t::left, key("key"), core::parameter_id_t(1)));
     REQUIRE(node_match->to_string() == R"_($match: {"key": {$eq: #1}})_");
 }
 
@@ -126,10 +126,10 @@ TEST_CASE("logical_plan::aggregate") {
     auto resource = std::pmr::synchronized_pool_resource();
     auto aggregate = make_node_aggregate(&resource, {database_name, collection_name});
 
-    aggregate->append_child(
-        make_node_match(&resource,
-                        {database_name, collection_name},
-                        make_compare_expression(&resource, compare_type::eq, key("key"), core::parameter_id_t(1))));
+    aggregate->append_child(make_node_match(
+        &resource,
+        {database_name, collection_name},
+        make_compare_expression(&resource, compare_type::eq, side_t::left, key("key"), core::parameter_id_t(1))));
 
     {
         std::vector<expression_ptr> expressions;
@@ -215,10 +215,10 @@ TEST_CASE("logical_plan::limit") {
 
 TEST_CASE("logical_plan::delete") {
     auto resource = std::pmr::synchronized_pool_resource();
-    auto match =
-        make_node_match(&resource,
-                        {database_name, collection_name},
-                        make_compare_expression(&resource, compare_type::eq, key("key"), core::parameter_id_t(1)));
+    auto match = make_node_match(
+        &resource,
+        {database_name, collection_name},
+        make_compare_expression(&resource, compare_type::eq, side_t::left, key("key"), core::parameter_id_t(1)));
     components::logical_plan::storage_parameters parameters{&resource};
     {
         auto node = make_node_delete_many(&resource, {database_name, collection_name}, match);
@@ -236,10 +236,10 @@ TEST_CASE("logical_plan::delete") {
 
 TEST_CASE("logical_plan::update") {
     auto resource = std::pmr::synchronized_pool_resource();
-    auto match =
-        make_node_match(&resource,
-                        {database_name, collection_name},
-                        make_compare_expression(&resource, compare_type::eq, key("key"), core::parameter_id_t(1)));
+    auto match = make_node_match(
+        &resource,
+        {database_name, collection_name},
+        make_compare_expression(&resource, compare_type::eq, side_t::left, key("key"), core::parameter_id_t(1)));
 
     update_expr_ptr update = new update_expr_set_t(components::expressions::key_t{"count"});
     update->left() = new update_expr_get_const_value_t(core::parameter_id_t(0));

--- a/components/serialization/deserializer.cpp
+++ b/components/serialization/deserializer.cpp
@@ -125,8 +125,8 @@ namespace components::serializer {
         return static_cast<expressions::update_expr_type>(working_tree_.top()->at(index).as_int64());
     }
 
-    expressions::update_expr_get_value_t::side_t json_deserializer_t::deserialize_update_expr_side(size_t index) {
-        return static_cast<expressions::update_expr_get_value_t::side_t>(working_tree_.top()->at(index).as_int64());
+    expressions::side_t json_deserializer_t::deserialize_expr_side(size_t index) {
+        return static_cast<expressions::side_t>(working_tree_.top()->at(index).as_int64());
     }
 
     logical_plan::index_type json_deserializer_t::deserialize_index_type(size_t index) {
@@ -240,8 +240,8 @@ namespace components::serializer {
         return static_cast<expressions::update_expr_type>(working_tree_.top()->ptr[index].via.u64);
     }
 
-    expressions::update_expr_get_value_t::side_t msgpack_deserializer_t::deserialize_update_expr_side(size_t index) {
-        return static_cast<expressions::update_expr_get_value_t::side_t>(working_tree_.top()->ptr[index].via.u64);
+    expressions::side_t msgpack_deserializer_t::deserialize_expr_side(size_t index) {
+        return static_cast<expressions::side_t>(working_tree_.top()->ptr[index].via.u64);
     }
 
     logical_plan::index_type msgpack_deserializer_t::deserialize_index_type(size_t index) {

--- a/components/serialization/deserializer.hpp
+++ b/components/serialization/deserializer.hpp
@@ -28,7 +28,7 @@ namespace components::serializer {
         virtual expressions::scalar_type deserialize_scalar_type(size_t index) = 0;
         virtual expressions::sort_order deserialize_sort_order(size_t index) = 0;
         virtual expressions::update_expr_type deserialize_update_expr_type(size_t index) = 0;
-        virtual expressions::update_expr_get_value_t::side_t deserialize_update_expr_side(size_t index) = 0;
+        virtual expressions::side_t deserialize_expr_side(size_t index) = 0;
         virtual logical_plan::index_type deserialize_index_type(size_t index) = 0;
         virtual logical_plan::join_type deserialize_join_type(size_t index) = 0;
         virtual core::parameter_id_t deserialize_param_id(size_t index) = 0;
@@ -71,7 +71,7 @@ namespace components::serializer {
         expressions::scalar_type deserialize_scalar_type(size_t index) override;
         expressions::sort_order deserialize_sort_order(size_t index) override;
         expressions::update_expr_type deserialize_update_expr_type(size_t index) override;
-        expressions::update_expr_get_value_t::side_t deserialize_update_expr_side(size_t index) override;
+        expressions::side_t deserialize_expr_side(size_t index) override;
         logical_plan::index_type deserialize_index_type(size_t index) override;
         logical_plan::join_type deserialize_join_type(size_t index) override;
         core::parameter_id_t deserialize_param_id(size_t index) override;
@@ -105,7 +105,7 @@ namespace components::serializer {
         expressions::scalar_type deserialize_scalar_type(size_t index) override;
         expressions::sort_order deserialize_sort_order(size_t index) override;
         expressions::update_expr_type deserialize_update_expr_type(size_t index) override;
-        expressions::update_expr_get_value_t::side_t deserialize_update_expr_side(size_t index) override;
+        expressions::side_t deserialize_expr_side(size_t index) override;
         logical_plan::index_type deserialize_index_type(size_t index) override;
         logical_plan::join_type deserialize_join_type(size_t index) override;
         core::parameter_id_t deserialize_param_id(size_t index) override;

--- a/components/serialization/serializer.cpp
+++ b/components/serialization/serializer.cpp
@@ -170,7 +170,7 @@ namespace components::serializer {
         working_tree_.top()->emplace_back(static_cast<uint8_t>(type));
     }
 
-    void json_serializer_t::append(std::string_view key, expressions::update_expr_get_value_t::side_t side) {
+    void json_serializer_t::append(std::string_view key, expressions::side_t side) {
         working_tree_.top()->emplace_back(static_cast<uint8_t>(side));
     }
 
@@ -286,7 +286,7 @@ namespace components::serializer {
         packer_.pack(static_cast<uint8_t>(type));
     }
 
-    void msgpack_serializer_t::append(std::string_view key, expressions::update_expr_get_value_t::side_t side) {
+    void msgpack_serializer_t::append(std::string_view key, expressions::side_t side) {
         packer_.pack(static_cast<uint8_t>(side));
     }
 

--- a/components/serialization/serializer.hpp
+++ b/components/serialization/serializer.hpp
@@ -78,7 +78,7 @@ namespace components::serializer {
         virtual void append(std::string_view key, expressions::scalar_type type) = 0;
         virtual void append(std::string_view key, expressions::sort_order order) = 0;
         virtual void append(std::string_view key, expressions::update_expr_type type) = 0;
-        virtual void append(std::string_view key, expressions::update_expr_get_value_t::side_t side) = 0;
+        virtual void append(std::string_view key, expressions::side_t side) = 0;
 
         void append(std::string_view key, const std::pmr::vector<logical_plan::node_ptr>& nodes);
         void append(std::string_view key, const std::pmr::vector<document::document_ptr>& documents);
@@ -125,7 +125,7 @@ namespace components::serializer {
         void append(std::string_view key, expressions::scalar_type type) override;
         void append(std::string_view key, expressions::sort_order order) override;
         void append(std::string_view key, expressions::update_expr_type type) override;
-        void append(std::string_view key, expressions::update_expr_get_value_t::side_t side) override;
+        void append(std::string_view key, expressions::side_t side) override;
         void append(std::string_view key, const std::string& str) override;
         void append(std::string_view key, const document::document_ptr& doc) override;
         void append(std::string_view key, const document::value_t& val) override;
@@ -158,7 +158,7 @@ namespace components::serializer {
         void append(std::string_view key, expressions::scalar_type type) override;
         void append(std::string_view key, expressions::sort_order order) override;
         void append(std::string_view key, expressions::update_expr_type type) override;
-        void append(std::string_view key, expressions::update_expr_get_value_t::side_t side) override;
+        void append(std::string_view key, expressions::side_t side) override;
         void append(std::string_view key, const std::string& str) override;
         void append(std::string_view key, const document::document_ptr& doc) override;
         void append(std::string_view key, const document::value_t& val) override;

--- a/components/sql/test/test_update.cpp
+++ b/components/sql/test/test_update.cpp
@@ -146,8 +146,7 @@ TEST_CASE("sql::update_from") {
         fields f;
         f.emplace_back(new update_expr_set_t(components::expressions::key_t{"price"}));
         update_expr_ptr calculate = new update_expr_calculate_t(update_expr_type::mult);
-        calculate->left() = new update_expr_get_value_t(components::expressions::key_t{"price"},
-                                                        update_expr_get_value_t::side_t::undefined);
+        calculate->left() = new update_expr_get_value_t(components::expressions::key_t{"price"}, side_t::undefined);
         calculate->right() = new update_expr_get_const_value_t(core::parameter_id_t{0});
         f.back()->left() = std::move(calculate);
         TEST_SIMPLE_UPDATE(R"_(UPDATE TestDatabase.TestCollection SET price = price * 1.5;)_",
@@ -160,13 +159,10 @@ TEST_CASE("sql::update_from") {
         fields f;
         f.emplace_back(new update_expr_set_t(components::expressions::key_t{"price"}));
         update_expr_ptr calculate_1 = new update_expr_calculate_t(update_expr_type::mult);
-        calculate_1->left() =
-            new update_expr_get_value_t(components::expressions::key_t{"price"}, update_expr_get_value_t::side_t::from);
-        calculate_1->right() = new update_expr_get_value_t(components::expressions::key_t{"discount"},
-                                                           update_expr_get_value_t::side_t::to);
+        calculate_1->left() = new update_expr_get_value_t(components::expressions::key_t{"price"}, side_t::right);
+        calculate_1->right() = new update_expr_get_value_t(components::expressions::key_t{"discount"}, side_t::left);
         update_expr_ptr calculate_2 = new update_expr_calculate_t(update_expr_type::sub);
-        calculate_2->left() =
-            new update_expr_get_value_t(components::expressions::key_t{"price"}, update_expr_get_value_t::side_t::from);
+        calculate_2->left() = new update_expr_get_value_t(components::expressions::key_t{"price"}, side_t::right);
         calculate_2->right() = std::move(calculate_1);
         f.back()->left() = std::move(calculate_2);
         TEST_SIMPLE_UPDATE(R"_(UPDATE TestDatabase.TestCollection

--- a/components/sql/transformer/impl/transform_update.cpp
+++ b/components/sql/transformer/impl/transform_update.cpp
@@ -131,17 +131,14 @@ namespace components::sql::transform {
                 std::string key = strVal(ref->fields->lst.back().data);
                 if (ref->fields->lst.size() == 1) {
                     // can`t check table here
-                    return {new update_expr_get_value_t(expressions::key_t{key},
-                                                        update_expr_get_value_t::side_t::undefined)};
+                    return {new update_expr_get_value_t(expressions::key_t{key}, side_t::undefined)};
                 } else if (ref->fields->lst.size() == 2) {
                     // just table
                     std::string table = strVal(ref->fields->lst.front().data);
                     if (table == to.collection) {
-                        return {
-                            new update_expr_get_value_t(expressions::key_t{key}, update_expr_get_value_t::side_t::to)};
+                        return {new update_expr_get_value_t(expressions::key_t{key}, side_t::left)};
                     } else if (table == from.collection) {
-                        return {new update_expr_get_value_t(expressions::key_t{key},
-                                                            update_expr_get_value_t::side_t::from)};
+                        return {new update_expr_get_value_t(expressions::key_t{key}, side_t::right)};
                     } else {
                         throw parser_exception_t("incorrect column path in UPDATE call", "");
                     }
@@ -152,11 +149,9 @@ namespace components::sql::transform {
                     collection_full_name_t check_table{strVal(ref->fields->lst.front().data),
                                                        strVal((++ref->fields->lst.begin())->data)};
                     if (check_table == to) {
-                        return {
-                            new update_expr_get_value_t(expressions::key_t{key}, update_expr_get_value_t::side_t::to)};
+                        return {new update_expr_get_value_t(expressions::key_t{key}, side_t::left)};
                     } else if (check_table == from) {
-                        return {new update_expr_get_value_t(expressions::key_t{key},
-                                                            update_expr_get_value_t::side_t::from)};
+                        return {new update_expr_get_value_t(expressions::key_t{key}, side_t::right)};
                     } else {
                         throw parser_exception_t("incorrect column path in UPDATE call", "");
                     }

--- a/components/sql/transformer/impl/transfrom_common.cpp
+++ b/components/sql/transformer/impl/transfrom_common.cpp
@@ -101,6 +101,8 @@ namespace components::sql::transform::impl {
                     return make_compare_expression(
                         params->parameters().resource(),
                         get_compare_type(strVal(node->name->lst.front().data)),
+                        // TODO: deduce expression side
+                        side_t::undefined,
                         components::expressions::key_t{key_left},
                         params->add_parameter(get_value(node->rexpr, params->parameters().tape()).first));
                 } else {
@@ -108,6 +110,8 @@ namespace components::sql::transform::impl {
                     return make_compare_expression(
                         params->parameters().resource(),
                         get_compare_type(strVal(node->name->lst.back().data)),
+                        // TODO: deduce expression side
+                        side_t::undefined,
                         components::expressions::key_t{key},
                         params->add_parameter(get_value(node->lexpr, params->parameters().tape()).first));
                 }

--- a/integration/cpp/test/test_collection.cpp
+++ b/integration/cpp/test/test_collection.cpp
@@ -7,6 +7,7 @@ static const database_name_t database_name = "testdatabase";
 static const collection_name_t collection_name = "testcollection";
 
 using components::expressions::compare_type;
+using components::expressions::side_t;
 using key = components::expressions::key_t;
 using id_par = core::parameter_id_t;
 using services::collection::context_collection_t;
@@ -103,6 +104,7 @@ TEST_CASE("integration::cpp::test_collection") {
                 components::logical_plan::make_node_aggregate(dispatcher->resource(), {database_name, collection_name});
             auto expr = components::expressions::make_compare_expression(dispatcher->resource(),
                                                                          compare_type::gt,
+                                                                         side_t::left,
                                                                          key{"count"},
                                                                          id_par{1});
             plan->append_child(components::logical_plan::make_node_match(dispatcher->resource(),
@@ -121,6 +123,7 @@ TEST_CASE("integration::cpp::test_collection") {
                 components::logical_plan::make_node_aggregate(dispatcher->resource(), {database_name, collection_name});
             auto expr = components::expressions::make_compare_expression(dispatcher->resource(),
                                                                          compare_type::regex,
+                                                                         side_t::left,
                                                                          key{"countStr"},
                                                                          id_par{1});
             plan->append_child(components::logical_plan::make_node_match(dispatcher->resource(),
@@ -141,10 +144,12 @@ TEST_CASE("integration::cpp::test_collection") {
                 components::expressions::make_compare_union_expression(dispatcher->resource(), compare_type::union_or);
             expr->append_child(components::expressions::make_compare_expression(dispatcher->resource(),
                                                                                 compare_type::gt,
+                                                                                side_t::left,
                                                                                 key{"count"},
                                                                                 id_par{1}));
             expr->append_child(components::expressions::make_compare_expression(dispatcher->resource(),
                                                                                 compare_type::regex,
+                                                                                side_t::left,
                                                                                 key{"countStr"},
                                                                                 id_par{2}));
             plan->append_child(components::logical_plan::make_node_match(dispatcher->resource(),
@@ -168,15 +173,18 @@ TEST_CASE("integration::cpp::test_collection") {
                 components::expressions::make_compare_union_expression(dispatcher->resource(), compare_type::union_or);
             expr_or->append_child(components::expressions::make_compare_expression(dispatcher->resource(),
                                                                                    compare_type::gt,
+                                                                                   side_t::left,
                                                                                    key{"count"},
                                                                                    id_par{1}));
             expr_or->append_child(components::expressions::make_compare_expression(dispatcher->resource(),
                                                                                    compare_type::regex,
+                                                                                   side_t::left,
                                                                                    key{"countStr"},
                                                                                    id_par{2}));
             expr_and->append_child(expr_or);
             expr_and->append_child(components::expressions::make_compare_expression(dispatcher->resource(),
                                                                                     compare_type::lte,
+                                                                                    side_t::left,
                                                                                     key{"count"},
                                                                                     id_par{3}));
 
@@ -214,6 +222,7 @@ TEST_CASE("integration::cpp::test_collection") {
                 components::logical_plan::make_node_aggregate(dispatcher->resource(), {database_name, collection_name});
             auto expr = components::expressions::make_compare_expression(dispatcher->resource(),
                                                                          compare_type::eq,
+                                                                         side_t::left,
                                                                          key{"_id"},
                                                                          id_par{1});
             plan->append_child(components::logical_plan::make_node_match(dispatcher->resource(),
@@ -230,6 +239,7 @@ TEST_CASE("integration::cpp::test_collection") {
                 components::logical_plan::make_node_aggregate(dispatcher->resource(), {database_name, collection_name});
             auto expr = components::expressions::make_compare_expression(dispatcher->resource(),
                                                                          compare_type::eq,
+                                                                         side_t::left,
                                                                          key{"count"},
                                                                          id_par{1});
             plan->append_child(components::logical_plan::make_node_match(dispatcher->resource(),
@@ -249,10 +259,12 @@ TEST_CASE("integration::cpp::test_collection") {
                 components::expressions::make_compare_union_expression(dispatcher->resource(), compare_type::union_and);
             expr->append_child(components::expressions::make_compare_expression(dispatcher->resource(),
                                                                                 compare_type::gt,
+                                                                                side_t::left,
                                                                                 key{"count"},
                                                                                 id_par{1}));
             expr->append_child(components::expressions::make_compare_expression(dispatcher->resource(),
                                                                                 compare_type::regex,
+                                                                                side_t::left,
                                                                                 key{"countStr"},
                                                                                 id_par{2}));
             plan->append_child(components::logical_plan::make_node_match(dispatcher->resource(),

--- a/integration/cpp/test/test_collection_logical_plan.cpp
+++ b/integration/cpp/test/test_collection_logical_plan.cpp
@@ -28,6 +28,7 @@ static const collection_name_t table_collection_right = "table_testcollection_ri
 using namespace components;
 using namespace components::cursor;
 using expressions::compare_type;
+using expressions::side_t;
 using key = components::expressions::key_t;
 using id_par = core::parameter_id_t;
 
@@ -158,6 +159,7 @@ TEST_CASE("integration::cpp::test_collection::logical_plan") {
                     logical_plan::make_node_aggregate(dispatcher->resource(), {doc_database_name, doc_collection_name});
                 auto expr = components::expressions::make_compare_expression(dispatcher->resource(),
                                                                              compare_type::gt,
+                                                                             side_t::left,
                                                                              key{"count"},
                                                                              id_par{1});
                 agg->append_child(logical_plan::make_node_match(dispatcher->resource(),
@@ -176,6 +178,7 @@ TEST_CASE("integration::cpp::test_collection::logical_plan") {
                     logical_plan::make_node_aggregate(dispatcher->resource(), {doc_database_name, doc_collection_name});
                 auto expr = components::expressions::make_compare_expression(dispatcher->resource(),
                                                                              compare_type::gt,
+                                                                             side_t::left,
                                                                              key{"count"},
                                                                              id_par{1});
                 agg->append_child(logical_plan::make_node_match(dispatcher->resource(),
@@ -203,6 +206,7 @@ TEST_CASE("integration::cpp::test_collection::logical_plan") {
                                                              {table_database_name, table_collection_name});
                 auto expr = components::expressions::make_compare_expression(dispatcher->resource(),
                                                                              compare_type::gt,
+                                                                             side_t::left,
                                                                              key{"count"},
                                                                              id_par{1});
                 agg->append_child(logical_plan::make_node_match(dispatcher->resource(),
@@ -221,6 +225,7 @@ TEST_CASE("integration::cpp::test_collection::logical_plan") {
                                                              {table_database_name, table_collection_name});
                 auto expr = components::expressions::make_compare_expression(dispatcher->resource(),
                                                                              compare_type::gt,
+                                                                             side_t::left,
                                                                              key{"count"},
                                                                              id_par{1});
                 agg->append_child(logical_plan::make_node_match(dispatcher->resource(),
@@ -278,6 +283,7 @@ TEST_CASE("integration::cpp::test_collection::logical_plan") {
                     logical_plan::make_node_aggregate(dispatcher->resource(), {doc_database_name, doc_collection_name});
                 auto expr = components::expressions::make_compare_expression(dispatcher->resource(),
                                                                              compare_type::gt,
+                                                                             side_t::left,
                                                                              key{"count"},
                                                                              id_par{1});
                 agg->append_child(logical_plan::make_node_match(dispatcher->resource(),
@@ -294,10 +300,13 @@ TEST_CASE("integration::cpp::test_collection::logical_plan") {
                 auto del = logical_plan::make_node_delete_many(
                     dispatcher->resource(),
                     {doc_database_name, doc_collection_name},
-                    logical_plan::make_node_match(
-                        dispatcher->resource(),
-                        {doc_database_name, doc_collection_name},
-                        make_compare_expression(dispatcher->resource(), compare_type::gt, key{"count"}, id_par{1})));
+                    logical_plan::make_node_match(dispatcher->resource(),
+                                                  {doc_database_name, doc_collection_name},
+                                                  make_compare_expression(dispatcher->resource(),
+                                                                          compare_type::gt,
+                                                                          side_t::left,
+                                                                          key{"count"},
+                                                                          id_par{1})));
                 auto params = logical_plan::make_parameter_node(dispatcher->resource());
                 params->add_parameter(id_par{1}, new_value(90));
                 auto cur = dispatcher->execute_plan(session, del, params);
@@ -310,6 +319,7 @@ TEST_CASE("integration::cpp::test_collection::logical_plan") {
                     logical_plan::make_node_aggregate(dispatcher->resource(), {doc_database_name, doc_collection_name});
                 auto expr = components::expressions::make_compare_expression(dispatcher->resource(),
                                                                              compare_type::gt,
+                                                                             side_t::left,
                                                                              key{"count"},
                                                                              id_par{1});
                 agg->append_child(logical_plan::make_node_match(dispatcher->resource(),
@@ -329,6 +339,7 @@ TEST_CASE("integration::cpp::test_collection::logical_plan") {
                                                              {table_database_name, table_collection_name});
                 auto expr = components::expressions::make_compare_expression(dispatcher->resource(),
                                                                              compare_type::gt,
+                                                                             side_t::left,
                                                                              key{"count"},
                                                                              id_par{1});
                 agg->append_child(logical_plan::make_node_match(dispatcher->resource(),
@@ -345,10 +356,13 @@ TEST_CASE("integration::cpp::test_collection::logical_plan") {
                 auto del = logical_plan::make_node_delete_many(
                     dispatcher->resource(),
                     {table_database_name, table_collection_name},
-                    logical_plan::make_node_match(
-                        dispatcher->resource(),
-                        {table_database_name, table_collection_name},
-                        make_compare_expression(dispatcher->resource(), compare_type::gt, key{"count"}, id_par{1})));
+                    logical_plan::make_node_match(dispatcher->resource(),
+                                                  {table_database_name, table_collection_name},
+                                                  make_compare_expression(dispatcher->resource(),
+                                                                          compare_type::gt,
+                                                                          side_t::left,
+                                                                          key{"count"},
+                                                                          id_par{1})));
                 auto params = logical_plan::make_parameter_node(dispatcher->resource());
                 params->add_parameter(id_par{1}, new_value(90));
                 auto cur = dispatcher->execute_plan(session, del, params);
@@ -361,6 +375,7 @@ TEST_CASE("integration::cpp::test_collection::logical_plan") {
                                                              {table_database_name, table_collection_name});
                 auto expr = components::expressions::make_compare_expression(dispatcher->resource(),
                                                                              compare_type::gt,
+                                                                             side_t::left,
                                                                              key{"count"},
                                                                              id_par{1});
                 agg->append_child(logical_plan::make_node_match(dispatcher->resource(),
@@ -432,6 +447,7 @@ TEST_CASE("integration::cpp::test_collection::logical_plan") {
                     logical_plan::make_node_aggregate(dispatcher->resource(), {doc_database_name, doc_collection_name});
                 auto expr = components::expressions::make_compare_expression(dispatcher->resource(),
                                                                              compare_type::lt,
+                                                                             side_t::left,
                                                                              key{"count"},
                                                                              id_par{1});
                 agg->append_child(logical_plan::make_node_match(dispatcher->resource(),
@@ -444,10 +460,13 @@ TEST_CASE("integration::cpp::test_collection::logical_plan") {
             }
             {
                 auto session = otterbrix::session_id_t();
-                auto match = logical_plan::make_node_match(
-                    dispatcher->resource(),
-                    {doc_database_name, doc_collection_name},
-                    make_compare_expression(dispatcher->resource(), compare_type::lt, key{"count"}, id_par{1}));
+                auto match = logical_plan::make_node_match(dispatcher->resource(),
+                                                           {doc_database_name, doc_collection_name},
+                                                           make_compare_expression(dispatcher->resource(),
+                                                                                   compare_type::lt,
+                                                                                   side_t::left,
+                                                                                   key{"count"},
+                                                                                   id_par{1}));
                 expressions::update_expr_ptr update_expr =
                     new expressions::update_expr_set_t(expressions::key_t{"count"});
                 update_expr->left() = new expressions::update_expr_get_const_value_t(id_par{2});
@@ -468,6 +487,7 @@ TEST_CASE("integration::cpp::test_collection::logical_plan") {
                     logical_plan::make_node_aggregate(dispatcher->resource(), {doc_database_name, doc_collection_name});
                 auto expr = components::expressions::make_compare_expression(dispatcher->resource(),
                                                                              compare_type::lt,
+                                                                             side_t::left,
                                                                              key{"count"},
                                                                              id_par{1});
                 agg->append_child(logical_plan::make_node_match(dispatcher->resource(),
@@ -485,6 +505,7 @@ TEST_CASE("integration::cpp::test_collection::logical_plan") {
                     logical_plan::make_node_aggregate(dispatcher->resource(), {doc_database_name, doc_collection_name});
                 auto expr = components::expressions::make_compare_expression(dispatcher->resource(),
                                                                              compare_type::eq,
+                                                                             side_t::left,
                                                                              key{"count"},
                                                                              id_par{1});
                 agg->append_child(logical_plan::make_node_match(dispatcher->resource(),
@@ -504,6 +525,7 @@ TEST_CASE("integration::cpp::test_collection::logical_plan") {
                                                              {table_database_name, table_collection_name});
                 auto expr = components::expressions::make_compare_expression(dispatcher->resource(),
                                                                              compare_type::lt,
+                                                                             side_t::left,
                                                                              key{"count"},
                                                                              id_par{1});
                 agg->append_child(logical_plan::make_node_match(dispatcher->resource(),
@@ -516,10 +538,13 @@ TEST_CASE("integration::cpp::test_collection::logical_plan") {
             }
             {
                 auto session = otterbrix::session_id_t();
-                auto match = logical_plan::make_node_match(
-                    dispatcher->resource(),
-                    {table_database_name, table_collection_name},
-                    make_compare_expression(dispatcher->resource(), compare_type::lt, key{"count"}, id_par{1}));
+                auto match = logical_plan::make_node_match(dispatcher->resource(),
+                                                           {table_database_name, table_collection_name},
+                                                           make_compare_expression(dispatcher->resource(),
+                                                                                   compare_type::lt,
+                                                                                   side_t::left,
+                                                                                   key{"count"},
+                                                                                   id_par{1}));
                 expressions::update_expr_ptr update_expr =
                     new expressions::update_expr_set_t(expressions::key_t{"count"});
                 update_expr->left() = new expressions::update_expr_get_const_value_t(id_par{2});
@@ -540,6 +565,7 @@ TEST_CASE("integration::cpp::test_collection::logical_plan") {
                                                              {table_database_name, table_collection_name});
                 auto expr = components::expressions::make_compare_expression(dispatcher->resource(),
                                                                              compare_type::lt,
+                                                                             side_t::left,
                                                                              key{"count"},
                                                                              id_par{1});
                 agg->append_child(logical_plan::make_node_match(dispatcher->resource(),
@@ -557,6 +583,7 @@ TEST_CASE("integration::cpp::test_collection::logical_plan") {
                                                              {table_database_name, table_collection_name});
                 auto expr = components::expressions::make_compare_expression(dispatcher->resource(),
                                                                              compare_type::eq,
+                                                                             side_t::left,
                                                                              key{"count"},
                                                                              id_par{1});
                 agg->append_child(logical_plan::make_node_match(dispatcher->resource(),
@@ -598,8 +625,7 @@ TEST_CASE("integration::cpp::test_collection::logical_plan") {
                 expressions::update_expr_ptr calculate_expr =
                     new expressions::update_expr_calculate_t(expressions::update_expr_type::mult);
                 calculate_expr->left() =
-                    new expressions::update_expr_get_value_t(expressions::key_t{"count"},
-                                                             expressions::update_expr_get_value_t::side_t::from);
+                    new expressions::update_expr_get_value_t(expressions::key_t{"count"}, expressions::side_t::right);
                 calculate_expr->right() = new expressions::update_expr_get_const_value_t(id_par{1});
                 update_expr->left() = std::move(calculate_expr);
 
@@ -652,8 +678,7 @@ TEST_CASE("integration::cpp::test_collection::logical_plan") {
                 expressions::update_expr_ptr calculate_expr =
                     new expressions::update_expr_calculate_t(expressions::update_expr_type::mult);
                 calculate_expr->left() =
-                    new expressions::update_expr_get_value_t(expressions::key_t{"count"},
-                                                             expressions::update_expr_get_value_t::side_t::from);
+                    new expressions::update_expr_get_value_t(expressions::key_t{"count"}, expressions::side_t::right);
                 calculate_expr->right() = new expressions::update_expr_get_const_value_t(id_par{1});
                 update_expr->left() = std::move(calculate_expr);
 
@@ -798,6 +823,42 @@ TEST_CASE("integration::cpp::test_collection::logical_plan") {
                             std::pmr::string("Name " + std::to_string((num + 25) * 2)));
                 }
             }
+            INFO("both are raw data with complex join expr") {
+                auto session = otterbrix::session_id_t();
+                auto params = logical_plan::make_parameter_node(dispatcher->resource());
+                params->add_parameter(core::parameter_id_t(1), new_value(int64_t{75}));
+                auto join = logical_plan::make_node_join(dispatcher->resource(), {}, logical_plan::join_type::inner);
+                join->append_child(logical_plan::make_node_raw_data(dispatcher->resource(), documents_left));
+                join->append_child(logical_plan::make_node_raw_data(dispatcher->resource(), documents_right));
+                {
+                    auto and_expr =
+                        expressions::make_compare_union_expression(dispatcher->resource(), compare_type::union_and);
+                    and_expr->append_child(expressions::make_compare_expression(dispatcher->resource(),
+                                                                                compare_type::eq,
+                                                                                expressions::key_t{"key_1"},
+                                                                                expressions::key_t{"key"}));
+                    and_expr->append_child(expressions::make_compare_expression(dispatcher->resource(),
+                                                                                compare_type::gt,
+                                                                                side_t::right,
+                                                                                expressions::key_t{"key"},
+                                                                                core::parameter_id_t(1)));
+
+                    join->append_expression(std::move(and_expr));
+                }
+                auto cur = dispatcher->execute_plan(session, join, params);
+                REQUIRE(cur->is_success());
+                REQUIRE(cur->size() == 13);
+
+                for (int num = 13; num < 26; ++num) {
+                    REQUIRE(cur->has_next());
+                    cur->next_document();
+                    REQUIRE(cur->get_document()->get_long("key_1") == (num + 25) * 2);
+                    REQUIRE(cur->get_document()->get_long("key") == (num + 25) * 2);
+                    REQUIRE(cur->get_document()->get_long("value") == (num + 25) * 2 * 10);
+                    REQUIRE(cur->get_document()->get_string("name") ==
+                            std::pmr::string("Name " + std::to_string((num + 25) * 2)));
+                }
+            }
             INFO("join raw data with aggregate") {
                 auto session = otterbrix::session_id_t();
                 auto aggregate = logical_plan::make_node_aggregate(dispatcher->resource(), {});
@@ -857,6 +918,7 @@ TEST_CASE("integration::cpp::test_collection::logical_plan") {
                                                           {},
                                                           make_compare_expression(dispatcher->resource(),
                                                                                   compare_type::lt,
+                                                                                  side_t::left,
                                                                                   key("key_1"),
                                                                                   core::parameter_id_t(1))));
                     }
@@ -1005,6 +1067,40 @@ TEST_CASE("integration::cpp::test_collection::logical_plan") {
                             "Name " + std::to_string((num + 25) * 2));
                 }
             }
+            INFO("both are raw data with complex join expr") {
+                auto session = otterbrix::session_id_t();
+                auto params = logical_plan::make_parameter_node(dispatcher->resource());
+                params->add_parameter(core::parameter_id_t(1), new_value(int64_t{75}));
+                auto join = logical_plan::make_node_join(dispatcher->resource(), {}, logical_plan::join_type::inner);
+                join->append_child(logical_plan::make_node_raw_data(dispatcher->resource(), chunk_left));
+                join->append_child(logical_plan::make_node_raw_data(dispatcher->resource(), chunk_right));
+                {
+                    auto and_expr =
+                        expressions::make_compare_union_expression(dispatcher->resource(), compare_type::union_and);
+                    and_expr->append_child(expressions::make_compare_expression(dispatcher->resource(),
+                                                                                compare_type::eq,
+                                                                                expressions::key_t{"key_1"},
+                                                                                expressions::key_t{"key"}));
+                    and_expr->append_child(expressions::make_compare_expression(dispatcher->resource(),
+                                                                                compare_type::gt,
+                                                                                side_t::right,
+                                                                                expressions::key_t{"key"},
+                                                                                core::parameter_id_t(1)));
+
+                    join->append_expression(std::move(and_expr));
+                }
+                auto cur = dispatcher->execute_plan(session, join, params);
+                REQUIRE(cur->is_success());
+                REQUIRE(cur->size() == 13);
+
+                for (int index = 0, num = 13; index < 13; ++index, ++num) {
+                    REQUIRE(cur->chunk_data().value(2, index).value<int64_t>() == (num + 25) * 2);
+                    REQUIRE(cur->chunk_data().value(5, index).value<int64_t>() == (num + 25) * 2);
+                    REQUIRE(cur->chunk_data().value(4, index).value<int64_t>() == (num + 25) * 2 * 10);
+                    REQUIRE(cur->chunk_data().value(1, index).value<std::string_view>() ==
+                            "Name " + std::to_string((num + 25) * 2));
+                }
+            }
             INFO("join raw data with aggregate") {
                 auto session = otterbrix::session_id_t();
                 auto aggregate = logical_plan::make_node_aggregate(dispatcher->resource(), {});
@@ -1064,6 +1160,7 @@ TEST_CASE("integration::cpp::test_collection::logical_plan") {
                                                           {},
                                                           make_compare_expression(dispatcher->resource(),
                                                                                   compare_type::lt,
+                                                                                  side_t::left,
                                                                                   key("key_1"),
                                                                                   core::parameter_id_t(1))));
                     }

--- a/integration/cpp/test/test_join.cpp
+++ b/integration/cpp/test/test_join.cpp
@@ -235,6 +235,22 @@ TEST_CASE("integration::cpp::test_join") {
         }
     }
 
+    INFO("two join predicates, with const") {
+        auto session = otterbrix::session_id_t();
+        {
+            std::stringstream query;
+            query << "SELECT * FROM " << database_name + "." << collection_name_1 << " INNER JOIN " << database_name
+                  << "." << collection_name_2 << " ON " << database_name << "." << collection_name_1 << ".key_1"
+                  << " = " << database_name << "." << collection_name_2 + ".key AND " << database_name << "."
+                  << collection_name_2 << ".key"
+                  << " > "
+                  << "75;";
+            auto cur = dispatcher->execute_sql(session, query.str());
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 13);
+        }
+    }
+
     INFO("self join ") {
         auto session = otterbrix::session_id_t();
         {

--- a/integration/cpp/test/test_save_load.cpp
+++ b/integration/cpp/test/test_save_load.cpp
@@ -15,6 +15,7 @@ static const collection_name_t collection_name = "testcollection";
 
 using namespace components::cursor;
 using components::expressions::compare_type;
+using components::expressions::side_t;
 using key = components::expressions::key_t;
 using id_par = core::parameter_id_t;
 
@@ -30,6 +31,7 @@ cursor_t_ptr find_doc(otterbrix::wrapper_dispatcher_t* dispatcher,
     auto aggregate = components::logical_plan::make_node_aggregate(dispatcher->resource(), {db_name, col_name});
     auto expr = components::expressions::make_compare_expression(dispatcher->resource(),
                                                                  compare_type::eq,
+                                                                 side_t::left,
                                                                  key{"_id"},
                                                                  id_par{1});
     aggregate->append_child(
@@ -144,6 +146,7 @@ TEST_CASE("integration::cpp::test_save_load::disk+wal") {
                         {db_name, col_name},
                         components::expressions::make_compare_expression(dispatcher->resource(),
                                                                          compare_type::eq,
+                                                                         side_t::left,
                                                                          key{"count"},
                                                                          core::parameter_id_t{1}));
                     auto params = components::logical_plan::make_parameter_node(dispatcher->resource());
@@ -159,10 +162,12 @@ TEST_CASE("integration::cpp::test_save_load::disk+wal") {
                                                                                        compare_type::union_and);
                     expr->append_child(components::expressions::make_compare_expression(dispatcher->resource(),
                                                                                         compare_type::gte,
+                                                                                        side_t::left,
                                                                                         key{"count"},
                                                                                         core::parameter_id_t{1}));
                     expr->append_child(components::expressions::make_compare_expression(dispatcher->resource(),
                                                                                         compare_type::lte,
+                                                                                        side_t::left,
                                                                                         key{"count"},
                                                                                         core::parameter_id_t{2}));
                     auto match = components::logical_plan::make_node_match(dispatcher->resource(),
@@ -183,6 +188,7 @@ TEST_CASE("integration::cpp::test_save_load::disk+wal") {
                         {db_name, col_name},
                         components::expressions::make_compare_expression(dispatcher->resource(),
                                                                          compare_type::eq,
+                                                                         side_t::left,
                                                                          key{"count"},
                                                                          core::parameter_id_t{1}));
                     auto params = components::logical_plan::make_parameter_node(dispatcher->resource());
@@ -206,6 +212,7 @@ TEST_CASE("integration::cpp::test_save_load::disk+wal") {
                         {db_name, col_name},
                         components::expressions::make_compare_expression(dispatcher->resource(),
                                                                          compare_type::gt,
+                                                                         side_t::left,
                                                                          key{"count"},
                                                                          core::parameter_id_t{1}));
                     auto params = components::logical_plan::make_parameter_node(dispatcher->resource());

--- a/integration/python/sql/convert.cpp
+++ b/integration/python/sql/convert.cpp
@@ -217,6 +217,7 @@ using components::expressions::compare_type;
 using components::expressions::get_compare_type;
 using components::expressions::make_compare_expression;
 using components::expressions::make_compare_union_expression;
+using components::expressions::side_t;
 
 using components::expressions::aggregate_expression_t;
 using components::expressions::aggregate_type;
@@ -276,7 +277,7 @@ void parse_find_condition_(std::pmr::memory_resource* resource,
         parse_find_condition_array_(resource, parent_condition, condition, real_key, aggregate, params);
     } else {
         auto value = params->add_parameter(to_value(condition, params->parameters().tape()));
-        auto sub_condition = make_compare_expression(resource, type, ex_key_t(real_key), value);
+        auto sub_condition = make_compare_expression(resource, type, side_t::left, ex_key_t(real_key), value);
         if (sub_condition->is_union()) {
             parse_find_condition_(resource, sub_condition.get(), condition, real_key, std::string(), aggregate, params);
         }

--- a/integration/python/sql/wrapper_collection.cpp
+++ b/integration/python/sql/wrapper_collection.cpp
@@ -126,9 +126,9 @@ namespace otterbrix {
                     components::expressions::update_expr_ptr calculate_expr =
                         new components::expressions::update_expr_calculate_t(
                             components::expressions::update_expr_type::add);
-                    calculate_expr->left() = new components::expressions::update_expr_get_value_t(
-                        components::expressions::key_t{key_str},
-                        components::expressions::update_expr_get_value_t::side_t::to);
+                    calculate_expr->left() =
+                        new components::expressions::update_expr_get_value_t(components::expressions::key_t{key_str},
+                                                                             components::expressions::side_t::left);
                     auto id = params->add_parameter(components::document::value_t(*value->get_mut()));
                     calculate_expr->right() = new components::expressions::update_expr_get_const_value_t(id);
                     updates.back()->left() = std::move(calculate_expr);
@@ -178,9 +178,9 @@ namespace otterbrix {
                     components::expressions::update_expr_ptr calculate_expr =
                         new components::expressions::update_expr_calculate_t(
                             components::expressions::update_expr_type::add);
-                    calculate_expr->left() = new components::expressions::update_expr_get_value_t(
-                        components::expressions::key_t{key_str},
-                        components::expressions::update_expr_get_value_t::side_t::to);
+                    calculate_expr->left() =
+                        new components::expressions::update_expr_get_value_t(components::expressions::key_t{key_str},
+                                                                             components::expressions::side_t::left);
                     auto id = params->add_parameter(components::document::value_t(*value->get_mut()));
                     calculate_expr->right() = new components::expressions::update_expr_get_const_value_t(id);
                     updates.back()->left() = std::move(calculate_expr);

--- a/services/wal/tests/test_wal.cpp
+++ b/services/wal/tests/test_wal.cpp
@@ -198,6 +198,7 @@ TEST_CASE("delete one test") {
                                                       {database_name, collection_name},
                                                       make_compare_expression(&resource,
                                                                               compare_type::eq,
+                                                                              side_t::left,
                                                                               components::expressions::key_t{"count"},
                                                                               core::parameter_id_t{1}));
         auto params = make_parameter_node(&resource);
@@ -237,6 +238,7 @@ TEST_CASE("delete many test") {
                                                       {database_name, collection_name},
                                                       make_compare_expression(&resource,
                                                                               compare_type::eq,
+                                                                              side_t::left,
                                                                               components::expressions::key_t{"count"},
                                                                               core::parameter_id_t{1}));
         auto params = make_parameter_node(&resource);
@@ -276,6 +278,7 @@ TEST_CASE("update one test") {
                                                       {database_name, collection_name},
                                                       make_compare_expression(&resource,
                                                                               compare_type::eq,
+                                                                              side_t::left,
                                                                               components::expressions::key_t{"count"},
                                                                               core::parameter_id_t{1}));
         auto params = make_parameter_node(&resource);
@@ -329,6 +332,7 @@ TEST_CASE("update many test") {
                                                       {database_name, collection_name},
                                                       make_compare_expression(&resource,
                                                                               compare_type::eq,
+                                                                              side_t::left,
                                                                               components::expressions::key_t{"count"},
                                                                               core::parameter_id_t{1}));
         auto params = make_parameter_node(&resource);


### PR DESCRIPTION
Before that, whenever we had comparison of 2 data nodes, right one couldn't be compared with a const value, only left one was possible