### PR TITLE
wrapper_dispatcher hotfix

### DIFF
--- a/integration/cpp/impl/session_blocker.hpp
+++ b/integration/cpp/impl/session_blocker.hpp
@@ -36,7 +36,7 @@ namespace otterbrix::impl {
         // this should be called when we already registered a session
         assert(it != end() && "session_block_t: session is not registered when value is being set");
         assert(!it->second.first && "session_block_t: value was already set");
-        it->second.first = true;
         *reinterpret_cast<T*>(it->second.second) = std::forward<T>(value);
+        it->second.first = true;
     }
 } // namespace otterbrix::impl


### PR DESCRIPTION
fix tag setting and value setting order
making tag setting last, we are guarantying value setting to be completed before other thread will be allowed try to read it