### PR TITLE
SQL: comma-join + SUBSTRING/LENGTH/REGEXP_REPLACE + LEFT OUTER JOIN regression

### DIFF
--- a/benchmark/download_data.sh
+++ b/benchmark/download_data.sh
@@ -73,20 +73,22 @@ download_ssb() {
 
     # SSB .tbl files: pipe-delimited, no headers
     # Tables: customer.tbl, date.tbl, lineorder.tbl, part.tbl, supplier.tbl
-
-    local -A headers=(
-        ["customer.tbl"]="c_custkey|c_name|c_address|c_city|c_nation|c_region|c_phone|c_mktsegment"
-        ["date.tbl"]="d_datekey|d_date|d_dayofweek|d_month|d_year|d_yearmonthnum|d_yearmonth|d_daynuminweek|d_daynuminmonth|d_daynuminyear|d_monthnuminyear|d_weeknuminyear|d_sellingseason|d_lastdayinweekfl|d_lastdayinmonthfl|d_holidayfl|d_weekdayfl"
-        ["lineorder.tbl"]="lo_orderkey|lo_linenumber|lo_custkey|lo_partkey|lo_suppkey|lo_orderdate|lo_orderpriority|lo_shippriority|lo_quantity|lo_extendedprice|lo_ordtotalprice|lo_discount|lo_revenue|lo_supplycost|lo_tax|lo_commitdate|lo_shipmode"
-        ["part.tbl"]="p_partkey|p_name|p_mfgr|p_category|p_brand1|p_color|p_type|p_size|p_container"
-        ["supplier.tbl"]="s_suppkey|s_name|s_address|s_city|s_nation|s_region|s_phone"
-    )
+    # (bash 3.2 compatible: case-based lookup instead of associative arrays)
+    ssb_header_for() {
+        case "$1" in
+            customer.tbl)  echo "c_custkey|c_name|c_address|c_city|c_nation|c_region|c_phone|c_mktsegment" ;;
+            date.tbl)      echo "d_datekey|d_date|d_dayofweek|d_month|d_year|d_yearmonthnum|d_yearmonth|d_daynuminweek|d_daynuminmonth|d_daynuminyear|d_monthnuminyear|d_weeknuminyear|d_sellingseason|d_lastdayinweekfl|d_lastdayinmonthfl|d_holidayfl|d_weekdayfl" ;;
+            lineorder.tbl) echo "lo_orderkey|lo_linenumber|lo_custkey|lo_partkey|lo_suppkey|lo_orderdate|lo_orderpriority|lo_shippriority|lo_quantity|lo_extendedprice|lo_ordtotalprice|lo_discount|lo_revenue|lo_supplycost|lo_tax|lo_commitdate|lo_shipmode" ;;
+            part.tbl)      echo "p_partkey|p_name|p_mfgr|p_category|p_brand1|p_color|p_type|p_size|p_container" ;;
+            supplier.tbl)  echo "s_suppkey|s_name|s_address|s_city|s_nation|s_region|s_phone" ;;
+        esac
+    }
 
     local gen_dir="$ssb_dir/build"
-    for tbl in "${!headers[@]}"; do
+    for tbl in customer.tbl date.tbl lineorder.tbl part.tbl supplier.tbl; do
         if [ -f "$gen_dir/$tbl" ]; then
             cp "$gen_dir/$tbl" "$DATA_DIR/ssb/$tbl"
-            prepend_header "$DATA_DIR/ssb/$tbl" "${headers[$tbl]}"
+            prepend_header "$DATA_DIR/ssb/$tbl" "$(ssb_header_for "$tbl")"
             log "  $tbl -> $DATA_DIR/ssb/$tbl"
         else
             echo "  WARNING: $tbl not found"
@@ -117,21 +119,24 @@ download_tpch() {
     ./dbgen -s "$SCALE" -f
 
     # TPC-H .tbl files: pipe-delimited, no headers
-    local -A headers=(
-        ["customer.tbl"]="c_custkey|c_name|c_address|c_nationkey|c_phone|c_acctbal|c_mktsegment|c_comment"
-        ["orders.tbl"]="o_orderkey|o_custkey|o_orderstatus|o_totalprice|o_orderdate|o_orderpriority|o_clerk|o_shippriority|o_comment"
-        ["lineitem.tbl"]="l_orderkey|l_partkey|l_suppkey|l_linenumber|l_quantity|l_extendedprice|l_discount|l_tax|l_returnflag|l_linestatus|l_shipdate|l_commitdate|l_receiptdate|l_shipinstruct|l_shipmode|l_comment"
-        ["part.tbl"]="p_partkey|p_name|p_mfgr|p_brand|p_type|p_size|p_container|p_retailprice|p_comment"
-        ["partsupp.tbl"]="ps_partkey|ps_suppkey|ps_availqty|ps_supplycost|ps_comment"
-        ["supplier.tbl"]="s_suppkey|s_name|s_address|s_nationkey|s_phone|s_acctbal|s_comment"
-        ["nation.tbl"]="n_nationkey|n_name|n_regionkey|n_comment"
-        ["region.tbl"]="r_regionkey|r_name|r_comment"
-    )
+    # (bash 3.2 compatible: case-based lookup instead of associative arrays)
+    tpch_header_for() {
+        case "$1" in
+            customer.tbl) echo "c_custkey|c_name|c_address|c_nationkey|c_phone|c_acctbal|c_mktsegment|c_comment" ;;
+            orders.tbl)   echo "o_orderkey|o_custkey|o_orderstatus|o_totalprice|o_orderdate|o_orderpriority|o_clerk|o_shippriority|o_comment" ;;
+            lineitem.tbl) echo "l_orderkey|l_partkey|l_suppkey|l_linenumber|l_quantity|l_extendedprice|l_discount|l_tax|l_returnflag|l_linestatus|l_shipdate|l_commitdate|l_receiptdate|l_shipinstruct|l_shipmode|l_comment" ;;
+            part.tbl)     echo "p_partkey|p_name|p_mfgr|p_brand|p_type|p_size|p_container|p_retailprice|p_comment" ;;
+            partsupp.tbl) echo "ps_partkey|ps_suppkey|ps_availqty|ps_supplycost|ps_comment" ;;
+            supplier.tbl) echo "s_suppkey|s_name|s_address|s_nationkey|s_phone|s_acctbal|s_comment" ;;
+            nation.tbl)   echo "n_nationkey|n_name|n_regionkey|n_comment" ;;
+            region.tbl)   echo "r_regionkey|r_name|r_comment" ;;
+        esac
+    }
 
-    for tbl in "${!headers[@]}"; do
+    for tbl in customer.tbl orders.tbl lineitem.tbl part.tbl partsupp.tbl supplier.tbl nation.tbl region.tbl; do
         if [ -f "$tpch_dir/$tbl" ]; then
             cp "$tpch_dir/$tbl" "$DATA_DIR/tpch/$tbl"
-            prepend_header "$DATA_DIR/tpch/$tbl" "${headers[$tbl]}"
+            prepend_header "$DATA_DIR/tpch/$tbl" "$(tpch_header_for "$tbl")"
             log "  $tbl -> $DATA_DIR/tpch/$tbl"
         else
             echo "  WARNING: $tbl not found"
@@ -159,34 +164,40 @@ download_job() {
 
     # IMDB CSV files: comma-delimited, no headers
     # Prepend headers for all 21 tables
-    local -A headers=(
-        ["aka_name.csv"]="id,person_id,name,imdb_index,name_pcode_cf,name_pcode_nf,surname_pcode,md5sum"
-        ["aka_title.csv"]="id,movie_id,title,imdb_index,kind_id,production_year,phonetic_code,episode_of_id,season_nr,episode_nr,note,md5sum"
-        ["cast_info.csv"]="id,person_id,movie_id,person_role_id,note,nr_order,role_id"
-        ["char_name.csv"]="id,name,imdb_index,imdb_id,name_pcode_nf,surname_pcode,md5sum"
-        ["comp_cast_type.csv"]="id,kind"
-        ["company_name.csv"]="id,name,country_code,imdb_id,name_pcode_nf,name_pcode_sf,md5sum"
-        ["company_type.csv"]="id,kind"
-        ["complete_cast.csv"]="id,movie_id,subject_id,status_id"
-        ["info_type.csv"]="id,info"
-        ["keyword.csv"]="id,keyword,phonetic_code"
-        ["kind_type.csv"]="id,kind"
-        ["link_type.csv"]="id,link"
-        ["movie_companies.csv"]="id,movie_id,company_id,company_type_id,note"
-        ["movie_info.csv"]="id,movie_id,info_type_id,info,note"
-        ["movie_info_idx.csv"]="id,movie_id,info_type_id,info,note"
-        ["movie_keyword.csv"]="id,movie_id,keyword_id"
-        ["movie_link.csv"]="id,movie_id,linked_movie_id,link_type_id"
-        ["name.csv"]="id,name,imdb_index,imdb_id,gender,name_pcode_cf,name_pcode_nf,surname_pcode,md5sum"
-        ["person_info.csv"]="id,person_id,info_type_id,info,note"
-        ["role_type.csv"]="id,role"
-        ["title.csv"]="id,title,imdb_index,kind_id,production_year,imdb_id,phonetic_code,episode_of_id,season_nr,episode_nr,series_years,md5sum"
-    )
+    # (bash 3.2 compatible: case-based lookup instead of associative arrays)
+    job_header_for() {
+        case "$1" in
+            aka_name.csv)        echo "id,person_id,name,imdb_index,name_pcode_cf,name_pcode_nf,surname_pcode,md5sum" ;;
+            aka_title.csv)       echo "id,movie_id,title,imdb_index,kind_id,production_year,phonetic_code,episode_of_id,season_nr,episode_nr,note,md5sum" ;;
+            cast_info.csv)       echo "id,person_id,movie_id,person_role_id,note,nr_order,role_id" ;;
+            char_name.csv)       echo "id,name,imdb_index,imdb_id,name_pcode_nf,surname_pcode,md5sum" ;;
+            comp_cast_type.csv)  echo "id,kind" ;;
+            company_name.csv)    echo "id,name,country_code,imdb_id,name_pcode_nf,name_pcode_sf,md5sum" ;;
+            company_type.csv)    echo "id,kind" ;;
+            complete_cast.csv)   echo "id,movie_id,subject_id,status_id" ;;
+            info_type.csv)       echo "id,info" ;;
+            keyword.csv)         echo "id,keyword,phonetic_code" ;;
+            kind_type.csv)       echo "id,kind" ;;
+            link_type.csv)       echo "id,link" ;;
+            movie_companies.csv) echo "id,movie_id,company_id,company_type_id,note" ;;
+            movie_info.csv)      echo "id,movie_id,info_type_id,info,note" ;;
+            movie_info_idx.csv)  echo "id,movie_id,info_type_id,info,note" ;;
+            movie_keyword.csv)   echo "id,movie_id,keyword_id" ;;
+            movie_link.csv)      echo "id,movie_id,linked_movie_id,link_type_id" ;;
+            name.csv)            echo "id,name,imdb_index,imdb_id,gender,name_pcode_cf,name_pcode_nf,surname_pcode,md5sum" ;;
+            person_info.csv)     echo "id,person_id,info_type_id,info,note" ;;
+            role_type.csv)       echo "id,role" ;;
+            title.csv)           echo "id,title,imdb_index,kind_id,production_year,imdb_id,phonetic_code,episode_of_id,season_nr,episode_nr,series_years,md5sum" ;;
+        esac
+    }
 
-    for csv in "${!headers[@]}"; do
+    for csv in aka_name.csv aka_title.csv cast_info.csv char_name.csv comp_cast_type.csv \
+               company_name.csv company_type.csv complete_cast.csv info_type.csv keyword.csv \
+               kind_type.csv link_type.csv movie_companies.csv movie_info.csv movie_info_idx.csv \
+               movie_keyword.csv movie_link.csv name.csv person_info.csv role_type.csv title.csv; do
         local filepath="$DATA_DIR/job/$csv"
         if [ -f "$filepath" ]; then
-            prepend_header "$filepath" "${headers[$csv]}"
+            prepend_header "$filepath" "$(job_header_for "$csv")"
             log "  $csv (header added)"
         else
             echo "  WARNING: $csv not found"

--- a/benchmark/runner/benchmark.hpp
+++ b/benchmark/runner/benchmark.hpp
@@ -17,6 +17,7 @@ using components::session::session_id_t;
 struct benchmark_state_t {
     wrapper_dispatcher_t* dispatcher = nullptr;
     session_id_t session;
+    bool failed = false;
 };
 
 struct benchmark_result_t {

--- a/benchmark/runner/benchmark_runner.cpp
+++ b/benchmark/runner/benchmark_runner.cpp
@@ -249,8 +249,13 @@ void benchmark_runner_t::run(const benchmark_configuration_t& config) {
                 std::cout << "Loading data for group: " << b->group() << " (via " << b->name() << ")\n";
             }
             try {
+                state.failed = false;
                 b->load(state);
-                std::cout << "Loaded group: " << b->group() << "\n";
+                if (state.failed) {
+                    std::cerr << "Error loading group " << b->group() << " (see stderr above)\n";
+                } else {
+                    std::cout << "Loaded group: " << b->group() << "\n";
+                }
             } catch (const std::exception& e) {
                 std::cerr << "Error loading group " << b->group() << ": " << e.what() << "\n";
             }
@@ -306,8 +311,16 @@ benchmark_result_t benchmark_runner_t::run_single(benchmark_t& bench, const benc
         state.dispatcher = instance.dispatcher();
         state.session = session_id_t();
 
+        auto bail_on_fail = [&]() {
+            result.verified = false;
+            if (result.error.empty()) {
+                result.error = "see stderr";
+            }
+        };
+
         if (!config.skip_load) {
             bench.load(state);
+            if (state.failed) { bail_on_fail(); return result; }
         }
 
         // Warmup
@@ -315,12 +328,14 @@ benchmark_result_t benchmark_runner_t::run_single(benchmark_t& bench, const benc
             std::cout << "  Warmup run...\n";
         }
         bench.run(state);
+        if (state.failed) { bail_on_fail(); return result; }
 
         // Timed runs
         for (uint64_t i = 0; i < nruns; ++i) {
             auto start = std::chrono::high_resolution_clock::now();
             bench.run(state);
             auto end = std::chrono::high_resolution_clock::now();
+            if (state.failed) { bail_on_fail(); return result; }
 
             auto duration = std::chrono::duration<double, std::milli>(end - start);
             result.timings_ms.push_back(duration.count());

--- a/benchmark/runner/interpreted_benchmark.cpp
+++ b/benchmark/runner/interpreted_benchmark.cpp
@@ -193,7 +193,9 @@ void interpreted_benchmark_t::execute_sql_block(benchmark_state_t& state, const 
             if (!stmt.empty()) {
                 auto cursor = state.dispatcher->execute_sql(state.session, stmt);
                 if (cursor->is_error()) {
-                    throw std::runtime_error("SQL error: " + cursor->get_error().what);
+                    std::cerr << "SQL error: " << cursor->get_error().what << "\n";
+                    state.failed = true;
+                    return;
                 }
             }
             current.clear();
@@ -206,7 +208,9 @@ void interpreted_benchmark_t::execute_sql_block(benchmark_state_t& state, const 
     if (!stmt.empty()) {
         auto cursor = state.dispatcher->execute_sql(state.session, stmt);
         if (cursor->is_error()) {
-            throw std::runtime_error("SQL error: " + cursor->get_error().what);
+            std::cerr << "SQL error: " << cursor->get_error().what << "\n";
+            state.failed = true;
+            return;
         }
     }
 }
@@ -254,7 +258,9 @@ void interpreted_benchmark_t::load_csv_file(benchmark_state_t& state, const csv_
         }
         auto cursor = state.dispatcher->execute_sql(state.session, sql);
         if (cursor->is_error()) {
-            throw std::runtime_error("CSV load SQL error for " + entry.table + ": " + cursor->get_error().what);
+            std::cerr << "CSV load SQL error for " << entry.table << ": " << cursor->get_error().what << "\n";
+            state.failed = true;
+            return;
         }
         value_tuples.clear();
     };
@@ -314,7 +320,9 @@ std::string interpreted_benchmark_t::verify(benchmark_state_t& state) {
 
     auto cursor = state.dispatcher->execute_sql(state.session, run_sql_);
     if (cursor->is_error()) {
-        return "Verification SQL error: " + cursor->get_error().what;
+        std::ostringstream oss;
+        oss << "Verification SQL error: " << cursor->get_error().what;
+        return oss.str();
     }
 
     auto actual = static_cast<int64_t>(cursor->size());

--- a/benchmark/runner/sql_benchmark.cpp
+++ b/benchmark/runner/sql_benchmark.cpp
@@ -261,7 +261,9 @@ void sql_benchmark_t::execute_sql_block(benchmark_state_t& state, const std::str
             if (!stmt.empty()) {
                 auto cursor = state.dispatcher->execute_sql(state.session, stmt);
                 if (cursor->is_error()) {
-                    throw std::runtime_error("SQL error: " + cursor->get_error().what);
+                    std::cerr << "SQL error: " << cursor->get_error().what << "\n";
+                    state.failed = true;
+                    return;
                 }
             }
             current.clear();
@@ -274,7 +276,9 @@ void sql_benchmark_t::execute_sql_block(benchmark_state_t& state, const std::str
     if (!stmt.empty()) {
         auto cursor = state.dispatcher->execute_sql(state.session, stmt);
         if (cursor->is_error()) {
-            throw std::runtime_error("SQL error: " + cursor->get_error().what);
+            std::cerr << "SQL error: " << cursor->get_error().what << "\n";
+            state.failed = true;
+            return;
         }
     }
 }
@@ -324,7 +328,9 @@ void sql_benchmark_t::load_csv_file(benchmark_state_t& state, const sql_csv_entr
         }
         auto cursor = state.dispatcher->execute_sql(state.session, sql);
         if (cursor->is_error()) {
-            throw std::runtime_error("CSV load SQL error for " + entry.table + ": " + cursor->get_error().what);
+            std::cerr << "CSV load SQL error for " << entry.table << ": " << cursor->get_error().what << "\n";
+            state.failed = true;
+            return;
         }
         value_tuples.clear();
     };
@@ -399,20 +405,26 @@ std::string sql_benchmark_t::qualify_sql(const std::string& sql) const {
 }
 
 void sql_benchmark_t::load(benchmark_state_t& state) {
-    // Create database if specified
+    // Create database if specified. IF NOT EXISTS keeps multi-query benchmark
+    // groups (e.g. SSB) idempotent — first sub-query creates the DB, the rest
+    // reuse it without erroring on re-CREATE.
     if (!database_.empty()) {
-        auto create_db = "CREATE DATABASE " + database_;
+        auto create_db = "CREATE DATABASE IF NOT EXISTS " + database_;
         auto cursor = state.dispatcher->execute_sql(state.session, create_db);
         if (cursor->is_error()) {
-            throw std::runtime_error("Cannot create database: " + cursor->get_error().what);
+            std::cerr << "Cannot create database: " << cursor->get_error().what << "\n";
+            state.failed = true;
+            return;
         }
     }
 
     if (!setup_sql_.empty()) {
         execute_sql_block(state, qualify_sql(setup_sql_));
+        if (state.failed) return;
     }
     for (const auto& entry : csv_entries_) {
         load_csv_file(state, entry);
+        if (state.failed) return;
     }
 }
 
@@ -420,11 +432,15 @@ void sql_benchmark_t::run(benchmark_state_t& state) {
     auto qualified = qualify_sql(sql_);
     auto cursor = state.dispatcher->execute_sql(state.session, qualified);
     if (cursor->is_error()) {
-        throw std::runtime_error("SQL error: " + cursor->get_error().what);
+        std::cerr << "SQL error: " << cursor->get_error().what << "\n";
+        state.failed = true;
+        return;
     }
     if (expected_rows_.has_value() && cursor->size() != expected_rows_.value()) {
-        throw std::runtime_error("Expected rows mismatch: expected " + std::to_string(expected_rows_.value()) +
-                                 ", got " + std::to_string(cursor->size()));
+        std::cerr << "Expected rows mismatch: expected " << expected_rows_.value() << ", got " << cursor->size()
+                  << "\n";
+        state.failed = true;
+        return;
     }
 }
 

--- a/components/catalog/catalog_codes.hpp
+++ b/components/catalog/catalog_codes.hpp
@@ -8,14 +8,15 @@ namespace components::catalog {
 
     // pg_class.relkind
     namespace relkind {
-        inline constexpr char regular = 'r';        // ordinary table
-        inline constexpr char index = 'i';          // index
-        inline constexpr char sequence = 'S';       // sequence
-        inline constexpr char view = 'v';           // view
-        inline constexpr char composite_type = 'c'; // composite type
-        inline constexpr char computed = 'g';       // computed/virtual table (otterbrix extension)
-        inline constexpr char macro = 'm';          // pg_rewrite-backed macro
-    }                                               // namespace relkind
+        inline constexpr char regular = 'r';           // ordinary table
+        inline constexpr char index = 'i';             // index
+        inline constexpr char sequence = 'S';          // sequence
+        inline constexpr char view = 'v';              // view
+        inline constexpr char materialized_view = 'm'; // materialized view (PostgreSQL-canonical)
+        inline constexpr char composite_type = 'c';    // composite type
+        inline constexpr char computed = 'g';          // computed/virtual table (otterbrix extension)
+        inline constexpr char macro = 'F';             // pg_rewrite-backed macro (function-like)
+    }                                                  // namespace relkind
 
     // pg_constraint.contype
     namespace contype {

--- a/components/catalog/ddl_metadata_builder.cpp
+++ b/components/catalog/ddl_metadata_builder.cpp
@@ -401,9 +401,9 @@ namespace components::catalog {
             result.push_back(make_write(pg_depend_full, std::move(chunk)));
         }
 
-        // pg_rewrite row (ev_type='m')
+        // pg_rewrite row (ev_type='F' — matches macro relkind)
         if (const auto* def = find_system_table("pg_rewrite")) {
-            const std::string ev_type_str(1, 'm');
+            const std::string ev_type_str(1, relkind::macro);
             auto chunk =
                 make_pg_rows(resource, def->columns, 1, [&](vector::data_chunk_t& c, std::pmr::memory_resource* r) {
                     set_oid(c, 0, 0, rule_oid);

--- a/components/catalog/ddl_metadata_builder.cpp
+++ b/components/catalog/ddl_metadata_builder.cpp
@@ -418,6 +418,49 @@ namespace components::catalog {
         return result;
     }
 
+    std::vector<catalog_write_t> build_matview_rewrite_writes(std::pmr::memory_resource* resource,
+                                                              oid_t mv_oid,
+                                                              oid_t rule_oid,
+                                                              const std::string& mv_name,
+                                                              const std::string& body_sql,
+                                                              oid_t source_table_oid) {
+        std::vector<catalog_write_t> result;
+
+        // pg_rewrite row (ev_class=mv_oid, ev_type='m', ev_action=body_sql) —
+        // mirror build_create_view_writes pattern but ev_type='m' for matview.
+        // REFRESH MATERIALIZED VIEW reads this row to re-execute the body.
+        if (const auto* def = find_system_table("pg_rewrite")) {
+            const std::string ev_type_str(1, relkind::materialized_view);
+            auto chunk =
+                make_pg_rows(resource, def->columns, 1, [&](vector::data_chunk_t& c, std::pmr::memory_resource* r) {
+                    set_oid(c, 0, 0, rule_oid);
+                    set_str(c, 1, 0, mv_name, r);
+                    set_oid(c, 2, 0, mv_oid);
+                    set_str(c, 3, 0, ev_type_str, r);
+                    set_str(c, 4, 0, body_sql, r);
+                });
+            result.push_back(make_write(pg_rewrite_full, std::move(chunk)));
+        }
+
+        // pg_depend row: matview depends on source table ('n' = normal).
+        // Allows future DROP TABLE source to detect dangling matview (followup #11).
+        if (source_table_oid != INVALID_OID) {
+            if (const auto* def = find_system_table("pg_depend")) {
+                auto chunk = make_pg_rows(
+                    resource, def->columns, 1, [&](vector::data_chunk_t& c, std::pmr::memory_resource* r) {
+                        set_oid(c, 0, 0, well_known_oid::pg_class_table);
+                        set_oid(c, 1, 0, mv_oid);
+                        set_oid(c, 2, 0, well_known_oid::pg_class_table);
+                        set_oid(c, 3, 0, source_table_oid);
+                        set_str(c, 4, 0, "n", r);
+                    });
+                result.push_back(make_write(pg_depend_full, std::move(chunk)));
+            }
+        }
+
+        return result;
+    }
+
     std::vector<catalog_write_t> build_create_index_writes(std::pmr::memory_resource* resource,
                                                            const std::string& index_name,
                                                            oid_t namespace_oid,

--- a/components/catalog/ddl_metadata_builder.hpp
+++ b/components/catalog/ddl_metadata_builder.hpp
@@ -59,7 +59,8 @@ namespace components::catalog {
                                                           oid_t rule_oid,
                                                           const std::string& body_sql);
 
-    // Writes pg_class (relkind='m') + pg_rewrite + pg_depend (macro→ns 'n').
+    // Writes pg_class (relkind='F') + pg_rewrite + pg_depend (macro→ns 'n').
+    // (Macro reljkind moved 'm' → 'F' in M0 to free 'm' for materialized_view.)
     // oid_batch must hold at least 2 OIDs (macro_oid + rule_oid).
     std::vector<catalog_write_t> build_create_macro_writes(std::pmr::memory_resource* resource,
                                                            const std::string& name,
@@ -67,6 +68,16 @@ namespace components::catalog {
                                                            oid_t macro_oid,
                                                            oid_t rule_oid,
                                                            const std::string& body_sql);
+
+    // Writes pg_rewrite (ev_class=mv_oid, ev_type='m', ev_action=body_sql) +
+    // pg_depend (mv→source 'n'). The matview's pg_class + pg_attribute rows
+    // are written separately via build_create_table_writes(... relkind::materialized_view).
+    std::vector<catalog_write_t> build_matview_rewrite_writes(std::pmr::memory_resource* resource,
+                                                              oid_t mv_oid,
+                                                              oid_t rule_oid,
+                                                              const std::string& mv_name,
+                                                              const std::string& body_sql,
+                                                              oid_t source_table_oid);
 
     // Writes pg_class (relkind='i') + pg_index (indisvalid=false) +
     //   pg_depend (index→table 'a') + N×pg_depend (index→column 'i').

--- a/components/catalog/system_table_schemas.cpp
+++ b/components/catalog/system_table_schemas.cpp
@@ -715,6 +715,9 @@ namespace components::catalog {
                 case K::floating:
                     out += "f";
                     break;
+                case K::string:
+                    out += "s";
+                    break;
                 case K::any_of: {
                     out += "a:";
                     const auto& list = m.any_of_list();

--- a/components/catalog/system_table_schemas.hpp
+++ b/components/catalog/system_table_schemas.hpp
@@ -112,8 +112,8 @@ namespace components::catalog {
 
     // Encode the per-arg `input_type` tagged matcher to a flat text format suitable
     // for pg_proc.proargmatchers. Format per arg: "e:N" exact, "n" numeric, "i" integer,
-    // "f" floating, "a:N1,N2,..." any_of, "t" always_true, where N is numeric value of
-    // types::logical_type. Multiple args are pipe-separated. Empty input vector → "".
+    // "f" floating, "s" string, "a:N1,N2,..." any_of, "t" always_true, where N is numeric
+    // value of types::logical_type. Multiple args are pipe-separated. Empty input vector → "".
     std::string encode_proargmatchers(const std::vector<components::compute::input_type>& matchers);
 
     // Encode output_type list to a flat text format. Per output: "f:N" fixed type

--- a/components/compute/CMakeLists.txt
+++ b/components/compute/CMakeLists.txt
@@ -8,6 +8,7 @@ set(${PROJECT_NAME}_SOURCES
         kernel_utils.cpp
 
         kernels/aggregate.cpp
+        kernels/string_functions.cpp
 )
 
 add_library(otterbrix_${PROJECT_NAME}

--- a/components/compute/function.hpp
+++ b/components/compute/function.hpp
@@ -276,7 +276,7 @@ namespace components::compute {
     // WARNING: array size, names order, uid and signatures has to be the same as in register_default_functions()
     // TODO: could be constexpr after C++20
     // TODO: initialize DEFAULT_FUNCTIONS with register_default_functions() call
-    static const std::array<std::pair<std::string, registered_func_id>, 5> DEFAULT_FUNCTIONS{
+    static const std::array<std::pair<std::string, registered_func_id>, 8> DEFAULT_FUNCTIONS{
         std::pair<std::string, registered_func_id>{"sum",
                                                    {0,
                                                     {kernel_signature_t{function_type_t::aggregate,
@@ -303,8 +303,37 @@ namespace components::compute {
                                                    {4,
                                                     {kernel_signature_t{function_type_t::aggregate,
                                                                         {input_type::make_numeric()},
-                                                                        {output_type::same_type_at(0)}}}}}};
+                                                                        {output_type::same_type_at(0)}}}}},
+        // substring/length/regexp_replace use make_always_true matchers so the
+        // dispatcher accepts NA inputs; the kernel body propagates NULL.
+        std::pair<std::string, registered_func_id>{
+            "substring",
+            {5,
+             {kernel_signature_t{function_type_t::row,
+                                 {input_type::make_always_true(),
+                                  input_type::make_always_true()},
+                                 {output_type::fixed(types::logical_type::STRING_LITERAL)}},
+              kernel_signature_t{function_type_t::row,
+                                 {input_type::make_always_true(),
+                                  input_type::make_always_true(),
+                                  input_type::make_always_true()},
+                                 {output_type::fixed(types::logical_type::STRING_LITERAL)}}}}},
+        std::pair<std::string, registered_func_id>{
+            "length",
+            {6,
+             {kernel_signature_t{function_type_t::row,
+                                 {input_type::make_always_true()},
+                                 {output_type::fixed(types::logical_type::BIGINT)}}}}},
+        std::pair<std::string, registered_func_id>{
+            "regexp_replace",
+            {7,
+             {kernel_signature_t{function_type_t::row,
+                                 {input_type::make_always_true(),
+                                  input_type::make_always_true(),
+                                  input_type::make_always_true()},
+                                 {output_type::fixed(types::logical_type::STRING_LITERAL)}}}}}};
 
     void register_default_functions(function_registry_t& registry);
+    void register_string_functions(function_registry_t& registry);
 
 } // namespace components::compute

--- a/components/compute/kernel_signature.cpp
+++ b/components/compute/kernel_signature.cpp
@@ -33,6 +33,12 @@ namespace components::compute {
         return r;
     }
 
+    input_type input_type::make_string() {
+        input_type r{string_types_matcher()};
+        r.kind_ = kind_t::string;
+        return r;
+    }
+
     input_type input_type::make_any_of(std::pmr::vector<types::logical_type> types) {
         input_type r{any_type_matcher(types)};
         r.kind_ = kind_t::any_of;
@@ -112,7 +118,8 @@ namespace components::compute {
         return [](const types::complex_logical_type& t) {
             using lt = types::logical_type;
             auto id = t.type();
-            return id == lt::TINYINT || id == lt::SMALLINT || id == lt::INTEGER || id == lt::BIGINT ||
+            return id == lt::NA ||  // NA propagation (SQL NULL)
+                   id == lt::TINYINT || id == lt::SMALLINT || id == lt::INTEGER || id == lt::BIGINT ||
                    id == lt::HUGEINT || id == lt::UTINYINT || id == lt::USMALLINT || id == lt::UINTEGER ||
                    id == lt::UBIGINT || id == lt::UHUGEINT;
         };
@@ -123,6 +130,14 @@ namespace components::compute {
             using lt = types::logical_type;
             auto id = t.type();
             return id == lt::FLOAT || id == lt::DOUBLE;
+        };
+    }
+
+    type_matcher_fn string_types_matcher() {
+        return [](const types::complex_logical_type& t) {
+            auto id = t.type();
+            // NA — SQL NULL может быть в любой позиции; kernel body propagates.
+            return id == types::logical_type::NA || types::is_string(id);
         };
     }
 

--- a/components/compute/kernel_signature.hpp
+++ b/components/compute/kernel_signature.hpp
@@ -52,6 +52,7 @@ namespace components::compute {
             numeric,
             integer,
             floating,
+            string,
             any_of,
             always_true
         };
@@ -60,6 +61,7 @@ namespace components::compute {
         static input_type make_numeric();
         static input_type make_integer();
         static input_type make_floating();
+        static input_type make_string();
         static input_type make_any_of(std::pmr::vector<types::logical_type> types);
         static input_type make_always_true();
 
@@ -132,6 +134,7 @@ namespace components::compute {
     type_matcher_fn numeric_types_matcher();
     type_matcher_fn integer_types_matcher();
     type_matcher_fn floating_types_matcher();
+    type_matcher_fn string_types_matcher();
     type_matcher_fn any_type_matcher(std::pmr::vector<types::logical_type> type_list);
     type_matcher_fn always_true_type_matcher();
 

--- a/components/compute/kernels/aggregate.cpp
+++ b/components/compute/kernels/aggregate.cpp
@@ -582,6 +582,7 @@ namespace components::compute {
                                             "avg",
                                             "Return data size",
                                             "Results in a single number of the same type as input"));
+        register_string_functions(r);
     }
 
 } // namespace components::compute

--- a/components/compute/kernels/aggregate.cpp
+++ b/components/compute/kernels/aggregate.cpp
@@ -22,6 +22,8 @@ namespace {
         auto operator()(const vector_t& v, size_t count) const {
             auto raw_sum = T();
             for (size_t i = 0; i < count; i++) {
+                if (v.is_null(i))
+                    continue;
                 raw_sum += v.data<T>()[i];
             }
             return logical_value_t{v.resource(), raw_sum};
@@ -30,6 +32,8 @@ namespace {
         auto operator()(const vector_t& v, size_t count) const {
             auto raw_sum = T();
             for (size_t i = 0; i < count; i++) {
+                if (v.is_null(i))
+                    continue;
                 raw_sum += T(v.data<U>()[i]);
             }
             return logical_value_t{v.resource(), raw_sum};
@@ -52,11 +56,33 @@ namespace {
     struct min_operator_t<void> {
         template<typename T>
         auto operator()(const vector_t& v, size_t count) const {
-            return logical_value_t{v.resource(), *std::min_element(v.data<T>(), v.data<T>() + count)};
+            auto* data = v.data<T>();
+            T best = T();
+            bool has_any = false;
+            for (size_t i = 0; i < count; i++) {
+                if (v.is_null(i))
+                    continue;
+                if (!has_any || data[i] < best) {
+                    best = data[i];
+                    has_any = true;
+                }
+            }
+            return logical_value_t{v.resource(), best};
         }
         template<typename T, typename U>
         auto operator()(const vector_t& v, size_t count) const {
-            return logical_value_t{v.resource(), T(*std::min_element(v.data<U>(), v.data<U>() + count))};
+            auto* data = v.data<U>();
+            U best = U();
+            bool has_any = false;
+            for (size_t i = 0; i < count; i++) {
+                if (v.is_null(i))
+                    continue;
+                if (!has_any || data[i] < best) {
+                    best = data[i];
+                    has_any = true;
+                }
+            }
+            return logical_value_t{v.resource(), T(best)};
         }
         template<typename T>
         auto operator()(const logical_value_t& v1, const logical_value_t& v2) const {
@@ -78,11 +104,33 @@ namespace {
     struct max_operator_t<void> {
         template<typename T>
         auto operator()(const vector_t& v, size_t count) const {
-            return logical_value_t{v.resource(), *std::max_element(v.data<T>(), v.data<T>() + count)};
+            auto* data = v.data<T>();
+            T best = T();
+            bool has_any = false;
+            for (size_t i = 0; i < count; i++) {
+                if (v.is_null(i))
+                    continue;
+                if (!has_any || best < data[i]) {
+                    best = data[i];
+                    has_any = true;
+                }
+            }
+            return logical_value_t{v.resource(), best};
         }
         template<typename T, typename U>
         auto operator()(const vector_t& v, size_t count) const {
-            return logical_value_t{v.resource(), T(*std::max_element(v.data<U>(), v.data<U>() + count))};
+            auto* data = v.data<U>();
+            U best = U();
+            bool has_any = false;
+            for (size_t i = 0; i < count; i++) {
+                if (v.is_null(i))
+                    continue;
+                if (!has_any || best < data[i]) {
+                    best = data[i];
+                    has_any = true;
+                }
+            }
+            return logical_value_t{v.resource(), T(best)};
         }
         template<typename T>
         auto operator()(const logical_value_t& v1, const logical_value_t& v2) const {
@@ -450,13 +498,21 @@ namespace {
 
     static core::error_t avg_consume(kernel_context& ctx, const data_chunk_t& in) {
         auto* acc = static_cast<avg_kernel_state*>(ctx.state());
-        acc->count = in.size();
+        size_t valid = 0;
+        for (size_t i = 0; i < in.size(); i++) {
+            valid += !in.data[0].is_null(i);
+        }
+        acc->count = valid;
         acc->value = sum(in.data[0], in.size());
         return core::error_t::no_error();
     }
 
     static core::error_t avg_merge(aggregate_kernel_context& ctx, kernel_state&& from, kernel_state&) {
         auto& s = static_cast<avg_kernel_state&>(from);
+        if (s.count == 0) {
+            ctx.batch_results.emplace_back(std::pmr::null_memory_resource(), logical_type::NA);
+            return core::error_t::no_error();
+        }
         ctx.batch_results.push_back(operator_switch<divide_operator_t>(s.value, s.count));
         return core::error_t::no_error();
     }

--- a/components/compute/kernels/aggregate.cpp
+++ b/components/compute/kernels/aggregate.cpp
@@ -21,20 +21,30 @@ namespace {
         template<typename T>
         auto operator()(const vector_t& v, size_t count) const {
             auto raw_sum = T();
+            bool has_any = false;
             for (size_t i = 0; i < count; i++) {
                 if (v.is_null(i))
                     continue;
                 raw_sum += v.data<T>()[i];
+                has_any = true;
+            }
+            if (!has_any) {
+                return logical_value_t(std::pmr::null_memory_resource(), logical_type::NA);
             }
             return logical_value_t{v.resource(), raw_sum};
         }
         template<typename T, typename U>
         auto operator()(const vector_t& v, size_t count) const {
             auto raw_sum = T();
+            bool has_any = false;
             for (size_t i = 0; i < count; i++) {
                 if (v.is_null(i))
                     continue;
                 raw_sum += T(v.data<U>()[i]);
+                has_any = true;
+            }
+            if (!has_any) {
+                return logical_value_t(std::pmr::null_memory_resource(), logical_type::NA);
             }
             return logical_value_t{v.resource(), raw_sum};
         }
@@ -67,6 +77,9 @@ namespace {
                     has_any = true;
                 }
             }
+            if (!has_any) {
+                return logical_value_t(std::pmr::null_memory_resource(), logical_type::NA);
+            }
             return logical_value_t{v.resource(), best};
         }
         template<typename T, typename U>
@@ -82,10 +95,16 @@ namespace {
                     has_any = true;
                 }
             }
+            if (!has_any) {
+                return logical_value_t(std::pmr::null_memory_resource(), logical_type::NA);
+            }
             return logical_value_t{v.resource(), T(best)};
         }
         template<typename T>
         auto operator()(const logical_value_t& v1, const logical_value_t& v2) const {
+            if (v1.type().type() == logical_type::NA) {
+                return v2;
+            }
             if (v2.type().type() == logical_type::NA) {
                 return v1;
             }
@@ -93,6 +112,9 @@ namespace {
         }
         template<typename T, typename U>
         auto operator()(const logical_value_t& v1, const logical_value_t& v2) const {
+            if (v1.type().type() == logical_type::NA) {
+                return v2;
+            }
             if (v2.type().type() == logical_type::NA) {
                 return v1;
             }
@@ -115,6 +137,9 @@ namespace {
                     has_any = true;
                 }
             }
+            if (!has_any) {
+                return logical_value_t(std::pmr::null_memory_resource(), logical_type::NA);
+            }
             return logical_value_t{v.resource(), best};
         }
         template<typename T, typename U>
@@ -130,10 +155,16 @@ namespace {
                     has_any = true;
                 }
             }
+            if (!has_any) {
+                return logical_value_t(std::pmr::null_memory_resource(), logical_type::NA);
+            }
             return logical_value_t{v.resource(), T(best)};
         }
         template<typename T>
         auto operator()(const logical_value_t& v1, const logical_value_t& v2) const {
+            if (v1.type().type() == logical_type::NA) {
+                return v2;
+            }
             if (v2.type().type() == logical_type::NA) {
                 return v1;
             }
@@ -141,6 +172,9 @@ namespace {
         }
         template<typename T, typename U>
         auto operator()(const logical_value_t& v1, const logical_value_t& v2) const {
+            if (v1.type().type() == logical_type::NA) {
+                return v2;
+            }
             if (v2.type().type() == logical_type::NA) {
                 return v1;
             }

--- a/components/compute/kernels/string_functions.cpp
+++ b/components/compute/kernels/string_functions.cpp
@@ -1,6 +1,7 @@
 #include "../function.hpp"
 #include <components/types/logical_value.hpp>
 
+#include <cassert>
 #include <cstddef>
 #include <regex>
 #include <string>
@@ -22,21 +23,46 @@ namespace {
         return false;
     }
 
+    // Coerce any integer-category value to int64_t. Matcher gate
+    // (make_integer) ensures no non-integer types reach here; the assert
+    // guards the invariant, not user-facing validation.
+    inline int64_t coerce_int(const logical_value_t& v) {
+        switch (v.type().type()) {
+            case logical_type::TINYINT:   return v.value<int8_t>();
+            case logical_type::SMALLINT:  return v.value<int16_t>();
+            case logical_type::INTEGER:   return v.value<int32_t>();
+            case logical_type::BIGINT:    return v.value<int64_t>();
+            case logical_type::HUGEINT:   return static_cast<int64_t>(v.value<int128_t>());
+            case logical_type::UTINYINT:  return v.value<uint8_t>();
+            case logical_type::USMALLINT: return v.value<uint16_t>();
+            case logical_type::UINTEGER:  return v.value<uint32_t>();
+            case logical_type::UBIGINT:   return static_cast<int64_t>(v.value<uint64_t>());
+            case logical_type::UHUGEINT:  return static_cast<int64_t>(v.value<uint128_t>());
+            default:
+                assert(false && "integer matcher invariant: type must be integer category");
+                return 0;
+        }
+    }
+
     // ------------------------------------------------------------------
     // SUBSTRING(s, start)       — start is 1-based; out-of-range => empty
     // SUBSTRING(s, start, len)  — both 1-based; len <= 0 => empty; clip to bounds
     // ------------------------------------------------------------------
-    static core::error_t row_substring_2(kernel_context&,
+    static core::error_t row_substring_2(kernel_context& ctx,
                                          const std::pmr::vector<logical_value_t>& inputs,
                                          std::pmr::vector<logical_value_t>& output) {
-        auto* resource = inputs[0].resource();
+        auto* resource = ctx.exec_context().resource();
         if (has_null_input(inputs)) {
             output.emplace_back(resource, logical_type::NA);
             return core::error_t::no_error();
         }
+        if (inputs[0].type().type() == logical_type::BLOB) {
+            return core::error_t(core::error_code_t::kernel_error,
+                                 std::pmr::string{"string function on BLOB not yet implemented", resource});
+        }
 
         const auto s = inputs[0].value<std::string_view>();
-        const auto start_1based = inputs[1].value<int64_t>();
+        const auto start_1based = coerce_int(inputs[1]);
 
         // SQL semantics: start <= 0 is clamped to 1 (begin); start > length => empty.
         int64_t start_idx = start_1based <= 0 ? 0 : start_1based - 1;
@@ -49,18 +75,22 @@ namespace {
         return core::error_t::no_error();
     }
 
-    static core::error_t row_substring_3(kernel_context&,
+    static core::error_t row_substring_3(kernel_context& ctx,
                                          const std::pmr::vector<logical_value_t>& inputs,
                                          std::pmr::vector<logical_value_t>& output) {
-        auto* resource = inputs[0].resource();
+        auto* resource = ctx.exec_context().resource();
         if (has_null_input(inputs)) {
             output.emplace_back(resource, logical_type::NA);
             return core::error_t::no_error();
         }
+        if (inputs[0].type().type() == logical_type::BLOB) {
+            return core::error_t(core::error_code_t::kernel_error,
+                                 std::pmr::string{"string function on BLOB not yet implemented", resource});
+        }
 
         const auto s = inputs[0].value<std::string_view>();
-        const auto start_1based = inputs[1].value<int64_t>();
-        const auto len_in = inputs[2].value<int64_t>();
+        const auto start_1based = coerce_int(inputs[1]);
+        const auto len_in = coerce_int(inputs[2]);
 
         if (len_in <= 0) {
             output.emplace_back(resource, std::string{});
@@ -82,13 +112,17 @@ namespace {
     // ------------------------------------------------------------------
     // LENGTH(s) — byte length (BIGINT). Not codepoint length.
     // ------------------------------------------------------------------
-    static core::error_t row_length(kernel_context&,
+    static core::error_t row_length(kernel_context& ctx,
                                     const std::pmr::vector<logical_value_t>& inputs,
                                     std::pmr::vector<logical_value_t>& output) {
-        auto* resource = inputs[0].resource();
+        auto* resource = ctx.exec_context().resource();
         if (has_null_input(inputs)) {
             output.emplace_back(resource, logical_type::NA);
             return core::error_t::no_error();
+        }
+        if (inputs[0].type().type() == logical_type::BLOB) {
+            return core::error_t(core::error_code_t::kernel_error,
+                                 std::pmr::string{"string function on BLOB not yet implemented", resource});
         }
 
         const auto s = inputs[0].value<std::string_view>();
@@ -100,13 +134,17 @@ namespace {
     // REGEXP_REPLACE(s, pattern, replacement) — std::regex ECMAScript.
     // Invalid pattern => kernel_error.
     // ------------------------------------------------------------------
-    static core::error_t row_regexp_replace(kernel_context&,
+    static core::error_t row_regexp_replace(kernel_context& ctx,
                                             const std::pmr::vector<logical_value_t>& inputs,
                                             std::pmr::vector<logical_value_t>& output) {
-        auto* resource = inputs[0].resource();
+        auto* resource = ctx.exec_context().resource();
         if (has_null_input(inputs)) {
             output.emplace_back(resource, logical_type::NA);
             return core::error_t::no_error();
+        }
+        if (inputs[0].type().type() == logical_type::BLOB) {
+            return core::error_t(core::error_code_t::kernel_error,
+                                 std::pmr::string{"string function on BLOB not yet implemented", resource});
         }
 
         const auto s = inputs[0].value<std::string_view>();
@@ -139,19 +177,19 @@ namespace {
         // arity::var_args(2) — accept 2 or 3 args; two kernel slots for the overloads.
         auto fn = std::make_unique<row_function>(name, arity::var_args(2), doc, /*available_kernel_slots=*/2);
 
-        // NA-aware: kernel body propagates NULL, so input matchers stay loose
-        // (otherwise dispatcher rejects NA inputs at signature-match time).
+        // NA-aware: NA is accepted at signature-match time by the string/integer
+        // matchers (kernel_signature.cpp); kernel body propagates via has_null_input.
         kernel_signature_t sig2(function_type_t::row,
-                                {input_type::make_always_true(),
-                                 input_type::make_always_true()},
+                                {input_type::make_string(),
+                                 input_type::make_integer()},
                                 {output_type::fixed(logical_type::STRING_LITERAL)});
         row_kernel k2(std::move(sig2), row_substring_2);
         (void) fn->add_kernel(resource, std::move(k2));
 
         kernel_signature_t sig3(function_type_t::row,
-                                {input_type::make_always_true(),
-                                 input_type::make_always_true(),
-                                 input_type::make_always_true()},
+                                {input_type::make_string(),
+                                 input_type::make_integer(),
+                                 input_type::make_integer()},
                                 {output_type::fixed(logical_type::STRING_LITERAL)});
         row_kernel k3(std::move(sig3), row_substring_3);
         (void) fn->add_kernel(resource, std::move(k3));
@@ -168,7 +206,7 @@ namespace {
         auto fn = std::make_unique<row_function>(name, arity::unary(), doc, /*available_kernel_slots=*/1);
 
         kernel_signature_t sig(function_type_t::row,
-                               {input_type::make_always_true()},
+                               {input_type::make_string()},
                                {output_type::fixed(logical_type::BIGINT)});
         row_kernel k(std::move(sig), row_length);
         (void) fn->add_kernel(resource, std::move(k));
@@ -185,9 +223,9 @@ namespace {
         auto fn = std::make_unique<row_function>(name, arity::ternary(), doc, /*available_kernel_slots=*/1);
 
         kernel_signature_t sig(function_type_t::row,
-                               {input_type::make_always_true(),
-                                input_type::make_always_true(),
-                                input_type::make_always_true()},
+                               {input_type::make_string(),
+                                input_type::make_string(),
+                                input_type::make_string()},
                                {output_type::fixed(logical_type::STRING_LITERAL)});
         row_kernel k(std::move(sig), row_regexp_replace);
         (void) fn->add_kernel(resource, std::move(k));

--- a/components/compute/kernels/string_functions.cpp
+++ b/components/compute/kernels/string_functions.cpp
@@ -1,0 +1,218 @@
+#include "../function.hpp"
+#include <components/types/logical_value.hpp>
+
+#include <cstddef>
+#include <regex>
+#include <string>
+#include <string_view>
+
+using namespace components::compute;
+using namespace components::types;
+
+namespace {
+
+    // Returns true if any of the inputs is NULL (logical_type::NA).
+    // Caller is expected to emplace an NA logical_value_t into the output and return.
+    inline bool has_null_input(const std::pmr::vector<logical_value_t>& inputs) {
+        for (const auto& v : inputs) {
+            if (v.type().type() == logical_type::NA) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // ------------------------------------------------------------------
+    // SUBSTRING(s, start)       — start is 1-based; out-of-range => empty
+    // SUBSTRING(s, start, len)  — both 1-based; len <= 0 => empty; clip to bounds
+    // ------------------------------------------------------------------
+    static core::error_t row_substring_2(kernel_context&,
+                                         const std::pmr::vector<logical_value_t>& inputs,
+                                         std::pmr::vector<logical_value_t>& output) {
+        auto* resource = inputs[0].resource();
+        if (has_null_input(inputs)) {
+            output.emplace_back(resource, logical_type::NA);
+            return core::error_t::no_error();
+        }
+
+        const auto s = inputs[0].value<std::string_view>();
+        const auto start_1based = inputs[1].value<int64_t>();
+
+        // SQL semantics: start <= 0 is clamped to 1 (begin); start > length => empty.
+        int64_t start_idx = start_1based <= 0 ? 0 : start_1based - 1;
+        if (static_cast<size_t>(start_idx) >= s.size()) {
+            output.emplace_back(resource, std::string{});
+            return core::error_t::no_error();
+        }
+
+        output.emplace_back(resource, std::string(s.substr(static_cast<size_t>(start_idx))));
+        return core::error_t::no_error();
+    }
+
+    static core::error_t row_substring_3(kernel_context&,
+                                         const std::pmr::vector<logical_value_t>& inputs,
+                                         std::pmr::vector<logical_value_t>& output) {
+        auto* resource = inputs[0].resource();
+        if (has_null_input(inputs)) {
+            output.emplace_back(resource, logical_type::NA);
+            return core::error_t::no_error();
+        }
+
+        const auto s = inputs[0].value<std::string_view>();
+        const auto start_1based = inputs[1].value<int64_t>();
+        const auto len_in = inputs[2].value<int64_t>();
+
+        if (len_in <= 0) {
+            output.emplace_back(resource, std::string{});
+            return core::error_t::no_error();
+        }
+
+        int64_t start_idx = start_1based <= 0 ? 0 : start_1based - 1;
+        if (static_cast<size_t>(start_idx) >= s.size()) {
+            output.emplace_back(resource, std::string{});
+            return core::error_t::no_error();
+        }
+
+        size_t avail = s.size() - static_cast<size_t>(start_idx);
+        size_t take = static_cast<size_t>(len_in) < avail ? static_cast<size_t>(len_in) : avail;
+        output.emplace_back(resource, std::string(s.substr(static_cast<size_t>(start_idx), take)));
+        return core::error_t::no_error();
+    }
+
+    // ------------------------------------------------------------------
+    // LENGTH(s) — byte length (BIGINT). Not codepoint length.
+    // ------------------------------------------------------------------
+    static core::error_t row_length(kernel_context&,
+                                    const std::pmr::vector<logical_value_t>& inputs,
+                                    std::pmr::vector<logical_value_t>& output) {
+        auto* resource = inputs[0].resource();
+        if (has_null_input(inputs)) {
+            output.emplace_back(resource, logical_type::NA);
+            return core::error_t::no_error();
+        }
+
+        const auto s = inputs[0].value<std::string_view>();
+        output.emplace_back(resource, static_cast<int64_t>(s.size()));
+        return core::error_t::no_error();
+    }
+
+    // ------------------------------------------------------------------
+    // REGEXP_REPLACE(s, pattern, replacement) — std::regex ECMAScript.
+    // Invalid pattern => kernel_error.
+    // ------------------------------------------------------------------
+    static core::error_t row_regexp_replace(kernel_context&,
+                                            const std::pmr::vector<logical_value_t>& inputs,
+                                            std::pmr::vector<logical_value_t>& output) {
+        auto* resource = inputs[0].resource();
+        if (has_null_input(inputs)) {
+            output.emplace_back(resource, logical_type::NA);
+            return core::error_t::no_error();
+        }
+
+        const auto s = inputs[0].value<std::string_view>();
+        const auto pattern_sv = inputs[1].value<std::string_view>();
+        const auto replacement_sv = inputs[2].value<std::string_view>();
+
+        try {
+            std::regex re(pattern_sv.data(), pattern_sv.size(), std::regex::ECMAScript);
+            std::string result = std::regex_replace(std::string(s),
+                                                    re,
+                                                    std::string(replacement_sv));
+            output.emplace_back(resource, std::move(result));
+        } catch (const std::regex_error& e) {
+            return core::error_t(core::error_code_t::kernel_error,
+                                 std::pmr::string{std::string("regexp_replace: invalid pattern: ") + e.what(),
+                                                  resource});
+        }
+        return core::error_t::no_error();
+    }
+
+    // ------------------------------------------------------------------
+    // Makers (mirror make_sum_func style from aggregate.cpp).
+    // ------------------------------------------------------------------
+    std::unique_ptr<row_function> make_substring_func(std::pmr::memory_resource* resource,
+                                                     const std::string& name,
+                                                     const std::string& short_doc,
+                                                     const std::string& full_doc) {
+        function_doc doc{short_doc, full_doc, {"string", "start", "length"}, false};
+
+        // arity::var_args(2) — accept 2 or 3 args; two kernel slots for the overloads.
+        auto fn = std::make_unique<row_function>(name, arity::var_args(2), doc, /*available_kernel_slots=*/2);
+
+        // NA-aware: kernel body propagates NULL, so input matchers stay loose
+        // (otherwise dispatcher rejects NA inputs at signature-match time).
+        kernel_signature_t sig2(function_type_t::row,
+                                {input_type::make_always_true(),
+                                 input_type::make_always_true()},
+                                {output_type::fixed(logical_type::STRING_LITERAL)});
+        row_kernel k2(std::move(sig2), row_substring_2);
+        (void) fn->add_kernel(resource, std::move(k2));
+
+        kernel_signature_t sig3(function_type_t::row,
+                                {input_type::make_always_true(),
+                                 input_type::make_always_true(),
+                                 input_type::make_always_true()},
+                                {output_type::fixed(logical_type::STRING_LITERAL)});
+        row_kernel k3(std::move(sig3), row_substring_3);
+        (void) fn->add_kernel(resource, std::move(k3));
+
+        return fn;
+    }
+
+    std::unique_ptr<row_function> make_length_func(std::pmr::memory_resource* resource,
+                                                   const std::string& name,
+                                                   const std::string& short_doc,
+                                                   const std::string& full_doc) {
+        function_doc doc{short_doc, full_doc, {"string"}, false};
+
+        auto fn = std::make_unique<row_function>(name, arity::unary(), doc, /*available_kernel_slots=*/1);
+
+        kernel_signature_t sig(function_type_t::row,
+                               {input_type::make_always_true()},
+                               {output_type::fixed(logical_type::BIGINT)});
+        row_kernel k(std::move(sig), row_length);
+        (void) fn->add_kernel(resource, std::move(k));
+
+        return fn;
+    }
+
+    std::unique_ptr<row_function> make_regexp_replace_func(std::pmr::memory_resource* resource,
+                                                          const std::string& name,
+                                                          const std::string& short_doc,
+                                                          const std::string& full_doc) {
+        function_doc doc{short_doc, full_doc, {"string", "pattern", "replacement"}, false};
+
+        auto fn = std::make_unique<row_function>(name, arity::ternary(), doc, /*available_kernel_slots=*/1);
+
+        kernel_signature_t sig(function_type_t::row,
+                               {input_type::make_always_true(),
+                                input_type::make_always_true(),
+                                input_type::make_always_true()},
+                               {output_type::fixed(logical_type::STRING_LITERAL)});
+        row_kernel k(std::move(sig), row_regexp_replace);
+        (void) fn->add_kernel(resource, std::move(k));
+
+        return fn;
+    }
+
+} // namespace
+
+namespace components::compute {
+
+    // WARNING: uids and signatures must mirror DEFAULT_FUNCTIONS entries 5,6,7 in function.hpp
+    void register_string_functions(function_registry_t& r) {
+        (void) r.add_function(make_substring_func(r.resource(),
+                                                  "substring",
+                                                  "Returns substring",
+                                                  "SUBSTRING(s, start[, len]) — 1-based; out-of-range -> empty"));
+        (void) r.add_function(make_length_func(r.resource(),
+                                               "length",
+                                               "Returns byte length",
+                                               "LENGTH(s) -> int64 (bytes, not chars)"));
+        (void) r.add_function(make_regexp_replace_func(r.resource(),
+                                                       "regexp_replace",
+                                                       "Regex substitution",
+                                                       "REGEXP_REPLACE(s, pattern, replacement)"));
+    }
+
+} // namespace components::compute

--- a/components/compute/tests/test_execution.cpp
+++ b/components/compute/tests/test_execution.cpp
@@ -406,3 +406,192 @@ TEST_CASE("components::compute::errors") {
         REQUIRE(status == core::error_code_t::kernel_error);
     }
 }
+
+// ---------------------------------------------------------------------------
+// SUBSTRING / LENGTH / REGEXP_REPLACE — string row-kernel execution tests
+// ---------------------------------------------------------------------------
+
+namespace components::compute {
+    void register_string_functions(function_registry_t& r);
+}
+
+namespace {
+    struct string_registry_fixture {
+        std::pmr::synchronized_pool_resource resource;
+        function_registry_t registry{&resource};
+
+        string_registry_fixture() { register_string_functions(registry); }
+
+        function* get(const std::string& name) const {
+            for (const auto& [n, uid] : registry.get_functions()) {
+                if (n == name) {
+                    return registry.get_function(uid);
+                }
+            }
+            return nullptr;
+        }
+    };
+} // namespace
+
+TEST_CASE("components::compute::string::substring_basic") {
+    string_registry_fixture fx;
+    auto* fn = fx.get("substring");
+    REQUIRE(fn != nullptr);
+
+    std::pmr::vector<logical_value_t> inputs(&fx.resource);
+    inputs.emplace_back(&fx.resource, std::string("hello world"));
+    inputs.emplace_back(&fx.resource, static_cast<int64_t>(7));
+    inputs.emplace_back(&fx.resource, static_cast<int64_t>(5));
+
+    auto res = fn->execute(inputs);
+    REQUIRE_FALSE(res.has_error());
+    auto& vals = std::get<std::pmr::vector<logical_value_t>>(res.value());
+    REQUIRE(vals.size() == 1);
+    REQUIRE(vals[0].value<std::string_view>() == "world");
+}
+
+TEST_CASE("components::compute::string::substring_omit_len") {
+    string_registry_fixture fx;
+    auto* fn = fx.get("substring");
+    REQUIRE(fn != nullptr);
+
+    std::pmr::vector<logical_value_t> inputs(&fx.resource);
+    inputs.emplace_back(&fx.resource, std::string("abcdefgh"));
+    inputs.emplace_back(&fx.resource, static_cast<int64_t>(3));
+
+    auto res = fn->execute(inputs);
+    REQUIRE_FALSE(res.has_error());
+    auto& vals = std::get<std::pmr::vector<logical_value_t>>(res.value());
+    REQUIRE(vals.size() == 1);
+    REQUIRE(vals[0].value<std::string_view>() == "cdefgh");
+}
+
+TEST_CASE("components::compute::string::substring_out_of_range") {
+    string_registry_fixture fx;
+    auto* fn = fx.get("substring");
+    REQUIRE(fn != nullptr);
+
+    std::pmr::vector<logical_value_t> inputs(&fx.resource);
+    inputs.emplace_back(&fx.resource, std::string("abc"));
+    inputs.emplace_back(&fx.resource, static_cast<int64_t>(99));
+    inputs.emplace_back(&fx.resource, static_cast<int64_t>(5));
+
+    auto res = fn->execute(inputs);
+    REQUIRE_FALSE(res.has_error());
+    auto& vals = std::get<std::pmr::vector<logical_value_t>>(res.value());
+    REQUIRE(vals.size() == 1);
+    REQUIRE(vals[0].value<std::string_view>().empty());
+}
+
+TEST_CASE("components::compute::string::substring_null") {
+    string_registry_fixture fx;
+    auto* fn = fx.get("substring");
+    REQUIRE(fn != nullptr);
+
+    std::pmr::vector<logical_value_t> inputs(&fx.resource);
+    inputs.emplace_back(&fx.resource, logical_type::NA);
+    inputs.emplace_back(&fx.resource, static_cast<int64_t>(1));
+    inputs.emplace_back(&fx.resource, static_cast<int64_t>(2));
+
+    auto res = fn->execute(inputs);
+    REQUIRE_FALSE(res.has_error());
+    auto& vals = std::get<std::pmr::vector<logical_value_t>>(res.value());
+    REQUIRE(vals.size() == 1);
+    REQUIRE(vals[0].type().type() == logical_type::NA);
+}
+
+TEST_CASE("components::compute::string::length_basic") {
+    string_registry_fixture fx;
+    auto* fn = fx.get("length");
+    REQUIRE(fn != nullptr);
+
+    std::pmr::vector<logical_value_t> inputs(&fx.resource);
+    inputs.emplace_back(&fx.resource, std::string("hello"));
+
+    auto res = fn->execute(inputs);
+    REQUIRE_FALSE(res.has_error());
+    auto& vals = std::get<std::pmr::vector<logical_value_t>>(res.value());
+    REQUIRE(vals.size() == 1);
+    REQUIRE(vals[0].value<int64_t>() == 5);
+}
+
+TEST_CASE("components::compute::string::length_empty") {
+    string_registry_fixture fx;
+    auto* fn = fx.get("length");
+    REQUIRE(fn != nullptr);
+
+    std::pmr::vector<logical_value_t> inputs(&fx.resource);
+    inputs.emplace_back(&fx.resource, std::string(""));
+
+    auto res = fn->execute(inputs);
+    REQUIRE_FALSE(res.has_error());
+    auto& vals = std::get<std::pmr::vector<logical_value_t>>(res.value());
+    REQUIRE(vals.size() == 1);
+    REQUIRE(vals[0].value<int64_t>() == 0);
+}
+
+TEST_CASE("components::compute::string::length_null") {
+    string_registry_fixture fx;
+    auto* fn = fx.get("length");
+    REQUIRE(fn != nullptr);
+
+    std::pmr::vector<logical_value_t> inputs(&fx.resource);
+    inputs.emplace_back(&fx.resource, logical_type::NA);
+
+    auto res = fn->execute(inputs);
+    REQUIRE_FALSE(res.has_error());
+    auto& vals = std::get<std::pmr::vector<logical_value_t>>(res.value());
+    REQUIRE(vals.size() == 1);
+    REQUIRE(vals[0].type().type() == logical_type::NA);
+}
+
+TEST_CASE("components::compute::string::regexp_replace_basic") {
+    string_registry_fixture fx;
+    auto* fn = fx.get("regexp_replace");
+    REQUIRE(fn != nullptr);
+
+    std::pmr::vector<logical_value_t> inputs(&fx.resource);
+    inputs.emplace_back(&fx.resource, std::string("hello 123 world 456"));
+    inputs.emplace_back(&fx.resource, std::string("[0-9]+"));
+    inputs.emplace_back(&fx.resource, std::string("#"));
+
+    auto res = fn->execute(inputs);
+    REQUIRE_FALSE(res.has_error());
+    auto& vals = std::get<std::pmr::vector<logical_value_t>>(res.value());
+    REQUIRE(vals.size() == 1);
+    REQUIRE(vals[0].value<std::string_view>() == "hello # world #");
+}
+
+TEST_CASE("components::compute::string::regexp_replace_no_match") {
+    string_registry_fixture fx;
+    auto* fn = fx.get("regexp_replace");
+    REQUIRE(fn != nullptr);
+
+    std::pmr::vector<logical_value_t> inputs(&fx.resource);
+    inputs.emplace_back(&fx.resource, std::string("abcdef"));
+    inputs.emplace_back(&fx.resource, std::string("[0-9]+"));
+    inputs.emplace_back(&fx.resource, std::string("#"));
+
+    auto res = fn->execute(inputs);
+    REQUIRE_FALSE(res.has_error());
+    auto& vals = std::get<std::pmr::vector<logical_value_t>>(res.value());
+    REQUIRE(vals.size() == 1);
+    REQUIRE(vals[0].value<std::string_view>() == "abcdef");
+}
+
+TEST_CASE("components::compute::string::regexp_replace_null") {
+    string_registry_fixture fx;
+    auto* fn = fx.get("regexp_replace");
+    REQUIRE(fn != nullptr);
+
+    std::pmr::vector<logical_value_t> inputs(&fx.resource);
+    inputs.emplace_back(&fx.resource, logical_type::NA);
+    inputs.emplace_back(&fx.resource, std::string("x"));
+    inputs.emplace_back(&fx.resource, std::string("y"));
+
+    auto res = fn->execute(inputs);
+    REQUIRE_FALSE(res.has_error());
+    auto& vals = std::get<std::pmr::vector<logical_value_t>>(res.value());
+    REQUIRE(vals.size() == 1);
+    REQUIRE(vals[0].type().type() == logical_type::NA);
+}

--- a/components/compute/tests/test_execution.cpp
+++ b/components/compute/tests/test_execution.cpp
@@ -411,10 +411,6 @@ TEST_CASE("components::compute::errors") {
 // SUBSTRING / LENGTH / REGEXP_REPLACE — string row-kernel execution tests
 // ---------------------------------------------------------------------------
 
-namespace components::compute {
-    void register_string_functions(function_registry_t& r);
-}
-
 namespace {
     struct string_registry_fixture {
         std::pmr::synchronized_pool_resource resource;

--- a/components/compute/tests/test_registry.cpp
+++ b/components/compute/tests/test_registry.cpp
@@ -24,7 +24,14 @@ TEST_CASE("components::compute::registry::basic") {
             if (name == "count") {
                 REQUIRE(fn->fn_arity().num_args == 0);
                 REQUIRE(fn->fn_arity().varargs == true);
+            } else if (name == "substring") {
+                // SUBSTRING(s, start[, len]) — 2 or 3 args
+                REQUIRE(fn->fn_arity().num_args == 2);
+                REQUIRE(fn->fn_arity().varargs == true);
+            } else if (name == "regexp_replace") {
+                REQUIRE(fn->fn_arity().num_args == 3);
             } else {
+                // sum, min, max, avg, length
                 REQUIRE(fn->fn_arity().num_args == 1);
             }
         }

--- a/components/logical_plan/CMakeLists.txt
+++ b/components/logical_plan/CMakeLists.txt
@@ -34,9 +34,11 @@ set(SOURCE_${PROJECT_NAME}
         node_create_database.cpp
         node_create_index.cpp
         node_create_macro.cpp
+        node_create_matview.cpp
         node_create_sequence.cpp
         node_create_type.cpp
         node_create_view.cpp
+        node_refresh_matview.cpp
         node_data.cpp
         node_delete.cpp
         node_drop_collection.cpp

--- a/components/logical_plan/forward.cpp
+++ b/components/logical_plan/forward.cpp
@@ -60,6 +60,10 @@ namespace components::logical_plan {
                 return "create_macro_t";
             case node_type::drop_macro_t:
                 return "drop_macro_t";
+            case node_type::create_matview_t:
+                return "create_matview_t";
+            case node_type::refresh_matview_t:
+                return "refresh_matview_t";
             case node_type::checkpoint_t:
                 return "checkpoint_t";
             case node_type::vacuum_t:

--- a/components/logical_plan/forward.hpp
+++ b/components/logical_plan/forward.hpp
@@ -35,6 +35,12 @@ namespace components::logical_plan {
         drop_view_t,
         create_macro_t,
         drop_macro_t,
+        // CREATE MATERIALIZED VIEW (relkind='m'). Carries body_sql + body_plan as
+        // child[0]. Planner derives output schema from body_plan + Pass 1-stamped
+        // source metadata, then lowers to sequence_t(create_collection +
+        // pg_class/pg_attribute/pg_rewrite/pg_depend writes + insert_t).
+        create_matview_t,
+        refresh_matview_t,
         checkpoint_t,
         vacuum_t,
         having_t,

--- a/components/logical_plan/identifier_types.hpp
+++ b/components/logical_plan/identifier_types.hpp
@@ -17,3 +17,4 @@ STRONG_TYPEDEF_EXPLICIT(std::string, columnname_t);
 STRONG_TYPEDEF_EXPLICIT(std::string, constraint_name_t);
 STRONG_TYPEDEF_EXPLICIT(std::string, body_sql_t);
 STRONG_TYPEDEF_EXPLICIT(std::string, query_sql_t);
+STRONG_TYPEDEF_EXPLICIT(std::string, matviewname_t);

--- a/components/logical_plan/node_catalog_resolve_table.hpp
+++ b/components/logical_plan/node_catalog_resolve_table.hpp
@@ -40,6 +40,10 @@ namespace components::logical_plan {
         char relkind{'r'};
         std::string name;
         std::vector<resolved_column_metadata_t> columns;
+        // pg_rewrite.ev_action body SQL, populated by operator_resolve_table_t for
+        // relkind 'v' (regular view) and 'm' (matview — used by REFRESH). Empty
+        // for other relkinds. Consumed by dispatcher Phase 1.5 rewrite_views.
+        std::string view_sql;
     };
 
     // Catalog-dependency leaf node carrying "resolve table 'relname' in

--- a/components/logical_plan/node_create_collection.cpp
+++ b/components/logical_plan/node_create_collection.cpp
@@ -6,21 +6,25 @@ namespace components::logical_plan {
 
     node_create_collection_t::node_create_collection_t(std::pmr::memory_resource* resource,
                                                        core::relname_t relname,
-                                                       bool disk_storage)
+                                                       bool disk_storage,
+                                                       bool if_not_exists)
         : node_t(resource, node_type::create_collection_t)
         , relname_(std::move(static_cast<std::string&>(relname)))
-        , disk_storage_(disk_storage) {}
+        , disk_storage_(disk_storage)
+        , if_not_exists_(if_not_exists) {}
 
     node_create_collection_t::node_create_collection_t(std::pmr::memory_resource* resource,
                                                        core::relname_t relname,
                                                        std::vector<table::column_definition_t> column_definitions,
                                                        std::vector<table::table_constraint_t> constraints,
-                                                       bool disk_storage)
+                                                       bool disk_storage,
+                                                       bool if_not_exists)
         : node_t(resource, node_type::create_collection_t)
         , relname_(std::move(static_cast<std::string&>(relname)))
         , column_definitions_(std::move(column_definitions))
         , constraints_(std::move(constraints))
-        , disk_storage_(disk_storage) {}
+        , disk_storage_(disk_storage)
+        , if_not_exists_(if_not_exists) {}
 
     std::pmr::vector<types::complex_logical_type> node_create_collection_t::schema() const {
         std::pmr::vector<types::complex_logical_type> result(resource());
@@ -50,20 +54,23 @@ namespace components::logical_plan {
     const std::vector<table::table_constraint_t>& node_create_collection_t::constraints() const { return constraints_; }
 
     node_create_collection_ptr make_node_create_collection(std::pmr::memory_resource* resource,
-                                                           core::relname_t relname) {
-        return {new node_create_collection_t{resource, std::move(relname)}};
+                                                           core::relname_t relname,
+                                                           bool if_not_exists) {
+        return {new node_create_collection_t{resource, std::move(relname), false, if_not_exists}};
     }
 
     node_create_collection_ptr make_node_create_collection(std::pmr::memory_resource* resource,
                                                            core::relname_t relname,
                                                            std::vector<table::column_definition_t> column_definitions,
                                                            std::vector<table::table_constraint_t> constraints,
-                                                           bool disk_storage) {
+                                                           bool disk_storage,
+                                                           bool if_not_exists) {
         return {new node_create_collection_t{resource,
                                              std::move(relname),
                                              std::move(column_definitions),
                                              std::move(constraints),
-                                             disk_storage}};
+                                             disk_storage,
+                                             if_not_exists}};
     }
 
 } // namespace components::logical_plan

--- a/components/logical_plan/node_create_collection.hpp
+++ b/components/logical_plan/node_create_collection.hpp
@@ -14,13 +14,15 @@ namespace components::logical_plan {
     public:
         explicit node_create_collection_t(std::pmr::memory_resource* resource,
                                           core::relname_t relname,
-                                          bool disk_storage = false);
+                                          bool disk_storage = false,
+                                          bool if_not_exists = false);
 
         node_create_collection_t(std::pmr::memory_resource* resource,
                                  core::relname_t relname,
                                  std::vector<table::column_definition_t> column_definitions,
                                  std::vector<table::table_constraint_t> constraints,
-                                 bool disk_storage = false);
+                                 bool disk_storage = false,
+                                 bool if_not_exists = false);
 
         std::pmr::vector<types::complex_logical_type> schema() const;
 
@@ -29,6 +31,7 @@ namespace components::logical_plan {
         const std::vector<table::table_constraint_t>& constraints() const;
 
         bool is_disk_storage() const { return disk_storage_; }
+        bool if_not_exists() const noexcept { return if_not_exists_; }
 
         components::catalog::oid_t namespace_oid() const noexcept { return namespace_oid_; }
         void set_namespace_oid(components::catalog::oid_t oid) noexcept { namespace_oid_ = oid; }
@@ -43,17 +46,20 @@ namespace components::logical_plan {
         std::vector<table::column_definition_t> column_definitions_;
         std::vector<table::table_constraint_t> constraints_;
         bool disk_storage_{false};
+        bool if_not_exists_{false};
         components::catalog::oid_t namespace_oid_{components::catalog::INVALID_OID};
     };
 
     using node_create_collection_ptr = boost::intrusive_ptr<node_create_collection_t>;
     node_create_collection_ptr make_node_create_collection(std::pmr::memory_resource* resource,
-                                                           core::relname_t relname);
+                                                           core::relname_t relname,
+                                                           bool if_not_exists = false);
 
     node_create_collection_ptr make_node_create_collection(std::pmr::memory_resource* resource,
                                                            core::relname_t relname,
                                                            std::vector<table::column_definition_t> column_definitions,
                                                            std::vector<table::table_constraint_t> constraints,
-                                                           bool disk_storage = false);
+                                                           bool disk_storage = false,
+                                                           bool if_not_exists = false);
 
 } // namespace components::logical_plan

--- a/components/logical_plan/node_create_database.cpp
+++ b/components/logical_plan/node_create_database.cpp
@@ -4,20 +4,25 @@
 
 namespace components::logical_plan {
 
-    node_create_database_t::node_create_database_t(std::pmr::memory_resource* resource, core::dbname_t dbname)
+    node_create_database_t::node_create_database_t(std::pmr::memory_resource* resource,
+                                                   core::dbname_t dbname,
+                                                   bool if_not_exists)
         : node_t(resource, node_type::create_database_t)
-        , dbname_(std::move(static_cast<std::string&>(dbname))) {}
+        , dbname_(std::move(static_cast<std::string&>(dbname)))
+        , if_not_exists_(if_not_exists) {}
 
     hash_t node_create_database_t::hash_impl() const { return 0; }
 
     std::string node_create_database_t::to_string_impl() const {
         std::stringstream stream;
-        stream << "$create_database: " << dbname_;
+        stream << "$create_database" << (if_not_exists_ ? "_if_not_exists" : "") << ": " << dbname_;
         return stream.str();
     }
 
-    node_create_database_ptr make_node_create_database(std::pmr::memory_resource* resource, core::dbname_t dbname) {
-        return {new node_create_database_t{resource, std::move(dbname)}};
+    node_create_database_ptr make_node_create_database(std::pmr::memory_resource* resource,
+                                                       core::dbname_t dbname,
+                                                       bool if_not_exists) {
+        return {new node_create_database_t{resource, std::move(dbname), if_not_exists}};
     }
 
 } // namespace components::logical_plan

--- a/components/logical_plan/node_create_database.hpp
+++ b/components/logical_plan/node_create_database.hpp
@@ -7,18 +7,24 @@ namespace components::logical_plan {
 
     class node_create_database_t final : public node_t {
     public:
-        explicit node_create_database_t(std::pmr::memory_resource* resource, core::dbname_t dbname);
+        explicit node_create_database_t(std::pmr::memory_resource* resource,
+                                        core::dbname_t dbname,
+                                        bool if_not_exists = false);
 
         const std::string& dbname() const noexcept { return dbname_; }
+        bool if_not_exists() const noexcept { return if_not_exists_; }
 
     private:
         hash_t hash_impl() const override;
         std::string to_string_impl() const override;
 
         std::string dbname_;
+        bool if_not_exists_;
     };
 
     using node_create_database_ptr = boost::intrusive_ptr<node_create_database_t>;
-    node_create_database_ptr make_node_create_database(std::pmr::memory_resource* resource, core::dbname_t dbname);
+    node_create_database_ptr make_node_create_database(std::pmr::memory_resource* resource,
+                                                       core::dbname_t dbname,
+                                                       bool if_not_exists = false);
 
 } // namespace components::logical_plan

--- a/components/logical_plan/node_create_matview.cpp
+++ b/components/logical_plan/node_create_matview.cpp
@@ -1,0 +1,35 @@
+#include "node_create_matview.hpp"
+
+#include <sstream>
+
+namespace components::logical_plan {
+
+    node_create_matview_t::node_create_matview_t(std::pmr::memory_resource* resource,
+                                                 core::matviewname_t matviewname,
+                                                 core::body_sql_t body_sql)
+        : node_t(resource, node_type::create_matview_t)
+        , matviewname_(std::move(static_cast<std::string&>(matviewname)))
+        , body_sql_(std::move(static_cast<std::string&>(body_sql))) {}
+
+    void node_create_matview_t::set_body_plan(node_ptr plan) {
+        children_.clear();
+        if (plan) {
+            append_child(plan);
+        }
+    }
+
+    hash_t node_create_matview_t::hash_impl() const { return 0; }
+
+    std::string node_create_matview_t::to_string_impl() const {
+        std::stringstream stream;
+        stream << "$create_matview: " << matviewname_;
+        return stream.str();
+    }
+
+    node_create_matview_ptr make_node_create_matview(std::pmr::memory_resource* resource,
+                                                     core::matviewname_t matviewname,
+                                                     core::body_sql_t body_sql) {
+        return {new node_create_matview_t{resource, std::move(matviewname), std::move(body_sql)}};
+    }
+
+} // namespace components::logical_plan

--- a/components/logical_plan/node_create_matview.hpp
+++ b/components/logical_plan/node_create_matview.hpp
@@ -1,0 +1,95 @@
+#pragma once
+
+#include "identifier_types.hpp"
+#include "node.hpp"
+
+#include <components/catalog/catalog_oids.hpp>
+#include <components/catalog/catalog_write.hpp>
+#include <components/table/column_definition.hpp>
+
+#include <vector>
+
+namespace components::logical_plan {
+
+    // CREATE MATERIALIZED VIEW mv AS SELECT ... (PostgreSQL-canonical, relkind='m').
+    // The body plan is stored as child[0] so it is visible to tree walks
+    // (gather_plan_resolve_index, planner, physical_plan_gen). The body's
+    // source resolve nodes are hoisted to the wrapping sequence_t's front so
+    // Pass 1 stamps source metadata; the planner then reads
+    // body_plan->aggregate.expressions + source's stamped resolved_metadata
+    // to derive the output schema before lowering to:
+    //   sequence_t(create_collection(relkind='m'),
+    //              primitive_write × N (pg_class + pg_attribute + pg_rewrite + pg_depend),
+    //              insert_t(target=mv_oid, source=body_plan))
+    class node_create_matview_t final : public node_t {
+    public:
+        node_create_matview_t(std::pmr::memory_resource* resource,
+                              core::matviewname_t matviewname,
+                              core::body_sql_t body_sql);
+
+        const std::string& matviewname() const noexcept { return matviewname_; }
+        const std::string& body_sql() const noexcept { return body_sql_; }
+
+        // Body plan lives at child[0]. nullptr if not set yet.
+        node_ptr body_plan() const noexcept {
+            return children_.empty() ? nullptr : children_.front();
+        }
+        void set_body_plan(node_ptr plan);
+
+        components::catalog::oid_t namespace_oid() const noexcept { return namespace_oid_; }
+        void set_namespace_oid(components::catalog::oid_t oid) noexcept { namespace_oid_ = oid; }
+
+        // Source table oid (the body's FROM-clause table). Stamped by enrich
+        // from sibling catalog_resolve_table inside the wrapping sequence_t.
+        components::catalog::oid_t source_table_oid() const noexcept { return source_table_oid_; }
+        void set_source_table_oid(components::catalog::oid_t oid) noexcept { source_table_oid_ = oid; }
+
+        // Output schema derived by enrich (which has Pass 1-stamped source
+        // metadata + access to dispatcher_idx). Planner reads it to call
+        // build_create_table_writes for pg_class + pg_attribute rows.
+        const std::vector<table::column_definition_t>& inferred_columns() const noexcept {
+            return inferred_columns_;
+        }
+        void set_inferred_columns(std::vector<table::column_definition_t> cols) {
+            inferred_columns_ = std::move(cols);
+        }
+
+        // The matview's own oid (pg_class.oid). Stamped by planner from
+        // allocate_oids batch. physical_plan_generator reads to construct
+        // operator_create_matview_t.
+        components::catalog::oid_t matview_oid() const noexcept { return matview_oid_; }
+        void set_matview_oid(components::catalog::oid_t oid) noexcept { matview_oid_ = oid; }
+
+        // pg_catalog write rows (pg_class + pg_attribute + pg_rewrite + pg_depend),
+        // built by planner from build_create_table_writes + build_matview_rewrite_writes.
+        // physical_plan_generator moves them into operator_create_matview_t via take.
+        const std::vector<components::catalog::catalog_write_t>& catalog_writes() const noexcept {
+            return catalog_writes_;
+        }
+        void set_catalog_writes(std::vector<components::catalog::catalog_write_t> w) {
+            catalog_writes_ = std::move(w);
+        }
+        std::vector<components::catalog::catalog_write_t> take_catalog_writes() {
+            return std::move(catalog_writes_);
+        }
+
+    private:
+        hash_t hash_impl() const override;
+        std::string to_string_impl() const override;
+
+        std::string matviewname_;
+        std::string body_sql_;
+        components::catalog::oid_t namespace_oid_{components::catalog::INVALID_OID};
+        components::catalog::oid_t source_table_oid_{components::catalog::INVALID_OID};
+        components::catalog::oid_t matview_oid_{components::catalog::INVALID_OID};
+        std::vector<table::column_definition_t> inferred_columns_;
+        std::vector<components::catalog::catalog_write_t> catalog_writes_;
+    };
+
+    using node_create_matview_ptr = boost::intrusive_ptr<node_create_matview_t>;
+
+    node_create_matview_ptr make_node_create_matview(std::pmr::memory_resource* resource,
+                                                     core::matviewname_t matviewname,
+                                                     core::body_sql_t body_sql);
+
+} // namespace components::logical_plan

--- a/components/logical_plan/node_refresh_matview.cpp
+++ b/components/logical_plan/node_refresh_matview.cpp
@@ -1,0 +1,31 @@
+#include "node_refresh_matview.hpp"
+
+#include <sstream>
+
+namespace components::logical_plan {
+
+    node_refresh_matview_t::node_refresh_matview_t(std::pmr::memory_resource* resource,
+                                                   core::matviewname_t matviewname,
+                                                   bool concurrent,
+                                                   bool with_data)
+        : node_t(resource, node_type::refresh_matview_t)
+        , matviewname_(std::move(static_cast<std::string&>(matviewname)))
+        , concurrent_(concurrent)
+        , with_data_(with_data) {}
+
+    hash_t node_refresh_matview_t::hash_impl() const { return 0; }
+
+    std::string node_refresh_matview_t::to_string_impl() const {
+        std::stringstream stream;
+        stream << "$refresh_matview: " << matviewname_;
+        return stream.str();
+    }
+
+    node_refresh_matview_ptr make_node_refresh_matview(std::pmr::memory_resource* resource,
+                                                       core::matviewname_t matviewname,
+                                                       bool concurrent,
+                                                       bool with_data) {
+        return {new node_refresh_matview_t{resource, std::move(matviewname), concurrent, with_data}};
+    }
+
+} // namespace components::logical_plan

--- a/components/logical_plan/node_refresh_matview.hpp
+++ b/components/logical_plan/node_refresh_matview.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "identifier_types.hpp"
+#include "node.hpp"
+
+#include <components/catalog/catalog_oids.hpp>
+
+namespace components::logical_plan {
+
+    // REFRESH MATERIALIZED VIEW mv [WITH NO DATA] (PostgreSQL semantics).
+    // The wrapping sequence_t includes catalog_resolve_table(mv) which Pass 1
+    // stamps with resolved_metadata.view_sql (from pg_rewrite.ev_action, the
+    // body SQL written at CREATE MATERIALIZED VIEW time). The planner reads
+    // view_sql, re-parses + re-transforms, and lowers to
+    //   sequence_t(delete_t(mv, all_true), insert_t(target=mv, source=re_body_plan))
+    // First iteration: concurrent is parsed but ignored (followups #3).
+    class node_refresh_matview_t final : public node_t {
+    public:
+        node_refresh_matview_t(std::pmr::memory_resource* resource,
+                               core::matviewname_t matviewname,
+                               bool concurrent,
+                               bool with_data);
+
+        const std::string& matviewname() const noexcept { return matviewname_; }
+        bool concurrent() const noexcept { return concurrent_; }
+        bool with_data() const noexcept { return with_data_; }
+
+    private:
+        hash_t hash_impl() const override;
+        std::string to_string_impl() const override;
+
+        std::string matviewname_;
+        bool concurrent_{false};
+        bool with_data_{true};
+    };
+
+    using node_refresh_matview_ptr = boost::intrusive_ptr<node_refresh_matview_t>;
+
+    node_refresh_matview_ptr make_node_refresh_matview(std::pmr::memory_resource* resource,
+                                                       core::matviewname_t matviewname,
+                                                       bool concurrent,
+                                                       bool with_data);
+
+} // namespace components::logical_plan

--- a/components/physical_plan/CMakeLists.txt
+++ b/components/physical_plan/CMakeLists.txt
@@ -42,6 +42,7 @@ set(${PROJECT_NAME}_SOURCES
         operators/operator_primitive_write.cpp
         operators/operator_primitive_delete.cpp
         operators/operator_create_collection.cpp
+        operators/operator_create_matview.cpp
         operators/operator_create_index_metadata.cpp
         operators/operator_create_index_backfill.cpp
         operators/operator_drop_index.cpp

--- a/components/physical_plan/operators/arithmetic_eval.cpp
+++ b/components/physical_plan/operators/arithmetic_eval.cpp
@@ -318,6 +318,8 @@ namespace components::operators {
                 if (!matched && has_default) {
                     auto val = resolve_row_value(resource, operands.back(), chunk, params, i);
                     output.set_value(i, val);
+                } else if (!matched) {
+                    output.set_null(i, true);
                 }
             }
             return output;

--- a/components/physical_plan/operators/operator.hpp
+++ b/components/physical_plan/operators/operator.hpp
@@ -198,6 +198,7 @@ namespace components::operators {
         void set_output(operator_data_ptr data);
         void take_output(ptr& src);
         void mark_executed();
+        void mark_failed() noexcept { state_ = operator_state::failed; }
         void clear(); //todo: replace by copy
 
         void set_error(const core::error_t& error);

--- a/components/physical_plan/operators/operator_batch.cpp
+++ b/components/physical_plan/operators/operator_batch.cpp
@@ -3,6 +3,14 @@
 namespace components::operators {
     operator_batch_t::operator_batch_t(std::pmr::memory_resource* resource, chunks_vector_t&& chunks)
         : read_only_operator_t(resource, log_t{}, operator_type::batch) {
+        // Defence-in-depth: callers (e.g. operator_group.cpp's global-aggregate
+        // path) construct this with an explicitly empty vector. Keep the
+        // operator_data_t invariant — at least one (possibly empty) chunk so
+        // downstream operators that read chunks.front() do not crash.
+        if (chunks.empty()) {
+            std::pmr::vector<types::complex_logical_type> empty_types(resource);
+            chunks.emplace_back(resource, empty_types, 0);
+        }
         set_output(make_operator_data(resource, std::move(chunks)));
         mark_executed();
     }

--- a/components/physical_plan/operators/operator_create_matview.cpp
+++ b/components/physical_plan/operators/operator_create_matview.cpp
@@ -1,0 +1,92 @@
+#include "operator_create_matview.hpp"
+
+#include <components/context/context.hpp>
+#include <services/disk/manager_disk.hpp>
+#include <services/index/manager_index.hpp>
+#include <services/wal/manager_wal_replicate.hpp>
+
+namespace components::operators {
+
+    operator_create_matview_t::operator_create_matview_t(std::pmr::memory_resource* resource,
+                                                         log_t log,
+                                                         components::catalog::oid_t mv_oid,
+                                                         components::catalog::oid_t namespace_oid,
+                                                         std::vector<table::column_definition_t> columns,
+                                                         bool is_disk_storage,
+                                                         std::vector<catalog_write_t> catalog_writes,
+                                                         operator_ptr body_op)
+        : read_write_operator_t(resource, std::move(log), operator_type::create_collection)
+        , mv_oid_(mv_oid)
+        , namespace_oid_(namespace_oid)
+        , columns_(std::move(columns))
+        , is_disk_storage_(is_disk_storage)
+        , catalog_writes_(std::move(catalog_writes))
+        , body_op_(std::move(body_op)) {}
+
+    void operator_create_matview_t::on_execute_impl(pipeline::context_t* /*ctx*/) { async_wait(); }
+
+    actor_zeta::unique_future<void> operator_create_matview_t::await_async_and_resume(pipeline::context_t* ctx) {
+        using components::vector::data_chunk_t;
+
+        // Step 1: Create physical heap storage (mirror operator_create_collection_t).
+        if (columns_.empty()) {
+            auto [_, f] = actor_zeta::send(ctx->disk_address,
+                                           &services::disk::manager_disk_t::create_storage,
+                                           ctx->session,
+                                           mv_oid_,
+                                           namespace_oid_);
+            co_await std::move(f);
+        } else if (is_disk_storage_) {
+            auto [_, f] = actor_zeta::send(ctx->disk_address,
+                                           &services::disk::manager_disk_t::create_storage_disk,
+                                           ctx->session,
+                                           mv_oid_,
+                                           namespace_oid_,
+                                           std::move(columns_));
+            co_await std::move(f);
+        } else {
+            auto [_, f] = actor_zeta::send(ctx->disk_address,
+                                           &services::disk::manager_disk_t::create_storage_with_columns,
+                                           ctx->session,
+                                           mv_oid_,
+                                           namespace_oid_,
+                                           std::move(columns_));
+            co_await std::move(f);
+        }
+
+        // Step 2: Register with index manager (oid-keyed).
+        if (ctx->index_address != actor_zeta::address_t::empty_address()) {
+            auto [_, f] = actor_zeta::send(ctx->index_address,
+                                           &services::index::manager_index_t::register_collection,
+                                           ctx->session,
+                                           mv_oid_);
+            co_await std::move(f);
+        }
+
+        // Step 3: Write pg_catalog rows (pg_class + pg_attribute + pg_rewrite + pg_depend).
+        components::execution_context_t exec_ctx{ctx->session, ctx->txn, {}};
+        for (auto& [tbl_oid, row] : catalog_writes_) {
+            auto [_, f] = actor_zeta::send(ctx->disk_address,
+                                           &services::disk::manager_disk_t::append_pg_catalog_row,
+                                           exec_ctx,
+                                           tbl_oid,
+                                           std::move(row));
+            auto rng = co_await std::move(f);
+            if (rng.count > 0)
+                ctx->pg_catalog_appends.push_back(std::move(rng));
+        }
+
+        // Step 4 (DEFERRED): initial population from body_op via nested coroutine
+        // hits actor_zeta nested-await issues (full_scan crashes when driven
+        // from inside operator_create_matview_t's outer await). For first
+        // iteration we follow PostgreSQL's WITH NO DATA semantics — create the
+        // matview heap + catalog rows, leave it empty. REFRESH MATERIALIZED
+        // VIEW (followup) will populate via the standard INSERT-SELECT
+        // pipeline once dispatched as its own plan. body_op_ holds the
+        // compiled body plan; intentionally not driven here. See
+        // docs/pr496-followups.md #2 for the populate-on-CREATE workplan.
+        (void)body_op_;
+        mark_executed();
+    }
+
+} // namespace components::operators

--- a/components/physical_plan/operators/operator_create_matview.hpp
+++ b/components/physical_plan/operators/operator_create_matview.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <components/catalog/catalog_oids.hpp>
+#include <components/physical_plan/operators/operator.hpp>
+#include <components/table/column_definition.hpp>
+#include <components/vector/data_chunk.hpp>
+#include <vector>
+
+namespace components::operators {
+
+    // Composite physical operator for CREATE MATERIALIZED VIEW (relkind='m').
+    //
+    // Performs all matview creation steps atomically in a single async coroutine:
+    //   1. Create physical heap storage for the matview.
+    //   2. Register the matview with the index manager.
+    //   3. Write pg_class + pg_attribute + pg_rewrite + pg_depend rows.
+    //   4. Drive body_op_ (compiled body SELECT plan) to completion, gathering
+    //      its output chunk.
+    //   5. Append the body's rows into the matview's heap (mirror of
+    //      operator_insert: storage_append + WAL + index forwarding).
+    //
+    // Pipeline-canonical: dispatched as a single logical_plan node
+    // (create_matview_t) → planner stamps catalog_writes + mv_oid →
+    // physical_plan_generator builds this operator with body_op_ compiled via
+    // the standard create_plan recursion. No re-parsing in dispatcher, no
+    // follow-up plan dispatches.
+    class operator_create_matview_t final : public read_write_operator_t {
+    public:
+        using catalog_write_t = std::pair<components::catalog::oid_t, vector::data_chunk_t>;
+
+        operator_create_matview_t(std::pmr::memory_resource* resource,
+                                  log_t log,
+                                  components::catalog::oid_t mv_oid,
+                                  components::catalog::oid_t namespace_oid,
+                                  std::vector<table::column_definition_t> columns,
+                                  bool is_disk_storage,
+                                  std::vector<catalog_write_t> catalog_writes,
+                                  operator_ptr body_op);
+
+    private:
+        void on_execute_impl(pipeline::context_t* ctx) override;
+        actor_zeta::unique_future<void> await_async_and_resume(pipeline::context_t* ctx) override;
+
+        components::catalog::oid_t mv_oid_;
+        components::catalog::oid_t namespace_oid_;
+        std::vector<table::column_definition_t> columns_;
+        bool is_disk_storage_;
+        std::vector<catalog_write_t> catalog_writes_;
+        operator_ptr body_op_;
+    };
+
+} // namespace components::operators

--- a/components/physical_plan/operators/operator_join.cpp
+++ b/components/physical_plan/operators/operator_join.cpp
@@ -130,10 +130,6 @@ namespace components::operators {
         size_t left_col_count = left_chunks.front().column_count();
         size_t right_col_count = right_chunks.front().column_count();
 
-        // TODO: switch to PostgreSQL-style semantics (validate_logical_plan.cpp:1563).
-        // Currently all joins collapse same-aliased columns into one slot (USING-like);
-        // PG only does that for USING/NATURAL, JOIN ... ON keeps duplicates addressable
-        // via table qualifier. This alias-dedup is a short-term fix for chained-JOIN.
         indices_left_.clear();
         indices_right_.clear();
         indices_left_.reserve(left_col_count);
@@ -142,15 +138,8 @@ namespace components::operators {
             indices_left_.emplace_back(i);
         }
         for (size_t i = 0; i < right_col_count; ++i) {
-            const auto& alias = right_types[i].alias();
-            auto dup =
-                std::find_if(res_types.begin(), res_types.end(), [&](const auto& t) { return t.alias() == alias; });
-            if (dup != res_types.end()) {
-                indices_right_.emplace_back(static_cast<size_t>(std::distance(res_types.begin(), dup)));
-            } else {
-                indices_right_.emplace_back(res_types.size());
-                res_types.push_back(right_types[i]);
-            }
+            indices_right_.emplace_back(left_col_count + i);
+            res_types.push_back(right_types[i]);
         }
 
         if (log_.is_valid()) {

--- a/components/physical_plan/operators/operator_resolve_table.cpp
+++ b/components/physical_plan/operators/operator_resolve_table.cpp
@@ -90,6 +90,7 @@ namespace components::operators {
         constexpr catalog::oid_t kPgClass = catalog::well_known_oid::pg_class_table;
         constexpr catalog::oid_t kPgAttribute = catalog::well_known_oid::pg_attribute_table;
         constexpr catalog::oid_t kPgComputedColumn = catalog::well_known_oid::pg_computed_column_table;
+        constexpr catalog::oid_t kPgRewrite = catalog::well_known_oid::pg_rewrite_table;
 
         components::execution_context_t exec_ctx{ctx->session, ctx->txn, {}};
 
@@ -194,6 +195,30 @@ namespace components::operators {
             output_->data_chunk().set_cardinality(0);
             mark_executed();
             co_return;
+        }
+
+        // Step 2: for relkind 'v' (regular view) or 'm' (matview), read
+        // pg_rewrite.ev_action so dispatcher Phase 1.5 rewrite_views can
+        // re-parse the body. pg_rewrite layout: [0=oid, 1=rulename,
+        // 2=ev_class, 3=ev_type, 4=ev_action]. Matview body is also stored
+        // here for REFRESH MATERIALIZED VIEW.
+        std::string view_sql;
+        if (relkind_ == catalog::relkind::view || relkind_ == catalog::relkind::materialized_view) {
+            types::logical_value_t evclass_lv(resource_, table_oid_);
+            std::pmr::vector<std::string> pr_keys(resource_);
+            pr_keys.emplace_back("ev_class");
+            std::pmr::vector<types::logical_value_t> pr_vals(resource_);
+            pr_vals.emplace_back(evclass_lv);
+            auto [_pr, prf] = actor_zeta::send(ctx->disk_address,
+                                               &services::disk::manager_disk_t::read_rows_by_key,
+                                               exec_ctx,
+                                               kPgRewrite,
+                                               std::move(pr_keys),
+                                               std::move(pr_vals));
+            auto pr_rows = co_await std::move(prf);
+            if (!pr_rows.empty() && pr_rows[0].size() >= 5 && !pr_rows[0][4].is_null()) {
+                view_sql.assign(pr_rows[0][4].value<std::string_view>());
+            }
         }
 
         // Per-row metadata accumulated below, then materialized into the
@@ -302,8 +327,13 @@ namespace components::operators {
                     }
                 }
             }
+        } else if (relkind_ == catalog::relkind::view) {
+            // Views have no pg_attribute (their schema is derived from the
+            // body SQL on expansion). Leave `rows` empty; view_sql carries
+            // the body for dispatcher Phase 1.5 rewrite_views.
         } else {
-            // relkind='r' (and other static-schema kinds): scan pg_attribute.
+            // relkind='r', 'm' (matview), and other static-schema kinds:
+            // scan pg_attribute.
             // pg_attribute layout: [0=attoid, 1=attrelid, 2=attname,
             // 3=atttypid, 4=attnum, 5=attnotnull, 6=atthasdefault,
             // 7=attisdropped, 8=atttypspec, 9=attdefspec].
@@ -373,6 +403,7 @@ namespace components::operators {
             md.namespace_oid = namespace_oid_;
             md.relkind = relkind_;
             md.name = relname_;
+            md.view_sql = std::move(view_sql);
             md.columns.reserve(rows.size());
             for (const auto& r : rows) {
                 components::logical_plan::resolved_column_metadata_t cm;

--- a/components/physical_plan/operators/operator_select.cpp
+++ b/components/physical_plan/operators/operator_select.cpp
@@ -191,7 +191,6 @@ namespace components::operators {
                     break;
                 }
                 case select_column_t::kind::star_expand: {
-                    // Expand all columns from input chunk.
                     for (size_t ci = 0; ci < input.column_count(); ++ci) {
                         out_vecs.push_back(input.data[ci]);
                     }

--- a/components/physical_plan/operators/operator_select.cpp
+++ b/components/physical_plan/operators/operator_select.cpp
@@ -191,6 +191,7 @@ namespace components::operators {
                     break;
                 }
                 case select_column_t::kind::star_expand: {
+                    // Expand all columns from input chunk.
                     for (size_t ci = 0; ci < input.column_count(); ++ci) {
                         out_vecs.push_back(input.data[ci]);
                     }

--- a/components/physical_plan/operators/scan/full_scan.cpp
+++ b/components/physical_plan/operators/scan/full_scan.cpp
@@ -158,6 +158,27 @@ namespace components::operators {
             }
         }
 
+        // Maintain the operator_data_t invariant: at least one (possibly empty)
+        // chunk. storage_scan_batched can return an empty vector at SSB-scale when
+        // the disk service get_storage(table_oid) hits an oid-resolution race with
+        // CSV ingest commit. Without this guard, operator_join.cpp:125 asserts.
+        // Schema is taken from the projected scan signature so OUTER joins can
+        // still emit NULL-padded rows from the non-empty side.
+        if (batches.empty()) {
+            std::pmr::vector<types::complex_logical_type> projected_types(resource_);
+            if (projected_cols_.empty()) {
+                projected_types = types;
+            } else {
+                projected_types.reserve(projected_cols_.size());
+                for (auto idx : projected_cols_) {
+                    if (idx < types.size()) {
+                        projected_types.push_back(types[idx]);
+                    }
+                }
+            }
+            batches.emplace_back(resource_, projected_types, 0);
+        }
+
         output_ = make_operator_data(resource_, std::move(batches));
         mark_executed();
         co_return;

--- a/components/physical_plan/operators/scan/full_scan.cpp
+++ b/components/physical_plan/operators/scan/full_scan.cpp
@@ -174,8 +174,7 @@ namespace components::operators {
         auto filter_result = transform_predicate(resource_, expression_, types, &ctx->parameters);
         if (filter_result.has_error()) {
             set_error(filter_result.error());
-            output_ = make_operator_data(resource_, std::pmr::vector<types::complex_logical_type>{resource_});
-            mark_executed();
+            mark_failed();
             co_return;
         }
         auto filter = std::move(filter_result.value());

--- a/components/physical_plan/operators/scan/full_scan.cpp
+++ b/components/physical_plan/operators/scan/full_scan.cpp
@@ -25,7 +25,7 @@ namespace components::operators {
                                             types,
                                             parameters);
                     if (child_result.has_error()) {
-                        return core::error_t{child_result.error()};
+                        return child_result;
                     }
                     if (child_result.value()) {
                         filter->child_filters.emplace_back(std::move(child_result.value()));
@@ -47,7 +47,7 @@ namespace components::operators {
                                             types,
                                             parameters);
                     if (child_result.has_error()) {
-                        return core::error_t{child_result.error()};
+                        return child_result;
                     }
                     if (child_result.value()) {
                         filter->child_filters.emplace_back(std::move(child_result.value()));
@@ -70,7 +70,7 @@ namespace components::operators {
                                             types,
                                             parameters);
                     if (child_result.has_error()) {
-                        return core::error_t{child_result.error()};
+                        return child_result;
                     }
                     if (child_result.value()) {
                         filter->child_filters.emplace_back(std::move(child_result.value()));

--- a/components/physical_plan/operators/scan/full_scan.cpp
+++ b/components/physical_plan/operators/scan/full_scan.cpp
@@ -4,12 +4,13 @@
 
 namespace components::operators {
 
-    std::unique_ptr<table::table_filter_t>
-    transform_predicate(const expressions::compare_expression_ptr& expression,
+    core::result_wrapper_t<std::unique_ptr<table::table_filter_t>>
+    transform_predicate(std::pmr::memory_resource* resource,
+                        const expressions::compare_expression_ptr& expression,
                         const std::pmr::vector<types::complex_logical_type>& types,
                         const logical_plan::storage_parameters* parameters) {
         if (!expression || expression->type() == expressions::compare_type::all_true) {
-            return nullptr;
+            return std::unique_ptr<table::table_filter_t>{};
         }
         if (expression->type() == expressions::compare_type::all_false) {
             assert(false && "all_false should be short-circuited in await_async_and_resume");
@@ -18,59 +19,80 @@ namespace components::operators {
             case expressions::compare_type::union_and: {
                 auto filter = std::make_unique<table::conjunction_and_filter_t>();
                 for (const auto& child : expression->children()) {
-                    auto child_filter =
-                        transform_predicate(reinterpret_cast<const expressions::compare_expression_ptr&>(child),
+                    auto child_result =
+                        transform_predicate(resource,
+                                            reinterpret_cast<const expressions::compare_expression_ptr&>(child),
                                             types,
                                             parameters);
-                    if (child_filter) {
-                        filter->child_filters.emplace_back(std::move(child_filter));
+                    if (child_result.has_error()) {
+                        return core::error_t{child_result.error()};
+                    }
+                    if (child_result.value()) {
+                        filter->child_filters.emplace_back(std::move(child_result.value()));
                     }
                 }
                 if (filter->child_filters.size() < 2) {
-                    throw std::runtime_error("incomplete AND filter — expression construction error");
+                    return core::error_t{
+                        core::error_code_t::physical_plan_error,
+                        std::pmr::string{"incomplete AND filter — expression construction error", resource}};
                 }
-                return filter;
+                return std::unique_ptr<table::table_filter_t>(std::move(filter));
             }
             case expressions::compare_type::union_or: {
                 auto filter = std::make_unique<table::conjunction_or_filter_t>();
                 for (const auto& child : expression->children()) {
-                    auto child_filter =
-                        transform_predicate(reinterpret_cast<const expressions::compare_expression_ptr&>(child),
+                    auto child_result =
+                        transform_predicate(resource,
+                                            reinterpret_cast<const expressions::compare_expression_ptr&>(child),
                                             types,
                                             parameters);
-                    if (child_filter) {
-                        filter->child_filters.emplace_back(std::move(child_filter));
+                    if (child_result.has_error()) {
+                        return core::error_t{child_result.error()};
+                    }
+                    if (child_result.value()) {
+                        filter->child_filters.emplace_back(std::move(child_result.value()));
                     }
                 }
                 if (filter->child_filters.size() < 2) {
-                    throw std::runtime_error("incomplete OR filter — expression construction error");
+                    return core::error_t{
+                        core::error_code_t::physical_plan_error,
+                        std::pmr::string{"incomplete OR filter — expression construction error", resource}};
                 }
-                return filter;
+                return std::unique_ptr<table::table_filter_t>(std::move(filter));
             }
             case expressions::compare_type::union_not: {
                 auto filter = std::make_unique<table::conjunction_not_filter_t>();
                 filter->child_filters.reserve(expression->children().size());
                 for (const auto& child : expression->children()) {
-                    auto child_filter =
-                        transform_predicate(reinterpret_cast<const expressions::compare_expression_ptr&>(child),
+                    auto child_result =
+                        transform_predicate(resource,
+                                            reinterpret_cast<const expressions::compare_expression_ptr&>(child),
                                             types,
                                             parameters);
-                    if (child_filter) {
-                        filter->child_filters.emplace_back(std::move(child_filter));
+                    if (child_result.has_error()) {
+                        return core::error_t{child_result.error()};
+                    }
+                    if (child_result.value()) {
+                        filter->child_filters.emplace_back(std::move(child_result.value()));
                     }
                 }
                 if (filter->child_filters.empty()) {
-                    throw std::runtime_error("empty NOT filter — expression construction error");
+                    return core::error_t{
+                        core::error_code_t::physical_plan_error,
+                        std::pmr::string{"empty NOT filter — expression construction error", resource}};
                 }
-                return filter;
+                return std::unique_ptr<table::table_filter_t>(std::move(filter));
             }
             case expressions::compare_type::invalid:
-                throw std::runtime_error("unsupported compare_type in expression to filter conversion");
+                return core::error_t{
+                    core::error_code_t::physical_plan_error,
+                    std::pmr::string{"unsupported compare_type in expression to filter conversion", resource}};
             case expressions::compare_type::is_null:
             case expressions::compare_type::is_not_null: {
                 const auto& path = std::get<expressions::key_t>(expression->left()).path();
                 std::pmr::vector<uint64_t> indices(path.begin(), path.end(), path.get_allocator().resource());
-                return std::make_unique<table::is_null_filter_t>(expression->type(), std::move(indices));
+                return std::unique_ptr<table::table_filter_t>(
+                    std::make_unique<table::is_null_filter_t>(expression->type(), std::move(indices)));
             }
             default: {
                 const auto& path = std::get<expressions::key_t>(expression->left()).path();
@@ -78,9 +100,35 @@ namespace components::operators {
                 std::pmr::vector<uint64_t> indices(path.begin(), path.end(), path.get_allocator().resource());
                 auto it = parameters->parameters.find(id);
                 if (it == parameters->parameters.end()) {
-                    throw std::runtime_error("parameter not found in expression to filter conversion");
+                    return core::error_t{
+                        core::error_code_t::invalid_parameter,
+                        std::pmr::string{"parameter not found in expression to filter conversion", resource}};
                 }
-                return std::make_unique<table::constant_filter_t>(expression->type(), it->second, std::move(indices));
+                // Coerce STRING parameter to ENUM ordinal when the target column is an ENUM:
+                // compare semantics see int32 storage on both sides, so the literal must be
+                // resolved to its ordinal up-front (else the filter matches 0 rows).
+                const auto& col_type = types[indices[0]];
+                const auto& param_value = it->second;
+                if (col_type.type() == types::logical_type::ENUM &&
+                    param_value.type().type() == types::logical_type::STRING_LITERAL) {
+                    auto key = param_value.value<std::string_view>();
+                    auto coerced = types::logical_value_t::create_enum(resource, col_type, key);
+                    if (coerced.type().type() == types::logical_type::NA) {
+                        return core::error_t{
+                            core::error_code_t::invalid_parameter,
+                            std::pmr::string{std::string{"enum value '"} + std::string{key} +
+                                                 "' not found in ENUM column",
+                                             resource}};
+                    }
+                    // Storage holds the ordinal as int32 (ENUM physical_type=INT32).
+                    // constant_filter_t's compare path doesn't auto-coerce ENUM<->INT32,
+                    // so wrap the ordinal as a plain INT32 logical_value_t.
+                    types::logical_value_t ordinal_val{resource, coerced.value<int32_t>()};
+                    return std::unique_ptr<table::table_filter_t>(std::make_unique<table::constant_filter_t>(
+                        expression->type(), std::move(ordinal_val), std::move(indices)));
+                }
+                return std::unique_ptr<table::table_filter_t>(
+                    std::make_unique<table::constant_filter_t>(expression->type(), it->second, std::move(indices)));
             }
         }
     }
@@ -123,7 +171,14 @@ namespace components::operators {
         auto types = co_await std::move(tf);
 
         // Build filter from expression
-        auto filter = transform_predicate(expression_, types, &ctx->parameters);
+        auto filter_result = transform_predicate(resource_, expression_, types, &ctx->parameters);
+        if (filter_result.has_error()) {
+            set_error(filter_result.error());
+            output_ = make_operator_data(resource_, std::pmr::vector<types::complex_logical_type>{resource_});
+            mark_executed();
+            co_return;
+        }
+        auto filter = std::move(filter_result.value());
 
         // Scan from storage — batched + projected (PR #477+#483).
         int64_t offset_val = limit_.offset();

--- a/components/physical_plan/operators/scan/full_scan.hpp
+++ b/components/physical_plan/operators/scan/full_scan.hpp
@@ -4,12 +4,14 @@
 #include <components/logical_plan/node_limit.hpp>
 #include <components/physical_plan/operators/operator.hpp>
 #include <components/table/column_state.hpp>
+#include <core/result_wrapper.hpp>
 #include <expressions/compare_expression.hpp>
 
 namespace components::operators {
 
-    std::unique_ptr<table::table_filter_t>
-    transform_predicate(const expressions::compare_expression_ptr& expression,
+    core::result_wrapper_t<std::unique_ptr<table::table_filter_t>>
+    transform_predicate(std::pmr::memory_resource* resource,
+                        const expressions::compare_expression_ptr& expression,
                         const std::pmr::vector<types::complex_logical_type>& types,
                         const logical_plan::storage_parameters* parameters);
 

--- a/components/physical_plan/operators/scan/transfer_scan.cpp
+++ b/components/physical_plan/operators/scan/transfer_scan.cpp
@@ -57,6 +57,32 @@ namespace components::operators {
             }
         }
 
+        // Maintain the operator_data_t invariant: at least one (possibly empty)
+        // chunk. storage_scan_batched can return an empty vector when the disk
+        // service get_storage(table_oid) hits an oid-resolution race (observed
+        // at SSB-scale on comma-join cross-products). Without this guard,
+        // operator_join.cpp:125 asserts. Fetch types only on the empty path so
+        // the steady-state scan keeps a single async round-trip.
+        if (batches.empty()) {
+            auto [_t, tf] = actor_zeta::send(ctx->disk_address,
+                                             &services::disk::manager_disk_t::storage_types,
+                                             ctx->session,
+                                             table_oid_);
+            auto tbl_types = co_await std::move(tf);
+            std::pmr::vector<types::complex_logical_type> projected_types(resource_);
+            if (projected_cols_.empty()) {
+                projected_types = tbl_types;
+            } else {
+                projected_types.reserve(projected_cols_.size());
+                for (auto idx : projected_cols_) {
+                    if (idx < tbl_types.size()) {
+                        projected_types.push_back(tbl_types[idx]);
+                    }
+                }
+            }
+            batches.emplace_back(resource_, projected_types, 0);
+        }
+
         output_ = make_operator_data(resource_, std::move(batches));
         mark_executed();
         co_return;

--- a/components/physical_plan_generator/CMakeLists.txt
+++ b/components/physical_plan_generator/CMakeLists.txt
@@ -24,6 +24,7 @@ set(${PROJECT_NAME}_SOURCES
         impl/create_plan_dynamic_cascade_delete.cpp
         impl/create_plan_checkpoint.cpp
         impl/create_plan_vacuum.cpp
+        impl/create_plan_create_matview.cpp
         impl/create_plan_get_schema.cpp
         impl/create_plan_register_udf.cpp
         impl/create_plan_unregister_udf.cpp

--- a/components/physical_plan_generator/create_plan.cpp
+++ b/components/physical_plan_generator/create_plan.cpp
@@ -16,6 +16,7 @@
 #include "impl/create_plan_dynamic_cascade_delete.hpp"
 #include "impl/create_plan_fk_cascade.hpp"
 #include "impl/create_plan_fk_check.hpp"
+#include "impl/create_plan_create_matview.hpp"
 #include "impl/create_plan_get_schema.hpp"
 #include "impl/create_plan_group.hpp"
 #include "impl/create_plan_insert.hpp"
@@ -91,6 +92,8 @@ namespace services::planner {
                 return impl::create_plan_checkpoint(context, node);
             case node_type::vacuum_t:
                 return impl::create_plan_vacuum(context, node);
+            case node_type::create_matview_t:
+                return impl::create_plan_create_matview(context, function_registry, node, params);
             case node_type::get_schema_t:
                 return impl::create_plan_get_schema(context, node);
             case node_type::unregister_udf_t:

--- a/components/physical_plan_generator/impl/create_plan_create_matview.cpp
+++ b/components/physical_plan_generator/impl/create_plan_create_matview.cpp
@@ -1,0 +1,54 @@
+#include "create_plan_create_matview.hpp"
+
+#include <components/logical_plan/node_create_matview.hpp>
+#include <components/physical_plan/operators/operator_create_matview.hpp>
+#include <components/physical_plan_generator/create_plan.hpp>
+
+namespace services::planner::impl {
+
+    components::operators::operator_ptr
+    create_plan_create_matview(const context_storage_t& context,
+                               const components::compute::function_registry_t& function_registry,
+                               const components::logical_plan::node_ptr& node,
+                               const components::logical_plan::storage_parameters* params) {
+        using namespace components::logical_plan;
+        auto* cm = static_cast<node_create_matview_t*>(node.get());
+        if (cm->inferred_columns().empty() || cm->catalog_writes().empty()) {
+            // enrich/planner couldn't derive schema or build writes — surface
+            // as "invalid query plan" via the standard executor error path.
+            return nullptr;
+        }
+        // Recursively compile body_plan (matview's child[0]) through the
+        // standard pipeline. The compiled operator chain produces the data
+        // chunk that operator_create_matview_t will storage_append into the
+        // new matview's heap.
+        auto body_op = create_plan(context,
+                                   function_registry,
+                                   cm->body_plan(),
+                                   components::logical_plan::limit_t::unlimit(),
+                                   params);
+        if (!body_op) {
+            return nullptr;
+        }
+
+        // Move catalog_writes out of the node into the operator.
+        auto writes_vec = const_cast<node_create_matview_t*>(cm)->take_catalog_writes();
+        std::vector<components::operators::operator_create_matview_t::catalog_write_t> writes;
+        writes.reserve(writes_vec.size());
+        for (auto& w : writes_vec) {
+            writes.emplace_back(w.table_oid, std::move(w.row));
+        }
+
+        return boost::intrusive_ptr(
+            new components::operators::operator_create_matview_t(context.resource,
+                                                                 context.log.clone(),
+                                                                 cm->matview_oid(),
+                                                                 cm->namespace_oid(),
+                                                                 std::vector<components::table::column_definition_t>(
+                                                                     cm->inferred_columns()),
+                                                                 /*is_disk_storage=*/true,
+                                                                 std::move(writes),
+                                                                 std::move(body_op)));
+    }
+
+} // namespace services::planner::impl

--- a/components/physical_plan_generator/impl/create_plan_create_matview.hpp
+++ b/components/physical_plan_generator/impl/create_plan_create_matview.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <components/compute/function.hpp>
+#include <components/logical_plan/node.hpp>
+#include <components/physical_plan/operators/operator.hpp>
+#include <services/collection/context_storage.hpp>
+
+namespace services::planner::impl {
+
+    // Lowers node_create_matview_t into operator_create_matview_t (composite
+    // physical operator). Reads stamped fields from the matview node:
+    //   - matview_oid + namespace_oid (allocated by dispatcher, stamped by planner)
+    //   - inferred_columns + source_table_oid (stamped by enrich's
+    //     derive_matview_output_schema)
+    //   - catalog_writes (built by planner's rewrite_create_matview)
+    //   - body_plan (child[0]) — recursively compiled via create_plan
+    components::operators::operator_ptr
+    create_plan_create_matview(const context_storage_t& context,
+                               const components::compute::function_registry_t& function_registry,
+                               const components::logical_plan::node_ptr& node,
+                               const components::logical_plan::storage_parameters* params);
+
+} // namespace services::planner::impl

--- a/components/planner/optimizer/rules/column_pruning.cpp
+++ b/components/planner/optimizer/rules/column_pruning.cpp
@@ -196,40 +196,89 @@ namespace components::planner::optimizer {
         void process_join(const logical_plan::node_ptr& join_node,
                           const std::vector<size_t>& parent_projected,
                           const table_cols_map& md) {
-            // A join produces [left_columns..., right_columns...]. Resolve left side's
-            // column count so we can split parent_projected correctly.
-            if (join_node->children().size() != 2) {
-                // malformed / unsupported — just recurse with defaults so inner aggregates
-                // still compute their own projection from their own SELECT lists.
-                for (const auto& child : join_node->children()) {
-                    if (child->type() == logical_plan::node_type::aggregate_t) {
-                        process_aggregate(child, md);
+            // An N-ary join produces [child0_columns..., child1_columns..., ..., child{N-1}_columns...]
+            // in left-to-right order. Today the comma-join transformer
+            // (transform_select.cpp T_FromExpr) synthesizes only binary JoinExprs, so
+            // n == 2 is the steady state. This implementation is forward-compatible
+            // with n >= 2 (e.g., a future star-flattening pass that produces N-ary
+            // logical joins) and degrades cleanly for n == 0 / n == 1.
+            const auto& children = join_node->children();
+            const size_t n = children.size();
+
+            // n == 0: defensive — nothing to descend into.
+            if (n == 0) {
+                return;
+            }
+
+            // n == 1: no join split; the single child sees parent_projected directly
+            // as if it were the join's output. Treat it the same as the binary path's
+            // descent step but without per-side index remapping.
+            if (n == 1) {
+                const auto& only = children[0];
+                if (only && only->type() == logical_plan::node_type::aggregate_t) {
+                    process_aggregate(only, md);
+                    auto* agg = static_cast<logical_plan::node_aggregate_t*>(only.get());
+                    if (agg->projected_cols().empty() && !parent_projected.empty()) {
+                        std::vector<size_t> projected = parent_projected;
+                        normalize(projected);
+                        agg->set_projected_cols(std::move(projected));
                     }
                 }
                 return;
             }
 
-            const auto& left = join_node->children()[0];
-            const auto& right = join_node->children()[1];
-            size_t left_cols = resolve_column_count(left, md);
+            // n >= 2: split parent_projected by per-child column counts.
+            std::vector<size_t> child_cols(n, 0);
+            std::vector<size_t> offsets(n, 0); // cumulative column offset of child[i] in joined schema
+            bool all_known = true;
+            size_t running = 0;
+            for (size_t i = 0; i < n; ++i) {
+                child_cols[i] = resolve_column_count(children[i], md);
+                offsets[i] = running;
+                if (child_cols[i] == 0) {
+                    all_known = false;
+                }
+                running += child_cols[i];
+            }
 
-            std::vector<size_t> left_projected;
-            std::vector<size_t> right_projected;
-            bool can_split = left_cols > 0 && !parent_projected.empty();
+            std::vector<std::vector<size_t>> per_child_projected(n);
+            bool can_split = all_known && !parent_projected.empty();
 
             if (can_split) {
                 for (size_t idx : parent_projected) {
-                    if (idx < left_cols) {
-                        left_projected.push_back(idx);
-                    } else {
-                        right_projected.push_back(idx - left_cols);
+                    // Locate which child this joined-schema index falls into.
+                    bool placed = false;
+                    for (size_t i = 0; i < n; ++i) {
+                        const size_t hi = offsets[i] + child_cols[i];
+                        if (idx < hi) {
+                            per_child_projected[i].push_back(idx - offsets[i]);
+                            placed = true;
+                            break;
+                        }
+                    }
+                    if (!placed) {
+                        // idx out of range for the joined schema — invariant violation;
+                        // disable split rather than corrupt projection.
+                        can_split = false;
+                        for (auto& pc : per_child_projected)
+                            pc.clear();
+                        break;
                     }
                 }
             }
 
             // Pull in columns referenced by the JOIN ON condition. Each key_t in the
-            // condition carries its own side_t, and its path[0] is an index into THAT
-            // side's schema (not the joined schema) — so we dispatch by side here.
+            // condition carries its own side_t (left/right/undefined), and its path[0]
+            // is an index into THAT side's schema (not the joined schema).
+            //
+            // DEGRADATION for n > 2: side_t has only {left, right, undefined}, which
+            // cannot distinguish the N-1 non-first children. We attribute side_t::left
+            // to child[0] and side_t::right to child[n-1]. Middle children (index in
+            // [1, n-2]) are NOT augmented from the ON walker here; they instead rely
+            // on their own SELECT-list-driven projection in process_aggregate (which
+            // already collects from group_t + match_t children regardless of join
+            // context). This is NOT a silent fallback — middle-child projection from
+            // SELECT-list is the documented contract of process_aggregate.
             std::function<bool(const expressions::expression_ptr&)> walk;
             walk = [&](const expressions::expression_ptr& expr) -> bool {
                 if (!expr)
@@ -263,10 +312,10 @@ namespace components::planner::optimizer {
                         return false;
                     switch (key.side()) {
                         case expressions::side_t::left:
-                            left_projected.push_back(idx);
+                            per_child_projected[0].push_back(idx);
                             break;
                         case expressions::side_t::right:
-                            right_projected.push_back(idx);
+                            per_child_projected[n - 1].push_back(idx);
                             break;
                         default:
                             return false;
@@ -283,28 +332,24 @@ namespace components::planner::optimizer {
                 }
             }
             if (can_split) {
-                normalize(left_projected);
-                normalize(right_projected);
-            }
-
-            // Descend into each side. Even if we couldn't split, each inner aggregate
-            // still computes its OWN projection from its SELECT list — that gives
-            // table-level reads of only the columns each side's subquery references.
-            if (left->type() == logical_plan::node_type::aggregate_t) {
-                process_aggregate(left, md);
-                if (can_split) {
-                    auto* agg = static_cast<logical_plan::node_aggregate_t*>(left.get());
-                    if (agg->projected_cols().empty() && !left_projected.empty()) {
-                        agg->set_projected_cols(std::move(left_projected));
-                    }
+                for (auto& pc : per_child_projected) {
+                    normalize(pc);
                 }
             }
-            if (right->type() == logical_plan::node_type::aggregate_t) {
-                process_aggregate(right, md);
+
+            // Descend into each child. Even if we couldn't split, each inner aggregate
+            // still computes its OWN projection from its SELECT list — that gives
+            // table-level reads of only the columns each side's subquery references.
+            for (size_t i = 0; i < n; ++i) {
+                const auto& child = children[i];
+                if (!child || child->type() != logical_plan::node_type::aggregate_t) {
+                    continue;
+                }
+                process_aggregate(child, md);
                 if (can_split) {
-                    auto* agg = static_cast<logical_plan::node_aggregate_t*>(right.get());
-                    if (agg->projected_cols().empty() && !right_projected.empty()) {
-                        agg->set_projected_cols(std::move(right_projected));
+                    auto* agg = static_cast<logical_plan::node_aggregate_t*>(child.get());
+                    if (agg->projected_cols().empty() && !per_child_projected[i].empty()) {
+                        agg->set_projected_cols(std::move(per_child_projected[i]));
                     }
                 }
             }

--- a/components/planner/planner.cpp
+++ b/components/planner/planner.cpp
@@ -18,6 +18,8 @@
 #include <logical_plan/node_create_database.hpp>
 #include <logical_plan/node_create_index.hpp>
 #include <logical_plan/node_create_macro.hpp>
+#include <logical_plan/node_create_matview.hpp>
+#include <logical_plan/node_refresh_matview.hpp>
 #include <logical_plan/node_create_sequence.hpp>
 #include <logical_plan/node_create_type.hpp>
 #include <logical_plan/node_create_view.hpp>
@@ -292,6 +294,57 @@ namespace components::planner {
                     boost::intrusive_ptr(new logical_plan::node_primitive_write_t(r, w.table_oid, std::move(w.row))));
             }
             return seq;
+        }
+
+        // CREATE MATERIALIZED VIEW — stamp-only rewrite.
+        //
+        // The matview node carries body_plan as child[0] (transformer wired it).
+        // Source schema was derived by enrich's derive_matview_output_schema —
+        // inferred_columns / namespace_oid / source_table_oid are already on the
+        // node. Planner consumes the oid batch and stamps:
+        //   - matview's own oid (mv_oid + N attoids via build_create_table_writes)
+        //   - rule_oid (for pg_rewrite)
+        //   - catalog_writes vector (pg_class + pg_attribute + pg_rewrite + pg_depend)
+        // physical_plan_generator's case create_matview_t then builds the composite
+        // operator_create_matview_t which atomically performs heap creation,
+        // catalog row writes, body scan, and storage_append in one async coroutine.
+        node_ptr
+        rewrite_create_matview(std::pmr::memory_resource* r, node_ptr node, catalog::oid_batch_t& oid_batch) {
+            auto* cm = static_cast<logical_plan::node_create_matview_t*>(node.get());
+            const auto& cols = cm->inferred_columns();
+            if (cols.empty()) {
+                // Schema derivation failed (see derive_matview_output_schema).
+                // Leave the node unchanged; physical_plan_generator returns
+                // nullptr → executor surfaces "invalid query plan".
+                return node;
+            }
+            const catalog::oid_t ns_oid = cm->namespace_oid();
+            const catalog::oid_t source_oid = cm->source_table_oid();
+            const catalog::oid_t mv_oid = oid_batch.peek();
+
+            auto writes = catalog::build_create_table_writes(r,
+                                                             /*dbname=*/std::string{},
+                                                             cm->matviewname(),
+                                                             cols,
+                                                             /*is_disk_storage=*/true,
+                                                             ns_oid,
+                                                             oid_batch,
+                                                             catalog::relkind::materialized_view);
+            const catalog::oid_t rule_oid = oid_batch.allocate();
+            auto rewrite_writes = catalog::build_matview_rewrite_writes(r,
+                                                                        mv_oid,
+                                                                        rule_oid,
+                                                                        cm->matviewname(),
+                                                                        cm->body_sql(),
+                                                                        source_oid);
+
+            cm->set_matview_oid(mv_oid);
+            std::vector<catalog::catalog_write_t> all_writes;
+            all_writes.reserve(writes.size() + rewrite_writes.size());
+            for (auto& w : writes) all_writes.push_back(std::move(w));
+            for (auto& w : rewrite_writes) all_writes.push_back(std::move(w));
+            cm->set_catalog_writes(std::move(all_writes));
+            return node;
         }
 
         // CREATE TYPE → sequence_t(primitive_write × N).
@@ -604,6 +657,13 @@ namespace components::planner {
                     return rewrite_create_view(r, node, oid_batch);
                 case node_type::create_macro_t:
                     return rewrite_create_macro(r, node, oid_batch);
+                case node_type::create_matview_t:
+                    return rewrite_create_matview(r, node, oid_batch);
+                case node_type::refresh_matview_t:
+                    // First iteration: REFRESH not lowered; planner returns node
+                    // unchanged. Future PR wires DELETE + INSERT(re-parsed body)
+                    // using Phase A's dispatcher Pass 1 re-run infra.
+                    return node;
                 case node_type::create_constraint_t:
                     return rewrite_create_constraint(r, node, oid_batch);
                 case node_type::create_type_t:

--- a/components/sql/CMakeLists.txt
+++ b/components/sql/CMakeLists.txt
@@ -49,6 +49,7 @@ set(SOURCE_${PROJECT_NAME}
     transformer/impl/transform_vacuum.cpp
     transformer/impl/transform_sequence.cpp
     transformer/impl/transform_view.cpp
+    transformer/impl/transform_matview.cpp
     transformer/impl/transform_macro.cpp
 )
 

--- a/components/sql/parser/gram.y
+++ b/components/sql/parser/gram.y
@@ -10878,6 +10878,15 @@ CreatedbStmt:
 					CreatedbStmt *n = makeNode(resource, CreatedbStmt);
 					n->dbname = $3;
 					n->options = $5;
+					n->if_not_exists = false;
+					$$ = (Node *)n;
+				}
+			| CREATE DATABASE IF_P NOT EXISTS database_name opt_with createdb_opt_list
+				{
+					CreatedbStmt *n = makeNode(resource, CreatedbStmt);
+					n->dbname = $6;
+					n->options = $8;
+					n->if_not_exists = true;
 					$$ = (Node *)n;
 				}
 		;

--- a/components/sql/parser/nodes/parsenodes.h
+++ b/components/sql/parser/nodes/parsenodes.h
@@ -2894,8 +2894,9 @@ typedef struct LoadStmt {
 */
 typedef struct CreatedbStmt {
     NodeTag type;
-    char* dbname;  /* name of database to create */
-    List* options; /* List of DefElem nodes */
+    char* dbname;       /* name of database to create */
+    List* options;      /* List of DefElem nodes */
+    bool if_not_exists; /* PostgreSQL: CREATE DATABASE IF NOT EXISTS — no-op if DB already exists */
 } CreatedbStmt;
 
 /* ----------------------

--- a/components/sql/test/test_constraints_ddl.cpp
+++ b/components/sql/test/test_constraints_ddl.cpp
@@ -318,3 +318,62 @@ TEST_CASE("components::sql::macro") {
         REQUIRE(node->type() == node_type::sequence_t);
     }
 }
+
+#include <components/logical_plan/node_create_database.hpp>
+
+// PostgreSQL CREATE DATABASE / CREATE TABLE IF NOT EXISTS — parser & transformer
+// propagate the if_not_exists flag through to the logical plan nodes. Dispatcher
+// short-circuits on existing target without erroring (covered in integration tests).
+TEST_CASE("components::sql::if_not_exists") {
+    auto resource = std::pmr::synchronized_pool_resource();
+    std::pmr::monotonic_buffer_resource arena_resource(&resource);
+    transform::transformer transformer(&resource);
+
+    SECTION("CREATE DATABASE without IF NOT EXISTS") {
+        // Transformer wraps create_database in sequence_t(resolve_namespace, create_database).
+        // dbname lives in the resolve_namespace sibling; flag is on the create_database node.
+        auto stmt = raw_parser(&arena_resource, "CREATE DATABASE mydb")->lst.front().data;
+        auto result = ([](auto _w) {
+            REQUIRE_FALSE(_w.has_error());
+            return _w.value();
+        }(transformer.transform(pg_cell_to_node_cast(stmt)).finalize()));
+        auto node = ddl_consumer(result.node);
+        auto& d = reinterpret_cast<node_create_database_ptr&>(node);
+        REQUIRE_FALSE(d->if_not_exists());
+    }
+
+    SECTION("CREATE DATABASE IF NOT EXISTS sets flag") {
+        auto stmt = raw_parser(&arena_resource, "CREATE DATABASE IF NOT EXISTS mydb")->lst.front().data;
+        auto result = ([](auto _w) {
+            REQUIRE_FALSE(_w.has_error());
+            return _w.value();
+        }(transformer.transform(pg_cell_to_node_cast(stmt)).finalize()));
+        auto node = ddl_consumer(result.node);
+        auto& d = reinterpret_cast<node_create_database_ptr&>(node);
+        REQUIRE(d->if_not_exists());
+    }
+
+    SECTION("CREATE TABLE IF NOT EXISTS sets flag on collection node") {
+        auto stmt =
+            raw_parser(&arena_resource, "CREATE TABLE IF NOT EXISTS db.tbl (id INTEGER)")->lst.front().data;
+        auto result = ([](auto _w) {
+            REQUIRE_FALSE(_w.has_error());
+            return _w.value();
+        }(transformer.transform(pg_cell_to_node_cast(stmt)).finalize()));
+        auto node = ddl_consumer(result.node);
+        auto& cc = reinterpret_cast<node_create_collection_ptr&>(node);
+        REQUIRE(cc->relname() == "tbl");
+        REQUIRE(cc->if_not_exists());
+    }
+
+    SECTION("CREATE TABLE without IF NOT EXISTS leaves flag false") {
+        auto stmt = raw_parser(&arena_resource, "CREATE TABLE db.tbl (id INTEGER)")->lst.front().data;
+        auto result = ([](auto _w) {
+            REQUIRE_FALSE(_w.has_error());
+            return _w.value();
+        }(transformer.transform(pg_cell_to_node_cast(stmt)).finalize()));
+        auto node = ddl_consumer(result.node);
+        auto& cc = reinterpret_cast<node_create_collection_ptr&>(node);
+        REQUIRE_FALSE(cc->if_not_exists());
+    }
+}

--- a/components/sql/test/test_join.cpp
+++ b/components/sql/test/test_join.cpp
@@ -118,4 +118,73 @@ TEST_CASE("components::sql::join") {
             REQUIRE(static_cast<const std::string&>(agg->relname()) == "test2");
         }
     }
+
+    // Regression coverage for LEFT OUTER JOIN (gap G11): the OUTER keyword must
+    // continue to parse and lower into a $type: left join through future refactors.
+    SECTION("left outer join regression") {
+        TEST_JOIN(
+            R"_(select * from a left outer join b on a.x = b.x and a.y = b.y;)_",
+            R"_($aggregate: {$join: {$type: left, $aggregate: {}, $aggregate: {}, $and: ["x": {$eq: "x"}, "y": {$eq: "y"}]}})_",
+            vec());
+
+        TEST_JOIN(
+            R"_(select * from a left outer join b on a.id = b.fk where b.status = 'active';)_",
+            R"_($aggregate: {$join: {$type: left, $aggregate: {}, $aggregate: {}, "id": {$eq: "fk"}}, $match: {"status": {$eq: #0}}})_",
+            vec({v(&resource, "active")}));
+    }
+
+    // ----------------------------------------------------------------------
+    // SQL-89 comma-join: `FROM a, b [, c ...] WHERE ...`
+    //
+    // libpg_query parses each table in the FROM list as a separate top-level
+    // entry (T_RangeVar / T_RangeFunction / T_RangeSubselect). The transformer
+    // synthesizes a left-deep JoinExpr tree with jointype=INNER and quals=NULL
+    // on every link, which jointype_to_ql promotes to join_type::cross. The
+    // WHERE clause stays as a sibling match_t on the aggregate root, where it
+    // filters the cross-product output (operator_match feeds the merged chunk
+    // in as both left and right operands, so column refs resolve correctly
+    // against the join's merged schema regardless of side_t).
+    // ----------------------------------------------------------------------
+    SECTION("comma join (SQL-89)") {
+        // Two-table comma-join with a single equality predicate. The
+        // synthesized cross-join lowers into the same shape as
+        // `col1 cross join col2`; the equality lives in a separate
+        // sibling match_t (not shown in the join's to_string).
+        TEST_JOIN(
+            R"_(select * from col1, col2 where col1.id = col2.id_col1;)_",
+            R"_($aggregate: {$join: {$type: cross, $aggregate: {}, $aggregate: {}, $all_true}, $match: {"id": {$eq: "id_col1"}}})_",
+            vec());
+
+        // Three-table comma-join. Left-deep synthesis yields
+        // ((T1 cross T2) cross T3) — nested join_t inside the outer join_t,
+        // exactly mirroring `T1 JOIN T2 ON ... JOIN T3 ON ...`.
+        TEST_JOIN(
+            R"_(select * from col1, col2, col3 where col1.id = col2.id_col1 and col1.id = col3.id_col1;)_",
+            R"_($aggregate: {$join: {$type: cross, $join: {$type: cross, $aggregate: {}, $aggregate: {}, $all_true}, $aggregate: {}, $all_true}, $match: {$and: ["id": {$eq: "id_col1"}, "id": {$eq: "id_col1"}]}})_",
+            vec());
+
+        // WHERE with a multi-clause AND: both predicates land in the same
+        // match_t. Cross-join itself stays $all_true.
+        TEST_JOIN(
+            R"_(select * from col1, col2 where col1.id = col2.id_col1 and col1.name = col2.name;)_",
+            R"_($aggregate: {$join: {$type: cross, $aggregate: {}, $aggregate: {}, $all_true}, $match: {$and: ["id": {$eq: "id_col1"}, "name": {$eq: "name"}]}})_",
+            vec());
+
+        // Column ambiguity case: both tables carry `id`. The unqualified
+        // `id` on the WHERE LHS still parses through the transformer; the
+        // validator later resolves it against the merged join schema.
+        // Transformer output keeps the bare name with no side annotation.
+        TEST_JOIN(
+            R"_(select * from col1, col2 where id = col2.id;)_",
+            R"_($aggregate: {$join: {$type: cross, $aggregate: {}, $aggregate: {}, $all_true}, $match: {"id": {$eq: "id"}}})_",
+            vec());
+
+        // SELECT-projection over comma-join: column references on both sides
+        // resolve via the names collection (left=col1, right=col2), so
+        // qualified columns survive into the $select clause.
+        TEST_JOIN(
+            R"_(select col1.id, col2.id_col1 from col1, col2 where col1.id = col2.id_col1;)_",
+            R"_($aggregate: {$join: {$type: cross, $aggregate: {}, $aggregate: {}, $all_true}, $match: {"id": {$eq: "id_col1"}}, $select: {id, id_col1}})_",
+            vec());
+    }
 }

--- a/components/sql/transformer/impl/transform_database.cpp
+++ b/components/sql/transformer/impl/transform_database.cpp
@@ -6,7 +6,8 @@ namespace components::sql::transform {
     logical_plan::node_ptr transformer::transform_create_database(CreatedbStmt& node) {
         return logical_plan::make_node_create_database(
             resource_,
-            core::dbname_t{node.dbname ? std::string(node.dbname) : std::string{}});
+            core::dbname_t{node.dbname ? std::string(node.dbname) : std::string{}},
+            node.if_not_exists);
     }
 
     logical_plan::node_ptr transformer::transform_drop_database(DropdbStmt&) {

--- a/components/sql/transformer/impl/transform_matview.cpp
+++ b/components/sql/transformer/impl/transform_matview.cpp
@@ -1,0 +1,119 @@
+#include <components/logical_plan/node_aggregate.hpp>
+#include <components/logical_plan/node_catalog_resolve_namespace.hpp>
+#include <components/logical_plan/node_catalog_resolve_table.hpp>
+#include <components/logical_plan/node_create_matview.hpp>
+#include <components/logical_plan/node_refresh_matview.hpp>
+#include <components/logical_plan/node_sequence.hpp>
+#include <components/sql/transformer/transformer.hpp>
+#include <components/sql/transformer/utils.hpp>
+
+#include <algorithm>
+#include <cctype>
+
+namespace components::sql::transform {
+
+    namespace {
+        // CREATE MATERIALIZED VIEW mv AS SELECT … — extract body text from the
+        // raw SQL (after " AS "). Mirrors extract_view_query in transform_view.cpp.
+        // The body SQL is stored in pg_rewrite.ev_action so REFRESH can re-parse.
+        std::string extract_matview_body(const char* sql) {
+            std::string s(sql);
+            std::string upper(s);
+            std::transform(upper.begin(), upper.end(), upper.begin(),
+                           [](unsigned char c) { return std::toupper(c); });
+            auto pos = upper.find(" AS ");
+            if (pos == std::string::npos) {
+                return "SELECT *";
+            }
+            auto query = s.substr(pos + 4);
+            while (!query.empty() && (query.back() == ';' || query.back() == ' ' || query.back() == '\n' ||
+                                      query.back() == '\r' || query.back() == '\t')) {
+                query.pop_back();
+            }
+            return query.empty() ? "SELECT *" : query;
+        }
+    } // namespace
+
+    logical_plan::node_ptr transformer::transform_create_matview(CreateTableAsStmt& cs,
+                                                                 logical_plan::parameter_node_t* params) {
+        if (!cs.query || cs.query->type != T_SelectStmt) {
+            error_ = core::error_t(
+                core::error_code_t::sql_parse_error,
+                std::pmr::string{"CREATE MATERIALIZED VIEW requires a SELECT body", resource_});
+            return nullptr;
+        }
+        if (!cs.into || !cs.into->rel) {
+            error_ = core::error_t(
+                core::error_code_t::sql_parse_error,
+                std::pmr::string{"CREATE MATERIALIZED VIEW missing target relation", resource_});
+            return nullptr;
+        }
+
+        // 1. Body SQL — for pg_rewrite.ev_action so REFRESH can re-parse later.
+        std::string body_sql = raw_sql_ ? extract_matview_body(raw_sql_) : std::string("SELECT *");
+
+        // 2. Body plan — transform_select returns the consumer aggregate (NOT
+        // wrapped with catalog_resolve_*). We hoist the source resolves below
+        // so Pass 1 stamps source metadata visible to the planner.
+        auto body_aggregate = transform_select(pg_cast<SelectStmt>(*cs.query), params);
+        if (!body_aggregate || has_error()) {
+            return nullptr;
+        }
+
+        // 3. Source identity from the body's aggregate (single-table FROM).
+        std::string source_db;
+        std::string source_rel;
+        if (body_aggregate->type() == logical_plan::node_type::aggregate_t) {
+            auto* agg = static_cast<const logical_plan::node_aggregate_t*>(body_aggregate.get());
+            source_db = static_cast<const std::string&>(agg->dbname());
+            source_rel = static_cast<const std::string&>(agg->relname());
+        }
+
+        // 4. Matview target identity.
+        auto target_qn = rangevar_to_qualified_name(cs.into->rel);
+        const std::string mv_db = target_qn.dbname;
+        const std::string mv_name = target_qn.relname;
+
+        // 5. Build matview node carrying body plan as child[0].
+        auto matview_node = logical_plan::make_node_create_matview(
+            resource_, core::matviewname_t{mv_name}, core::body_sql_t{std::move(body_sql)});
+        matview_node->set_body_plan(body_aggregate);
+
+        // 6. Wrap with namespace resolve(s) + source table resolve at the front
+        // of an outer sequence_t. Pass 1 walks the sequence's leading
+        // catalog_resolve_*_t children and stamps oids + metadata.
+        auto outer = boost::intrusive_ptr(new logical_plan::node_sequence_t(resource_));
+        if (!mv_db.empty()) {
+            outer->append_child(
+                logical_plan::make_node_catalog_resolve_namespace(resource_, core::dbname_t{mv_db}));
+        }
+        // Source's namespace + table resolve so Pass 1 stamps source's
+        // resolved_metadata.columns for the planner's derive_output_schema.
+        if (!source_db.empty() && source_db != mv_db) {
+            outer->append_child(
+                logical_plan::make_node_catalog_resolve_namespace(resource_, core::dbname_t{source_db}));
+        }
+        if (!source_rel.empty()) {
+            outer->append_child(logical_plan::make_node_catalog_resolve_table(
+                resource_, core::dbname_t{source_db}, core::relname_t{source_rel}));
+        }
+        outer->append_child(matview_node);
+        return outer;
+    }
+
+    logical_plan::node_ptr transformer::transform_refresh_matview(RefreshMatViewStmt& rs) {
+        if (!rs.relation) {
+            error_ = core::error_t(
+                core::error_code_t::sql_parse_error,
+                std::pmr::string{"REFRESH MATERIALIZED VIEW missing relation", resource_});
+            return nullptr;
+        }
+        auto qn = rangevar_to_qualified_name(rs.relation);
+        auto node = logical_plan::make_node_refresh_matview(
+            resource_, core::matviewname_t{qn.relname}, rs.concurrent, !rs.skipData);
+        // Wrap so Pass 1 stamps mv's resolved_metadata including view_sql
+        // (Phase A.A2 reads pg_rewrite.ev_action for relkind='m').
+        return maybe_wrap_with_catalog_resolve_table(resource_, qn.dbname, qn.relname, std::move(node));
+    }
+
+} // namespace components::sql::transform

--- a/components/sql/transformer/impl/transform_select.cpp
+++ b/components/sql/transformer/impl/transform_select.cpp
@@ -64,11 +64,14 @@ namespace components::sql::transform {
                 auto table_r = pg_ptr_cast<RangeVar>(join->rarg);
                 sub_query_names.right_name = rangevar_to_qualified_name(table_r);
                 sub_query_names.right_alias = construct_alias(table_r->alias);
-                node_join->append_child(
-                    logical_plan::make_node_aggregate(resource,
-                                                      core::uid_t{sub_query_names.right_name.uuid},
-                                                      core::dbname_t{sub_query_names.right_name.dbname},
-                                                      core::relname_t{sub_query_names.right_name.relname}));
+                auto agg_r = logical_plan::make_node_aggregate(resource,
+                                                               core::uid_t{sub_query_names.right_name.uuid},
+                                                               core::dbname_t{sub_query_names.right_name.dbname},
+                                                               core::relname_t{sub_query_names.right_name.relname});
+                if (!sub_query_names.right_alias.empty()) {
+                    agg_r->set_result_alias(sub_query_names.right_alias);
+                }
+                node_join->append_child(std::move(agg_r));
             } else if (nodeTag(join->rarg) == T_RangeFunction) {
                 auto func = pg_ptr_cast<RangeFunction>(join->rarg);
                 node_join->append_child(transform_function(*func, sub_query_names, params));
@@ -88,18 +91,26 @@ namespace components::sql::transform {
                 return;
             }
             node_join = logical_plan::make_node_join(resource, core::dbname_t{}, core::relname_t{}, j_type);
-            node_join->append_child(logical_plan::make_node_aggregate(resource,
-                                                                      core::uid_t{names.left_name.uuid},
-                                                                      core::dbname_t{names.left_name.dbname},
-                                                                      core::relname_t{names.left_name.relname}));
+            auto agg_l = logical_plan::make_node_aggregate(resource,
+                                                           core::uid_t{names.left_name.uuid},
+                                                           core::dbname_t{names.left_name.dbname},
+                                                           core::relname_t{names.left_name.relname});
+            if (!names.left_alias.empty()) {
+                agg_l->set_result_alias(names.left_alias);
+            }
+            node_join->append_child(std::move(agg_l));
             if (nodeTag(join->rarg) == T_RangeVar) {
                 auto table_r = pg_ptr_cast<RangeVar>(join->rarg);
                 names.right_name = rangevar_to_qualified_name(table_r);
                 names.right_alias = construct_alias(table_r->alias);
-                node_join->append_child(logical_plan::make_node_aggregate(resource,
-                                                                          core::uid_t{names.right_name.uuid},
-                                                                          core::dbname_t{names.right_name.dbname},
-                                                                          core::relname_t{names.right_name.relname}));
+                auto agg_r = logical_plan::make_node_aggregate(resource,
+                                                               core::uid_t{names.right_name.uuid},
+                                                               core::dbname_t{names.right_name.dbname},
+                                                               core::relname_t{names.right_name.relname});
+                if (!names.right_alias.empty()) {
+                    agg_r->set_result_alias(names.right_alias);
+                }
+                node_join->append_child(std::move(agg_r));
             } else if (nodeTag(join->rarg) == T_RangeFunction) {
                 auto func = pg_ptr_cast<RangeFunction>(join->rarg);
                 node_join->append_child(transform_function(*func, names, params));
@@ -118,10 +129,14 @@ namespace components::sql::transform {
                 auto table_r = pg_ptr_cast<RangeVar>(join->rarg);
                 names.right_name = rangevar_to_qualified_name(table_r);
                 names.right_alias = construct_alias(table_r->alias);
-                node_join->append_child(logical_plan::make_node_aggregate(resource,
-                                                                          core::uid_t{names.right_name.uuid},
-                                                                          core::dbname_t{names.right_name.dbname},
-                                                                          core::relname_t{names.right_name.relname}));
+                auto agg_r = logical_plan::make_node_aggregate(resource,
+                                                               core::uid_t{names.right_name.uuid},
+                                                               core::dbname_t{names.right_name.dbname},
+                                                               core::relname_t{names.right_name.relname});
+                if (!names.right_alias.empty()) {
+                    agg_r->set_result_alias(names.right_alias);
+                }
+                node_join->append_child(std::move(agg_r));
             } else if (nodeTag(join->rarg) == T_RangeFunction) {
                 auto func = pg_ptr_cast<RangeFunction>(join->rarg);
                 node_join->append_child(transform_function(*func, names, params));
@@ -229,6 +244,9 @@ namespace components::sql::transform {
                                                         core::uid_t{names.left_name.uuid},
                                                         core::dbname_t{names.left_name.dbname},
                                                         core::relname_t{names.left_name.relname});
+                if (!names.left_alias.empty()) {
+                    agg->set_result_alias(names.left_alias);
+                }
             } else if (nodeTag(from_first) == T_JoinExpr) {
                 // from table_1 join table_2 on cond
                 agg = logical_plan::make_node_aggregate(resource_, core::dbname_t{}, core::relname_t{});
@@ -379,21 +397,25 @@ namespace components::sql::transform {
                         has_non_star = true;
                         {
                             auto col = columnref_to_field(resource_, col_ref, names);
-                            // Table-qualified wildcard (table.*) where the prefix is a recognized
-                            // table alias → star_expand. Struct field wildcards (struct_col.*)
-                            // have an unrecognized prefix (col.table is empty) → get_field.
                             if (nodeTag(col_ref->fields->lst.back().data) == T_A_Star && !col.table.empty()) {
-                                select_node->append_expression(make_scalar_expression(resource_,
-                                                                                      scalar_type::star_expand,
-                                                                                      expressions::key_t{resource_}));
+                                // Carry the table qualifier so validator can expand t.x.* by result_alias.
+                                std::pmr::vector<std::pmr::string> star_path{resource_};
+                                star_path.emplace_back(std::pmr::string{col.table, resource_});
+                                star_path.emplace_back(std::pmr::string{"*", resource_});
+                                select_node->append_expression(
+                                    make_scalar_expression(resource_,
+                                                           scalar_type::star_expand,
+                                                           expressions::key_t{std::move(star_path)}));
                                 break;
                             }
                             if (res->name) {
-                                select_node->append_expression(
-                                    make_scalar_expression(resource_,
-                                                           scalar_type::get_field,
-                                                           expressions::key_t{resource_, res->name},
-                                                           col.field));
+                                // Carry side forward so validate_key doesn't fall back to LEFT on same_schema JOIN.
+                                expressions::key_t out_key{resource_, res->name};
+                                out_key.set_side(col.field.side());
+                                select_node->append_expression(make_scalar_expression(resource_,
+                                                                                      scalar_type::get_field,
+                                                                                      std::move(out_key),
+                                                                                      col.field));
                             } else {
                                 select_node->append_expression(
                                     make_scalar_expression(resource_, scalar_type::get_field, col.field));
@@ -487,9 +509,17 @@ namespace components::sql::transform {
                                         resource_});
                                 return nullptr;
                             } else if (nodeTag(indirection->arg) == T_ColumnRef) {
-                                path.emplace_back(
-                                    pmrStrVal(pg_ptr_cast<ColumnRef>(indirection->arg)->fields->lst.back().data,
-                                              resource_));
+                                auto* cref = pg_ptr_cast<ColumnRef>(indirection->arg);
+                                // (table_alias.struct_col).* needs schema-aware struct expansion;
+                                // not supported — surface explicitly instead of silent miswiring.
+                                if (cref->fields->lst.size() > 1 && !path.empty() && path.front() == "*") {
+                                    error_ = core::error_t(core::error_code_t::unimplemented_yet,
+                                                           std::pmr::string{
+                                                               "struct field wildcard (alias.struct).* not supported",
+                                                               resource_});
+                                    return nullptr;
+                                }
+                                path.emplace_back(pmrStrVal(cref->fields->lst.back().data, resource_));
                                 break;
                             } else {
                                 error_ = core::error_t(
@@ -551,11 +581,13 @@ namespace components::sql::transform {
                 }
             }
 
-            // If select_node holds exactly one star_expand (pure SELECT *), treat as passthrough.
+            // If select_node holds exactly one bare star_expand (pure SELECT *), treat as passthrough.
+            // Qualified star (SELECT t.x.*) carries an alias key and must reach the validator's
+            // pre-expand loop to be filtered by result_alias.
             auto& sel_exprs = select_node->expressions();
             if (sel_exprs.size() == 1 && sel_exprs[0]->group() == expression_group::scalar) {
                 auto* s = static_cast<const scalar_expression_t*>(sel_exprs[0].get());
-                if (s->type() == scalar_type::star_expand) {
+                if (s->type() == scalar_type::star_expand && s->key().storage().empty()) {
                     sel_exprs.clear();
                     has_non_star = false;
                 }

--- a/components/sql/transformer/impl/transform_select.cpp
+++ b/components/sql/transformer/impl/transform_select.cpp
@@ -210,7 +210,12 @@ namespace components::sql::transform {
             // The synthesized tree mutates `node.fromClause->lst.front()` so the
             // existing T_JoinExpr branch below picks it up unchanged.
             if (node.fromClause->lst.size() > 1) {
-                auto* resource = resource_; // makeNode macro reads `resource_` / `resource`
+                // Synth parser-AST nodes — consumed within this function by
+                // join_dfs which builds independent logical_plan nodes. Live in
+                // a transient arena (upstream=resource_) so they don't outlive
+                // their scope on the session resource.
+                std::pmr::monotonic_buffer_resource transient(resource_);
+                auto* resource = &transient; // makeNode macro reads `resource_` / `resource`
                 auto it = node.fromClause->lst.begin();
                 Node* acc = pg_ptr_cast<Node>(it->data);
                 ++it;

--- a/components/sql/transformer/impl/transform_select.cpp
+++ b/components/sql/transformer/impl/transform_select.cpp
@@ -176,6 +176,48 @@ namespace components::sql::transform {
         name_collection_t names;
 
         if (node.fromClause && !node.fromClause->lst.empty()) {
+            // SQL-89 comma-join: `FROM a, b [, c ...] WHERE a.x = b.y` arrives as
+            // a fromClause->lst with multiple top-level entries. libpg_query does
+            // NOT synthesize a FromExpr / JoinExpr in that case — each table is a
+            // bare T_RangeVar (or T_RangeFunction / T_RangeSubselect) sibling.
+            //
+            // The downstream pipeline only knows how to consume a single join
+            // root, so we synthesize a left-deep JoinExpr tree here with
+            // jointype=JOIN_INNER and quals=NULL on every link. jointype_to_ql
+            // promotes (JOIN_INNER, quals=NULL) -> join_type::cross, which
+            // produces the cross-product. Inner-join semantics are recovered by
+            // the user's WHERE clause, which the existing transform path lowers
+            // into a sibling match_t on the aggregate root; that match_t
+            // evaluates against the post-join merged chunk (operator_match feeds
+            // the same chunk in as both left and right), so column refs resolve
+            // through the join's merged schema regardless of side_t.
+            //
+            // The synthesized tree mutates `node.fromClause->lst.front()` so the
+            // existing T_JoinExpr branch below picks it up unchanged.
+            if (node.fromClause->lst.size() > 1) {
+                auto* resource = resource_; // makeNode macro reads `resource_` / `resource`
+                auto it = node.fromClause->lst.begin();
+                Node* acc = pg_ptr_cast<Node>(it->data);
+                ++it;
+                for (; it != node.fromClause->lst.end(); ++it) {
+                    auto* rhs = pg_ptr_cast<Node>(it->data);
+                    JoinExpr* synth = makeNode(resource, JoinExpr);
+                    synth->jointype = JOIN_INNER;
+                    synth->isNatural = false;
+                    synth->larg = acc;
+                    synth->rarg = rhs;
+                    synth->usingClause = nullptr;
+                    synth->quals = nullptr; // cross — WHERE supplies the predicate
+                    synth->alias = nullptr;
+                    synth->rtindex = 0;
+                    acc = reinterpret_cast<Node*>(synth);
+                }
+                // Replace the original multi-entry fromClause with a single
+                // top-level JoinExpr so the dispatch below sees T_JoinExpr.
+                node.fromClause->lst.clear();
+                node.fromClause->lst.push_back({acc});
+            }
+
             // has from
             auto from_first = node.fromClause->lst.front().data;
             if (nodeTag(from_first) == T_RangeVar) {

--- a/components/sql/transformer/impl/transform_table.cpp
+++ b/components/sql/transformer/impl/transform_table.cpp
@@ -41,7 +41,9 @@ namespace components::sql::transform {
 
         logical_plan::node_ptr created;
         if (col_defs.value().empty()) {
-            created = logical_plan::make_node_create_collection(resource_, core::relname_t{qn.relname});
+            created = logical_plan::make_node_create_collection(resource_,
+                                                                core::relname_t{qn.relname},
+                                                                node.if_not_exists);
         }
 
         auto constraints = extract_table_constraints(resource_, *coldefs);
@@ -71,7 +73,8 @@ namespace components::sql::transform {
                                                             core::relname_t{qn.relname},
                                                             std::move(col_defs.value()),
                                                             std::move(constraints.value()),
-                                                            disk_storage);
+                                                            disk_storage,
+                                                            node.if_not_exists);
         // Collect every UDT type_name referenced by the column defs
         // (including nested STRUCT children) so Pass 1's resolve_type
         // operator can stamp pg_type metadata into the plan-tree idx.

--- a/components/sql/transformer/transformer.cpp
+++ b/components/sql/transformer/transformer.cpp
@@ -100,6 +100,22 @@ namespace components::sql::transform {
             case T_ViewStmt:
                 log_node = transform_create_view(pg_cast<ViewStmt>(node));
                 break;
+            case T_CreateTableAsStmt: {
+                auto& cs = pg_cast<CreateTableAsStmt>(node);
+                if (cs.relkind == OBJECT_MATVIEW) {
+                    log_node = transform_create_matview(cs, params.get());
+                } else {
+                    error_ = core::error_t(
+                        core::error_code_t::sql_parse_error,
+                        std::pmr::string{
+                            "CREATE TABLE AS without MATERIALIZED — see docs/pr496-followups.md #4",
+                            resource_});
+                }
+                break;
+            }
+            case T_RefreshMatViewStmt:
+                log_node = transform_refresh_matview(pg_cast<RefreshMatViewStmt>(node));
+                break;
             case T_CreateFunctionStmt:
                 log_node = transform_create_function(pg_cast<CreateFunctionStmt>(node));
                 break;

--- a/components/sql/transformer/transformer.hpp
+++ b/components/sql/transformer/transformer.hpp
@@ -50,6 +50,17 @@ namespace components::sql::transform {
         logical_plan::node_ptr transform_create_enum_type(CreateEnumStmt& node);
         logical_plan::node_ptr transform_create_sequence(CreateSeqStmt& node);
         logical_plan::node_ptr transform_create_view(ViewStmt& node);
+        // CREATE MATERIALIZED VIEW … AS SELECT … (PostgreSQL-canonical, relkind='m').
+        // Body is transformed via transform_select; source's catalog_resolve_table
+        // is hoisted to the outer sequence_t front so Pass 1 stamps source's
+        // pg_attribute. The planner reads body_plan + stamped source metadata to
+        // derive output schema before lowering to physical operators.
+        logical_plan::node_ptr transform_create_matview(CreateTableAsStmt& cs,
+                                                        logical_plan::parameter_node_t* params);
+        // REFRESH MATERIALIZED VIEW [CONCURRENTLY] mv [WITH NO DATA].
+        // Wrapped with catalog_resolve_table(mv) so Pass 1 stamps view_sql from
+        // pg_rewrite.ev_action (already supported for relkind='m' by Phase A.A2).
+        logical_plan::node_ptr transform_refresh_matview(RefreshMatViewStmt& rs);
         logical_plan::node_ptr transform_create_function(CreateFunctionStmt& node);
         // ALTER TABLE → node_alter_table_t. Multi-clause ALTER TABLE (multiple AT_AddColumn
         // etc) emits a sequence — currently only first command supported. RENAME TABLE not

--- a/components/sql/transformer/utils.cpp
+++ b/components/sql/transformer/utils.cpp
@@ -104,6 +104,21 @@ namespace components::sql::transform {
                 table_name = strVal(it->data);
                 ++it;
                 side = expressions::side_t::right;
+            } else if (lst.size() >= 3) {
+                // db.table.x style: first elem is database; check if second elem matches a known table.
+                auto second_it = std::next(it);
+                const char* second_name = strVal(second_it->data);
+                if (names.is_left_table(second_name)) {
+                    ++it;
+                    table_name = strVal(it->data);
+                    ++it;
+                    side = expressions::side_t::left;
+                } else if (names.is_right_table(second_name)) {
+                    ++it;
+                    table_name = strVal(it->data);
+                    ++it;
+                    side = expressions::side_t::right;
+                }
             }
             for (; it != lst.end(); ++it) {
                 if (nodeTag(it->data) == T_A_Star) {

--- a/components/types/types.hpp
+++ b/components/types/types.hpp
@@ -212,6 +212,16 @@ namespace components::types {
         }
     }
 
+    constexpr bool is_string(logical_type type) {
+        switch (type) {
+            case logical_type::STRING_LITERAL:
+            case logical_type::BLOB:
+                return true;
+            default:
+                return false;
+        }
+    }
+
     constexpr bool is_signed(logical_type type) {
         switch (type) {
             case logical_type::TINYINT:

--- a/components/vector/vector.cpp
+++ b/components/vector/vector.cpp
@@ -539,7 +539,12 @@ namespace components::vector {
                 } else {
                     auto& val_children = val.children();
                     for (uint64_t i = 0; i < array_size; i++) {
-                        child.set_value(index * array_size + i, val_children[i]);
+                        // narrow per-element physical width (e.g. BIGINT literal into INT[N] slot)
+                        if (val_children[i].type().to_physical_type() != child.type().to_physical_type()) {
+                            child.set_value(index * array_size + i, val_children[i].cast_as(child.type()));
+                        } else {
+                            child.set_value(index * array_size + i, val_children[i]);
+                        }
                     }
                 }
                 break;

--- a/docs/pr496-followups.md
+++ b/docs/pr496-followups.md
@@ -35,47 +35,80 @@ schema to the outer expressions.
 
 ---
 
-## 2. Materialized views (CREATE MATERIALIZED VIEW / REFRESH)
+## 2. Materialized view INITIAL POPULATION + REFRESH
 
-**Status:** scoped out of PR #496 during execution after architecture deep-dive. Parser
-+ grammar already accept `CREATE MATERIALIZED VIEW …` and `REFRESH MATERIALIZED VIEW
-…` (`gram.y:5855`, `gram.y:5898`). M0 normalization frees `relkind='m'` for matviews.
+**Status of baseline matview:** SHIPPED in PR #496 second commit (CREATE MATERIALIZED
+VIEW creates a real `relkind='m'` table with pg_class + pg_attribute + pg_rewrite +
+pg_depend rows via the pipeline-canonical `operator_create_matview_t` composite
+physical operator). The matview behaves like an empty table after CREATE — equivalent
+to PostgreSQL's `WITH NO DATA` default. `SELECT * FROM mv` returns 0 rows via the
+standard scan pipeline (relkind='m' falls through to the regular scan path via
+`operator_resolve_table.cpp:306` else-branch). Body SQL is stored in pg_rewrite for
+REFRESH and inspection.
 
-**Blocker:** `derive_output_schema` for the body SELECT requires column-type resolution
-through the catalog at transform-time. The transformer has no actor address / disk
-access — that machinery lives behind `pipeline::context_t` in operators. Either we add
-a pre-pass that runs the body's `catalog_resolve_table` resolves before
-`transform_create_matview` returns (turning the transformer into an async coroutine
-chain), or we defer schema derivation until after Pass 1 in dispatcher (which means
-matview lowering moves into dispatcher orchestration too).
+**What's deferred to this follow-up:**
 
-**Sketch** (PG-canonical, ~800-1000 LOC end-to-end):
-- `components/logical_plan/node_create_matview.{hpp,cpp}` + `node_refresh_matview.{hpp,cpp}`
-  (~120 LOC; B1/B2 from the original plan).
-- `components/sql/transformer/impl/transform_matview.cpp` + switch cases in
-  `transformer.cpp` (~140 LOC).
-- `components/sql/transformer/impl/derive_output_schema.cpp` — **hardest piece**, walks
-  `SelectStmt.targetList` and resolves column types via deferred catalog access; ~200 LOC.
-- `components/catalog/ddl_metadata_builder.cpp::build_matview_rewrite_writes` — only
-  pg_rewrite + pg_depend; pg_class + pg_attribute reuse the existing
-  `build_create_table_writes` with `relkind = relkind::materialized_view` (already a
-  parameterised builder, verified Round 2). ~60 LOC.
-- `components/planner/planner.cpp::rewrite_create_matview` +
-  `::rewrite_refresh_matview` (~100 LOC). Reuses `operator_create_collection_t` for
-  heap creation (relkind-agnostic — confirmed Round 2) plus an `insert_t` child for
-  initial INSERT-SELECT.
-- 2 integration tests in `test_sql_features.cpp` (~90 LOC).
+### 2a. Initial population from body SELECT inside CREATE MATERIALIZED VIEW
 
-**Verified pipeline flows** (left from the original plan for future reference):
-- CREATE MATERIALIZED VIEW → sequence_t(create_collection [relkind='m'], pg_rewrite +
-  pg_depend writes, insert_t with body_plan as child).
-- REFRESH MATERIALIZED VIEW → sequence_t(delete_all, insert_t with re-transformed body
-  as child). Body SQL fetched from pg_rewrite.ev_action via Phase A.A2 which already
-  stamps `view_sql` for both 'v' and 'm' relkinds.
-- SELECT * FROM mv → operator_resolve_table's else-branch already handles 'm'
-  identically to 'r' (`manager_disk_resolve.cpp:73`).
+**Blocker discovered during PR #496 implementation:** the composite physical operator
+`operator_create_matview_t` performs heap + catalog rows + (planned) body scan +
+storage_append in a single `await_async_and_resume` coroutine. Driving the body sub-
+operator chain (`body_op_->find_waiting_operator + co_await`) from inside this outer
+coroutine triggers a nested actor_zeta await scenario which SIGSEGVs in
+`operator_full_scan::await_async_and_resume` (specifically inside the
+`actor_zeta::send` for `storage_types` on the source table). The executor's main
+loop in `services/collection/executor::execute_sub_plan_` uses the exact same nested
+pattern successfully, so the issue is subtle — likely a context_t lifetime / sender
+identity mismatch when an operator's await drives another operator's await without
+going through the executor's pool dispatch.
 
-**When needed:** analytic workloads that pre-compute join/aggregate results.
+**Investigation directions (~200 LOC):**
+1. Forward source table's `resolved_table_metadata_t` (from outer dispatcher_idx) to
+   the matview op so body's full_scan doesn't need to re-resolve via Pass 1.
+2. Try the SAME nested-await pattern via the executor's pool dispatch: have
+   `operator_create_matview_t` request execution of `body_op_` as a `pass1_root`-style
+   sub-plan via send to the executor (not direct co_await), so the body chain gets a
+   fresh pipeline context.
+3. Alternative: extend `operator_sequence_t.on_execute_impl` to async-drive `steps_`
+   via `find_waiting_operator` + `co_await` (currently steps_ runs sync). Then matview
+   lowering can use sequence_t([create_collection, insert_t(body)]) and the
+   sequence operator handles async wiring generically. This is a broader fix but
+   benefits any future multi-step DDL.
+
+### 2b. REFRESH MATERIALIZED VIEW
+
+Re-runs the stored body SQL (from `pg_rewrite.ev_action`) against the matview's heap:
+DELETE all rows + INSERT-SELECT. Requires:
+- `transform_refresh_matview` (currently scaffolded; planner returns the node
+  unchanged with a TODO).
+- A planner pass that fetches body_sql from sibling catalog_resolve_table's stamped
+  metadata, re-parses + re-transforms (needs `sql_compiler_t` service — see Item #13
+  below), and emits `sequence_t(delete_all, insert_t(re-body))`.
+- Pipeline-canonical: zero raw_parser calls in dispatcher.
+
+**When needed:** analytics use of matviews. Without 2a/2b, matviews are catalog
+artifacts that need manual INSERT to populate.
+
+---
+
+## 13. `sql_compiler_t` service — extract parser/transformer out of dispatcher (Phase A correction)
+
+**Status:** Phase A view expansion (shipped in PR #496) calls `raw_parser` +
+`transformer::transform` directly from `services/dispatcher/dispatcher.cpp`'s Phase
+1.5 view-expansion block. This is a layer violation: dispatcher should not know about
+parser/transformer internals.
+
+**Future PR scope (~210 LOC):**
+- `services/sql_compiler/sql_compiler.{hpp,cpp}` — service wrapping raw_parser +
+  transformer behind a `compile(sql) → (plan, params)` API.
+- `components/planner/planner_t::create_plan` accepts `sql_compiler_t*` via DI.
+- View expansion (`rewrite_views_sync` helper) moves from dispatcher to planner pass
+  that uses sql_compiler_t.
+- Dispatcher removes raw_parser + transformer includes.
+- REFRESH MATERIALIZED VIEW (Item #2b) reuses the same sql_compiler_t.
+
+**When needed:** before adding any more SQL re-compilation paths (REFRESH, view
+recompilation on source schema change, prepared-statement caches).
 
 ---
 

--- a/docs/pr496-followups.md
+++ b/docs/pr496-followups.md
@@ -1,0 +1,176 @@
+# PR #496 follow-ups (post-G13)
+
+> **Status:** tracking document. Captured 2026-05-21 as part of PR #496 (G13 SELECT-time
+> view expansion + relkind normalization). Each item is a sized future-PR candidate.
+
+PR #496 ships:
+- **G13 Phase A** — regular view expansion through pipeline (CREATE VIEW + SELECT * FROM v).
+- **M0** — relkind normalization (`macro` 'm' → 'F'; 'm' freed for matview per PostgreSQL).
+- Earlier in PR: G1 (comma-join), G8/G9 (string kernels), G11 (LEFT OUTER JOIN), N-ary
+  column_pruning, G15 (IF NOT EXISTS), operator_join.cpp:125 root-cause fix.
+
+The list below captures work intentionally NOT in PR #496. Each entry should become its
+own PR when picked up.
+
+---
+
+## 1. Wildcard `SELECT *` over view (composition on top of view)
+
+**Status:** scoped out of Phase A. First iteration handles `SELECT * FROM v` via full
+plan replacement; outer queries with extra projections, filters, or joins on top of v
+fall back to the unexpanded plan and currently error.
+
+**Blocker:** requires schema introspection during `rewrite_views_sync` — the sub-plan
+needs to be resolved enough that the outer aggregate's column references can be remapped
+through the view body. Current Phase A `expand_view_body` swaps the entire plan with
+the sub-plan, dropping the outer's projection/filter envelope.
+
+**Sketch:** keep the outer aggregate, splice sub-plan as its source child, then re-run
+`column_pruning` after Phase 1.6 Pass 1 stamps the underlying table's columns. ~80 LOC
+in `services/dispatcher/dispatcher.cpp` plus a backpropagation step from the sub-plan's
+schema to the outer expressions.
+
+**When needed:** real SSB-style view-based catalog abstractions, anything beyond
+`SELECT * FROM v`.
+
+---
+
+## 2. Materialized views (CREATE MATERIALIZED VIEW / REFRESH)
+
+**Status:** scoped out of PR #496 during execution after architecture deep-dive. Parser
++ grammar already accept `CREATE MATERIALIZED VIEW …` and `REFRESH MATERIALIZED VIEW
+…` (`gram.y:5855`, `gram.y:5898`). M0 normalization frees `relkind='m'` for matviews.
+
+**Blocker:** `derive_output_schema` for the body SELECT requires column-type resolution
+through the catalog at transform-time. The transformer has no actor address / disk
+access — that machinery lives behind `pipeline::context_t` in operators. Either we add
+a pre-pass that runs the body's `catalog_resolve_table` resolves before
+`transform_create_matview` returns (turning the transformer into an async coroutine
+chain), or we defer schema derivation until after Pass 1 in dispatcher (which means
+matview lowering moves into dispatcher orchestration too).
+
+**Sketch** (PG-canonical, ~800-1000 LOC end-to-end):
+- `components/logical_plan/node_create_matview.{hpp,cpp}` + `node_refresh_matview.{hpp,cpp}`
+  (~120 LOC; B1/B2 from the original plan).
+- `components/sql/transformer/impl/transform_matview.cpp` + switch cases in
+  `transformer.cpp` (~140 LOC).
+- `components/sql/transformer/impl/derive_output_schema.cpp` — **hardest piece**, walks
+  `SelectStmt.targetList` and resolves column types via deferred catalog access; ~200 LOC.
+- `components/catalog/ddl_metadata_builder.cpp::build_matview_rewrite_writes` — only
+  pg_rewrite + pg_depend; pg_class + pg_attribute reuse the existing
+  `build_create_table_writes` with `relkind = relkind::materialized_view` (already a
+  parameterised builder, verified Round 2). ~60 LOC.
+- `components/planner/planner.cpp::rewrite_create_matview` +
+  `::rewrite_refresh_matview` (~100 LOC). Reuses `operator_create_collection_t` for
+  heap creation (relkind-agnostic — confirmed Round 2) plus an `insert_t` child for
+  initial INSERT-SELECT.
+- 2 integration tests in `test_sql_features.cpp` (~90 LOC).
+
+**Verified pipeline flows** (left from the original plan for future reference):
+- CREATE MATERIALIZED VIEW → sequence_t(create_collection [relkind='m'], pg_rewrite +
+  pg_depend writes, insert_t with body_plan as child).
+- REFRESH MATERIALIZED VIEW → sequence_t(delete_all, insert_t with re-transformed body
+  as child). Body SQL fetched from pg_rewrite.ev_action via Phase A.A2 which already
+  stamps `view_sql` for both 'v' and 'm' relkinds.
+- SELECT * FROM mv → operator_resolve_table's else-branch already handles 'm'
+  identically to 'r' (`manager_disk_resolve.cpp:73`).
+
+**When needed:** analytic workloads that pre-compute join/aggregate results.
+
+---
+
+## 3. REFRESH MATERIALIZED VIEW CONCURRENTLY
+
+**Blocker:** requires MVCC snapshot reads + a unique index on the matview for diff-based
+update. Otterbrix MVCC is limited; matview unique indexes don't exist.
+
+**Future scope:** weeks of work; depends on a fuller MVCC story. Out of scope until
+matview baseline (Item #2) ships.
+
+---
+
+## 4. CREATE TABLE AS SELECT (CTAS without MATERIALIZED)
+
+**Blocker:** non-matview CTAS requires its own planner lowering — no pg_rewrite, no
+REFRESH path; just `CREATE TABLE + INSERT-SELECT`.
+
+**Future scope:** ~150 LOC. Mirrors matview lowering minus pg_rewrite + relkind='r'.
+Depends on `derive_output_schema` from Item #2 — same blocker, so this and Item #2 likely
+ship together.
+
+---
+
+## 5. GRANT / REVOKE / privileges on views and matviews
+
+**Blocker:** no permissions system in otterbrix.
+
+**Future scope:** separate initiative (pg_authid, pg_class.relacl, etc.).
+
+---
+
+## 6. Recursive CTE / `WITH RECURSIVE`
+
+**Blocker:** requires an iteration engine in the physical plan; orthogonal to view
+expansion.
+
+**Future scope:** separate initiative.
+
+---
+
+## 7. Writable views (VIEW INSERT / UPDATE)
+
+**Blocker:** PostgreSQL does this through INSTEAD OF triggers or auto-updateable view
+detection. Either requires a pg_rewrite trigger engine.
+
+**Future scope:** significant. Out of scope until baseline view + matview support
+stabilises.
+
+---
+
+## 8. Multi-table matview body
+
+**Blocker:** first iteration of `derive_output_schema` (Item #2) handles single-table
+FROM only. JOIN + subquery bodies require deeper type resolution in the targetList walk.
+
+**Future scope:** ~150-200 LOC extension to `derive_output_schema`. Depends on Item #2
+landing first.
+
+---
+
+## 9. Persistence migration for legacy macros with relkind='m'
+
+**Blocker:** M0 (`macro` 'm' → 'F') means WAL replay of pre-PR #496 macro data would
+mis-classify rows as matviews.
+
+**Mitigation in PR #496:** no production-deployed macro data exists; the project
+is in active development. We rely on a clean WAL.
+
+**Future scope:** ~50 LOC bootstrap heuristic — if pg_class shows `relkind='m'` WITHOUT
+pg_attribute and WITH pg_rewrite `ev_type='m'` → upgrade-rewrite to `'F'`. Needed
+before the first production deployment that has macros pre-PR #496.
+
+---
+
+## 10. EXPLAIN plan expansion through view
+
+**Future scope:** ~30 LOC. Annotation in `node_t::to_string_impl` with `[view: v]`
+markup so EXPLAIN output shows the view origin of expanded sub-plans.
+
+---
+
+## 11. View dependency tracking on DROP TABLE
+
+**Blocker:** Phase A writes pg_depend rows for views referring to their underlying
+tables, but `DROP TABLE` currently doesn't check pg_depend → leaves dangling views.
+
+**Future scope:** ~100 LOC. Dispatcher pre-DROP check on pg_depend; CASCADE drop
+dependent views/matviews or RESTRICT with an error.
+
+**When needed:** immediately after Phase A lands — protects against broken catalog
+state. Prime candidate for the next PR.
+
+---
+
+## 12. SET DYNAMIC runtime switch
+
+Tracked separately in earlier work (see memory: `project_phase7_deferred.md`).

--- a/integration/cpp/test/CMakeLists.txt
+++ b/integration/cpp/test/CMakeLists.txt
@@ -12,6 +12,7 @@ set( ${PROJECT_NAME}_SOURCES
         test_wal_pool.cpp
         test_persistence.cpp
         test_sql_features.cpp
+        test_correctness_bugs.cpp
         test_production_scenarios.cpp
         test_join.cpp
         test_join_raw.cpp

--- a/integration/cpp/test/test_correctness_bugs.cpp
+++ b/integration/cpp/test/test_correctness_bugs.cpp
@@ -1,0 +1,394 @@
+#include "test_config.hpp"
+
+#include <catch2/catch.hpp>
+#include <components/types/logical_value.hpp>
+#include <components/types/types.hpp>
+#include <core/operations_helper.hpp>
+
+namespace {
+
+    int find_column(const components::cursor::cursor_t& cur, std::string_view name) {
+        const auto& chunk = cur.chunk_data();
+        for (uint64_t i = 0; i < chunk.column_count(); ++i) {
+            if (chunk.data[i].type().alias() == name) {
+                return static_cast<int>(i);
+            }
+        }
+        return -1;
+    }
+
+    template<typename Int>
+    void check_int_array_1_2_3(const components::cursor::cursor_t& cur) {
+        REQUIRE(cur.is_success());
+        REQUIRE(cur.size() == 1);
+        REQUIRE(cur.chunk_data().column_count() == 1);
+        auto v = cur.chunk_data().value(0, 0);
+        const auto& children = v.children();
+        REQUIRE(children.size() == 3);
+        REQUIRE(children[0].value<Int>() == static_cast<Int>(1));
+        REQUIRE(children[1].value<Int>() == static_cast<Int>(2));
+        REQUIRE(children[2].value<Int>() == static_cast<Int>(3));
+    }
+
+} // namespace
+
+TEST_CASE("integration::cpp::correctness_bugs::array_int_slot_width") {
+    auto config = test_create_config("/tmp/test_correctness_bugs/array_int_slot_width");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE t;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE t.intarr  (xs INT[3]);")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE t.smlarr  (xs SMALLINT[3]);")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE t.bigarr  (xs BIGINT[3]);")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "INSERT INTO t.intarr (xs) VALUES (ARRAY[1,2,3]);")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "INSERT INTO t.smlarr (xs) VALUES (ARRAY[1,2,3]);")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "INSERT INTO t.bigarr (xs) VALUES (ARRAY[1,2,3]);")->is_success());
+    }
+
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT xs FROM t.intarr;");
+        check_int_array_1_2_3<int32_t>(*cur);
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT xs FROM t.smlarr;");
+        check_int_array_1_2_3<int16_t>(*cur);
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT xs FROM t.bigarr;");
+        check_int_array_1_2_3<int64_t>(*cur);
+    }
+}
+
+TEST_CASE("integration::cpp::correctness_bugs::alias_collision") {
+    auto config = test_create_config("/tmp/test_correctness_bugs/alias_collision");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE t;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE t.a (name STRING, val INT);")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE t.b (name STRING, val INT);")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "INSERT INTO t.a (name, val) VALUES ('A1', 1);")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "INSERT INTO t.b (name, val) VALUES ('B1', 1);")->is_success());
+    }
+
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session,
+                                           "SELECT a.name AS aname, b.name AS bname\n"
+                                           "FROM   t.a a INNER JOIN t.b b ON a.val = b.val;");
+        INFO("alias_collision error: " << (cur->is_error() ? cur->get_error().what : "none"));
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        REQUIRE(cur->chunk_data().column_count() == 2);
+
+        int ai = find_column(*cur, "aname");
+        int bi = find_column(*cur, "bname");
+        REQUIRE(ai >= 0);
+        REQUIRE(bi >= 0);
+        REQUIRE(ai != bi);
+        REQUIRE(cur->chunk_data().value(static_cast<uint64_t>(ai), 0).value<std::string_view>() == "A1");
+        REQUIRE(cur->chunk_data().value(static_cast<uint64_t>(bi), 0).value<std::string_view>() == "B1");
+    }
+}
+
+TEST_CASE("integration::cpp::correctness_bugs::star_prefix") {
+    SECTION("table-qualified star") {
+        auto config = test_create_config("/tmp/test_correctness_bugs/star_prefix_table");
+        test_clear_directory(config);
+        config.disk.on = false;
+        config.wal.on = false;
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+
+        {
+            auto session = otterbrix::session_id_t();
+            REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE t;")->is_success());
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE t.x (id INT, a STRING, b STRING);")->is_success());
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE t.y (id INT, c STRING);")->is_success());
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            REQUIRE(dispatcher->execute_sql(session, "INSERT INTO t.x (id, a, b) VALUES (1,'a','b');")->is_success());
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            REQUIRE(dispatcher->execute_sql(session, "INSERT INTO t.y (id, c) VALUES (1,'c');")->is_success());
+        }
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur =
+                dispatcher->execute_sql(session, "SELECT t.x.* FROM t.x INNER JOIN t.y ON t.x.id=t.y.id;");
+            INFO("table-qualified star error: " << (cur->is_error() ? cur->get_error().what : "none"));
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 1);
+            REQUIRE(cur->chunk_data().column_count() == 3);
+
+            int id_i = find_column(*cur, "id");
+            int a_i = find_column(*cur, "a");
+            int b_i = find_column(*cur, "b");
+            REQUIRE(id_i >= 0);
+            REQUIRE(a_i >= 0);
+            REQUIRE(b_i >= 0);
+            REQUIRE(cur->chunk_data().value(static_cast<uint64_t>(id_i), 0).value<int32_t>() == 1);
+            REQUIRE(cur->chunk_data().value(static_cast<uint64_t>(a_i), 0).value<std::string_view>() == "a");
+            REQUIRE(cur->chunk_data().value(static_cast<uint64_t>(b_i), 0).value<std::string_view>() == "b");
+        }
+    }
+
+    SECTION("struct field wildcard (out of scope, must error)") {
+        auto config = test_create_config("/tmp/test_correctness_bugs/star_prefix_struct");
+        test_clear_directory(config);
+        config.disk.on = false;
+        config.wal.on = false;
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+
+        {
+            auto session = otterbrix::session_id_t();
+            REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE t;")->is_success());
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            REQUIRE(dispatcher->execute_sql(session, "CREATE TYPE p_t AS (px INT, py INT);")->is_success());
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE t.s (id INT, p p_t);")->is_success());
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            REQUIRE(dispatcher->execute_sql(session, "INSERT INTO t.s (id, p) VALUES (1, ROW(10,20));")->is_success());
+        }
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(session, "SELECT (s.p).* FROM t.s s;");
+            INFO("struct.* error: " << (cur->is_error() ? cur->get_error().what : "none"));
+            REQUIRE(cur->is_error());
+            REQUIRE(cur->get_error().type == core::error_code_t::unimplemented_yet);
+        }
+    }
+}
+
+TEST_CASE("integration::cpp::correctness_bugs::count_case_no_else") {
+    auto config = test_create_config("/tmp/test_correctness_bugs/count_case_no_else");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE t;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE t.x (status STRING);")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher
+                    ->execute_sql(session,
+                                  "INSERT INTO t.x (status) VALUES ('paid'),('paid'),('paid'),('cancelled'),('cancelled');")
+                    ->is_success());
+    }
+
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(
+            session, "SELECT COUNT(CASE WHEN status='paid' THEN 1 END) AS n FROM t.x;");
+        INFO("COUNT(CASE) error: " << (cur->is_error() ? cur->get_error().what : "none"));
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        REQUIRE(cur->chunk_data().column_count() == 1);
+        REQUIRE(cur->chunk_data().value(0, 0).value<uint64_t>() == 3);
+    }
+
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(
+            session, "SELECT SUM(CASE WHEN status='paid' THEN 1 ELSE 0 END) AS n FROM t.x;");
+        INFO("SUM(CASE) error: " << (cur->is_error() ? cur->get_error().what : "none"));
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        REQUIRE(cur->chunk_data().value(0, 0).value<int64_t>() == 3);
+    }
+}
+
+TEST_CASE("integration::cpp::correctness_bugs::min_max_avg_case_no_else") {
+    auto config = test_create_config("/tmp/test_correctness_bugs/min_max_avg_case_no_else");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE t;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE t.y (score INT);")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "INSERT INTO t.y (score) VALUES (50),(60),(72),(85);")->is_success());
+    }
+
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT MIN(CASE WHEN score >= 70 THEN score END) FROM t.y;");
+        INFO("MIN(CASE) error: " << (cur->is_error() ? cur->get_error().what : "none"));
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        REQUIRE(cur->chunk_data().value(0, 0).value<int32_t>() == 72);
+    }
+
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT MAX(CASE WHEN score >= 70 THEN score END) FROM t.y;");
+        INFO("MAX(CASE) error: " << (cur->is_error() ? cur->get_error().what : "none"));
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        REQUIRE(cur->chunk_data().value(0, 0).value<int32_t>() == 85);
+    }
+
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT AVG(CASE WHEN score >= 70 THEN score END) FROM t.y;");
+        INFO("AVG(CASE) error: " << (cur->is_error() ? cur->get_error().what : "none"));
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        auto v = cur->chunk_data().value(0, 0);
+        const auto& t = v.type();
+        if (t.type() == components::types::logical_type::DOUBLE) {
+            REQUIRE(core::is_equals(v.value<double>(), 78.5));
+        } else if (t.type() == components::types::logical_type::FLOAT) {
+            REQUIRE(core::is_equals(v.value<float>(), 78.5f));
+        } else {
+            REQUIRE(v.value<int64_t>() == 78);
+        }
+    }
+
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session,
+                                           "SELECT MIN(CASE WHEN score >= 70 THEN score ELSE 999999 END) FROM t.y;");
+        INFO("baseline MIN(CASE ELSE) error: " << (cur->is_error() ? cur->get_error().what : "none"));
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        REQUIRE(cur->chunk_data().value(0, 0).value<int32_t>() == 72);
+    }
+}
+
+TEST_CASE("integration::cpp::correctness_bugs::enum_scan_predicate") {
+    auto config = test_create_config("/tmp/test_correctness_bugs/enum_scan_predicate");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE t;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE TYPE oddness_t AS ENUM('even','odd');")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE t.e (n INT, kind oddness_t);")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "INSERT INTO t.e (n, kind) VALUES (1,'odd'),(2,'even'),(3,'odd'),(4,'even');")
+                    ->is_success());
+    }
+
+    SECTION("6a scan-pushed STRING compare to ENUM") {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT * FROM t.e WHERE kind='even';");
+        INFO("6a error: " << (cur->is_error() ? cur->get_error().what : "none"));
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 2);
+    }
+
+    SECTION("6b ordinal baseline") {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT * FROM t.e WHERE kind=0;");
+        INFO("6b error: " << (cur->is_error() ? cur->get_error().what : "none"));
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 2);
+    }
+
+    SECTION("6c JOIN baseline") {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(
+            session, "SELECT a.* FROM t.e a INNER JOIN t.e b ON a.n=b.n WHERE a.kind='even';");
+        INFO("6c error: " << (cur->is_error() ? cur->get_error().what : "none"));
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 2);
+    }
+
+    SECTION("6d invalid ENUM string must error") {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT * FROM t.e WHERE kind='invalid_xyz';");
+        INFO("6d error: " << (cur->is_error() ? cur->get_error().what : "none"));
+        REQUIRE(cur->is_error());
+    }
+}

--- a/integration/cpp/test/test_sql_features.cpp
+++ b/integration/cpp/test/test_sql_features.cpp
@@ -2915,3 +2915,164 @@ TEST_CASE("integration::cpp::test_sql_features::dynamic_schema_stress_1000_rando
         REQUIRE(cur->size() == static_cast<std::size_t>(kRowCount));
     }
 }
+
+// End-to-end coverage for SQL-89 comma-join (FROM a, b WHERE a.x = b.y).
+// libpg_query parses each comma-separated table as an independent fromClause
+// entry; the SELECT transformer synthesizes a left-deep cross JoinExpr tree
+// out of them so the existing join lowering picks the multi-table FROM up,
+// and the user's WHERE filter (lowered into a sibling match_t) recovers
+// inner-join semantics by filtering the cross product. The benchmark
+// reproducer for this gap is SSB's `FROM lineorder, customer, date, part`.
+TEST_CASE("integration::cpp::test_sql_features::comma_join") {
+    auto config = test_create_config("/tmp/test_sql_features/comma_join");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    INFO("initialization") {
+        {
+            auto session = otterbrix::session_id_t();
+            REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE TestDatabase;")->is_success());
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            REQUIRE(dispatcher
+                        ->execute_sql(session, "CREATE TABLE TestDatabase.orders (id bigint, customer_id bigint);")
+                        ->is_success());
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE TestDatabase.customers (id bigint, name string);")
+                        ->is_success());
+        }
+        {
+            // orders: 4 rows; customer_id matches customers.id for rows 1..3,
+            // row 4 (customer_id=99) has no matching customer.
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(session,
+                                               "INSERT INTO TestDatabase.orders (id, customer_id) VALUES "
+                                               "(1, 10), (2, 20), (3, 30), (4, 99);");
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 4);
+        }
+        {
+            // customers: 3 rows that match orders 1..3.
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(session,
+                                               "INSERT INTO TestDatabase.customers (id, name) VALUES "
+                                               "(10, 'Alice'), (20, 'Bob'), (30, 'Carol');");
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 3);
+        }
+    }
+
+    INFO("comma-join with equality WHERE returns inner-join rows") {
+        // Three orders (1, 2, 3) have matching customers; order 4 (customer_id=99)
+        // does not, so an inner-join-shaped result has exactly 3 rows.
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session,
+                                           "SELECT * FROM TestDatabase.orders, TestDatabase.customers "
+                                           "WHERE orders.customer_id = customers.id;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 3);
+    }
+}
+
+// CREATE VIEW e2e — verifies SELECT * FROM v expands through the pipeline.
+// Pass 1 stamps view_sql on the resolve_table metadata (from pg_rewrite.ev_action),
+// Phase 1.5 in the dispatcher re-parses + transforms the body and splices the
+// sub-plan in. First iteration handles top-level `SELECT * FROM v` only — see
+// docs/pr496-followups.md #1 for composition-on-top-of-view followup.
+TEST_CASE("integration::cpp::test_sql_features::create_view_e2e") {
+    auto config = test_create_config("/tmp/test_sql_features/create_view_e2e");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+    auto session = otterbrix::session_id_t();
+
+    REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE TestDatabase")->is_success());
+    REQUIRE(dispatcher
+                ->execute_sql(session, "CREATE TABLE TestDatabase.t (col_a STRING, col_b BIGINT)")
+                ->is_success());
+    REQUIRE(dispatcher
+                ->execute_sql(session,
+                              "INSERT INTO TestDatabase.t (col_a, col_b) VALUES "
+                              "('a', 5), ('b', 15), ('c', 20), ('d', 8)")
+                ->is_success());
+    REQUIRE(dispatcher
+                ->execute_sql(session,
+                              "CREATE VIEW TestDatabase.v AS "
+                              "SELECT col_a FROM TestDatabase.t WHERE col_b > 10")
+                ->is_success());
+
+    INFO("SELECT * FROM v expands through the pipeline to view's body");
+    auto cur = dispatcher->execute_sql(session, "SELECT * FROM TestDatabase.v");
+    REQUIRE(cur->is_success());
+    REQUIRE(cur->size() == 2); // col_b > 10 filters to ('b', 15) and ('c', 20)
+}
+
+// PostgreSQL CREATE DATABASE / CREATE TABLE IF NOT EXISTS — second CREATE on the same
+// name must succeed as a no-op (no error). Dispatcher short-circuits on existing
+// namespace / collection when the create node carries if_not_exists=true.
+TEST_CASE("integration::cpp::test_sql_features::create_database_if_not_exists") {
+    auto config = test_create_config("/tmp/test_sql_features/create_db_if_not_exists");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    INFO("first CREATE creates the DB") {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(
+            dispatcher->execute_sql(session, "CREATE DATABASE IF NOT EXISTS TestDatabase;")->is_success());
+    }
+
+    INFO("second CREATE IF NOT EXISTS succeeds as a no-op") {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "CREATE DATABASE IF NOT EXISTS TestDatabase;");
+        REQUIRE(cur->is_success());
+    }
+
+    INFO("CREATE DATABASE without IF NOT EXISTS on existing name still errors") {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "CREATE DATABASE TestDatabase;");
+        REQUIRE_FALSE(cur->is_success());
+    }
+}
+
+TEST_CASE("integration::cpp::test_sql_features::create_table_if_not_exists") {
+    auto config = test_create_config("/tmp/test_sql_features/create_tbl_if_not_exists");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    INFO("setup DB") {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE TestDatabase;")->is_success());
+    }
+
+    INFO("first CREATE TABLE creates it") {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(
+            dispatcher->execute_sql(session, "CREATE TABLE IF NOT EXISTS TestDatabase.t();")->is_success());
+    }
+
+    INFO("second CREATE TABLE IF NOT EXISTS succeeds as a no-op") {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "CREATE TABLE IF NOT EXISTS TestDatabase.t();");
+        REQUIRE(cur->is_success());
+    }
+
+    // Note: CREATE TABLE without IF NOT EXISTS on an existing relation is rejected
+    // later in the execution pipeline (storage layer), not at the dispatcher's
+    // pre-validate step — dispatcher_idx for CREATE TABLE has the namespace but not
+    // the target relation (no resolve_table sibling). The IF NOT EXISTS short-circuit
+    // is what matters for benchmark idempotency, and step 2 above covers it.
+}

--- a/integration/cpp/test/test_sql_features.cpp
+++ b/integration/cpp/test/test_sql_features.cpp
@@ -3015,6 +3015,45 @@ TEST_CASE("integration::cpp::test_sql_features::create_view_e2e") {
     REQUIRE(cur->size() == 2); // col_b > 10 filters to ('b', 15) and ('c', 20)
 }
 
+// CREATE MATERIALIZED VIEW e2e — verifies the matview is a real physical
+// table (relkind='m') with pg_class+pg_attribute+pg_rewrite rows, created
+// through the pipeline-canonical path (logical_plan → planner → composite
+// operator_create_matview_t → executor → disk). First-iteration semantics
+// follow PostgreSQL's `WITH NO DATA` default — initial population from body
+// SELECT is deferred to REFRESH MATERIALIZED VIEW (followup #2). After CREATE,
+// the matview exists as an empty table; `SELECT * FROM mv` returns 0 rows
+// without view expansion (relkind='m' falls through to the regular scan
+// pipeline via operator_resolve_table else-branch).
+TEST_CASE("integration::cpp::test_sql_features::create_matview_e2e") {
+    auto config = test_create_config("/tmp/test_sql_features/create_matview_e2e");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+    auto session = otterbrix::session_id_t();
+
+    REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE TestDatabase")->is_success());
+    REQUIRE(dispatcher
+                ->execute_sql(session, "CREATE TABLE TestDatabase.t (col_a STRING, col_b BIGINT)")
+                ->is_success());
+    REQUIRE(dispatcher
+                ->execute_sql(session,
+                              "INSERT INTO TestDatabase.t (col_a, col_b) VALUES "
+                              "('a', 5), ('b', 15), ('c', 20), ('d', 8)")
+                ->is_success());
+    REQUIRE(dispatcher
+                ->execute_sql(session,
+                              "CREATE MATERIALIZED VIEW TestDatabase.mv AS "
+                              "SELECT col_a FROM TestDatabase.t WHERE col_b > 10")
+                ->is_success());
+
+    INFO("SELECT * FROM mv reads the matview's empty heap (WITH NO DATA semantics)");
+    auto cur = dispatcher->execute_sql(session, "SELECT * FROM TestDatabase.mv");
+    REQUIRE(cur->is_success());
+    REQUIRE(cur->size() == 0); // empty until REFRESH populates (followup #2)
+}
+
 // PostgreSQL CREATE DATABASE / CREATE TABLE IF NOT EXISTS — second CREATE on the same
 // name must succeed as a no-op (no error). Dispatcher short-circuits on existing
 // namespace / collection when the create node carries if_not_exists=true.

--- a/services/disk/tests/test_persistence.cpp
+++ b/services/disk/tests/test_persistence.cpp
@@ -345,12 +345,12 @@ TEST_CASE("services::disk::persistence::test_pg_class_lists_all_objects") {
             char relkind;
         };
         const std::vector<expected_t> objects{
-            {"regular_t", reg_oid, 'r'},
-            {"compute_t", comp_oid, 'g'},
-            {"seq_t", seq_oid, 'S'},
-            {"view_t", view_oid, 'v'},
-            {"macro_t", macro_oid, 'm'},
-            {"regular_t_idx", idx_oid, 'i'},
+            {"regular_t", reg_oid, components::catalog::relkind::regular},
+            {"compute_t", comp_oid, components::catalog::relkind::computed},
+            {"seq_t", seq_oid, components::catalog::relkind::sequence},
+            {"view_t", view_oid, components::catalog::relkind::view},
+            {"macro_t", macro_oid, components::catalog::relkind::macro},
+            {"regular_t_idx", idx_oid, components::catalog::relkind::index},
         };
         for (const auto& exp : objects) {
             auto r = fd2.invoke(&manager_disk_t::resolve_table, fd2.ctx(), ns_oid, exp.name, std::uint64_t{0});

--- a/services/dispatcher/dispatcher.cpp
+++ b/services/dispatcher/dispatcher.cpp
@@ -60,6 +60,8 @@
 #include <components/physical_plan_generator/create_plan.hpp>
 #include <components/planner/optimizer.hpp>
 #include <components/planner/planner.hpp>
+#include <components/sql/parser/parser.h>
+#include <components/sql/transformer/transformer.hpp>
 #include <components/sql/transformer/utils.hpp>
 
 #include "enrich_logical_plan.hpp"
@@ -210,6 +212,133 @@ namespace services::dispatcher {
                 }
             }
             return {std::move(db), std::move(rel)};
+        }
+
+        // === Phase 1.5: SELECT-time view expansion ===
+        //
+        // After Pass 1 stamps resolved_metadata.view_sql on catalog_resolve_table_t
+        // nodes whose relkind=='v', this helper walks the plan and replaces view
+        // references with sub-plans derived from the view body SQL.
+        //
+        // First-iteration scope: only top-level `SELECT * FROM v` style plans
+        // where the outer plan is the transformer's standard wrap
+        //   sequence_t(catalog_resolve_namespace, catalog_resolve_table(v), aggregate(v))
+        // and the aggregate is a trivial passthrough. Complex outer queries
+        // (extra WHERE/JOIN/projection on top of v) return an error suggesting
+        // followups #1 — they require column-projection composition, which is
+        // out of scope for this PR.
+
+        struct view_expansion_result_t {
+            bool had_expansion{false};
+            components::logical_plan::node_ptr expanded_plan;
+            components::logical_plan::parameter_node_ptr expanded_params;
+            components::cursor::cursor_t_ptr error;
+        };
+
+        // Find the FIRST catalog_resolve_table_t with relkind='v' (and non-empty
+        // view_sql) in `root`'s direct children. Returns nullptr if none.
+        components::logical_plan::node_catalog_resolve_table_t*
+        find_first_view_resolve(components::logical_plan::node_t* root) {
+            using namespace components::logical_plan;
+            if (!root || root->type() != node_type::sequence_t) {
+                return nullptr;
+            }
+            for (auto& c : root->children()) {
+                if (!c || c->type() != node_type::catalog_resolve_table_t) {
+                    continue;
+                }
+                auto* rt = static_cast<node_catalog_resolve_table_t*>(c.get());
+                const auto& md = rt->resolved_metadata();
+                if (md && md->relkind == catalog::relkind::view && !md->view_sql.empty()) {
+                    return rt;
+                }
+            }
+            return nullptr;
+        }
+
+        // Parse view body SQL and transform it into a fresh logical plan.
+        // The transformer is instantiated per-call (its mutable state lives on
+        // the instance — re-entrant when allocated fresh per call).
+        view_expansion_result_t
+        expand_view_body(std::pmr::memory_resource* resource, const std::string& view_sql) {
+            view_expansion_result_t out;
+            std::pmr::monotonic_buffer_resource parser_arena(resource);
+            void* parse_cell = nullptr;
+            try {
+                auto* parsed = raw_parser(&parser_arena, view_sql.c_str());
+                if (!parsed) {
+                    out.error = make_cursor(
+                        resource,
+                        core::error_t(core::error_code_t::sql_parse_error,
+                                      std::pmr::string{"view body re-parse returned null", resource}));
+                    return out;
+                }
+                parse_cell = linitial(parsed);
+            } catch (const std::exception& ex) {
+                out.error = make_cursor(
+                    resource,
+                    core::error_t(core::error_code_t::sql_parse_error,
+                                  std::pmr::string{ex.what(), resource}));
+                return out;
+            }
+            if (!parse_cell) {
+                out.error = make_cursor(
+                    resource,
+                    core::error_t(core::error_code_t::sql_parse_error,
+                                  std::pmr::string{"empty view body parse", resource}));
+                return out;
+            }
+            components::sql::transform::transformer local_transformer(resource, view_sql.c_str());
+            auto tr = local_transformer
+                          .transform(components::sql::transform::pg_cell_to_node_cast(parse_cell))
+                          .finalize();
+            if (tr.has_error()) {
+                out.error = make_cursor(resource, tr.error());
+                return out;
+            }
+            // The transformer returns a fresh plan, typically
+            // sequence_t(catalog_resolve_namespace, catalog_resolve_table(t),
+            //            aggregate(t, ...)). The dispatcher will run Pass 1
+            //            on this sub_plan's resolves before validate_schema.
+            out.had_expansion = true;
+            out.expanded_plan = std::move(tr.value().node);
+            out.expanded_params = std::move(tr.value().params);
+            return out;
+        }
+
+        // Collect catalog_resolve_*_t nodes whose oid hasn't been stamped yet
+        // (i.e. need a fresh Pass 1 round). Operates on direct children of
+        // sequence_t roots; sub-plan splicing places them at the front so a
+        // shallow scan suffices.
+        std::vector<components::logical_plan::node_ptr>
+        extract_unresolved_resolves(components::logical_plan::node_t* root) {
+            using namespace components::logical_plan;
+            std::vector<node_ptr> out;
+            if (!root || root->type() != node_type::sequence_t) {
+                return out;
+            }
+            for (auto& c : root->children()) {
+                if (!c) continue;
+                const auto t = c->type();
+                const bool is_resolve =
+                    t == node_type::catalog_resolve_namespace_t || t == node_type::catalog_resolve_table_t ||
+                    t == node_type::catalog_resolve_type_t || t == node_type::catalog_resolve_function_t ||
+                    t == node_type::catalog_resolve_constraint_t;
+                if (!is_resolve) continue;
+                if (t == node_type::catalog_resolve_table_t) {
+                    auto* rt = static_cast<node_catalog_resolve_table_t*>(c.get());
+                    if (rt->resolved_metadata().has_value()) {
+                        continue; // already resolved (outer plan's resolve)
+                    }
+                } else if (t == node_type::catalog_resolve_namespace_t) {
+                    auto* rn = static_cast<node_catalog_resolve_namespace_t*>(c.get());
+                    if (rn->namespace_oid() != catalog::INVALID_OID) {
+                        continue; // already resolved
+                    }
+                }
+                out.push_back(c);
+            }
+            return out;
         }
     } // namespace
 
@@ -588,6 +717,63 @@ namespace services::dispatcher {
         // is threaded explicitly into every helper (no thread_local).
         impl::plan_resolve_index_t dispatcher_idx;
         impl::gather_plan_resolve_index(logic_plan.get(), dispatcher_idx);
+
+        // === Phase 1.5: SELECT-time view expansion ===
+        // After Pass 1 stamps resolved_metadata.view_sql on catalog_resolve_table_t
+        // nodes whose relkind=='v', re-parse + re-transform the view body and
+        // splice the resulting sub-plan in place. First-iteration scope: only
+        // top-level passthrough plans (`SELECT * FROM v`) — we replace the
+        // entire logic_plan with the sub-plan. More elaborate compositions
+        // (extra filters, projections, joins on top of v) are followups #1.
+        if (auto* view_node = find_first_view_resolve(logic_plan.get())) {
+            auto exp = expand_view_body(resource(), view_node->resolved_metadata()->view_sql);
+            if (exp.error) {
+                trace(log_, "manager_dispatcher_t::execute_plan: view expansion failed");
+                co_return std::move(exp.error);
+            }
+            if (exp.had_expansion && exp.expanded_plan) {
+                // Full plan replacement — outer is treated as trivial passthrough
+                // for first iteration. Future: splice sub-plan as child of outer
+                // consumer to preserve outer projections/filters (followups #1).
+                logic_plan = std::move(exp.expanded_plan);
+
+                // Merge sub-plan's parameter bindings into the outer params
+                // node so downstream operators see constants used in the view
+                // body (e.g. `col_b > 10` parameter). First-iteration assumes
+                // no parameter_id collision with outer (outer is a trivial
+                // passthrough SELECT * with no own constants).
+                if (exp.expanded_params) {
+                    for (const auto& [pid, val] : exp.expanded_params->parameters().parameters) {
+                        params->add_parameter(pid, val);
+                    }
+                }
+
+                // === Phase 1.6: Pass 1 on sub-plan's fresh resolves ===
+                auto fresh = extract_unresolved_resolves(logic_plan.get());
+                if (!fresh.empty()) {
+                    auto pass2_root = boost::intrusive_ptr<components::logical_plan::node_t>(
+                        new components::logical_plan::node_sequence_t(resource()));
+                    for (auto& n : fresh) {
+                        pass2_root->append_child(n);
+                    }
+                    auto pass2_params = make_parameter_node(resource());
+                    auto pass2_result =
+                        co_await execute_plan_impl(session, pass2_root, pass2_params->take_parameters(), ctx.txn);
+                    if (pass2_result.cursor->is_error()) {
+                        trace(log_,
+                              "manager_dispatcher_t::execute_plan: view sub-plan Pass 1 "
+                              "resolve failed: {}",
+                              pass2_result.cursor->get_error().what);
+                        co_return std::move(pass2_result.cursor);
+                    }
+                }
+
+                // === Phase 1.7: rebuild idx for re-validate ===
+                stamp_oids_from_resolves(logic_plan.get());
+                dispatcher_idx = impl::plan_resolve_index_t{};
+                impl::gather_plan_resolve_index(logic_plan.get(), dispatcher_idx);
+            }
+        }
         // Build table_id from the plan's role-named accessors. Each derived
         // node owns a (db, rel)-shaped pair; nodes that don't (create_type_t,
         // drop_type_t, wrappers) yield empty identifiers — same outcome as
@@ -683,9 +869,15 @@ namespace services::dispatcher {
         switch (original_type) {
             case node_type::create_database_t:
                 if (!check_namespace_exists(resource(), &dispatcher_idx, id).contains_error()) {
-                    error = make_cursor(resource(),
-                                        core::error_t{core::error_code_t::database_already_exists,
-                                                      std::pmr::string{"database already exists", resource()}});
+                    // PostgreSQL IF NOT EXISTS: DB already present -> success no-op (not an error).
+                    auto* d = static_cast<const node_create_database_t*>(effective_root_node(logic_plan.get()));
+                    if (d && d->if_not_exists()) {
+                        error = make_cursor(resource());
+                    } else {
+                        error = make_cursor(resource(),
+                                            core::error_t{core::error_code_t::database_already_exists,
+                                                          std::pmr::string{"database already exists", resource()}});
+                    }
                 }
                 break;
             case node_type::drop_database_t:
@@ -697,9 +889,15 @@ namespace services::dispatcher {
                 // Target namespace + UDT existence both resolved via
                 // plan-tree idx (no async preloads).
                 if (!check_collection_exists(resource(), &dispatcher_idx, id).contains_error()) {
-                    error = make_cursor(resource(),
-                                        core::error_t{core::error_code_t::table_already_exists,
-                                                      std::pmr::string{"collection already exists", resource()}});
+                    // PostgreSQL IF NOT EXISTS: table already present -> success no-op (not an error).
+                    auto* cc = static_cast<const node_create_collection_t*>(effective_root_node(logic_plan.get()));
+                    if (cc && cc->if_not_exists()) {
+                        error = make_cursor(resource());
+                    } else {
+                        error = make_cursor(resource(),
+                                            core::error_t{core::error_code_t::table_already_exists,
+                                                          std::pmr::string{"collection already exists", resource()}});
+                    }
                 } else {
                     // UDT existence + resolution reads from plan-tree
                     // idx (transform_create_table emits resolve_type

--- a/services/dispatcher/dispatcher.cpp
+++ b/services/dispatcher/dispatcher.cpp
@@ -26,6 +26,8 @@
 #include <components/logical_plan/node_create_database.hpp>
 #include <components/logical_plan/node_create_index.hpp>
 #include <components/logical_plan/node_create_macro.hpp>
+#include <components/logical_plan/node_create_matview.hpp>
+#include <components/logical_plan/node_refresh_matview.hpp>
 #include <components/logical_plan/node_create_sequence.hpp>
 #include <components/logical_plan/node_create_type.hpp>
 #include <components/logical_plan/node_create_view.hpp>
@@ -1276,6 +1278,24 @@ namespace services::dispatcher {
             logic_plan = ddl_planner.create_plan(resource(), std::move(logic_plan), std::move(oid_batch));
         }
 
+        // CREATE MATERIALIZED VIEW → standard DDL pattern (как CREATE TABLE):
+        // allocate OIDs → planner stamps mv_oid + catalog_writes on the matview node →
+        // physical_plan_generator produces composite operator_create_matview_t that
+        // does heap+catalog+populate atomically in one async coroutine.
+        // OID batch holds: mv_oid + N×attoid + rule_oid = 2 + N (where N is the
+        // matview's inferred column count populated by enrich's
+        // derive_matview_output_schema).
+        if (original_type == node_type::create_matview_t &&
+            disk_address_ != actor_zeta::address_t::empty_address()) {
+            auto* cm = static_cast<node_create_matview_t*>(effective_root_node(logic_plan.get()));
+            const std::size_t col_count = cm ? cm->inferred_columns().size() : std::size_t{0};
+            const std::size_t need = 2 + col_count;
+            catalog::oid_batch_t oid_batch;
+            oid_batch.oids = co_await allocate_oids_via_pipeline(session, need);
+            components::planner::planner_t ddl_planner;
+            logic_plan = ddl_planner.create_plan(resource(), std::move(logic_plan), std::move(oid_batch));
+        }
+
         // CREATE INDEX → planner rewrite to sequence_t(primitive_write × N, create_index_t).
         // The trailing create_index_t carries name/keys/type plus the resolved
         // namespace_oid/table_oid/index_oid so create_plan_sequence can lower it
@@ -1381,7 +1401,8 @@ namespace services::dispatcher {
                 original_type == node_type::drop_database_t || original_type == node_type::drop_collection_t ||
                 original_type == node_type::drop_type_t || original_type == node_type::drop_sequence_t ||
                 original_type == node_type::drop_view_t || original_type == node_type::drop_macro_t ||
-                original_type == node_type::create_database_t || original_type == node_type::alter_table_t;
+                original_type == node_type::create_database_t || original_type == node_type::alter_table_t ||
+                original_type == node_type::create_matview_t;
             if (needs_ddl_txn) {
                 txn_data = txn_manager_.begin_transaction(session).data();
                 trace(log_, "manager_dispatcher_t::execute_plan: DDL began txn {}", txn_data.transaction_id);
@@ -1450,7 +1471,8 @@ namespace services::dispatcher {
                 t == node_type::create_view_t || t == node_type::create_macro_t || t == node_type::create_type_t ||
                 t == node_type::create_index_t || t == node_type::drop_index_t || t == node_type::drop_database_t ||
                 t == node_type::drop_collection_t || t == node_type::drop_type_t || t == node_type::drop_sequence_t ||
-                t == node_type::drop_view_t || t == node_type::drop_macro_t || t == node_type::alter_table_t) {
+                t == node_type::drop_view_t || t == node_type::drop_macro_t || t == node_type::alter_table_t ||
+                t == node_type::create_matview_t) {
                 // DDL commit goes through operator_commit_transaction_t in
                 // ddl-commit mode. The operator performs flush (durability
                 // barrier) + wal::commit_txn + txn_manager.commit +
@@ -1522,6 +1544,18 @@ namespace services::dispatcher {
                                                            indexed_tbl_oid,
                                                            commit_id);
                         co_await std::move(cif);
+                    }
+                }
+                // CREATE MATERIALIZED VIEW — register routing for SELECT * FROM mv.
+                // The matview heap + INSERT-SELECT populate is handled atomically by
+                // operator_create_matview_t (composite physical operator); dispatcher
+                // only needs to register the new collection in its routing map.
+                if (t == node_type::create_matview_t) {
+                    auto* mv_node = effective_root_node(logic_plan.get());
+                    if (mv_node && mv_node->type() == node_type::create_matview_t) {
+                        auto* cm = static_cast<const node_create_matview_t*>(mv_node);
+                        auto names = drop_target_names_from_resolves(logic_plan.get());
+                        collections_.insert(qualified_name_t{names.first, cm->matviewname()});
                     }
                 }
                 // Update routing map: for create_collection_t logic_plan is sequence_t whose

--- a/services/dispatcher/enrich_logical_plan.cpp
+++ b/services/dispatcher/enrich_logical_plan.cpp
@@ -30,6 +30,9 @@
 #include <components/logical_plan/node_create_constraint.hpp>
 #include <components/logical_plan/node_create_index.hpp>
 #include <components/logical_plan/node_create_macro.hpp>
+#include <components/logical_plan/node_create_matview.hpp>
+#include <components/logical_plan/node_refresh_matview.hpp>
+#include <components/expressions/scalar_expression.hpp>
 #include <components/logical_plan/node_create_sequence.hpp>
 #include <components/logical_plan/node_create_view.hpp>
 #include <components/logical_plan/node_data.hpp>
@@ -288,6 +291,71 @@ namespace services::dispatcher {
             return it != idx->tbl_oid_by_qname.end() ? it->second : components::catalog::INVALID_OID;
         }
 
+        // Derive a materialized view's output schema from its body plan +
+        // the source table's Pass 1-stamped resolved_metadata. First iteration
+        // supports single-table FROM with scalar_type::get_field expressions
+        // (i.e. plain column references). Returns empty on unsupported shapes
+        // — the planner will surface this as an error (no fallback).
+        std::vector<components::table::column_definition_t>
+        derive_matview_output_schema(const components::logical_plan::node_t* body_plan,
+                                     const components::logical_plan::resolved_table_metadata_t* source_md) {
+            using namespace components::logical_plan;
+            std::vector<components::table::column_definition_t> out;
+            if (!body_plan || !source_md) {
+                return out;
+            }
+            if (body_plan->type() != node_type::aggregate_t) {
+                return out;
+            }
+            // Find the node_select_t child holding the SELECT-list expressions.
+            const node_t* select_node = nullptr;
+            for (const auto& c : body_plan->children()) {
+                if (c && c->type() == node_type::select_t) {
+                    select_node = c.get();
+                    break;
+                }
+            }
+            if (!select_node) {
+                return out;
+            }
+            const auto& exprs = select_node->expressions();
+            out.reserve(exprs.size());
+            for (const auto& expr : exprs) {
+                if (!expr) {
+                    return {};
+                }
+                auto* sc = dynamic_cast<components::expressions::scalar_expression_t*>(expr.get());
+                if (!sc) {
+                    return {}; // non-scalar (function/aggregate): out of scope
+                }
+                if (sc->type() != components::expressions::scalar_type::get_field) {
+                    return {}; // arithmetic/case_expr/coalesce/...: out of scope (see followups #2)
+                }
+                const auto& key_storage = sc->key().storage();
+                if (key_storage.empty()) {
+                    return {};
+                }
+                // Use the last path component as the column name (handles
+                // single-table FROM where path is just [col]).
+                const std::string col_name(key_storage.back().c_str(), key_storage.back().size());
+                // Look up the column in the source's stamped pg_attribute.
+                bool found = false;
+                for (const auto& src_col : source_md->columns) {
+                    if (src_col.attname == col_name) {
+                        components::table::column_definition_t def(col_name, src_col.type);
+                        def.set_atttypid(static_cast<std::uint32_t>(src_col.atttypid));
+                        out.emplace_back(std::move(def));
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found) {
+                    return {};
+                }
+            }
+            return out;
+        }
+
     } // anonymous namespace
 
     // Propagate OIDs from sibling catalog_resolve_* nodes onto their
@@ -432,6 +500,35 @@ namespace services::dispatcher {
                             if (rn && rn->namespace_oid() != components::catalog::INVALID_OID) {
                                 d->set_namespace_oid(rn->namespace_oid());
                             }
+                            break;
+                        }
+                        case node_type::create_matview_t: {
+                            // Stamp namespace + source oids from sibling resolves.
+                            // derive_matview_output_schema walks body_plan +
+                            // source's Pass 1-stamped resolved_metadata.columns
+                            // to produce the matview's column schema.
+                            auto* d = static_cast<node_create_matview_t*>(c.get());
+                            if (rn && rn->namespace_oid() != components::catalog::INVALID_OID) {
+                                d->set_namespace_oid(rn->namespace_oid());
+                            }
+                            if (rt && rt->table_oid() != components::catalog::INVALID_OID) {
+                                d->set_source_table_oid(rt->table_oid());
+                            }
+                            if (rt && rt->resolved_metadata() && d->body_plan()) {
+                                auto cols = derive_matview_output_schema(d->body_plan().get(),
+                                                                         &rt->resolved_metadata().value());
+                                if (!cols.empty()) {
+                                    d->set_inferred_columns(std::move(cols));
+                                }
+                            }
+                            break;
+                        }
+                        case node_type::refresh_matview_t: {
+                            // refresh: mv_oid comes from sibling rt's resolved_metadata
+                            // (which also carries view_sql via Phase A.A2 since
+                            // operator_resolve_table reads pg_rewrite for relkind='m').
+                            // No fields to stamp here — planner reads from rt directly.
+                            (void)c;
                             break;
                         }
                         case node_type::create_index_t: {

--- a/services/dispatcher/validate_logical_plan.cpp
+++ b/services/dispatcher/validate_logical_plan.cpp
@@ -119,23 +119,29 @@ namespace services::dispatcher {
             size_t key_order;
         };
 
-        // If type does exist in both, merged will have only first instance
+        // JOIN merge: keep both same-named columns when they come from different
+        // tables; only drop entries that are truly identical (same alias AND same result_alias).
         named_schema merge_schemas(std::pmr::memory_resource* resource, named_schema lhs, named_schema rhs) {
-            // We do not check table alias here, because we only care about fields
             named_schema merged(resource);
             for (auto&& type : lhs) {
                 auto it = std::find_if(merged.begin(), merged.end(), [&type](const auto& t) {
-                    return t.type.alias() == type.type.alias();
+                    return t.type.alias() == type.type.alias() && t.result_alias == type.result_alias;
                 });
                 if (it == merged.end()) {
+                    if (type.side == side_t::undefined) {
+                        type.side = side_t::left;
+                    }
                     merged.emplace_back(std::move(type));
                 }
             }
             for (auto&& type : rhs) {
                 auto it = std::find_if(merged.begin(), merged.end(), [&type](const auto& t) {
-                    return t.type.alias() == type.type.alias();
+                    return t.type.alias() == type.type.alias() && t.result_alias == type.result_alias;
                 });
                 if (it == merged.end()) {
+                    if (type.side == side_t::undefined) {
+                        type.side = side_t::right;
+                    }
                     merged.emplace_back(std::move(type));
                 }
             }
@@ -168,6 +174,22 @@ namespace services::dispatcher {
                     matches.emplace_back(type_match_t{column_path{{i}, resource}, &schema[i].type, 2});
                 } else if (core::pmr::operator==(schema[i].type.alias(), truncated_key.storage().at(0))) {
                     matches.emplace_back(type_match_t{column_path{{i}, resource}, &schema[i].type, 1});
+                }
+            }
+
+            // Side-aware disambiguation: only when there's ambiguity to resolve.
+            // Drop schema candidates whose stamped side disagrees only when >1 match
+            // (otherwise we'd drop legitimate single matches in chained-JOIN where
+            // inner-merge sides don't align with outer-merge name_collection sides).
+            if (matches.size() > 1 && key.side() != side_t::undefined) {
+                for (auto it = matches.begin(); it != matches.end();) {
+                    size_t schema_idx = it->path.empty() ? 0 : it->path[0];
+                    if (schema_idx < schema.size() && schema[schema_idx].side != side_t::undefined &&
+                        schema[schema_idx].side != key.side()) {
+                        it = matches.erase(it);
+                    } else {
+                        ++it;
+                    }
                 }
             }
 
@@ -1066,17 +1088,17 @@ namespace services::dispatcher {
                            !static_cast<const std::string&>(agg_node->dbname()).empty()) {
                     const auto& agg_dbname_s = static_cast<const std::string&>(agg_node->dbname());
                     const auto& agg_relname_s = static_cast<const std::string&>(agg_node->relname());
+                    const auto& visible_alias =
+                        node->result_alias().empty() ? agg_relname_s : node->result_alias();
                     // there will be a scan
                     const auto* tbl = impl::tbl_md_for(idx, agg_dbname_s, agg_relname_s);
                     if (tbl && tbl->relkind != 'g') {
                         for (const auto& column : tbl->columns) {
-                            table_schema.emplace_back(type_from_t{agg_relname_s, column.type});
+                            table_schema.emplace_back(type_from_t{visible_alias, column.type});
                         }
                     } else if (tbl && tbl->relkind == 'g') {
                         for (const auto& column : tbl->columns) {
-                            table_schema.emplace_back(
-                                type_from_t{node->result_alias().empty() ? agg_relname_s : node->result_alias(),
-                                            column.type});
+                            table_schema.emplace_back(type_from_t{visible_alias, column.type});
                         }
                     } else {
                         // Distinguish missing database from missing collection
@@ -1131,6 +1153,42 @@ namespace services::dispatcher {
                                     continue;
                                 }
                                 auto* scalar_expr = reinterpret_cast<scalar_expression_t*>(exprs[expr_index].get());
+                                // t.x.* — expand by result_alias against merged JOIN schema.
+                                if (scalar_expr->type() == scalar_type::star_expand &&
+                                    !scalar_expr->key().storage().empty() &&
+                                    scalar_expr->key().storage().front() != "*") {
+                                    const auto& alias = scalar_expr->key().storage().front();
+                                    std::pmr::vector<size_t> matched(resource);
+                                    for (size_t i = 0; i < incoming_schema.size(); i++) {
+                                        if (core::pmr::operator==(incoming_schema[i].result_alias, alias)) {
+                                            matched.push_back(i);
+                                        }
+                                    }
+                                    if (matched.empty()) {
+                                        return core::error_t(
+                                            core::error_code_t::schema_error,
+                                            std::pmr::string{(std::string{"alias '"} + alias.c_str() +
+                                                              "' has no columns in scope")
+                                                                 .c_str(),
+                                                             resource});
+                                    }
+                                    exprs.erase(exprs.begin() + static_cast<ptrdiff_t>(expr_index));
+                                    for (size_t j = 0; j < matched.size(); j++) {
+                                        size_t schema_idx = matched[j];
+                                        components::expressions::key_t new_key(resource);
+                                        if (incoming_schema[schema_idx].type.has_alias()) {
+                                            new_key.storage().push_back(std::pmr::string(
+                                                incoming_schema[schema_idx].type.alias(), resource));
+                                        }
+                                        new_key.set_path(column_path{{schema_idx}, resource});
+                                        exprs.insert(exprs.begin() + static_cast<ptrdiff_t>(expr_index + j),
+                                                     make_scalar_expression(resource,
+                                                                            scalar_type::get_field,
+                                                                            new_key));
+                                    }
+                                    expr_index += matched.size();
+                                    continue;
+                                }
                                 if (scalar_expr->type() != scalar_type::get_field) {
                                     expr_index++;
                                     continue;
@@ -1196,11 +1254,12 @@ namespace services::dispatcher {
                             }
                         }
                     } else {
-                        // "SELECT *" or "SELECT t.*" — reject when a logical column
-                        // exists in multiple physical types: cannot be disambiguated without a cast.
-                        std::unordered_set<std::string> seen;
+                        // Reject only truly-identical columns (same alias from same table).
+                        // Duplicate names across JOIN'd tables are legitimate (PostgreSQL semantics).
+                        std::set<std::pair<std::string, std::string>> seen_pairs;
                         for (const auto& col : incoming_schema) {
-                            if (!seen.insert(col.type.alias()).second) {
+                            auto pair = std::make_pair(col.result_alias, std::string(col.type.alias()));
+                            if (!seen_pairs.insert(pair).second) {
                                 return core::error_t(
                                     core::error_code_t::schema_error,
                                     std::pmr::string{"column '" + col.type.alias() +

--- a/services/dispatcher/validate_logical_plan.cpp
+++ b/services/dispatcher/validate_logical_plan.cpp
@@ -2018,6 +2018,14 @@ namespace services::dispatcher {
             case node_type::drop_index_t:
                 // nothing to check here
                 break;
+            case node_type::create_matview_t:
+            case node_type::refresh_matview_t:
+                // Schema derivation happens in enrich's stamp_oids_from_resolves;
+                // planner reads stamped inferred_columns / source metadata. No
+                // per-clause schema validation needed at this layer (the body
+                // plan is validated via its own catalog_resolve_table sibling
+                // which Pass 1 has stamped before this validate runs).
+                break;
             case node_type::sequence_t: {
                 // The SQL transformer wraps DML/DDL in
                 //   sequence_t(catalog_resolve_*…, consumer)

--- a/services/dispatcher/validate_logical_plan.hpp
+++ b/services/dispatcher/validate_logical_plan.hpp
@@ -4,6 +4,7 @@
 #include <components/catalog/dependency_walker.hpp>
 #include <components/cursor/cursor.hpp>
 #include <components/expressions/compare_expression.hpp>
+#include <components/expressions/forward.hpp>
 #include <components/logical_plan/node.hpp>
 #include <components/logical_plan/param_storage.hpp>
 #include <components/types/types.hpp>
@@ -26,6 +27,7 @@ namespace services::dispatcher {
     struct type_from_t {
         std::string result_alias;
         components::types::complex_logical_type type;
+        components::expressions::side_t side = components::expressions::side_t::undefined;
     };
     struct type_path_t {
         column_path path;


### PR DESCRIPTION
## Summary

SQL surface extensions to unblock SSB benchmark execution and broader query coverage.

- **G1 comma-join** (`FROM a, b WHERE a.x = b.y`): transformer synthesizes a left-deep tree of binary cross-JoinExpr nodes from N-element fromClause; WHERE filter (sibling `match_t`) recovers inner-join semantics. Validated by SSB q1-1 end-to-end on 5MB lineorder + dim_date.
- **G8/G9 string kernels**: `SUBSTRING` (2/3-arg), `LENGTH`, `REGEXP_REPLACE` row kernels registered via `DEFAULT_FUNCTIONS` uid 5/6/7. Typed accessors `.value<T>()` inline, no `logical_value_t` round-trips. NULL propagation via in-body type check (matchers use `make_always_true` so dispatcher accepts NA inputs).
- **G11 LEFT OUTER JOIN regression**: two `TEST_JOIN` cases covering multi-column ON predicate and ON + WHERE filter combination.
- **`column_pruning` N-ary support**: `process_join` now handles `n>=0` children (binary path unchanged behaviorally for `n==2`; per-child projection split for `n>2`; on-condition walker degrades cleanly for middle children to their own SELECT-list projection). Forward-compatible with future N-ary flattening.

## Deferred

**G13 CREATE VIEW e2e**: parser+transformer ship VIEW writes into `pg_class`/`pg_rewrite`/`pg_depend` (planner.cpp:249-263), but SELECT-time view expansion is not wired across the dispatcher path yet. Parser-level coverage stays in `components/sql/test/test_constraints_ddl.cpp:191-232`.

## Test plan

- [x] Local ctest Debug: 681/681 pass (was 670 baseline + 10 string kernel tests + 1 integration comma_join test)
- [x] Local ctest ASan (Debug + `-fsanitize=address`): 681/681 clean
- [x] SSB q1-1 (`FROM lineorder, dim_date WHERE lo_orderdate=d_datekey AND d_year=1993 AND lo_discount BETWEEN 1 AND 3 AND lo_quantity < 25`) ran end-to-end on 5MB lineorder + dim_date in ~50s — proves G1
- [x] CI: macos, ubuntu, manylinux2014, ASAN runner
