### PR TITLE
Error handling update

### DIFF
--- a/components/compute/function.cpp
+++ b/components/compute/function.cpp
@@ -160,7 +160,6 @@ namespace components::compute {
             if (func_.doc().options_required && !options && !func_.default_options()) {
                 return core::error_t(
                     core::error_code_t::kernel_error,
-
                     std::pmr::string{"Function " + func_.name() + " cannot be executed without options",
                                      kernel_ctx_.value().exec_context().resource()});
             }

--- a/components/cursor/tests/test_cursor.cpp
+++ b/components/cursor/tests/test_cursor.cpp
@@ -14,12 +14,6 @@ TEST_CASE("components::cursor::construction") {
         REQUIRE(cursor->is_success());
         REQUIRE_FALSE(cursor->is_error());
     }
-    INFO("failed operation cursor") {
-        auto cursor =
-            components::cursor::make_cursor(&resource, core::error_t(&resource, core::error_code_t::other_error));
-        REQUIRE_FALSE(cursor->is_success());
-        REQUIRE(cursor->is_error());
-    }
     INFO("successful operation cursor") {
         auto cursor = components::cursor::make_cursor(&resource, core::error_t::no_error());
         REQUIRE(cursor->is_success());

--- a/core/result_wrapper.hpp
+++ b/core/result_wrapper.hpp
@@ -4,6 +4,7 @@
 #include <memory_resource>
 #include <optional>
 #include <source_location>
+#include <string>
 
 namespace core {
 

--- a/core/result_wrapper.hpp
+++ b/core/result_wrapper.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <cassert>
-#include <memory>
 #include <memory_resource>
+#include <optional>
 #include <source_location>
 
 namespace core {
@@ -58,27 +58,27 @@ namespace core {
     struct error_t {
         error_code_t type;
         std::pmr::string what;
-#if defined(DEV_MODE)
+#if not defined(NDEBUG)
         std::source_location error_origin{};
 
-        explicit error_t(std::pmr::memory_resource* resource,
-                         error_code_t type,
-                         std::source_location location = std::source_location::current())
-            : type(type)
-            , what(resource)
-            , error_origin(location) {}
         explicit error_t(error_code_t type,
                          const std::pmr::string& what,
                          std::source_location location = std::source_location::current())
             : type(type)
             , what(what)
-            , error_origin(location) {}
+            , error_origin(location) {
+            assert(type != error_code_t::none &&
+                   "no error state of error_t can only be created using no_error() constructor");
+        }
         explicit error_t(error_code_t type,
                          std::pmr::string&& what,
                          std::source_location location = std::source_location::current())
             : type(type)
             , what(std::move(what))
-            , error_origin(location) {}
+            , error_origin(location) {
+            assert(type != error_code_t::none &&
+                   "no error state of error_t can only be created using no_error() constructor");
+        }
 
         error_t& operator=(const error_t& other) {
             type = other.type;
@@ -94,9 +94,6 @@ namespace core {
         }
 #else
 
-        explicit error_t(std::pmr::memory_resource* resource, error_code_t type)
-            : type(type)
-            , what(resource) {}
         explicit error_t(error_code_t type, const std::pmr::string& what)
             : type(type)
             , what(what) {}
@@ -138,23 +135,14 @@ namespace core {
 
     // has implicit constructors to simplify usage
     template<typename T>
-    requires(!std::is_same_v<std::decay<T>, error_t>) class result_wrapper_t {
+    requires(!std::is_same_v<std::decay<T>, error_t> && !std::is_same_v<T, void>) class result_wrapper_t {
     private:
         static constexpr bool trivial_store = std::is_default_constructible_v<T>;
-        using Store_T = std::conditional_t<trivial_store, T, std::unique_ptr<T>>;
+        using Store_T = std::conditional_t<trivial_store, T, std::optional<T>>;
 
     public:
         template<typename... Args>
-        result_wrapper_t(Args&&... args) requires(trivial_store&& std::constructible_from<T, Args...>)
-            : value_(std::forward<Args>(args)...)
-            , error_(error_t::no_error()) {}
-        template<typename... Args>
-        result_wrapper_t(Args&&... args) requires(!trivial_store && std::constructible_from<T, Args...>)
-            : value_(std::make_unique<T>(std::forward<Args>(args)...))
-            , error_(error_t::no_error()) {}
-        template<typename... Args>
-        result_wrapper_t(Args&&... args) requires(!trivial_store &&
-                                                  std::constructible_from<std::unique_ptr<T>, Args...>)
+        result_wrapper_t(Args&&... args) requires(std::constructible_from<T, Args...>)
             : value_(std::forward<Args>(args)...)
             , error_(error_t::no_error()) {}
 
@@ -163,78 +151,54 @@ namespace core {
         result_wrapper_t(error_t&& error)
             : error_(std::move(error)) {}
 
-#if defined(DEV_MODE)
-        result_wrapper_t(const result_wrapper_t& other) requires(trivial_store&& std::is_copy_constructible_v<T>)
+#if not defined(NDEBUG)
+        result_wrapper_t(const result_wrapper_t& other) requires(std::is_copy_constructible_v<T>)
             : value_(other.value_)
             , error_(other.error_) {}
-        result_wrapper_t(const result_wrapper_t& other) requires(!trivial_store && std::is_copy_constructible_v<T>)
-            : value_(other.value_ ? std::make_unique<T>(*other.value_) : std::unique_ptr<T>{})
-            , error_(other.error_) {}
 
-        result_wrapper_t(result_wrapper_t&& other) noexcept
+        result_wrapper_t(result_wrapper_t&& other) noexcept requires(std::is_move_constructible_v<T>)
             : value_(std::move(other.value_))
             , error_(std::move(other.error_)) {}
 
-        result_wrapper_t&
-        operator=(const result_wrapper_t& other) requires(trivial_store&& std::is_copy_constructible_v<T>) {
-            value_ = std::make_unique<T>(other.value_);
+        result_wrapper_t& operator=(const result_wrapper_t& other) requires(std::is_copy_assignable_v<T>) {
+            value_ = other.value_;
             error_ = other.error_;
-#if defined(DEV_MODE)
             error_checked_ = false;
-#endif
-            return *this;
-        }
-        result_wrapper_t& operator=(const result_wrapper_t& other) requires(!trivial_store &&
-                                                                            std::is_copy_constructible_v<T>) {
-            value_ = other.value_ ? std::make_unique<T>(*other.value_) : std::unique_ptr<T>{};
-            error_ = other.error_;
-#if defined(DEV_MODE)
-            error_checked_ = false;
-#endif
             return *this;
         }
 
-        result_wrapper_t& operator=(result_wrapper_t&& other) noexcept {
+        result_wrapper_t& operator=(result_wrapper_t&& other) noexcept requires(std::is_move_assignable_v<T>) {
             value_ = std::move(other.value_);
             error_ = other.error_;
-#if defined(DEV_MODE)
             error_checked_ = false;
-#endif
+            other.error_checked_ = true;
             return *this;
         }
 #else
-        result_wrapper_t(const result_wrapper_t& other) requires(trivial_store&& std::is_copy_constructible_v<T>) =
-            default;
-        result_wrapper_t(const result_wrapper_t& other) requires(!trivial_store && std::is_copy_constructible_v<T>)
-            : value_(other.value_ ? std::make_unique<T>(*other.value_) : std::unique_ptr<T>{})
-            , error_(other.error_) {}
+        result_wrapper_t(const result_wrapper_t& other) requires(std::is_copy_constructible_v<T>) = default;
 
-        result_wrapper_t(result_wrapper_t&&) noexcept = default;
+        result_wrapper_t(result_wrapper_t&&) noexcept requires(std::is_move_constructible_v<T>) = default;
 
-        result_wrapper_t&
-        operator=(const result_wrapper_t& other) requires(trivial_store&& std::is_copy_constructible_v<T>) = default;
-        result_wrapper_t& operator=(const result_wrapper_t& other) requires(!trivial_store &&
-                                                                            std::is_copy_constructible_v<T>) {
-            value_ = other.value_ ? std::make_unique<T>(*other.value_) : std::unique_ptr<T>{};
-            error_ = other.error_;
-            return *this;
-        }
+        result_wrapper_t& operator=(const result_wrapper_t& other) requires(std::is_copy_assignable_v<T>) = default;
 
-        result_wrapper_t& operator=(result_wrapper_t&&) noexcept = default;
+        result_wrapper_t& operator=(result_wrapper_t&&) noexcept requires(std::is_move_assignable_v<T>) = default;
 #endif
 
         bool has_error() const noexcept {
-#if defined(DEV_MODE)
+#if not defined(NDEBUG)
             error_checked_ = true;
 #endif
             return error_.type != error_code_t::none;
         }
-        const error_t& error() const noexcept { return error_; }
-        const T& value() const noexcept {
-#if defined(DEV_MODE)
-            assert(error_checked_);
+        const error_t& error() const noexcept {
+#if not defined(NDEBUG)
+            error_checked_ = true;
 #endif
-            assert(!has_error());
+            return error_;
+        }
+        const T& value() const noexcept {
+            assert(error_checked_ && "result_wrapper_t::value() called without checking for errors");
+            assert(!has_error() && "result_wrapper_t::value() called with error present");
             if constexpr (trivial_store) {
                 return value_;
             } else {
@@ -242,10 +206,8 @@ namespace core {
             }
         }
         T& value() noexcept {
-#if defined(DEV_MODE)
-            assert(error_checked_);
-#endif
-            assert(!has_error());
+            assert(error_checked_ && "result_wrapper_t::value() called without checking for errors");
+            assert(!has_error() && "result_wrapper_t::value() called with error present");
             if constexpr (trivial_store) {
                 return value_;
             } else {
@@ -255,17 +217,19 @@ namespace core {
         bool operator()() const noexcept { return !has_error(); }
 
         template<typename U>
-        requires(!std::is_same_v<T, U>) [[nodiscard]] result_wrapper_t<U> convert_error() const {
+        requires(!std::is_same_v<T, U>) [[nodiscard]] result_wrapper_t<U> convert_error() {
             assert(error_.contains_error());
-            return result_wrapper_t<U>(error_);
+            return result_wrapper_t<U>(std::move(error_));
         }
 
     private:
         Store_T value_;
-        error_t error_;
-#if defined(DEV_MODE)
+#if not defined(NDEBUG)
         mutable bool error_checked_{false};
 #endif
+        error_t error_;
     };
+
+    // TODO: assert for unchecked errors in the destructor of result_wrapper_t
 
 } // namespace core

--- a/docs/error_handling.md
+++ b/docs/error_handling.md
@@ -1,0 +1,58 @@
+# Otterbrix error handling approach
+
+## Basic overview
+* We are actively discourage using exceptions for error handling. They might be used to indicate an unrecoverable or unreachable state
+* For errors caused by the user, like invalid query, for example, errors should be as clear as possible
+* For internal errors we do not enforce any specific pattern, performance take priority there
+
+## User errors
+
+For returning errors to the user we use 2 classes:
+
+### core::error_t
+
+Consists of:
+* Numeric **error code**
+* std::pmr::string **clarifying message**
+* std::source_location **origin** of error_t creation - in Debug mode only
+
+One thing to keep in mind: message should be initialized with resource, that will survive long enough for user to see the message
+
+**Best practices:**
+* error_code_t should indicate what kind of error has occurred. Not to vague and not to detailed. If your error is not represented by any of the existing code, feel free to add one yourself
+* Message is passed to the user, where they can see an error code and a message, be descriptive about what went wrong and, if possible, add some hints how to fix it
+* 'no_error()' uniformly indicates errorless state, error code set to **none**
+* error_t as return type (or part of it) should be marked as **nodiscard**
+* There are 2 ways to check if error_t is in error state: method 'contains_error()' and comparing it to 'no_error()' first one is more efficient, because it does not create a temporary object and looks cleaner
+* Avoid repeating between error code and message, e.g. error_code_t::table_not_exists with message: "table not exists"
+* Avoid using memory_resource from 'message', because in 'no_error' state it is set to 'std::pmr::null_memory_resource()'
+* Avoid using error_code_t::other_error **if you know** what actually caused that error
+
+### core::result_wrapper_t<T>
+
+Consists of:
+* error_t **error**
+* storage for **return value**, able to handle non-default constructable types
+* mutable **error_checked** boolean - in Debug mode only
+
+It is implicitly convertable from **T** and **error_t** for ease of use
+Error is not mutable by design, in order to prevent invalid states (has no value and no error, or has value and error)
+Can be converted to other result_wrapper_t instantiation, if contains an error
+In Debug mode asserts that error was checked before accessing stored value
+result_wrapper_t technically does not have a default state (there is either a value or an error), but it could be achieved with default constructible type **T**
+
+**Best practices:**
+* Should be used in places where meaningful result is not guarantied
+* Current implementation does not allow for <void> instantiation -> use plain error_t for that
+* **convert_error<To>()** is useful in cases where result_wrapper_t<**From**> has to be converted to result_wrapper_t<**To**>, because it is the only way to move 'error_t'
+* result_wrapper_t<T> as return type should be marked as **nodiscard**
+* Avoid using result_wrapper_t<T> inside other structures (as return type), e.g. std::pair<result_wrapper_t<T>, U>, instead try to include whole result inside: result_wrapper_t<std::pair<T, U>>
+* Even though it does support conversion to boolean, if it encouraged to use 'has_error()' method
+
+### Known issues
+
+* Currently, there is no rigid structure for error_code_t
+* It is possible to ignore plain error_t with error and result_wrapper_t<> if function was not marked as **nodiscard**
+* Using std::string error_t could be 'constexpr', optimizing return of no_error() and result_wrapper_t with value
+* error_t does not fit requirements for actor_zeta::unique_future<T>, and has to be wrapper in something (here result_wrapper_t<void> could be useful)
+* result_wrapper_t is most useful in Debug build, but we do not run it on CI/CD currently, and it is possible to miss errors, if not checked locally

--- a/services/dispatcher/validate_logical_plan.cpp
+++ b/services/dispatcher/validate_logical_plan.cpp
@@ -1401,7 +1401,7 @@ namespace services::dispatcher {
                                     auto& sub_expr = std::get<expression_ptr>(param);
                                     if (sub_expr->group() == expression_group::scalar) {
                                         auto* sub_scalar = reinterpret_cast<scalar_expression_t*>(sub_expr.get());
-                                        core::error_t resolve_error{resource, core::error_code_t::none};
+                                        core::error_t resolve_error = core::error_t::no_error();
                                         std::function<complex_logical_type(param_storage&)> resolve_arith_type;
                                         resolve_arith_type = [&](param_storage& p) -> complex_logical_type {
                                             if (std::holds_alternative<components::expressions::key_t>(p)) {


### PR DESCRIPTION
I have added documentation for core::error_t and core::result_wrapper_t

And improved it a bit:
* std::optional performs better for than std::unique_ptr for non default constructable types (if they are smaller than 128-256 bytes)
* instead of enforcing error checking in DEV_MODE + Debug, it is just in Debug
* added asserts to prevent creating non_error with error message
* removed constructor with error_code and no message
* added clarifying messages to asserts
* convert_error<>() now moves error, making it more efficient