### PR TITLE
Jsonb operators on computing

### DIFF
--- a/components/compute/function.cpp
+++ b/components/compute/function.cpp
@@ -330,6 +330,14 @@ namespace components::compute {
         return default_registry_.get();
     }
 
+    void function_registry_t::reset_default() {
+        // Ensure init_flag_ has fired (so get_default() won't later overwrite our
+        // fresh instance), then replace with a clean builtins-only registry.
+        (void) get_default();
+        default_registry_ = std::make_unique<function_registry_t>(std::pmr::get_default_resource());
+        default_registry_->register_builtin_functions();
+    }
+
     core::result_wrapper_t<function_uid> function_registry_t::add_function(function_ptr function) {
         if (!function) {
             core::error_t(core::error_code_t::function_registry_error,

--- a/components/compute/function.hpp
+++ b/components/compute/function.hpp
@@ -244,6 +244,13 @@ namespace components::compute {
 
         static function_registry_t* get_default();
 
+        // Replace the process-global default registry with a fresh one holding
+        // only the builtin functions. Used by tests to isolate the global UDF
+        // registry between independent instances (a UDF registered by one test
+        // otherwise leaks into get_default() and corrupts the next). NOT
+        // thread-safe — call only when no queries are in flight.
+        static void reset_default();
+
         [[nodiscard]] core::result_wrapper_t<function_uid> add_function(function_ptr function);
         // Insert with a caller-supplied UID. Used when the canonical UID was
         // chosen by another registry (e.g. the global default) and per-executor

--- a/components/expressions/forward.cpp
+++ b/components/expressions/forward.cpp
@@ -81,6 +81,10 @@ namespace components::expressions {
                 return "unary_minus";
             case scalar_type::star_expand:
                 return "star_expand";
+            case scalar_type::jsonb_expand:
+                return "jsonb_expand";
+            case scalar_type::jsonb_delete:
+                return "jsonb_delete";
             default:
                 return "invalid";
         }

--- a/components/expressions/forward.hpp
+++ b/components/expressions/forward.hpp
@@ -60,7 +60,14 @@ namespace components::expressions {
         coalesce,
         case_when,
         unary_minus,
-        star_expand
+        star_expand,
+        // JSONB table-valued operators on computing tables. Both carry a path
+        // prefix in the expression key; validate_logical_plan expands them into
+        // get_field columns against the resolved schema:
+        //   jsonb_expand — '->' / '#>' : columns under the prefix, rerooted
+        //   jsonb_delete — '-'  / '#-' : all columns EXCEPT those under the prefix
+        jsonb_expand,
+        jsonb_delete
     };
 
     enum class sort_order : std::int8_t

--- a/components/expressions/key.hpp
+++ b/components/expressions/key.hpp
@@ -21,7 +21,8 @@ namespace components::expressions {
             : side_{key.side_}
             , storage_{std::move(key.storage_)}
             , path_{std::move(key.path_)}
-            , cast_type_{std::move(key.cast_type_)} {}
+            , cast_type_{std::move(key.cast_type_)}
+            , variant_select_{key.variant_select_} {}
 
         key_t(const key_t& key) = default;
         key_t& operator=(const key_t& key) = default;
@@ -104,6 +105,13 @@ namespace components::expressions {
 
         void set_cast_type(types::complex_logical_type type) { cast_type_ = std::move(type); }
 
+        // '::?' type-variant selection: among several columns sharing this key's
+        // name (computing multi-type fields), pick the one whose physical type
+        // matches cast_type(). Unlike a '::' cast, no value conversion is done.
+        bool is_variant_select() const { return variant_select_; }
+
+        void set_variant_select(bool v) { variant_select_ = v; }
+
         auto is_null() const -> bool { return storage_.empty(); }
 
         auto side() const -> side_t { return side_; }
@@ -137,6 +145,7 @@ namespace components::expressions {
         std::pmr::vector<std::pmr::string> storage_;
         std::pmr::vector<size_t> path_;
         std::optional<types::complex_logical_type> cast_type_;
+        bool variant_select_ = false;
     };
 
     template<class OStream>

--- a/components/physical_plan/operators/operator_resolve_table.cpp
+++ b/components/physical_plan/operators/operator_resolve_table.cpp
@@ -264,11 +264,16 @@ namespace components::operators {
 
             struct cc_candidate_t {
                 catalog::oid_t attoid;
+                std::string attname;
                 catalog::oid_t atttypid;
                 std::string atttypspec;
                 std::int64_t attversion;
                 std::int64_t attrefcount;
             };
+            // Key by (attname, atttypid, atttypspec) — NOT attname alone — so a
+            // computing table exposes SEVERAL columns sharing a name but with
+            // different types (multi-type fields). Per variant keep the
+            // max(attversion) row; tombstones (refcount<=0) are dropped below.
             std::unordered_map<std::string, cc_candidate_t> latest_any;
 
             for (const auto& row : cc_rows) {
@@ -276,8 +281,8 @@ namespace components::operators {
                     continue;
                 if (row[2].is_null() || row[5].is_null())
                     continue;
-                std::string attname{row[2].value<std::string_view>()};
                 cc_candidate_t cand;
+                cand.attname.assign(row[2].value<std::string_view>());
                 cand.attoid = row[1].is_null() ? catalog::INVALID_OID
                                                : static_cast<catalog::oid_t>(row[1].value<std::uint32_t>());
                 cand.atttypid = row[3].is_null() ? catalog::INVALID_OID
@@ -288,18 +293,20 @@ namespace components::operators {
                 cand.attversion = row[5].value<std::int64_t>();
                 cand.attrefcount = row[6].is_null() ? 0 : row[6].value<std::int64_t>();
 
-                auto it = latest_any.find(attname);
+                std::string key = cand.attname + '\x1f' +
+                                  std::to_string(static_cast<unsigned>(cand.atttypid)) + '\x1f' + cand.atttypspec;
+                auto it = latest_any.find(key);
                 if (it == latest_any.end() || it->second.attversion < cand.attversion) {
-                    latest_any[attname] = std::move(cand);
+                    latest_any[std::move(key)] = std::move(cand);
                 }
             }
-            // Filter: only entries whose chosen (max-version) row is live.
-            for (auto& [name, cand] : latest_any) {
+            // Filter: only variants whose chosen (max-version) row is live.
+            for (auto& [key, cand] : latest_any) {
                 if (cand.attrefcount <= 0)
                     continue;
                 out_row_t r;
                 r.attoid = cand.attoid;
-                r.attname = name;
+                r.attname = std::move(cand.attname);
                 r.atttypid = cand.atttypid;
                 r.atttypspec = std::move(cand.atttypspec);
                 rows.push_back(std::move(r));
@@ -319,12 +326,33 @@ namespace components::operators {
                                                ctx->session,
                                                table_oid_);
             auto storage_types = co_await std::move(stf);
+            // Map each resolved variant to its physical storage column by
+            // (name, type): with multi-type fields several storage columns share
+            // a name, so the type disambiguates. `claimed` prevents two variants
+            // from binding to the same physical column. Falls back to the first
+            // unclaimed same-name column when types don't compare exactly.
+            std::vector<bool> claimed(storage_types.size(), false);
             for (auto& r : rows) {
+                const types::complex_logical_type rtype =
+                    r.atttypspec.empty() ? types::complex_logical_type(catalog::oid_to_builtin_type(r.atttypid))
+                                         : catalog::decode_type_spec(resource_, r.atttypspec);
+                std::int32_t name_only = -1;
                 for (std::size_t i = 0; i < storage_types.size(); ++i) {
-                    if (storage_types[i].has_alias() && storage_types[i].alias() == r.attname) {
+                    if (claimed[i] || !storage_types[i].has_alias() || storage_types[i].alias() != r.attname) {
+                        continue;
+                    }
+                    if (name_only < 0) {
+                        name_only = static_cast<std::int32_t>(i);
+                    }
+                    if (storage_types[i].type() == rtype.type()) {
                         r.chunk_position = static_cast<std::int32_t>(i);
+                        claimed[i] = true;
                         break;
                     }
+                }
+                if (r.chunk_position < 0 && name_only >= 0) {
+                    r.chunk_position = name_only;
+                    claimed[static_cast<std::size_t>(name_only)] = true;
                 }
             }
         } else if (relkind_ == catalog::relkind::view) {

--- a/components/sql/parser/gram.y
+++ b/components/sql/parser/gram.y
@@ -589,7 +589,7 @@ TypeName *SystemTypeName(std::pmr::memory_resource* resource, char *name);
  */
 %token <str>	IDENT FCONST SCONST BCONST XCONST Op
 %token <ival>	ICONST PARAM
-%token			TYPECAST DOT_DOT COLON_EQUALS
+%token			TYPECAST TYPECAST_Q DOT_DOT COLON_EQUALS
 
 /*
  * If you want to make any keyword changes, update the keyword table in
@@ -1100,6 +1100,11 @@ TypeName *SystemTypeName(std::pmr::memory_resource* resource, char *name);
 
 
 
+/* '::?' type-variant selection binds LOOSER than the jsonb path operators
+ * (Op), so `t -> 'a' ->> 'b' ::? type` selects the variant of the whole
+ * navigated field rather than of the last key literal. (Plain '::' stays
+ * tight — see TYPECAST below.) */
+%left		TYPECAST_Q
 %left		Op OPERATOR		/* multi-character ops and user-defined operators */
 %nonassoc	NOTNULL
 %nonassoc	ISNULL
@@ -13542,6 +13547,12 @@ interval_second:
 a_expr:		c_expr									{ $$ = $1; }
 			| a_expr TYPECAST Typename
 					{ $$ = makeTypeCast(resource, $1, $3, @2); }
+			| a_expr TYPECAST_Q Typename
+					{
+						TypeCast *n = (TypeCast *) makeTypeCast(resource, $1, $3, @2);
+						n->variant_select = true;
+						$$ = (Node *) n;
+					}
 			| a_expr COLLATE any_name
 				{
 					CollateClause *n = makeNode(resource, CollateClause);
@@ -13929,6 +13940,12 @@ b_expr:		c_expr
 				{ $$ = $1; }
 			| b_expr TYPECAST Typename
 				{ $$ = makeTypeCast(resource, $1, $3, @2); }
+			| b_expr TYPECAST_Q Typename
+				{
+					TypeCast *n = (TypeCast *) makeTypeCast(resource, $1, $3, @2);
+					n->variant_select = true;
+					$$ = (Node *) n;
+				}
 			| '+' b_expr					%prec UMINUS
 				{ $$ = (Node *) makeSimpleA_Expr(resource, AEXPR_OP, "+", NULL, $2, @1); }
 			| '-' b_expr					%prec UMINUS
@@ -16618,6 +16635,7 @@ makeTypeCast(std::pmr::memory_resource* resource, Node *arg, TypeName *type, int
 	n->arg = arg;
 	n->typeName = type;
 	n->location = location;
+	n->variant_select = false;
 	return (Node *) n;
 }
 

--- a/components/sql/parser/nodes/parsenodes.h
+++ b/components/sql/parser/nodes/parsenodes.h
@@ -320,6 +320,10 @@ typedef struct TypeCast {
     Node* arg;          /* the expression being casted */
     TypeName* typeName; /* the target type */
     int location;       /* token location, or -1 if unknown */
+    /* '::?' type-variant selection: pick the same-named column whose physical
+     * type matches typeName (computing multi-type fields), instead of casting.
+     * false for a normal '::' cast. */
+    bool variant_select;
 } TypeCast;
 
 /*

--- a/components/sql/parser/scan.l
+++ b/components/sql/parser/scan.l
@@ -336,6 +336,7 @@ ident_cont		[A-Za-z\200-\377_0-9\$]
 identifier		{ident_start}{ident_cont}*
 
 typecast		"::"
+typecast_q		"::?"
 dot_dot			\.\.
 colon_equals	":="
 
@@ -795,6 +796,11 @@ other			.
 					ident = downcase_truncate_identifier(yyextra->resource, yytext, yyleng, true);
 					yylval->str = ident;
 					return IDENT;
+				}
+
+{typecast_q}	{
+					SET_YYLLOC();
+					return TYPECAST_Q;
 				}
 
 {typecast}		{

--- a/components/sql/transformer/impl/transform_select.cpp
+++ b/components/sql/transformer/impl/transform_select.cpp
@@ -449,6 +449,9 @@ namespace components::sql::transform {
                             auto col_ref = columnref_to_field(resource_, pg_ptr_cast<ColumnRef>(cast->arg), names);
                             auto field_name = std::string(col_ref.field.storage().back());
                             col_ref.field.set_cast_type(target_type_res.value());
+                            if (cast->variant_select) {
+                                col_ref.field.set_variant_select(true);
+                            }
                             std::string alias = res->name ? res->name : field_name;
                             has_non_star = true;
                             select_node->append_expression(make_scalar_expression(resource_,
@@ -456,6 +459,38 @@ namespace components::sql::transform {
                                                                                   expressions::key_t{resource_, alias},
                                                                                   std::move(col_ref.field)));
                             break;
+                        }
+                        // '<jsonb nav chain> ::? type' — e.g. `m -> 'a' ->> 'b' ::? string`.
+                        // Resolve the chain to its flattened key, then attach the
+                        // type so find_types picks the matching multi-type variant.
+                        if (cast->arg && nodeTag(cast->arg) == T_A_Expr) {
+                            auto* sub = pg_ptr_cast<A_Expr>(cast->arg);
+                            if (sub->kind == AEXPR_OP && sub->name &&
+                                nodeTag(sub->name->lst.front().data) == T_String &&
+                                is_jsonb_nav_operator(strVal(sub->name->lst.front().data))) {
+                                auto target_type_res = get_type(resource_, cast->typeName);
+                                if (target_type_res.has_error()) {
+                                    error_ = target_type_res.error();
+                                    break;
+                                }
+                                expressions::key_t field_key{resource_};
+                                if (!resolve_jsonb_scalar_key(sub, names, field_key)) {
+                                    return nullptr;
+                                }
+                                field_key.set_cast_type(target_type_res.value());
+                                if (cast->variant_select) {
+                                    field_key.set_variant_select(true);
+                                }
+                                std::string alias = res->name ? res->name
+                                                              : std::string(field_key.storage().back());
+                                has_non_star = true;
+                                select_node->append_expression(
+                                    make_scalar_expression(resource_,
+                                                           scalar_type::get_field,
+                                                           expressions::key_t{resource_, alias},
+                                                           std::move(field_key)));
+                                break;
+                            }
                         }
                         [[fallthrough]];
                     }
@@ -473,10 +508,56 @@ namespace components::sql::transform {
                         auto a_expr = pg_ptr_cast<A_Expr>(res->val);
                         if (a_expr->kind == AEXPR_OP) {
                             auto op_str = std::string_view(strVal(a_expr->name->lst.front().data));
+                            // JSONB delete: '#-' always; '-' only when the left side is
+                            // the table itself (document root) — otherwise it is plain
+                            // arithmetic subtraction. a_expr->lexpr is null for unary
+                            // minus ('-x'), so guard before probing it.
+                            if (op_str == "#-" ||
+                                (op_str == "-" && a_expr->lexpr && jsonb_lhs_is_table(a_expr->lexpr, names))) {
+                                has_non_star = true;
+                                expressions::key_t prefix_key{resource_};
+                                if (!resolve_jsonb_prefix_key(a_expr, names, prefix_key)) {
+                                    return nullptr;
+                                }
+                                select_node->append_expression(
+                                    make_scalar_expression(resource_, scalar_type::jsonb_delete, prefix_key));
+                                break;
+                            }
                             if (is_arithmetic_operator(op_str)) {
                                 has_non_star = true;
                                 logical_plan::node_ptr sel_node = select_node;
                                 transform_select_a_expr(a_expr, res->name, names, params, sel_node);
+                                break;
+                            }
+                            if (is_jsonb_nav_operator(op_str)) {
+                                has_non_star = true;
+                                if (jsonb_nav_returns_scalar(op_str)) {
+                                    // Scalar jsonb navigation (->> / #>>) collapses to a
+                                    // get_field on the flattened slash-joined column key.
+                                    expressions::key_t field_key{resource_};
+                                    if (!resolve_jsonb_scalar_key(a_expr, names, field_key)) {
+                                        return nullptr;
+                                    }
+                                    if (res->name) {
+                                        select_node->append_expression(
+                                            make_scalar_expression(resource_,
+                                                                   scalar_type::get_field,
+                                                                   expressions::key_t{resource_, res->name},
+                                                                   field_key));
+                                    } else {
+                                        select_node->append_expression(
+                                            make_scalar_expression(resource_, scalar_type::get_field, field_key));
+                                    }
+                                } else {
+                                    // Table-valued navigation (-> / #>): expand the subtree
+                                    // under the prefix into its (rerooted) columns.
+                                    expressions::key_t prefix_key{resource_};
+                                    if (!resolve_jsonb_prefix_key(a_expr, names, prefix_key)) {
+                                        return nullptr;
+                                    }
+                                    select_node->append_expression(
+                                        make_scalar_expression(resource_, scalar_type::jsonb_expand, prefix_key));
+                                }
                                 break;
                             }
                         }

--- a/components/sql/transformer/impl/transfrom_common.cpp
+++ b/components/sql/transformer/impl/transfrom_common.cpp
@@ -4,10 +4,12 @@
 #include <components/logical_plan/node_function.hpp>
 #include <components/sql/transformer/transformer.hpp>
 #include <components/sql/transformer/utils.hpp>
+#include <components/types/logical_value.hpp>
 
 using namespace components::expressions;
 
 namespace components::sql::transform {
+
 
     expression_ptr transformer::transform_a_expr_arithmetic(A_Expr* node,
                                                             const name_collection_t& names,
@@ -59,6 +61,13 @@ namespace components::sql::transform {
                     auto sub_op = std::string_view(strVal(sub_expr->name->lst.front().data));
                     if (is_arithmetic_operator(sub_op)) {
                         return transform_a_expr_arithmetic(sub_expr, names, params);
+                    }
+                    if (is_jsonb_nav_operator(sub_op)) {
+                        expressions::key_t k{resource_};
+                        if (!resolve_jsonb_scalar_key(sub_expr, names, k)) {
+                            return nullptr;
+                        }
+                        return k;
                     }
                 }
                 error_ = core::error_t(core::error_code_t::sql_parse_error,
@@ -137,6 +146,9 @@ namespace components::sql::transform {
                     auto col_ref = columnref_to_field(resource_, pg_ptr_cast<ColumnRef>(cast->arg), names);
                     col_ref.deduce_side(names);
                     col_ref.field.set_cast_type(target_type_res.value());
+                    if (cast->variant_select) {
+                        col_ref.field.set_variant_select(true);
+                    }
                     return col_ref.field;
                 }
                 return add_param_value(node, params);
@@ -148,6 +160,13 @@ namespace components::sql::transform {
                 auto sub_expr = pg_ptr_cast<A_Expr>(node);
                 if (sub_expr->kind == AEXPR_OP) {
                     auto sub_op = std::string_view(strVal(sub_expr->name->lst.front().data));
+                    if (is_jsonb_nav_operator(sub_op)) {
+                        expressions::key_t k{resource_};
+                        if (!resolve_jsonb_scalar_key(sub_expr, names, k)) {
+                            return nullptr;
+                        }
+                        return k;
+                    }
                     if (is_arithmetic_operator(sub_op)) {
                         auto sub_stype = get_arithmetic_scalar_type(sub_op);
                         if (sub_stype == scalar_type::invalid) {
@@ -366,6 +385,11 @@ namespace components::sql::transform {
                                                    param_id);
                 }
 
+                // JSONB key existence: '?' / '?|' / '?&'. Desugars to IS NOT NULL.
+                if (op_str == "?" || op_str == "?|" || op_str == "?&") {
+                    return transform_jsonb_exists(node, names, params, op_str);
+                }
+
                 auto comp_type = get_compare_type(op_str);
                 if (comp_type == compare_type::invalid) {
                     error_ = core::error_t(core::error_code_t::sql_parse_error,
@@ -396,7 +420,33 @@ namespace components::sql::transform {
                                 auto col_ref = columnref_to_field(resource_, pg_ptr_cast<ColumnRef>(cast->arg), names);
                                 col_ref.deduce_side(names);
                                 col_ref.field.set_cast_type(target_type_res.value());
+                                if (cast->variant_select) {
+                                    col_ref.field.set_variant_select(true);
+                                }
                                 return col_ref.field;
+                            }
+                            // '<jsonb nav chain> ::? type' in a predicate, e.g.
+                            // WHERE m -> 'a' ->> 'b' ::? bigint > 0.
+                            if (cast->arg && nodeTag(cast->arg) == T_A_Expr) {
+                                auto* sub = pg_ptr_cast<A_Expr>(cast->arg);
+                                if (sub->kind == AEXPR_OP && sub->name &&
+                                    nodeTag(sub->name->lst.front().data) == T_String &&
+                                    is_jsonb_nav_operator(strVal(sub->name->lst.front().data))) {
+                                    auto target_type_res = get_type(resource_, cast->typeName);
+                                    if (target_type_res.has_error()) {
+                                        error_ = target_type_res.error();
+                                        return nullptr;
+                                    }
+                                    expressions::key_t k{resource_};
+                                    if (!resolve_jsonb_scalar_key(sub, names, k)) {
+                                        return nullptr;
+                                    }
+                                    k.set_cast_type(target_type_res.value());
+                                    if (cast->variant_select) {
+                                        k.set_variant_select(true);
+                                    }
+                                    return k;
+                                }
                             }
                             return add_param_value(node, params);
                         }
@@ -413,6 +463,13 @@ namespace components::sql::transform {
                                 auto sub_op = std::string_view(strVal(sub->name->lst.front().data));
                                 if (is_arithmetic_operator(sub_op)) {
                                     return transform_a_expr_arithmetic(sub, names, params);
+                                }
+                                if (is_jsonb_nav_operator(sub_op)) {
+                                    expressions::key_t k{resource_};
+                                    if (!resolve_jsonb_scalar_key(sub, names, k)) {
+                                        return nullptr;
+                                    }
+                                    return k;
                                 }
                             }
                             error_ = core::error_t(
@@ -593,6 +650,289 @@ namespace components::sql::transform {
         }
     }
 
+    bool transformer::resolve_jsonb_base(Node* lexpr,
+                                         const name_collection_t& names,
+                                         std::pmr::vector<std::pmr::string>& segments,
+                                         expressions::side_t& side) {
+        if (nodeTag(lexpr) == T_ColumnRef) {
+            auto* ref = pg_ptr_cast<ColumnRef>(lexpr);
+            auto& lst = ref->fields->lst;
+            if (lst.size() == 1 && nodeTag(lst.back().data) == T_String) {
+                std::string base_name = strVal(lst.back().data);
+                if (names.is_left_table(base_name)) {
+                    side = expressions::side_t::left; // bare table name -> document root
+                } else if (names.is_right_table(base_name)) {
+                    side = expressions::side_t::right;
+                } else {
+                    segments.emplace_back(std::pmr::string{base_name.c_str(), resource_}); // column at root
+                }
+            } else {
+                auto cr = columnref_to_field(resource_, ref, names);
+                cr.deduce_side(names);
+                side = cr.field.side();
+                for (const auto& s : cr.field.storage()) {
+                    segments.emplace_back(s);
+                }
+            }
+            return true;
+        }
+        if (nodeTag(lexpr) == T_A_Indirection) {
+            auto cr = indirection_to_field(resource_, pg_ptr_cast<A_Indirection>(lexpr), names);
+            cr.deduce_side(names);
+            side = cr.field.side();
+            for (const auto& s : cr.field.storage()) {
+                segments.emplace_back(s);
+            }
+            return true;
+        }
+        error_ = core::error_t(core::error_code_t::sql_parse_error,
+                               std::pmr::string{"unsupported base operand for jsonb operator", resource_});
+        return false;
+    }
+
+    bool transformer::collect_jsonb_path(A_Expr* node,
+                                         const name_collection_t& names,
+                                         std::pmr::vector<std::pmr::string>& segments,
+                                         expressions::side_t& side) {
+        auto op = std::string_view(strVal(node->name->lst.front().data));
+
+        // Left operand: either a deeper jsonb navigation step, or the base
+        // (table name / column) the whole chain is rooted at.
+        Node* lexpr = node->lexpr;
+        if (nodeTag(lexpr) == T_A_Expr) {
+            auto* sub = pg_ptr_cast<A_Expr>(lexpr);
+            if (sub->kind == AEXPR_OP && sub->name && nodeTag(sub->name->lst.front().data) == T_String &&
+                is_jsonb_nav_operator(strVal(sub->name->lst.front().data))) {
+                if (!collect_jsonb_path(sub, names, segments, side)) {
+                    return false;
+                }
+            } else {
+                error_ = core::error_t(core::error_code_t::sql_parse_error,
+                                       std::pmr::string{"unsupported left operand in jsonb operator chain", resource_});
+                return false;
+            }
+        } else if (!resolve_jsonb_base(lexpr, names, segments, side)) {
+            return false;
+        }
+
+        // Right operand: the key(s) this step navigates into.
+        std::string key_str = get_str_value(node->rexpr);
+        if (has_error()) {
+            return false;
+        }
+        auto push_segment = [&](const std::string& s) {
+            // trim surrounding spaces (PG-style '{a, b}')
+            size_t b = s.find_first_not_of(' ');
+            size_t e = s.find_last_not_of(' ');
+            if (b == std::string::npos) {
+                return;
+            }
+            std::string trimmed = s.substr(b, e - b + 1);
+            segments.emplace_back(std::pmr::string{trimmed.c_str(), resource_});
+        };
+        if (jsonb_op_takes_path(op)) {
+            // '#>' / '#>>' / '#-' : a whole path. Accept PG array '{a,b}' or dotted 'a.b'.
+            std::string path = key_str;
+            if (path.size() >= 2 && path.front() == '{' && path.back() == '}') {
+                path = path.substr(1, path.size() - 2);
+                size_t start = 0;
+                while (true) {
+                    size_t comma = path.find(',', start);
+                    push_segment(path.substr(start, comma - start));
+                    if (comma == std::string::npos) {
+                        break;
+                    }
+                    start = comma + 1;
+                }
+            } else {
+                size_t start = 0;
+                while (true) {
+                    size_t dot = path.find('.', start);
+                    push_segment(path.substr(start, dot - start));
+                    if (dot == std::string::npos) {
+                        break;
+                    }
+                    start = dot + 1;
+                }
+            }
+        } else {
+            // '->' / '->>' : a single key.
+            segments.emplace_back(std::pmr::string{key_str.c_str(), resource_});
+        }
+        return true;
+    }
+
+    bool transformer::jsonb_lhs_is_table(Node* node, const name_collection_t& names) const {
+        if (!node || nodeTag(node) != T_ColumnRef) {
+            return false;
+        }
+        auto& lst = pg_ptr_cast<ColumnRef>(node)->fields->lst;
+        if (lst.size() != 1 || nodeTag(lst.back().data) != T_String) {
+            return false;
+        }
+        std::string nm = strVal(lst.back().data);
+        return names.is_left_table(nm) || names.is_right_table(nm);
+    }
+
+    bool transformer::resolve_jsonb_prefix_key(A_Expr* node,
+                                               const name_collection_t& names,
+                                               expressions::key_t& out_key) {
+        std::pmr::vector<std::pmr::string> segments(resource_);
+        expressions::side_t side = expressions::side_t::undefined;
+        if (!collect_jsonb_path(node, names, segments, side)) {
+            return false;
+        }
+        if (segments.empty()) {
+            error_ = core::error_t(core::error_code_t::sql_parse_error,
+                                   std::pmr::string{"empty jsonb path", resource_});
+            return false;
+        }
+        std::pmr::string joined(resource_);
+        for (size_t i = 0; i < segments.size(); ++i) {
+            if (i != 0) {
+                joined += "/";
+            }
+            joined += segments[i];
+        }
+        out_key = expressions::key_t(resource_, std::move(joined), side);
+        if (out_key.side() == expressions::side_t::undefined && names.right_name.empty() &&
+            names.right_alias.empty()) {
+            out_key.set_side(expressions::side_t::left);
+        }
+        return true;
+    }
+
+    bool transformer::resolve_jsonb_scalar_key(A_Expr* node,
+                                               const name_collection_t& names,
+                                               expressions::key_t& out_key) {
+        auto op = std::string_view(strVal(node->name->lst.front().data));
+        if (!jsonb_nav_returns_scalar(op)) {
+            // '->' / '#>' return jsonb (a sub-table) — only valid in a relation
+            // position (FROM/JOIN), not as a scalar in SELECT/WHERE.
+            error_ = core::error_t(
+                core::error_code_t::sql_parse_error,
+                std::pmr::string{"jsonb operator '" + std::string(op) +
+                                     "' returns a table and cannot be used as a scalar value; "
+                                     "terminate the chain with '->>' or '#>>'",
+                                 resource_});
+            return false;
+        }
+        std::pmr::vector<std::pmr::string> segments(resource_);
+        expressions::side_t side = expressions::side_t::undefined;
+        if (!collect_jsonb_path(node, names, segments, side)) {
+            return false;
+        }
+        if (segments.empty()) {
+            error_ = core::error_t(core::error_code_t::sql_parse_error,
+                                   std::pmr::string{"empty jsonb path", resource_});
+            return false;
+        }
+        std::pmr::string joined(resource_);
+        for (size_t i = 0; i < segments.size(); ++i) {
+            if (i != 0) {
+                joined += "/";
+            }
+            joined += segments[i];
+        }
+        out_key = expressions::key_t(resource_, std::move(joined), side);
+        // Single-table queries leave side undefined; pin to left so the value
+        // getter can read it (mirrors transform_a_expr_func).
+        if (out_key.side() == expressions::side_t::undefined && names.right_name.empty() &&
+            names.right_alias.empty()) {
+            out_key.set_side(expressions::side_t::left);
+        }
+        return true;
+    }
+
+    expression_ptr transformer::transform_jsonb_exists(A_Expr* node,
+                                                       const name_collection_t& names,
+                                                       logical_plan::parameter_node_t* params,
+                                                       std::string_view op) {
+        // Left operand: document (table root) or a navigation prefix.
+        std::pmr::vector<std::pmr::string> prefix(resource_);
+        expressions::side_t side = expressions::side_t::undefined;
+        Node* lexpr = node->lexpr;
+        if (nodeTag(lexpr) == T_A_Expr) {
+            auto* sub = pg_ptr_cast<A_Expr>(lexpr);
+            if (sub->kind == AEXPR_OP && sub->name && nodeTag(sub->name->lst.front().data) == T_String &&
+                is_jsonb_nav_operator(strVal(sub->name->lst.front().data))) {
+                if (!collect_jsonb_path(sub, names, prefix, side)) {
+                    return nullptr;
+                }
+            } else {
+                error_ = core::error_t(core::error_code_t::sql_parse_error,
+                                       std::pmr::string{"unsupported left operand for jsonb '?'", resource_});
+                return nullptr;
+            }
+        } else if (!resolve_jsonb_base(lexpr, names, prefix, side)) {
+            return nullptr;
+        }
+
+        // Right operand: a single key ('?') or a text array '{x,y}' ('?|','?&').
+        std::string rhs = get_str_value(node->rexpr);
+        if (has_error()) {
+            return nullptr;
+        }
+        std::pmr::vector<std::pmr::string> keys(resource_);
+        auto push_key = [&](const std::string& raw) {
+            size_t b = raw.find_first_not_of(" \"");
+            size_t e = raw.find_last_not_of(" \"");
+            if (b == std::string::npos) {
+                return;
+            }
+            keys.emplace_back(std::pmr::string{raw.substr(b, e - b + 1).c_str(), resource_});
+        };
+        if (op == "?") {
+            keys.emplace_back(std::pmr::string{rhs.c_str(), resource_});
+        } else {
+            std::string body = rhs;
+            if (body.size() >= 2 && body.front() == '{' && body.back() == '}') {
+                body = body.substr(1, body.size() - 2);
+            }
+            size_t start = 0;
+            while (true) {
+                size_t comma = body.find(',', start);
+                push_key(body.substr(start, comma - start));
+                if (comma == std::string::npos) {
+                    break;
+                }
+                start = comma + 1;
+            }
+        }
+
+        if (keys.empty()) {
+            // '?&' over no keys is vacuously true; '?|' over no keys is false.
+            return make_compare_expression(params->parameters().resource(),
+                                           op == "?&" ? compare_type::all_true : compare_type::all_false);
+        }
+
+        expressions::side_t use_side = side;
+        if (use_side == expressions::side_t::undefined && names.right_name.empty() && names.right_alias.empty()) {
+            use_side = expressions::side_t::left;
+        }
+        auto build_exists = [&](const std::pmr::string& k) -> compare_expression_ptr {
+            std::pmr::string joined(resource_);
+            for (const auto& seg : prefix) {
+                joined += seg;
+                joined += "/";
+            }
+            joined += k;
+            expressions::key_t key(resource_, std::move(joined), use_side);
+            auto dummy = params->add_parameter(
+                types::logical_value_t(resource_, types::complex_logical_type{types::logical_type::NA}));
+            return make_compare_expression(params->parameters().resource(), compare_type::is_not_null, key, dummy);
+        };
+        if (keys.size() == 1) {
+            return build_exists(keys[0]);
+        }
+        auto combined = make_compare_union_expression(params->parameters().resource(),
+                                                      op == "?&" ? compare_type::union_and : compare_type::union_or);
+        for (const auto& k : keys) {
+            combined->append_child(build_exists(k));
+        }
+        return combined;
+    }
+
     logical_plan::node_ptr transformer::transform_function(RangeFunction& node,
                                                            const name_collection_t& names,
                                                            logical_plan::parameter_node_t* params) {
@@ -717,6 +1057,13 @@ namespace components::sql::transform {
                 auto sub = pg_ptr_cast<A_Expr>(node);
                 if (sub->kind == AEXPR_OP) {
                     auto sub_op = std::string_view(strVal(sub->name->lst.front().data));
+                    if (is_jsonb_nav_operator(sub_op)) {
+                        expressions::key_t k{resource_};
+                        if (!resolve_jsonb_scalar_key(sub, names, k)) {
+                            return nullptr;
+                        }
+                        return k;
+                    }
                     if (is_arithmetic_operator(sub_op)) {
                         auto stype = get_arithmetic_scalar_type(sub_op);
                         auto expr = make_scalar_expression(resource_, stype);

--- a/components/sql/transformer/transformer.hpp
+++ b/components/sql/transformer/transformer.hpp
@@ -135,6 +135,48 @@ namespace components::sql::transform {
                                                             const name_collection_t& names,
                                                             logical_plan::parameter_node_t* params);
 
+        // --- JSONB navigation (-> ->> #> #>>) ----------------------------
+        // Resolve a scalar (text-returning, ->> / #>>) jsonb navigation chain
+        // into the single slash-joined column key it addresses (e.g.
+        // `t -> 'a' ->> 'b'` -> key "a/b"). The chain collapses to one path:
+        // the base operand (a bare table name contributes nothing/root, a
+        // column contributes its name) followed by every operator's key(s).
+        // On a table-returning top operator (-> / #>) in this scalar position,
+        // or any malformed operand, sets error_ and returns false.
+        bool resolve_jsonb_scalar_key(A_Expr* node,
+                                      const name_collection_t& names,
+                                      expressions::key_t& out_key);
+        // Recursive worker: appends this chain's path segments (in order) and
+        // sets `side` from the base operand. Accepts any nav operator.
+        bool collect_jsonb_path(A_Expr* node,
+                                const name_collection_t& names,
+                                std::pmr::vector<std::pmr::string>& segments,
+                                expressions::side_t& side);
+        // Resolve the base (left-most) operand of a jsonb chain into its path
+        // segments + side. A bare table name yields no segments (document root);
+        // a column yields its name.
+        bool resolve_jsonb_base(Node* lexpr,
+                                const name_collection_t& names,
+                                std::pmr::vector<std::pmr::string>& segments,
+                                expressions::side_t& side);
+
+        // Table-valued jsonb operators ('->','#>' expand; '-','#-' delete).
+        // Collapse the chain into a single slash-joined prefix key (e.g. 'a/b').
+        // Used in the SELECT list; validate_logical_plan turns the resulting
+        // jsonb_expand / jsonb_delete expression into get_field columns.
+        bool resolve_jsonb_prefix_key(A_Expr* node, const name_collection_t& names, expressions::key_t& out_key);
+        // True if `node` is a bare identifier naming the FROM table/alias — i.e.
+        // the document root. Distinguishes 't - x' (jsonb delete) from arithmetic.
+        bool jsonb_lhs_is_table(Node* node, const name_collection_t& names) const;
+
+        // jsonb key existence: '?' (one key), '?|' (any of), '?&' (all of).
+        // Desugars each key to an IS NOT NULL test on the flattened path, then
+        // combines with OR ('?'/'?|') or AND ('?&').
+        expressions::expression_ptr transform_jsonb_exists(A_Expr* node,
+                                                          const name_collection_t& names,
+                                                          logical_plan::parameter_node_t* params,
+                                                          std::string_view op);
+
         expressions::expression_ptr
         transform_null_test(NullTest* node, const name_collection_t& names, logical_plan::parameter_node_t* params);
 

--- a/components/sql/transformer/utils.cpp
+++ b/components/sql/transformer/utils.cpp
@@ -150,6 +150,14 @@ namespace components::sql::transform {
         return ref;
     }
 
+    bool is_jsonb_nav_operator(std::string_view op) {
+        return op == "->" || op == "->>" || op == "#>" || op == "#>>";
+    }
+
+    bool jsonb_nav_returns_scalar(std::string_view op) { return op == "->>" || op == "#>>"; }
+
+    bool jsonb_op_takes_path(std::string_view op) { return op == "#>" || op == "#>>" || op == "#-"; }
+
     std::string node_tag_to_string(NodeTag type) {
         switch (type) {
             case T_A_Expr:

--- a/components/sql/transformer/utils.hpp
+++ b/components/sql/transformer/utils.hpp
@@ -207,6 +207,24 @@ namespace components::sql::transform {
         return expressions::scalar_type::invalid;
     }
 
+    // --- JSONB operators -------------------------------------------------
+    // Path-navigation jsonb operators. On a computing table (relkind='g')
+    // nested fields are flattened into a single column whose name is the
+    // path joined by '/', so navigation reduces to building that joined key.
+    //   ->  /  #>   return jsonb  -> a (sub)table (relation position only)
+    //   ->> / #>>   return text   -> a typed scalar value (SELECT/WHERE)
+    // '#>'/'#>>' take a whole path on the right ('{a,b}' or dotted 'a.b').
+    inline bool is_jsonb_nav_operator(std::string_view op) {
+        return op == "->" || op == "->>" || op == "#>" || op == "#>>";
+    }
+
+    // True for the scalar (text-returning) variants usable in SELECT/WHERE.
+    inline bool jsonb_nav_returns_scalar(std::string_view op) { return op == "->>" || op == "#>>"; }
+
+    // True for operators whose right operand is a whole path ('{a,b}' / 'a.b'),
+    // not a single key — '#>', '#>>' (navigation) and '#-' (delete by path).
+    inline bool jsonb_op_takes_path(std::string_view op) { return op == "#>" || op == "#>>" || op == "#-"; }
+
     std::string node_tag_to_string(NodeTag type);
     std::string expr_kind_to_string(A_Expr_Kind type);
     std::string like_to_regex(const std::string& pattern);

--- a/components/sql/transformer/utils.hpp
+++ b/components/sql/transformer/utils.hpp
@@ -214,16 +214,14 @@ namespace components::sql::transform {
     //   ->  /  #>   return jsonb  -> a (sub)table (relation position only)
     //   ->> / #>>   return text   -> a typed scalar value (SELECT/WHERE)
     // '#>'/'#>>' take a whole path on the right ('{a,b}' or dotted 'a.b').
-    inline bool is_jsonb_nav_operator(std::string_view op) {
-        return op == "->" || op == "->>" || op == "#>" || op == "#>>";
-    }
+    bool is_jsonb_nav_operator(std::string_view op);
 
     // True for the scalar (text-returning) variants usable in SELECT/WHERE.
-    inline bool jsonb_nav_returns_scalar(std::string_view op) { return op == "->>" || op == "#>>"; }
+    bool jsonb_nav_returns_scalar(std::string_view op);
 
     // True for operators whose right operand is a whole path ('{a,b}' / 'a.b'),
     // not a single key — '#>', '#>>' (navigation) and '#-' (delete by path).
-    inline bool jsonb_op_takes_path(std::string_view op) { return op == "#>" || op == "#>>" || op == "#-"; }
+    bool jsonb_op_takes_path(std::string_view op);
 
     std::string node_tag_to_string(NodeTag type);
     std::string expr_kind_to_string(A_Expr_Kind type);

--- a/integration/cpp/test/test_computed_schema.cpp
+++ b/integration/cpp/test/test_computed_schema.cpp
@@ -1,5 +1,7 @@
 #include "test_config.hpp"
 #include <catch2/catch.hpp>
+#include <set>
+#include <string>
 
 // Tests for computed_schema (dynamic per-type columnar storage)
 // A computed-schema table is created with CREATE TABLE db.t() — no fixed columns.
@@ -115,6 +117,70 @@ TEST_CASE("integration::cpp::test_computed_schema::evolving_schema") {
     }
 }
 
+// Multi-type field: a computing table keeps several columns with the same name
+// but different types. SELECT * returns ALL of them; an explicit reference to the
+// ambiguous name errors (type selection is needed — see ::? in a later step).
+TEST_CASE("integration::cpp::test_computed_schema::multitype_select_star") {
+    auto config = test_create_config("/tmp/test_computed_schema/multitype_star");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+    auto exec = [&](const std::string& sql) {
+        auto session = otterbrix::session_id_t();
+        return dispatcher->execute_sql(session, sql);
+    };
+
+    REQUIRE(exec("CREATE DATABASE cs_testdb;")->is_success());
+    REQUIRE(exec("CREATE TABLE cs_testdb.mt ();")->is_success());
+    REQUIRE(exec("INSERT INTO cs_testdb.mt (id, val) VALUES (1, 1), (2, 2);")->is_success());
+    REQUIRE(exec("INSERT INTO cs_testdb.mt (id, val) VALUES (3, 'hello');")->is_success());
+
+    SECTION("SELECT * returns both 'val' variants with their own values") {
+        auto cur = exec("SELECT * FROM cs_testdb.mt ORDER BY id;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 3);
+        REQUIRE(cur->chunk_data().column_count() == 3);
+
+        // Locate the two 'val' columns by physical type.
+        const auto& chunk = cur->chunk_data();
+        int bigint_val = -1, string_val = -1;
+        for (size_t c = 0; c < chunk.column_count(); ++c) {
+            if (std::string(chunk.data[c].type().alias()) != "val") {
+                continue;
+            }
+            if (chunk.data[c].type().type() == components::types::logical_type::BIGINT) {
+                bigint_val = static_cast<int>(c);
+            } else {
+                string_val = static_cast<int>(c);
+            }
+        }
+        REQUIRE(bigint_val >= 0);
+        REQUIRE(string_val >= 0);
+
+        // bigint variant: rows id=1,2 have values; id=3 (string row) is NULL.
+        REQUIRE(chunk.value(static_cast<size_t>(bigint_val), 0).value<int64_t>() == 1);
+        REQUIRE(chunk.value(static_cast<size_t>(bigint_val), 1).value<int64_t>() == 2);
+        REQUIRE(chunk.value(static_cast<size_t>(bigint_val), 2).is_null());
+        // string variant: only id=3 has a value.
+        REQUIRE(chunk.value(static_cast<size_t>(string_val), 0).is_null());
+        REQUIRE(chunk.value(static_cast<size_t>(string_val), 1).is_null());
+        REQUIRE(chunk.value(static_cast<size_t>(string_val), 2).value<std::string_view>() == "hello");
+    }
+
+    SECTION("an explicit reference to the multi-type name is ambiguous") {
+        REQUIRE_FALSE(exec("SELECT val FROM cs_testdb.mt;")->is_success());
+    }
+
+    SECTION("an unambiguous column still works") {
+        auto cur = exec("SELECT id FROM cs_testdb.mt ORDER BY id;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 3);
+        REQUIRE(cur->chunk_data().value(0, 0).value<int64_t>() == 1);
+    }
+}
+
 TEST_CASE("integration::cpp::test_computed_schema::delete_rows") {
     auto config = test_create_config("/tmp/test_computed_schema/delete");
     test_clear_directory(config);
@@ -157,78 +223,257 @@ TEST_CASE("integration::cpp::test_computed_schema::delete_rows") {
     }
 }
 
-// TODO: fix
-/*
-TEST_CASE("integration::cpp::test_computed_schema::multi_type_field") {
-    auto config = test_create_config("/tmp/test_computed_schema/multi_type");
+// JSONB scalar navigation (->> and #>>) over a computing table.
+// Nested fields are flattened: INSERT (a.b, a.c) creates columns "a/b","a/c".
+// A scalar jsonb chain (terminated by ->>/#>>) addresses one flattened column.
+TEST_CASE("integration::cpp::test_computed_schema::jsonb_scalar_navigation") {
+    auto config = test_create_config("/tmp/test_computed_schema/jsonb_scalar");
     test_clear_directory(config);
     config.disk.on = false;
     config.wal.on = false;
     test_spaces space(config);
     auto* dispatcher = space.dispatcher();
 
-    {
+    auto exec = [&](const std::string& sql) {
         auto session = otterbrix::session_id_t();
-        dispatcher->execute_sql(session, "CREATE DATABASE cs_testdb;");
-    }
-    {
-        auto session = otterbrix::session_id_t();
-        auto cur = dispatcher->execute_sql(session, "CREATE TABLE cs_testdb.t4 ();");
+        return dispatcher->execute_sql(session, sql);
+    };
+
+    REQUIRE(exec("CREATE DATABASE cs_testdb;")->is_success());
+    REQUIRE(exec("CREATE TABLE cs_testdb.j ();")->is_success());
+    REQUIRE(exec("INSERT INTO cs_testdb.j (a.b, a.c, x) VALUES (1, 2, 9), (10, 20, 90);")->is_success());
+
+    SECTION("-> ... ->> resolves a nested leaf to its native value") {
+        auto cur = exec("SELECT x, j -> 'a' ->> 'b' AS b FROM cs_testdb.j ORDER BY x;");
         REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 2);
+        REQUIRE(cur->chunk_data().column_count() == 2);
+        REQUIRE(cur->chunk_data().value(1, 0).value<int64_t>() == 1);
+        REQUIRE(cur->chunk_data().value(1, 1).value<int64_t>() == 10);
     }
 
-    // Insert 'id' as bigint
-    {
+    SECTION("->> on a top-level field") {
+        auto cur = exec("SELECT j ->> 'x' AS xx FROM cs_testdb.j ORDER BY x;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->chunk_data().value(0, 0).value<int64_t>() == 9);
+        REQUIRE(cur->chunk_data().value(0, 1).value<int64_t>() == 90);
+        REQUIRE(std::string(cur->chunk_data().data[0].type().alias()) == "xx");
+    }
+
+    SECTION("#>> with dotted path and PG-array path are equivalent") {
+        auto dotted = exec("SELECT j #>> 'a.c' AS c FROM cs_testdb.j ORDER BY x;");
+        REQUIRE(dotted->is_success());
+        REQUIRE(dotted->chunk_data().value(0, 0).value<int64_t>() == 2);
+        REQUIRE(dotted->chunk_data().value(0, 1).value<int64_t>() == 20);
+
+        auto arr = exec("SELECT j #>> '{a,c}' AS c FROM cs_testdb.j ORDER BY x;");
+        REQUIRE(arr->is_success());
+        REQUIRE(arr->chunk_data().value(0, 0).value<int64_t>() == 2);
+        REQUIRE(arr->chunk_data().value(0, 1).value<int64_t>() == 20);
+    }
+
+    SECTION("jsonb scalar usable in WHERE") {
+        auto cur = exec("SELECT x FROM cs_testdb.j WHERE j -> 'a' ->> 'b' = 10;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        REQUIRE(cur->chunk_data().value(0, 0).value<int64_t>() == 90);
+
+        auto cur2 = exec("SELECT x FROM cs_testdb.j WHERE j #>> '{a,c}' = 2;");
+        REQUIRE(cur2->is_success());
+        REQUIRE(cur2->size() == 1);
+        REQUIRE(cur2->chunk_data().value(0, 0).value<int64_t>() == 9);
+    }
+
+    SECTION("a chain still ending in -> resolves to a single leaf column") {
+        // j -> 'a' -> 'b' : prefix a/b is a leaf -> one column named 'b'
+        auto cur = exec("SELECT j -> 'a' -> 'b' FROM cs_testdb.j ORDER BY x;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->chunk_data().column_count() == 1);
+        REQUIRE(std::string(cur->chunk_data().data[0].type().alias()) == "b");
+        REQUIRE(cur->chunk_data().value(0, 0).value<int64_t>() == 1);
+        REQUIRE(cur->chunk_data().value(0, 1).value<int64_t>() == 10);
+    }
+}
+
+// JSONB key existence '?' / '?|' / '?&'. Per row, a key "exists" iff its
+// flattened column is present and non-null (IS NOT NULL on the joined path).
+// Note: a key absent from the table schema currently errors (see plan §0.1),
+// so tests use keys that exist in the schema.
+TEST_CASE("integration::cpp::test_computed_schema::jsonb_exists") {
+    auto config = test_create_config("/tmp/test_computed_schema/jsonb_exists");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    auto exec = [&](const std::string& sql) {
         auto session = otterbrix::session_id_t();
-        auto cur = dispatcher->execute_sql(session, "INSERT INTO cs_testdb.t4 (id, val) VALUES (1, 1), (2, 2);");
+        return dispatcher->execute_sql(session, sql);
+    };
+
+    REQUIRE(exec("CREATE DATABASE cs_testdb;")->is_success());
+    REQUIRE(exec("CREATE TABLE cs_testdb.qe ();")->is_success());
+    // row0: a/b=1, x=9 ; row1: a/b=5, x=NULL (x absent from this INSERT)
+    REQUIRE(exec("INSERT INTO cs_testdb.qe (a.b, x) VALUES (1, 9);")->is_success());
+    REQUIRE(exec("INSERT INTO cs_testdb.qe (a.b) VALUES (5);")->is_success());
+
+    SECTION("? matches rows where the key is present and non-null") {
+        auto cur = exec("SELECT qe -> 'a' ->> 'b' AS b FROM cs_testdb.qe WHERE qe ? 'x';");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        REQUIRE(cur->chunk_data().value(0, 0).value<int64_t>() == 1);
+    }
+
+    SECTION("?| any-of") {
+        auto cur = exec("SELECT qe -> 'a' ->> 'b' AS b FROM cs_testdb.qe WHERE qe ?| '{x}';");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        REQUIRE(cur->chunk_data().value(0, 0).value<int64_t>() == 1);
+    }
+
+    SECTION("?& all-of") {
+        auto cur = exec("SELECT qe -> 'a' ->> 'b' AS b FROM cs_testdb.qe WHERE qe ?& '{x}';");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        REQUIRE(cur->chunk_data().value(0, 0).value<int64_t>() == 1);
+    }
+
+    SECTION("existence on a nested path prefix") {
+        // both rows have a/b present -> 2 rows
+        auto cur = exec("SELECT qe -> 'a' ->> 'b' AS b FROM cs_testdb.qe WHERE qe -> 'a' ? 'b';");
         REQUIRE(cur->is_success());
         REQUIRE(cur->size() == 2);
     }
+}
 
-    // Insert 'id' as string — creates a second physical column id__STRING_LITERAL
-    {
+// JSONB delete '-' / '#-' over a computing table. Returns a table = all columns
+// except those under the deleted prefix (column-set exclusion, expanded in SELECT).
+TEST_CASE("integration::cpp::test_computed_schema::jsonb_delete") {
+    auto config = test_create_config("/tmp/test_computed_schema/jsonb_delete");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    auto exec = [&](const std::string& sql) {
         auto session = otterbrix::session_id_t();
-        auto cur = dispatcher->execute_sql(session, "INSERT INTO cs_testdb.t4 (id, val) VALUES (3, 'hello');");
+        return dispatcher->execute_sql(session, sql);
+    };
+    auto alias_set = [](const auto& cur) {
+        std::set<std::string> s;
+        for (size_t c = 0; c < cur->chunk_data().column_count(); ++c) {
+            s.insert(std::string(cur->chunk_data().data[c].type().alias()));
+        }
+        return s;
+    };
+
+    REQUIRE(exec("CREATE DATABASE cs_testdb;")->is_success());
+    REQUIRE(exec("CREATE TABLE cs_testdb.jd ();")->is_success());
+    REQUIRE(exec("INSERT INTO cs_testdb.jd (a.b, a.c, x) VALUES (1, 2, 9), (10, 20, 90);")->is_success());
+
+    SECTION("- 'x' drops a top-level key") {
+        auto cur = exec("SELECT jd - 'x' FROM cs_testdb.jd;");
         REQUIRE(cur->is_success());
-        REQUIRE(cur->size() == 1);
+        REQUIRE(cur->size() == 2);
+        REQUIRE(alias_set(cur) == std::set<std::string>{"a/b", "a/c"});
     }
 
-    // SELECT * must fail: 'id' has two physical types (bigint and string)
-    {
-        auto session = otterbrix::session_id_t();
-        auto cur = dispatcher->execute_sql(session, "SELECT * FROM cs_testdb.t4;");
-        REQUIRE_FALSE(cur->is_success());
-        REQUIRE(cur->is_error());
-        REQUIRE(cur->get_error().type == core::error_code_t::schema_error);
+    SECTION("- 'a' drops a whole subtree") {
+        auto cur = exec("SELECT jd - 'a' FROM cs_testdb.jd;");
+        REQUIRE(cur->is_success());
+        REQUIRE(alias_set(cur) == std::set<std::string>{"x"});
     }
 
-    {
+    SECTION("#- 'a.b' drops one nested leaf, keeps the sibling") {
+        auto cur = exec("SELECT jd #- 'a.b' FROM cs_testdb.jd;");
+        REQUIRE(cur->is_success());
+        REQUIRE(alias_set(cur) == std::set<std::string>{"a/c", "x"});
+    }
+}
+
+// JSONB table-valued navigation '->' / '#>' in the SELECT list expands the
+// subtree under the prefix into its (rerooted) columns. NB: this is the
+// SELECT-list form; `SELECT * FROM t -> 'a'` is intentionally not supported
+// (it would require a parser/grammar change).
+TEST_CASE("integration::cpp::test_computed_schema::jsonb_expand") {
+    auto config = test_create_config("/tmp/test_computed_schema/jsonb_expand");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    auto exec = [&](const std::string& sql) {
         auto session = otterbrix::session_id_t();
-        auto cur = dispatcher->execute_sql(session, "SELECT t4.* FROM cs_testdb.t4;");
-        REQUIRE_FALSE(cur->is_success());
-        REQUIRE(cur->is_error());
-        REQUIRE(cur->get_error().type == core::error_code_t::schema_error);
+        return dispatcher->execute_sql(session, sql);
+    };
+    auto alias_set = [](const auto& cur) {
+        std::set<std::string> s;
+        for (size_t c = 0; c < cur->chunk_data().column_count(); ++c) {
+            s.insert(std::string(cur->chunk_data().data[c].type().alias()));
+        }
+        return s;
+    };
+
+    REQUIRE(exec("CREATE DATABASE cs_testdb;")->is_success());
+    REQUIRE(exec("CREATE TABLE cs_testdb.je ();")->is_success());
+    REQUIRE(exec("INSERT INTO cs_testdb.je (a.b, a.c, x) VALUES (1, 2, 9);")->is_success());
+
+    SECTION("-> 'a' expands the subtree, rerooted (strips the 'a/' prefix)") {
+        auto cur = exec("SELECT je -> 'a' FROM cs_testdb.je;");
+        REQUIRE(cur->is_success());
+        REQUIRE(alias_set(cur) == std::set<std::string>{"b", "c"}); // a/b -> b, a/c -> c
     }
 
-    // Select val as string: rows 1-2 have NULL for val (no string was inserted), row 3 has "hello"
-    {
+    SECTION("#> 'a' (single-element path) expands the same way") {
+        auto cur = exec("SELECT je #> 'a' FROM cs_testdb.je;");
+        REQUIRE(cur->is_success());
+        REQUIRE(alias_set(cur) == std::set<std::string>{"b", "c"});
+    }
+
+    SECTION("-> to a leaf yields a single rerooted column with the value") {
+        auto cur = exec("SELECT je -> 'a' -> 'c' FROM cs_testdb.je;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->chunk_data().column_count() == 1);
+        REQUIRE(std::string(cur->chunk_data().data[0].type().alias()) == "c");
+        REQUIRE(cur->chunk_data().value(0, 0).value<int64_t>() == 2);
+    }
+}
+
+// Multi-type field: '::?type' selects the same-named column whose physical type
+// matches (the '::' cast is left for value conversion). 'val' is inserted as
+// bigint then string, producing two physical 'val' columns.
+TEST_CASE("integration::cpp::test_computed_schema::multitype_variant_select") {
+    auto config = test_create_config("/tmp/test_computed_schema/multitype_variant");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+    auto exec = [&](const std::string& sql) {
         auto session = otterbrix::session_id_t();
-        auto cur = dispatcher->execute_sql(session, "SELECT id, val::string FROM cs_testdb.t4 ORDER BY id;");
+        return dispatcher->execute_sql(session, sql);
+    };
+
+    REQUIRE(exec("CREATE DATABASE cs_testdb;")->is_success());
+    REQUIRE(exec("CREATE TABLE cs_testdb.t4 ();")->is_success());
+    REQUIRE(exec("INSERT INTO cs_testdb.t4 (id, val) VALUES (1, 1), (2, 2);")->is_success());
+    REQUIRE(exec("INSERT INTO cs_testdb.t4 (id, val) VALUES (3, 'hello');")->is_success());
+
+    SECTION("::?string selects the string variant (bigint rows are NULL)") {
+        auto cur = exec("SELECT id, val::?string FROM cs_testdb.t4 ORDER BY id;");
         REQUIRE(cur->is_success());
         REQUIRE(cur->size() == 3);
         REQUIRE(cur->chunk_data().column_count() == 2);
         REQUIRE(cur->chunk_data().value(1, 0).is_null());
         REQUIRE(cur->chunk_data().value(1, 1).is_null());
-        {
-            auto v = cur->chunk_data().value(1, 2);
-            REQUIRE(v.value<const std::string&>() == "hello");
-        }
+        REQUIRE(cur->chunk_data().value(1, 2).value<std::string_view>() == "hello");
     }
 
-    // Select val as bigint: rows 1-2 have (1,2), row 3 has NULL for val::bigint (no bigint was inserted)
-    {
-        auto session = otterbrix::session_id_t();
-        auto cur = dispatcher->execute_sql(session, "SELECT id, val::bigint FROM cs_testdb.t4 ORDER BY id;");
+    SECTION("::?bigint selects the bigint variant (string row is NULL)") {
+        auto cur = exec("SELECT id, val::?bigint FROM cs_testdb.t4 ORDER BY id;");
         REQUIRE(cur->is_success());
         REQUIRE(cur->size() == 3);
         REQUIRE(cur->chunk_data().column_count() == 2);
@@ -237,27 +482,172 @@ TEST_CASE("integration::cpp::test_computed_schema::multi_type_field") {
         REQUIRE(cur->chunk_data().value(1, 2).is_null());
     }
 
-    // WHERE val::bigint
-    {
-        auto session = otterbrix::session_id_t();
-        auto cur =
-            dispatcher->execute_sql(session,
-                                    "SELECT id, val::bigint FROM cs_testdb.t4 WHERE val::bigint > 0 ORDER BY id;");
+    SECTION("::?type works in WHERE") {
+        auto cur = exec("SELECT id, val::?bigint FROM cs_testdb.t4 WHERE val::?bigint > 0 ORDER BY id;");
         REQUIRE(cur->is_success());
         REQUIRE(cur->size() == 2);
-        REQUIRE(cur->chunk_data().column_count() == 2);
         REQUIRE(cur->chunk_data().value(1, 0).value<int64_t>() == 1);
         REQUIRE(cur->chunk_data().value(1, 1).value<int64_t>() == 2);
     }
 
-    // TODO do correct error
-    // SELECT val (no cast) — val has 2 types, which is error
-    {
-        auto session = otterbrix::session_id_t();
-        auto cur = dispatcher->execute_sql(session, "SELECT val FROM cs_testdb.t4;");
-        REQUIRE_FALSE(cur->is_success());
-        REQUIRE(cur->is_error());
-        REQUIRE(cur->get_error().type == core::error_code_t::field_not_exists);
+    SECTION("an unselected multi-type reference is an error") {
+        REQUIRE_FALSE(exec("SELECT val FROM cs_testdb.t4;")->is_success());
     }
 }
-*/
+
+// The jsonb operators coexist with a multi-type field in the same table: they
+// resolve single-type fields normally, drop/expand around the multi-type one,
+// and an unselected reference to the multi-type name stays ambiguous.
+TEST_CASE("integration::cpp::test_computed_schema::jsonb_operators_with_multitype") {
+    auto config = test_create_config("/tmp/test_computed_schema/jsonb_multitype");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+    auto exec = [&](const std::string& sql) {
+        auto session = otterbrix::session_id_t();
+        return dispatcher->execute_sql(session, sql);
+    };
+    auto alias_set = [](const auto& cur) {
+        std::set<std::string> s;
+        for (size_t c = 0; c < cur->chunk_data().column_count(); ++c) {
+            s.insert(std::string(cur->chunk_data().data[c].type().alias()));
+        }
+        return s;
+    };
+
+    REQUIRE(exec("CREATE DATABASE cs_testdb;")->is_success());
+    REQUIRE(exec("CREATE TABLE cs_testdb.m ();")->is_success());
+    // x: single-type; v: multi-type (bigint then string); a/b: single-type (only row 1).
+    REQUIRE(exec("INSERT INTO cs_testdb.m (x, v, a.b) VALUES (1, 10, 100);")->is_success());
+    REQUIRE(exec("INSERT INTO cs_testdb.m (x, v) VALUES (2, 'str');")->is_success());
+
+    SECTION("->> resolves a single-type field next to a multi-type one") {
+        auto cur = exec("SELECT m ->> 'x' FROM cs_testdb.m ORDER BY x;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 2);
+        REQUIRE(cur->chunk_data().value(0, 0).value<int64_t>() == 1);
+        REQUIRE(cur->chunk_data().value(0, 1).value<int64_t>() == 2);
+    }
+
+    SECTION("-> ... ->> resolves a nested single-type leaf") {
+        auto cur = exec("SELECT m -> 'a' ->> 'b' FROM cs_testdb.m ORDER BY x;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->chunk_data().value(0, 0).value<int64_t>() == 100);
+        REQUIRE(cur->chunk_data().value(0, 1).is_null());
+    }
+
+    SECTION("'-' drops every variant of the multi-type field") {
+        auto cur = exec("SELECT m - 'v' FROM cs_testdb.m;");
+        REQUIRE(cur->is_success());
+        REQUIRE(alias_set(cur) == std::set<std::string>{"x", "a/b"});
+    }
+
+    SECTION("'?' on a present field") {
+        auto cur = exec("SELECT x FROM cs_testdb.m WHERE m ? 'x' ORDER BY x;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 2);
+    }
+
+    SECTION("scalar nav to the multi-type name is ambiguous") {
+        REQUIRE_FALSE(exec("SELECT m ->> 'v' FROM cs_testdb.m;")->is_success());
+    }
+
+    SECTION("::? still selects the multi-type variant") {
+        auto cur = exec("SELECT v::?bigint FROM cs_testdb.m WHERE x = 1;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->chunk_data().value(0, 0).value<int64_t>() == 10);
+    }
+}
+
+// Per-operator multi-type semantics: '?' exists if ANY variant is non-null;
+// '::?' composes onto a jsonb-nav chain to pick the variant of a nested
+// multi-type leaf.
+TEST_CASE("integration::cpp::test_computed_schema::jsonb_multitype_semantics") {
+    auto config = test_create_config("/tmp/test_computed_schema/jsonb_mt_sem");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+    auto exec = [&](const std::string& sql) {
+        auto session = otterbrix::session_id_t();
+        return dispatcher->execute_sql(session, sql);
+    };
+
+    REQUIRE(exec("CREATE DATABASE cs_testdb;")->is_success());
+    REQUIRE(exec("CREATE TABLE cs_testdb.mm ();")->is_success());
+    // v and a/b are multi-type (bigint then string); row 3 has neither.
+    REQUIRE(exec("INSERT INTO cs_testdb.mm (id, v, a.b) VALUES (1, 10, 100);")->is_success());
+    REQUIRE(exec("INSERT INTO cs_testdb.mm (id, v, a.b) VALUES (2, 'sv', 'sb');")->is_success());
+    REQUIRE(exec("INSERT INTO cs_testdb.mm (id) VALUES (3);")->is_success());
+
+    SECTION("'?' is true if ANY variant is non-null (false only if all null)") {
+        auto cur = exec("SELECT id FROM cs_testdb.mm WHERE mm ? 'v' ORDER BY id;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 2); // rows 1 (bigint) and 2 (string); row 3 excluded
+        REQUIRE(cur->chunk_data().value(0, 0).value<int64_t>() == 1);
+        REQUIRE(cur->chunk_data().value(0, 1).value<int64_t>() == 2);
+    }
+
+    SECTION("nested '?' over a multi-type leaf") {
+        auto cur = exec("SELECT id FROM cs_testdb.mm WHERE mm -> 'a' ? 'b' ORDER BY id;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 2);
+    }
+
+    SECTION("'::?' composes onto a jsonb-nav chain (bigint variant)") {
+        auto cur = exec("SELECT id, mm -> 'a' ->> 'b' ::? bigint AS b FROM cs_testdb.mm ORDER BY id;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 3);
+        REQUIRE(cur->chunk_data().value(1, 0).value<int64_t>() == 100); // row1: bigint a/b
+        REQUIRE(cur->chunk_data().value(1, 1).is_null());               // row2: string variant
+        REQUIRE(cur->chunk_data().value(1, 2).is_null());               // row3: absent
+    }
+
+    SECTION("'::?' composes onto a jsonb-nav chain (string variant)") {
+        auto cur = exec("SELECT id, mm -> 'a' ->> 'b' ::? string AS b FROM cs_testdb.mm ORDER BY id;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->chunk_data().value(1, 0).is_null());
+        REQUIRE(cur->chunk_data().value(1, 1).value<std::string_view>() == "sb");
+        REQUIRE(cur->chunk_data().value(1, 2).is_null());
+    }
+
+    SECTION("scalar nav to a multi-type leaf without ::? is ambiguous") {
+        REQUIRE_FALSE(exec("SELECT mm -> 'a' ->> 'b' FROM cs_testdb.mm;")->is_success());
+    }
+
+    SECTION("'::?' over a nav chain works in WHERE") {
+        auto cur = exec("SELECT id FROM cs_testdb.mm WHERE mm -> 'a' ->> 'b' ::? bigint > 50 ORDER BY id;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1); // only row 1 (a/b bigint = 100); row 2 is string, row 3 absent
+        REQUIRE(cur->chunk_data().value(0, 0).value<int64_t>() == 1);
+    }
+}
+
+// Regression: unary minus ('-x') has a null left operand. The '-' jsonb-delete
+// detection must not treat it as a delete (or it dereferences null). See the
+// crash that 'INSERT ... ; SELECT -x' would otherwise cause.
+TEST_CASE("integration::cpp::test_computed_schema::unary_minus_not_jsonb_delete") {
+    auto config = test_create_config("/tmp/test_computed_schema/unary_minus");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+    auto exec = [&](const std::string& sql) {
+        auto session = otterbrix::session_id_t();
+        return dispatcher->execute_sql(session, sql);
+    };
+
+    REQUIRE(exec("CREATE DATABASE cs_testdb;")->is_success());
+    REQUIRE(exec("CREATE TABLE cs_testdb.u ();")->is_success());
+    REQUIRE(exec("INSERT INTO cs_testdb.u (x) VALUES (5), (7);")->is_success());
+
+    auto cur = exec("SELECT -x FROM cs_testdb.u ORDER BY x;");
+    REQUIRE(cur->is_success());
+    REQUIRE(cur->size() == 2);
+    REQUIRE(cur->chunk_data().value(0, 0).value<int64_t>() == -5);
+    REQUIRE(cur->chunk_data().value(0, 1).value<int64_t>() == -7);
+}

--- a/integration/cpp/test/test_config.hpp
+++ b/integration/cpp/test/test_config.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <components/compute/function.hpp>
 #include <integration/cpp/base_spaces.hpp>
 
 inline configuration::config test_create_config(const std::filesystem::path& path = std::filesystem::current_path()) {
@@ -16,5 +17,12 @@ inline void test_clear_directory(const configuration::config& config) {
 class test_spaces final : public otterbrix::base_otterbrix_t {
 public:
     test_spaces(const configuration::config& config)
-        : otterbrix::base_otterbrix_t(config) {}
+        : otterbrix::base_otterbrix_t(config) {
+        // Isolate the process-global UDF registry between test cases: each test
+        // gets a fresh builtins-only default registry so user functions from a
+        // previous test don't leak into this one (which crashed test_batch_join
+        // when run after test_batch_where — a stale aggregate UDF resolved to a
+        // null function at plan-gen).
+        components::compute::function_registry_t::reset_default();
+    }
 };

--- a/services/disk/manager_disk.hpp
+++ b/services/disk/manager_disk.hpp
@@ -491,12 +491,17 @@ namespace services::disk {
             // Used by checkpoint_all (sidecar lands next to .otbx) and drop_storage
             // (physical file removal).
             std::filesystem::path otbx_path;
+            // Computing (relkind='g', dynamic-schema) table: created schema-less via
+            // create_storage. Only such tables may hold several columns with the same
+            // name but different types (multi-type fields); regular tables coerce.
+            bool is_computed = false;
 
-            /// In-memory: schema-less
+            /// In-memory: schema-less (computing / relkind='g' dynamic schema)
             explicit collection_storage_entry_t(std::pmr::memory_resource* resource)
                 : table_storage(resource)
                 , storage(std::make_unique<components::storage::table_storage_adapter_t>(table_storage.table(),
-                                                                                         resource)) {}
+                                                                                         resource))
+                , is_computed(true) {}
 
             /// In-memory: with columns
             explicit collection_storage_entry_t(std::pmr::memory_resource* resource,

--- a/services/disk/manager_disk_storage.cpp
+++ b/services/disk/manager_disk_storage.cpp
@@ -323,6 +323,14 @@ namespace services::disk {
             co_return std::make_pair(uint64_t{0}, uint64_t{0});
         }
 
+        // Computing (relkind='g') tables may hold several columns with the same
+        // name but different types (multi-type fields): schema growth and column
+        // matching key on (name, type) instead of name alone, and no coercion.
+        bool is_computed_table = false;
+        if (auto it = storages_.find(table_oid); it != storages_.end()) {
+            is_computed_table = it->second->is_computed;
+        }
+
         // 1. Schema adoption
         if (!s->has_schema() && data->column_count() > 0) {
             s->adopt_schema(data->types());
@@ -344,7 +352,12 @@ namespace services::disk {
         // (now-unfilled) column — producing a NOT NULL violation on the
         // original. test_collection::insert::"insert with conversions"
         // exercises this exact path.
-        if (s->has_schema() && data->column_count() > 0 && data->column_count() != s->columns().size()) {
+        // Computing tables grow per (name,type), regardless of chunk width, so a
+        // same-name different-type field becomes a separate physical column.
+        // Non-computing tables keep the original width-difference guard (an
+        // alias mismatch at equal width is a rename/type-conversion, not growth).
+        if (s->has_schema() && data->column_count() > 0 &&
+            (is_computed_table || data->column_count() != s->columns().size())) {
             auto it = storages_.find(table_oid);
             if (it != storages_.end() && it->second->table_storage.mode() == storage_mode_t::IN_MEMORY) {
                 std::vector<components::table::column_definition_t> new_columns;
@@ -353,9 +366,10 @@ namespace services::disk {
                         continue;
                     }
                     const auto alias = data->data[col].type().alias();
+                    const auto ctype = data->data[col].type().type();
                     bool present = false;
                     for (const auto& tc : s->columns()) {
-                        if (tc.name() == alias) {
+                        if (tc.name() == alias && (!is_computed_table || tc.type().type() == ctype)) {
                             present = true;
                             break;
                         }
@@ -388,12 +402,16 @@ namespace services::disk {
 
             std::vector<components::vector::vector_t> expanded_data;
             expanded_data.reserve(table_columns.size());
-            const bool positional_fallback = (data->column_count() == table_columns.size());
+            // Computing tables match by (name, type) so each type-variant lands in
+            // its own physical column; unmatched variants get NULL. Positional
+            // fallback is disabled there (it assumes one column per name).
+            const bool positional_fallback = !is_computed_table && (data->column_count() == table_columns.size());
             for (size_t t = 0; t < table_columns.size(); t++) {
                 bool found = false;
                 for (uint64_t col = 0; col < data->column_count(); col++) {
                     if (data->data[col].type().has_alias() &&
-                        data->data[col].type().alias() == table_columns[t].name()) {
+                        data->data[col].type().alias() == table_columns[t].name() &&
+                        (!is_computed_table || data->data[col].type().type() == table_columns[t].type().type())) {
                         expanded_data.push_back(std::move(data->data[col]));
                         found = true;
                         break;

--- a/services/dispatcher/enrich_logical_plan.cpp
+++ b/services/dispatcher/enrich_logical_plan.cpp
@@ -17,6 +17,7 @@
 #include "plan_resolve_index.hpp"
 #include "resolve_type.hpp"
 
+#include <components/catalog/catalog_codes.hpp>
 #include <components/expressions/scalar_expression.hpp>
 #include <components/logical_plan/node_aggregate.hpp>
 #include <components/logical_plan/node_alter_column_add.hpp>
@@ -126,7 +127,8 @@ namespace services::dispatcher {
             // collapse those variants (e.g. a string 'val' cast to an existing
             // BIGINT 'val'). Storage adopts the literal type directly, so the
             // INTEGER/BIGINT width concern below does not apply there.
-            if (md->relkind != 'g' && !node->children().empty() && node->children().front() &&
+            if (md->relkind != components::catalog::relkind::computed && !node->children().empty() &&
+                node->children().front() &&
                 node->children().front()->type() == components::logical_plan::node_type::data_t) {
                 auto* dat = static_cast<components::logical_plan::node_data_t*>(node->children().front().get());
                 auto& chunk = dat->data_chunk();

--- a/services/dispatcher/enrich_logical_plan.cpp
+++ b/services/dispatcher/enrich_logical_plan.cpp
@@ -120,7 +120,13 @@ namespace services::dispatcher {
             // with the 8-byte payload. Rebuild each column vector with the
             // table's declared type; cast_as on logical_value_t handles the
             // recursive STRUCT/ARRAY descent.
-            if (!node->children().empty() && node->children().front() &&
+            // Skip for computing tables (relkind='g'): they adopt the literal's
+            // own type and may keep several same-name columns of different types
+            // (multi-type fields). Coercing every value to one resolved type would
+            // collapse those variants (e.g. a string 'val' cast to an existing
+            // BIGINT 'val'). Storage adopts the literal type directly, so the
+            // INTEGER/BIGINT width concern below does not apply there.
+            if (md->relkind != 'g' && !node->children().empty() && node->children().front() &&
                 node->children().front()->type() == components::logical_plan::node_type::data_t) {
                 auto* dat = static_cast<components::logical_plan::node_data_t*>(node->children().front().get());
                 auto& chunk = dat->data_chunk();

--- a/services/dispatcher/validate_logical_plan.cpp
+++ b/services/dispatcher/validate_logical_plan.cpp
@@ -60,6 +60,7 @@
 #include <optional>
 #include <queue>
 #include <set>
+#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -277,7 +278,23 @@ namespace services::dispatcher {
                 matches.erase(it);
             }
 
-            // if result contains multiple types, try to disambiguate via cast_type_ hint
+            // '::?' type-variant selection: among several same-name columns
+            // (computing multi-type fields), keep only the one whose physical type
+            // matches the requested type. Disambiguates what would otherwise be an
+            // ambiguous name; an empty result falls through to "not found" below.
+            if (key.is_variant_select() && key.has_cast_type()) {
+                const auto want = key.cast_type().type();
+                type_paths filtered{resource};
+                for (auto& tp : result) {
+                    if (tp.type.type() == want) {
+                        filtered.push_back(std::move(tp));
+                    }
+                }
+                result = std::move(filtered);
+            }
+
+            // if result still contains multiple types, try to disambiguate via the
+            // cast_type_ hint; if it remains ambiguous, that is an error
             if (result.size() > 1) {
                 if (truncated_key.has_cast_type()) {
                     auto cast_lt = truncated_key.cast_type().type();
@@ -380,6 +397,57 @@ namespace services::dispatcher {
                     return column_path_left;
                 }
             }
+        }
+
+        // Rewrite an is_not_null / is_null predicate on a multi-type field into
+        // an OR / AND over its per-type-variant columns: the key "exists" iff ANY
+        // variant is non-null, and is null only if ALL variants are null. This is
+        // how jsonb '?'/'?|'/'?&' behave over multi-type fields. Other compare
+        // types on such a name stay ambiguous (use '::?type' to pick a variant).
+        components::expressions::expression_ptr
+        rewrite_multitype_null_checks(std::pmr::memory_resource* resource,
+                                      const components::expressions::expression_ptr& expr,
+                                      const named_schema& schema) {
+            using namespace components::expressions;
+            if (!expr || expr->group() != expression_group::compare) {
+                return expr;
+            }
+            auto* cmp = static_cast<compare_expression_t*>(expr.get());
+            if (cmp->is_union()) {
+                auto rebuilt = make_compare_union_expression(resource, cmp->type());
+                for (const auto& ch : cmp->children()) {
+                    rebuilt->append_child(rewrite_multitype_null_checks(resource, ch, schema));
+                }
+                return rebuilt;
+            }
+            const bool is_nn = cmp->type() == compare_type::is_not_null;
+            const bool is_n = cmp->type() == compare_type::is_null;
+            if ((!is_nn && !is_n) || !std::holds_alternative<components::expressions::key_t>(cmp->left())) {
+                return expr;
+            }
+            const auto& key = std::get<components::expressions::key_t>(cmp->left());
+            if (key.storage().empty()) {
+                return expr;
+            }
+            const std::string name = key.as_string();
+            std::vector<components::types::complex_logical_type> variants;
+            for (const auto& c : schema) {
+                if (c.type.has_alias() && std::string(c.type.alias()) == name) {
+                    variants.push_back(c.type);
+                }
+            }
+            if (variants.size() <= 1) {
+                return expr; // single-type (or unknown) — leave as-is
+            }
+            auto combined =
+                make_compare_union_expression(resource, is_nn ? compare_type::union_or : compare_type::union_and);
+            for (const auto& vt : variants) {
+                components::expressions::key_t vkey = key;
+                vkey.set_cast_type(vt);
+                vkey.set_variant_select(true);
+                combined->append_child(make_compare_expression(resource, cmp->type(), vkey, cmp->right()));
+            }
+            return combined;
         }
 
         [[nodiscard]] core::result_wrapper_t<named_schema>
@@ -1272,6 +1340,11 @@ namespace services::dispatcher {
                     same_schema = true;
                 }
                 if (node_match) {
+                    // Expand is_not_null/is_null on multi-type fields into OR/AND
+                    // over their variants (jsonb '?'/'?|'/'?&' over multi-type).
+                    for (auto& e : node_match->expressions()) {
+                        e = impl::rewrite_multitype_null_checks(resource, e, incoming_schema);
+                    }
                     auto res = impl::validate_schema(resource,
                                                      idx,
                                                      node_match,
@@ -1371,6 +1444,61 @@ namespace services::dispatcher {
                             }
                         }
 
+                        // Pre-expand table-valued jsonb operators (jsonb_expand '->'/'#>'
+                        // and jsonb_delete '-'/'#-') into individual get_field columns
+                        // against the resolved schema. On a computing table nested fields
+                        // are flattened to columns named by their slash-joined path, so:
+                        //   expand prefix P -> every column == P or under "P/", rerooted
+                        //                      (strip "P/"; a leaf == P keeps its last seg)
+                        //   delete prefix P -> every column NOT under P (kept as-is)
+                        {
+                            auto& exprs = node_select->expressions();
+                            for (size_t ei = 0; ei < exprs.size();) {
+                                if (exprs[ei]->group() != expression_group::scalar) {
+                                    ei++;
+                                    continue;
+                                }
+                                auto* se = reinterpret_cast<scalar_expression_t*>(exprs[ei].get());
+                                const bool is_expand = se->type() == scalar_type::jsonb_expand;
+                                const bool is_delete = se->type() == scalar_type::jsonb_delete;
+                                if (!is_expand && !is_delete) {
+                                    ei++;
+                                    continue;
+                                }
+                                const std::string prefix = se->key().as_string();
+                                const std::string prefix_slash = prefix + "/";
+                                // (output_name, source_alias) pairs
+                                std::vector<std::pair<std::string, std::string>> cols;
+                                for (const auto& sc : incoming_schema) {
+                                    if (!sc.type.has_alias()) {
+                                        continue;
+                                    }
+                                    std::string alias(sc.type.alias());
+                                    const bool under =
+                                        alias == prefix || alias.rfind(prefix_slash, 0) == 0;
+                                    if (is_delete) {
+                                        if (!under) {
+                                            cols.emplace_back(alias, alias);
+                                        }
+                                    } else if (under) {
+                                        std::string out = alias == prefix
+                                                              ? prefix.substr(prefix.find_last_of('/') + 1)
+                                                              : alias.substr(prefix_slash.size());
+                                        cols.emplace_back(std::move(out), std::move(alias));
+                                    }
+                                }
+                                exprs.erase(exprs.begin() + static_cast<ptrdiff_t>(ei));
+                                for (size_t j = 0; j < cols.size(); j++) {
+                                    components::expressions::key_t out_key(resource, cols[j].first.c_str());
+                                    components::expressions::key_t src_key(resource, cols[j].second.c_str());
+                                    exprs.insert(
+                                        exprs.begin() + static_cast<ptrdiff_t>(ei + j),
+                                        make_scalar_expression(resource, scalar_type::get_field, out_key, src_key));
+                                }
+                                ei += cols.size();
+                            }
+                        }
+
                         // Resolve key paths in node_select scalar expressions against incoming schema.
                         // Aggregates are always in node_group_t now, so only scalar expressions appear here.
                         for (auto& expr : node_select->expressions()) {
@@ -1400,12 +1528,20 @@ namespace services::dispatcher {
                             }
                         }
                     } else {
-                        // Reject only truly-identical columns (same alias from same table).
-                        // Duplicate names across JOIN'd tables are legitimate (PostgreSQL semantics).
-                        std::set<std::pair<std::string, std::string>> seen_pairs;
+                        // "SELECT *" / "SELECT t.*" — emit every column, including
+                        // several same-name columns of different types (multi-type
+                        // fields on a computing table); the wildcard simply returns
+                        // them all (an EXPLICIT reference to such a name still errors
+                        // as ambiguous in find_types and must use type selection).
+                        // Duplicate names across JOIN'd tables are likewise legitimate
+                        // (PostgreSQL semantics). Reject only a truly-identical column:
+                        // same output alias AND same source name AND same physical type.
+                        std::set<std::tuple<std::string, std::string, components::types::logical_type>> seen_cols;
                         for (const auto& col : incoming_schema) {
-                            auto pair = std::make_pair(col.result_alias, std::string(col.type.alias()));
-                            if (!seen_pairs.insert(pair).second) {
+                            auto k = std::make_tuple(col.result_alias,
+                                                     std::string(col.type.alias()),
+                                                     col.type.type());
+                            if (!seen_cols.insert(k).second) {
                                 return core::error_t(
                                     core::error_code_t::schema_error,
                                     std::pmr::string{"column '" + col.type.alias() +

--- a/services/dispatcher/validate_logical_plan.cpp
+++ b/services/dispatcher/validate_logical_plan.cpp
@@ -60,7 +60,6 @@
 #include <optional>
 #include <queue>
 #include <set>
-#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -1536,12 +1535,16 @@ namespace services::dispatcher {
                         // Duplicate names across JOIN'd tables are likewise legitimate
                         // (PostgreSQL semantics). Reject only a truly-identical column:
                         // same output alias AND same source name AND same physical type.
-                        std::set<std::tuple<std::string, std::string, components::types::logical_type>> seen_cols;
+                        struct column_key {
+                            std::string result_alias;
+                            std::string name;
+                            logical_type type;
+                            auto operator<=>(const column_key&) const = default;
+                        };
+                        std::set<column_key> seen_cols;
                         for (const auto& col : incoming_schema) {
-                            auto k = std::make_tuple(col.result_alias,
-                                                     std::string(col.type.alias()),
-                                                     col.type.type());
-                            if (!seen_cols.insert(k).second) {
+                            column_key key{col.result_alias, std::string(col.type.alias()), col.type.type()};
+                            if (!seen_cols.insert(std::move(key)).second) {
                                 return core::error_t(
                                     core::error_code_t::schema_error,
                                     std::pmr::string{"column '" + col.type.alias() +


### PR DESCRIPTION
1. fixed multitype columns in computing tables
2. on multitype columns must choose type with `::?` operator (was `::` in the past)
3. done most of jsonb operators: `->` `->>` `#>` `#>>` `?` `?|` `?&` `-` `#-` 