### PR TITLE
wrapper_dispatcher fix proposal

### DIFF
--- a/integration/cpp/impl/session_blocker.cpp
+++ b/integration/cpp/impl/session_blocker.cpp
@@ -5,29 +5,29 @@ namespace otterbrix::impl {
     using components::session::session_id_t;
 
     session_block_t::session_block_t(std::pmr::memory_resource* resource)
-        : std::pmr::unordered_map<session_id_t, bool>(resource) {}
+        : std::pmr::unordered_map<session_id_t, std::pair<bool, void*>>(resource) {}
 
     bool session_block_t::empty() noexcept {
         std::shared_lock lock(mutex_);
-        return std::pmr::unordered_map<session_id_t, bool>::empty();
+        return std::pmr::unordered_map<session_id_t, std::pair<bool, void*>>::empty();
     }
 
     size_t session_block_t::size() noexcept {
         std::shared_lock lock(mutex_);
-        return std::pmr::unordered_map<session_id_t, bool>::size();
+        return std::pmr::unordered_map<session_id_t, std::pair<bool, void*>>::size();
     }
 
     void session_block_t::clear() noexcept {
         std::lock_guard lock(mutex_);
-        return std::pmr::unordered_map<session_id_t, bool>::clear();
+        return std::pmr::unordered_map<session_id_t, std::pair<bool, void*>>::clear();
     }
 
-    bool session_block_t::set_value(const session_id_t& session, bool value) {
+    bool session_block_t::set_value(const session_id_t& session, std::pair<bool, void*> value) {
         std::lock_guard lock(mutex_);
         // it is possible that there is someone trying to create new session with the same id
         //! if this is a problem, solution will be to generate a new session
         auto it = insert_or_assign(session, value);
-        if (!value && !it.second) {
+        if (!value.first && !it.second) {
             // if value == true, it is a return call and should be possible
             // if value == false and there is already a session here, then it should be illegal
             return false;
@@ -35,13 +35,21 @@ namespace otterbrix::impl {
         return true;
     }
 
+    void session_block_t::set_value_flag(const session_id_t& session, bool value) {
+        std::lock_guard lock(mutex_);
+        auto it = find(session);
+        // this should be called when we already registered a session
+        assert(it != end());
+        it->second.first = value;
+    }
+
     void session_block_t::remove_session(const session_id_t& session) {
         std::lock_guard lock(mutex_);
         erase(session);
     }
 
-    bool session_block_t::value(const session_id_t& session) {
+    std::pair<bool, void*> session_block_t::value(const session_id_t& session) {
         std::shared_lock lock(mutex_);
-        return std::pmr::unordered_map<session_id_t, bool>::at(session);
+        return std::pmr::unordered_map<session_id_t, std::pair<bool, void*>>::at(session);
     }
 } // namespace otterbrix::impl

--- a/integration/cpp/impl/session_blocker.hpp
+++ b/integration/cpp/impl/session_blocker.hpp
@@ -1,12 +1,14 @@
 #pragma once
 
+#include <cassert>
 #include <components/session/session.hpp>
 #include <memory_resource>
 #include <shared_mutex>
 #include <unordered_map>
 
 namespace otterbrix::impl {
-    class session_block_t : private std::pmr::unordered_map<components::session::session_id_t, bool> {
+
+    class session_block_t : private std::pmr::unordered_map<components::session::session_id_t, std::pair<bool, void*>> {
     public:
         explicit session_block_t(std::pmr::memory_resource* resource);
 
@@ -14,11 +16,27 @@ namespace otterbrix::impl {
         size_t size() noexcept;
         void clear() noexcept;
         // return false if there is a hash conflict
-        bool set_value(const components::session::session_id_t& session, bool value);
+        bool set_value(const components::session::session_id_t& session, std::pair<bool, void*> value);
+        // when there is no intention of reading value
+        void set_value_flag(const components::session::session_id_t& session, bool value);
+        // sets pair.first to true, and writes value to par.second address
+        template<typename T>
+        void set_value(const components::session::session_id_t& session, T value);
         void remove_session(const components::session::session_id_t& session);
-        bool value(const components::session::session_id_t& session);
+        std::pair<bool, void*> value(const components::session::session_id_t& session);
 
     private:
         std::shared_mutex mutex_;
     };
+
+    template<typename T>
+    void session_block_t::set_value(const components::session::session_id_t& session, T value) {
+        std::lock_guard lock(mutex_);
+        auto it = find(session);
+        // this should be called when we already registered a session
+        assert(it != end() && "session_block_t: session is not registered when value is being set");
+        assert(!it->second.first && "session_block_t: value was already set");
+        it->second.first = true;
+        *reinterpret_cast<T*>(it->second.second) = std::forward<T>(value);
+    }
 } // namespace otterbrix::impl

--- a/integration/cpp/wrapper_dispatcher.cpp
+++ b/integration/cpp/wrapper_dispatcher.cpp
@@ -70,7 +70,8 @@ namespace otterbrix {
     auto wrapper_dispatcher_t::load() -> void {
         session_id_t session;
         trace(log_, "wrapper_dispatcher_t::load session: {}", session.data());
-        session_id_t approved_session = init(session);
+        // this nullptr won't be accessed
+        session_id_t approved_session = init(session, nullptr);
         actor_zeta::send(manager_dispatcher_, address(), core::handler_id(core::route::load), approved_session);
         wait(approved_session);
     }
@@ -110,7 +111,8 @@ namespace otterbrix {
                                           const collection_name_t& collection,
                                           document_ptr document) -> cursor_t_ptr {
         trace(log_, "wrapper_dispatcher_t::insert_one session: {}, collection name: {} ", session.data(), collection);
-        session_id_t approved_session = init(session);
+        cursor_t_ptr result_store_;
+        session_id_t approved_session = init(session, &result_store_);
         auto plan = components::logical_plan::make_node_insert(resource(), {database, collection}, {document});
         actor_zeta::send(manager_dispatcher_,
                          address(),
@@ -118,7 +120,8 @@ namespace otterbrix {
                          approved_session,
                          plan,
                          components::logical_plan::make_parameter_node(resource()));
-        return wait_result(approved_session);
+        wait(approved_session);
+        return result_store_;
     }
 
     auto wrapper_dispatcher_t::insert_many(const session_id_t& session,
@@ -126,7 +129,8 @@ namespace otterbrix {
                                            const collection_name_t& collection,
                                            const std::pmr::vector<document_ptr>& documents) -> cursor_t_ptr {
         trace(log_, "wrapper_dispatcher_t::insert_many session: {}, collection name: {} ", session.data(), collection);
-        session_id_t approved_session = init(session);
+        cursor_t_ptr result_store_;
+        session_id_t approved_session = init(session, &result_store_);
         auto plan = components::logical_plan::make_node_insert(resource(), {database, collection}, documents);
         actor_zeta::send(manager_dispatcher_,
                          address(),
@@ -134,7 +138,8 @@ namespace otterbrix {
                          approved_session,
                          plan,
                          components::logical_plan::make_parameter_node(resource()));
-        return wait_result(approved_session);
+        wait(approved_session);
+        return result_store_;
     }
 
     auto wrapper_dispatcher_t::find(const session_id_t& session,
@@ -167,7 +172,8 @@ namespace otterbrix {
               session.data(),
               condition->collection_full_name().database,
               condition->collection_full_name().collection);
-        session_id_t approved_session = init(session);
+        cursor_t_ptr result_store_;
+        session_id_t approved_session = init(session, &result_store_);
         auto plan =
             components::logical_plan::make_node_delete_one(resource(), condition->collection_full_name(), condition);
         actor_zeta::send(manager_dispatcher_,
@@ -176,7 +182,8 @@ namespace otterbrix {
                          approved_session,
                          plan,
                          std::move(params));
-        return wait_result(approved_session);
+        wait(approved_session);
+        return result_store_;
     }
 
     auto wrapper_dispatcher_t::delete_many(const components::session::session_id_t& session,
@@ -187,7 +194,8 @@ namespace otterbrix {
               session.data(),
               condition->collection_full_name().database,
               condition->collection_full_name().collection);
-        session_id_t approved_session = init(session);
+        cursor_t_ptr result_store_;
+        session_id_t approved_session = init(session, &result_store_);
         auto plan =
             components::logical_plan::make_node_delete_many(resource(), condition->collection_full_name(), condition);
         actor_zeta::send(manager_dispatcher_,
@@ -196,7 +204,8 @@ namespace otterbrix {
                          approved_session,
                          plan,
                          std::move(params));
-        return wait_result(approved_session);
+        wait(approved_session);
+        return result_store_;
     }
 
     auto wrapper_dispatcher_t::update_one(const components::session::session_id_t& session,
@@ -209,7 +218,8 @@ namespace otterbrix {
               session.data(),
               condition->collection_full_name().database,
               condition->collection_full_name().collection);
-        session_id_t approved_session = init(session);
+        cursor_t_ptr result_store_;
+        session_id_t approved_session = init(session, &result_store_);
         auto plan = components::logical_plan::make_node_update_one(resource(),
                                                                    condition->collection_full_name(),
                                                                    condition,
@@ -221,7 +231,8 @@ namespace otterbrix {
                          approved_session,
                          plan,
                          std::move(params));
-        return wait_result(approved_session);
+        wait(approved_session);
+        return result_store_;
     }
 
     auto wrapper_dispatcher_t::update_many(const components::session::session_id_t& session,
@@ -234,7 +245,8 @@ namespace otterbrix {
               session.data(),
               condition->collection_full_name().database,
               condition->collection_full_name().collection);
-        session_id_t approved_session = init(session);
+        cursor_t_ptr result_store_;
+        session_id_t approved_session = init(session, &result_store_);
         auto plan = components::logical_plan::make_node_update_many(resource(),
                                                                     condition->collection_full_name(),
                                                                     condition,
@@ -246,21 +258,24 @@ namespace otterbrix {
                          approved_session,
                          plan,
                          std::move(params));
-        return wait_result(approved_session);
+        wait(approved_session);
+        return result_store_;
     }
 
     auto wrapper_dispatcher_t::size(const session_id_t& session,
                                     const database_name_t& database,
                                     const collection_name_t& collection) -> size_t {
         trace(log_, "wrapper_dispatcher_t::size session: {}, collection name : {} ", session.data(), collection);
-        session_id_t approved_session = init(session);
+        size_t result_store_;
+        session_id_t approved_session = init(session, &result_store_);
         actor_zeta::send(manager_dispatcher_,
                          address(),
                          collection::handler_id(collection::route::size),
                          approved_session,
                          database,
                          collection);
-        return wait_size(approved_session);
+        wait(approved_session);
+        return result_store_;
     }
 
     auto wrapper_dispatcher_t::create_index(const session_id_t& session,
@@ -303,13 +318,15 @@ namespace otterbrix {
                                           const std::pmr::vector<std::pair<database_name_t, collection_name_t>>& ids)
         -> components::cursor::cursor_t_ptr {
         trace(log_, "wrapper_dispatcher_t::get_schema session: {}", session.data());
-        session_id_t approved_session = init(session);
+        cursor_t_ptr result_store_;
+        session_id_t approved_session = init(session, &result_store_);
         actor_zeta::send(manager_dispatcher_,
                          address(),
                          collection::handler_id(collection::route::schema),
                          approved_session,
                          ids);
-        return wait_result(approved_session);
+        wait(approved_session);
+        return result_store_;
     }
 
     auto wrapper_dispatcher_t::make_scheduler() noexcept -> actor_zeta::scheduler_abstract_t* {
@@ -332,62 +349,51 @@ namespace otterbrix {
     void wrapper_dispatcher_t::execute_plan_finish(const session_id_t& session, cursor_t_ptr cursor) {
         trace(log_, "wrapper_dispatcher_t::execute_plan_finish session: {} {}", session.data(), cursor->is_success());
         std::unique_lock<std::mutex> lk(output_mtx_);
-        cursor_store_ = std::move(cursor);
-        notify(session);
+        notify(session, std::move(cursor));
     }
 
     auto wrapper_dispatcher_t::size_finish(const session_id_t& session, size_t size) -> void {
         trace(log_, "wrapper_dispatcher_t::size_finish session: {} {}", session.data(), size);
         std::unique_lock<std::mutex> lk(output_mtx_);
-        size_store_ = size;
-        notify(session);
+        notify(session, size);
     }
 
     auto wrapper_dispatcher_t::schema_finish(const components::session::session_id_t& session,
                                              components::cursor::cursor_t_ptr cursor) -> void {
         trace(log_, "wrapper_dispatcher_t::schema_finish session: {} {}", session.data(), cursor->is_success());
         std::unique_lock<std::mutex> lk(output_mtx_);
-        cursor_store_ = std::move(cursor);
-        notify(session);
+        notify(session, std::move(cursor));
     }
 
-    session_id_t wrapper_dispatcher_t::init(const session_id_t& session) {
+    session_id_t wrapper_dispatcher_t::init(const session_id_t& session, void* local_storage) {
         session_id_t res_session = session;
-        while (!blocker_.set_value(res_session, false)) {
+        while (!blocker_.set_value(res_session, {false, local_storage})) {
             res_session = session_id_t();
             trace(log_, "wrapper_dispatcher_t::init session hash collision! New session is: {}", res_session.data());
         }
         return res_session;
     }
 
-    components::cursor::cursor_t_ptr wrapper_dispatcher_t::wait_result(const session_id_t& session) {
-        std::unique_lock<std::mutex> lk(output_mtx_);
-        cv_.wait(lk, [this, &session]() { return blocker_.value(session); });
-        blocker_.remove_session(session);
-
-        if (cursor_store_->is_error()) {
-            //todo: handling error
-            std::cerr << cursor_store_->get_error().what << std::endl;
-        }
-
-        return std::move(cursor_store_);
-    }
-
-    size_t wrapper_dispatcher_t::wait_size(const session_id_t& session) {
-        std::unique_lock<std::mutex> lk(output_mtx_);
-        cv_.wait(lk, [this, &session]() { return blocker_.value(session); });
-        blocker_.remove_session(session);
-        return std::move(size_store_);
-    }
-
     void wrapper_dispatcher_t::wait(const session_id_t& session) {
         std::unique_lock<std::mutex> lk(output_mtx_);
-        cv_.wait(lk, [this, &session]() { return blocker_.value(session); });
+        cv_.wait(lk, [this, &session]() { return blocker_.value(session).first; });
         blocker_.remove_session(session);
     }
 
     void wrapper_dispatcher_t::notify(const session_id_t& session) {
-        blocker_.set_value(session, true);
+        blocker_.set_value_flag(session, true);
+        // multiple threads can be waiting
+        cv_.notify_all();
+    }
+
+    void wrapper_dispatcher_t::notify(const session_id_t& session, size_t size) {
+        blocker_.set_value<size_t>(session, size);
+        // multiple threads can be waiting
+        cv_.notify_all();
+    }
+
+    void wrapper_dispatcher_t::notify(const session_id_t& session, cursor_t_ptr cursor) {
+        blocker_.set_value<cursor_t_ptr>(session, std::move(cursor));
         // multiple threads can be waiting
         cv_.notify_all();
     }
@@ -396,7 +402,8 @@ namespace otterbrix {
                                                  components::logical_plan::node_ptr node,
                                                  components::logical_plan::parameter_node_ptr params) {
         trace(log_, "wrapper_dispatcher_t::send_plan session: {}, {} ", session.data(), node->to_string());
-        session_id_t approved_session = init(session);
+        cursor_t_ptr result_store_;
+        session_id_t approved_session = init(session, &result_store_);
         assert(params);
         actor_zeta::send(manager_dispatcher_,
                          address(),
@@ -404,7 +411,8 @@ namespace otterbrix {
                          approved_session,
                          std::move(node),
                          std::move(params));
-        return wait_result(approved_session);
+        wait(approved_session);
+        return result_store_;
     }
 
 } // namespace otterbrix

--- a/integration/cpp/wrapper_dispatcher.hpp
+++ b/integration/cpp/wrapper_dispatcher.hpp
@@ -118,11 +118,11 @@ namespace otterbrix {
         auto schema_finish(const session_id_t& session, components::cursor::cursor_t_ptr cursor) -> void;
 
         // due to hashing, incoming session can be unusable, and has to be replaced
-        session_id_t init(const session_id_t& session);
-        components::cursor::cursor_t_ptr wait_result(const session_id_t& session);
-        size_t wait_size(const session_id_t& session);
+        session_id_t init(const session_id_t& session, void* local_storage);
         void wait(const session_id_t& session);
         void notify(const session_id_t& session);
+        void notify(const session_id_t& session, size_t size);
+        void notify(const session_id_t& session, components::cursor::cursor_t_ptr cursor);
 
         auto send_plan(const session_id_t& session,
                        components::logical_plan::node_ptr node,
@@ -136,8 +136,6 @@ namespace otterbrix {
         spin_lock input_mtx_;
         std::condition_variable cv_;
         impl::session_block_t blocker_;
-        components::cursor::cursor_t_ptr cursor_store_;
-        size_t size_store_;
         bool bool_store_;
     };
 } // namespace otterbrix


### PR DESCRIPTION
My proposal to fix wrapper_dispatcher result returning:

* removed shared variable
* each request creates its own variable, address of which is stored in session blocker
* when result is acquired by wrapper_dispatcher, result is written to that address
* it is guarantied that local variable will live long enough, since it is allocated on a stack and won't be freed until function is exited, which happens only after previous step

