### PR TITLE
feat(sql, trasformer): add lexer/grammar + trasformer extension API

### DIFF
--- a/cmake/otterbrix_parser_extension.cmake
+++ b/cmake/otterbrix_parser_extension.cmake
@@ -1,0 +1,43 @@
+# otterbrix_add_parser_extension(<lib_name>
+#     PREFIX  <grammar_prefix>     # optional, defaults to <lib_name>
+#     SOURCES <cpp files...>)
+#
+# Builds a parser extension (its own flex+bison grammar) as a static library
+# named otterbrix_<lib_name>, aliased otterbrix::<lib_name>, linked against
+# otterbrix::sql. It hides the per-extension bison/flex wiring.
+#
+# Layout expected in calling directory:
+#   <prefix>_gram.y   — bison grammar, %name-prefix="<prefix>_yy"
+#   <prefix>_scan.l   — flex scanner,  %option prefix="<prefix>_yy"
+#   plus the SOURCES (the parse driver + transform stage, plain C++)
+#
+function(otterbrix_add_parser_extension lib_name)
+    cmake_parse_arguments(EXT "" "PREFIX" "SOURCES" ${ARGN})
+    if (NOT EXT_PREFIX)
+        set(EXT_PREFIX ${lib_name})
+    endif ()
+
+    find_package(BISON REQUIRED)
+    find_package(FLEX REQUIRED)
+
+    bison_target(${EXT_PREFIX}_parser
+            ${CMAKE_CURRENT_SOURCE_DIR}/${EXT_PREFIX}_gram.y
+            ${CMAKE_CURRENT_BINARY_DIR}/${EXT_PREFIX}_gram.cpp
+            DEFINES_FILE ${CMAKE_CURRENT_BINARY_DIR}/${EXT_PREFIX}_gram.hpp)
+    flex_target(${EXT_PREFIX}_lexer
+            ${CMAKE_CURRENT_SOURCE_DIR}/${EXT_PREFIX}_scan.l
+            ${CMAKE_CURRENT_BINARY_DIR}/${EXT_PREFIX}_scan.cpp
+            DEFINES_FILE ${CMAKE_CURRENT_BINARY_DIR}/${EXT_PREFIX}_scan.h)
+    add_flex_bison_dependency(${EXT_PREFIX}_lexer ${EXT_PREFIX}_parser)
+
+    add_library(otterbrix_${lib_name} STATIC
+            ${BISON_${EXT_PREFIX}_parser_OUTPUTS}
+            ${FLEX_${EXT_PREFIX}_lexer_OUTPUTS}
+            ${EXT_SOURCES})
+    add_library(otterbrix::${lib_name} ALIAS otterbrix_${lib_name})
+
+    target_include_directories(otterbrix_${lib_name} PUBLIC
+            ${CMAKE_CURRENT_SOURCE_DIR}   # <lib_name>.hpp, <prefix>_ast.hpp
+            ${CMAKE_CURRENT_BINARY_DIR})  # generated <prefix>_gram.hpp
+    target_link_libraries(otterbrix_${lib_name} PUBLIC otterbrix::sql)
+endfunction()

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -19,6 +19,6 @@ add_subdirectory(vector)
 add_subdirectory(table)
 add_subdirectory(storage)
 
-#if (DEV_MODE)
+if (DEV_MODE)
     add_subdirectory(tests)
-#endif()
+endif()

--- a/components/physical_plan/operators/operator_data.hpp
+++ b/components/physical_plan/operators/operator_data.hpp
@@ -3,7 +3,7 @@
 #include <boost/intrusive_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ref_counter.hpp>
 #include <memory_resource>
-#include <vector/data_chunk.hpp>
+#include <components/vector/data_chunk.hpp>
 #include <vector>
 
 namespace components::operators {

--- a/components/physical_plan/operators/operator_join.hpp
+++ b/components/physical_plan/operators/operator_join.hpp
@@ -5,7 +5,7 @@
 #include <components/physical_plan/operators/operator.hpp>
 #include <components/physical_plan/operators/operator_data.hpp>
 #include <components/vector/data_chunk.hpp>
-#include <expressions/compare_expression.hpp>
+#include <components/expressions/compare_expression.hpp>
 
 namespace components::operators {
 

--- a/components/physical_plan/operators/scan/full_scan.hpp
+++ b/components/physical_plan/operators/scan/full_scan.hpp
@@ -5,7 +5,7 @@
 #include <components/physical_plan/operators/operator.hpp>
 #include <components/table/column_state.hpp>
 #include <core/result_wrapper.hpp>
-#include <expressions/compare_expression.hpp>
+#include <components/expressions/compare_expression.hpp>
 
 namespace components::operators {
 

--- a/components/sql/CMakeLists.txt
+++ b/components/sql/CMakeLists.txt
@@ -21,6 +21,7 @@ set(SOURCE_${PROJECT_NAME}
     parser/scansup.cpp
     parser/keyword.cpp
     parser/parser.cpp
+    parser/extension.cpp
     parser/expr_location.cpp
     parser/guc.cpp
 
@@ -83,5 +84,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-all")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-all")
 
 if (DEV_MODE)
+    add_subdirectory(demo_extension)
     add_subdirectory(test)
 endif ()

--- a/components/sql/demo_extension/CMakeLists.txt
+++ b/components/sql/demo_extension/CMakeLists.txt
@@ -1,0 +1,8 @@
+project(demo_extension CXX)
+
+include(otterbrix_parser_extension)
+
+# use to simplify bison/flex generation
+otterbrix_add_parser_extension(demo_extension
+        PREFIX demo
+        SOURCES demo_extension.cpp)

--- a/components/sql/demo_extension/README.md
+++ b/components/sql/demo_extension/README.md
@@ -1,0 +1,80 @@
+# demo_extension — reference parser extension
+
+A complete, minimal parser extension: the toy language `DEMO <arithmetic>`
+(e.g. `DEMO 2 + 3 * 4`). Copy this directory as the template for a real grammar
+extension (ksql, an S3 source, …).
+
+A parser extension lets you teach otterbrix syntax the core SQL grammar does not
+know. The core bison parser always runs **first**; only queries it rejects are
+offered to the registered extensions (DuckDB's strategy — a successful core
+parse never pays for extensions). An extension that recognizes the query owns it
+end to end: its own lexer, its own grammar, its own AST, lowered to a
+`logical_plan` that runs on the normal engine.
+
+## The two stages
+
+```
+query string ──parse──▶ ExtensionNode (wraps your AST) ──transform──▶ logical_plan
+```
+
+- **parse** (`demo_scan.l` + `demo_gram.y`, driven from `demo_extension.cpp`):
+  recognize your syntax, build your own AST, wrap its root in an `ExtensionNode`
+  envelope. Returns a `core::result_wrapper_t<List*>`:
+  - a non-NIL tree → you claimed and parsed it,
+  - an `error_t` → it's yours but malformed,
+  - `NIL` → not yours; the next extension (or the core error) is tried.
+- **transform** (`demo_extension.cpp`): the transformer routes the `ExtensionNode`
+  back to you by `extension_id` and you walk your AST into a `logical_plan` node.
+
+## Files
+
+| File | Role |
+|------|------|
+| `demo_ast.hpp`        | your own AST nodes (plain arena-allocated structs — no PG nodes) |
+| `demo_gram.y`         | reentrant bison grammar, `%name-prefix="demo_yy"`, wraps the root via `make_extension_node` |
+| `demo_scan.l`         | reentrant flex scanner, `%option prefix="demo_yy"`, tokenizes + the `DEMO` keyword |
+| `demo_extension.cpp`  | `parse` (scanner driver) + `transform` + `make_demo_extension()` factory |
+| `demo_extension.hpp`  | the two stage declarations + the registrable factory |
+| `CMakeLists.txt`      | one `otterbrix_add_parser_extension(...)` call |
+
+## Authoring your own
+
+1. **AST** — define your node structs (`demo_ast.hpp`). Allocate from the parser
+   arena (`resource->allocate(...)`); the tree lives as long as the parse.
+2. **Grammar + scanner** — `<name>_gram.y` and `<name>_scan.l`, each with a
+   unique reentrant prefix (`%name-prefix` / `%option prefix`) so they never
+   clash with the core `base_yy` / `core_yy` parser. The grammar's top rule wraps
+   its root: `*out = make_extension_node(resource, "<id>", root);`
+   (see `make_extension_node` in `parser/nodes/parsenodes.h`).
+3. **parse** — stand the scanner up with the one-line guard
+   `using my_scanner = EXTENSION_FLEX_SCANNER(<name>_yy);`, peek the first token
+   to claim the query (return `NIL` if it isn't yours), then call `<name>_yyparse`.
+4. **transform** — `static_cast` the `ExtensionNode::data` back to your root and
+   build a `logical_plan` node. `params` is there if your syntax has placeholders.
+5. **factory** — `make_<name>_extension()` returns
+   `parser_extension_t{"<id>", &parse, &transform}`. The `<id>` ties the parse-time
+   envelope to the transform-time routing.
+6. **CMake** — `otterbrix_add_parser_extension(<lib> PREFIX <name> SOURCES <name>.cpp)`.
+
+## Registering
+
+Per **instance**, not globally — an extension enabled on one database is invisible
+to another:
+
+```cpp
+space.dispatcher()->add_parser_extension(make_demo_extension());
+// now `DEMO 1 + 20` runs on this instance and yields 21
+```
+
+Or use the parser standalone (no instance), handing a registry straight to
+`raw_parser`:
+
+```cpp
+parser_extension_registry_t registry;
+registry.add(make_demo_extension());
+List* tree = raw_parser(arena, "DEMO 7", registry);
+```
+
+See `components/sql/test/test_parser_extension.cpp` (parser-level) and
+`integration/cpp/test/test_demo_extension.cpp` (end-to-end + per-instance
+isolation) for the exercised behaviour.

--- a/components/sql/demo_extension/demo_ast.hpp
+++ b/components/sql/demo_extension/demo_ast.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <memory_resource>
+
+namespace demo_ext {
+    enum class demo_kind
+    {
+        number,
+        add,
+        subtract,
+        multiply,
+        divide
+    };
+
+    struct demo_node {
+        demo_kind kind;
+        long value;     // valid when kind == number
+        demo_node* lhs; // valid for binary ops
+        demo_node* rhs;
+    };
+
+    inline demo_node* make_number(std::pmr::memory_resource* resource, long value) {
+        auto* node = static_cast<demo_node*>(resource->allocate(sizeof(demo_node)));
+        node->kind = demo_kind::number;
+        node->value = value;
+        node->lhs = nullptr;
+        node->rhs = nullptr;
+        return node;
+    }
+
+    inline demo_node* make_binary(std::pmr::memory_resource* resource, demo_kind kind, demo_node* lhs, demo_node* rhs) {
+        auto* node = static_cast<demo_node*>(resource->allocate(sizeof(demo_node)));
+        node->kind = kind;
+        node->value = 0;
+        node->lhs = lhs;
+        node->rhs = rhs;
+        return node;
+    }
+} // namespace demo_ext

--- a/components/sql/demo_extension/demo_extension.cpp
+++ b/components/sql/demo_extension/demo_extension.cpp
@@ -1,0 +1,75 @@
+#include "demo_extension.hpp"
+
+#include "demo_ast.hpp"
+#include "demo_gram.hpp"
+#include "demo_scan.h"
+
+#include <cassert>
+#include <string_view>
+
+#include <components/logical_plan/node_data.hpp>
+#include <components/logical_plan/param_storage.hpp>
+#include <components/sql/parser/flex_scanner_guard.hpp>
+#include <components/sql/parser/nodes/parsenodes.h>
+#include <components/sql/parser/pg_std_list.h>
+#include <components/types/logical_value.hpp>
+
+namespace {
+    // demo's scanner: the shared macro binds the demo_yy entry points into the RAII guard type
+    using demo_scanner = EXTENSION_FLEX_SCANNER(demo_yy);
+
+    long evaluate(const demo_ext::demo_node* node) {
+        switch (node->kind) {
+            case demo_ext::demo_kind::number:
+                return node->value;
+            case demo_ext::demo_kind::add:
+                return evaluate(node->lhs) + evaluate(node->rhs);
+            case demo_ext::demo_kind::subtract:
+                return evaluate(node->lhs) - evaluate(node->rhs);
+            case demo_ext::demo_kind::multiply:
+                return evaluate(node->lhs) * evaluate(node->rhs);
+            case demo_ext::demo_kind::divide:
+                return evaluate(node->lhs) / evaluate(node->rhs);
+        }
+        return 0;
+    }
+} // namespace
+
+namespace demo_ext {
+    using namespace components::sql::parser;
+
+    parse_extension_result_t parse(std::pmr::memory_resource* resource, const std::string& query) {
+        demo_scanner scanner(query.c_str());
+        if (!scanner.valid()) {
+            return NIL; // scanner failed — not ours
+        }
+
+        // route by our own keyword, consume the first token here, the grammar parses the rest
+        YYSTYPE first_value{};
+        if (scanner.next_token(&first_value) != KW_DEMO) {
+            return NIL;
+        }
+
+        Node* root = nullptr;
+        if (demo_yyparse(scanner.handle(), resource, &root) != 0 || root == nullptr) {
+            return core::error_t(core::error_code_t::sql_parse_error,
+                                 std::pmr::string{"demo: invalid arithmetic expression", resource});
+        }
+        return list_make1(resource, root);
+    }
+
+    components::logical_plan::node_ptr transform(std::pmr::memory_resource* resource,
+                                                 ExtensionNode* node,
+                                                 components::logical_plan::parameter_node_t* /*params*/) {
+        // The transformer routes by extension_id, so this only ever runs for our own nodes
+        assert(node->extension_id != nullptr && std::string_view(node->extension_id) == "demo");
+        const auto* root = static_cast<const demo_node*>(node->data);
+
+        components::types::logical_value_t value(resource, static_cast<int64_t>(evaluate(root)));
+        components::vector::data_chunk_t chunk(resource, {}, 1);
+        chunk.set_cardinality(1);
+        chunk.data.emplace_back(resource, value.type(), chunk.capacity());
+        chunk.set_value(0, 0, std::move(value));
+        return components::logical_plan::make_node_raw_data(resource, std::move(chunk));
+    }
+} // namespace demo_ext

--- a/components/sql/demo_extension/demo_extension.hpp
+++ b/components/sql/demo_extension/demo_extension.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <memory_resource>
+#include <string>
+
+#include <components/sql/parser/extension.hpp>
+
+/*
+ * Example parser extension: a tiny "DEMO <arithmetic>" language.
+ *
+ * It demonstrates the two stages every extension implements, wired together by
+ * make_demo_extension():
+ *   - parse     (demo_scan.l)        : raw query  -> ExtensionNode wrapping demo's own AST
+ *   - transform (demo_extension.cpp) : ExtensionNode -> logical_plan
+ */
+namespace demo_ext {
+    components::sql::parser::parse_extension_result_t parse(std::pmr::memory_resource* resource,
+                                                            const std::string& query);
+
+    components::logical_plan::node_ptr transform(std::pmr::memory_resource* resource,
+                                                 ExtensionNode* node,
+                                                 components::logical_plan::parameter_node_t* params);
+} // namespace demo_ext
+
+inline components::sql::parser::parser_extension_t make_demo_extension() {
+    return components::sql::parser::parser_extension_t{"demo", &demo_ext::parse, &demo_ext::transform};
+}

--- a/components/sql/demo_extension/demo_gram.y
+++ b/components/sql/demo_extension/demo_gram.y
@@ -1,0 +1,73 @@
+/*-------------------------------------------------------------------------
+ *
+ * demo_gram.y
+ *      Tiny arithmetic grammar used as part of example extension.
+ *
+ * A self-contained, reentrant bison parser with its own `demo_yy` prefix, fully
+ * isolated from the main `base_yy` grammar. It builds its OWN AST (demo_ext::demo_node)
+ * and wraps the root in an ExtensionNode envelope.
+ *
+ * Grammar:  expr := expr ('+'|'-') term | term
+ *           term := term ('*'|'/') factor | factor
+ *           factor := NUMBER | '(' expr ')'
+ *
+ *-------------------------------------------------------------------------
+ */
+
+%code requires {
+    #include <memory_resource>
+    #include "demo_ast.hpp"
+    #include <components/sql/parser/nodes/parsenodes.h>
+}
+
+%code {
+    /* Defined by the flex scanner (demo_scan.l). */
+    int demo_yylex(YYSTYPE* yylval_param, void* yyscanner);
+    void demo_yyerror(void* scanner, std::pmr::memory_resource* resource, Node** out, const char* message);
+}
+
+%pure-parser
+%name-prefix="demo_yy"
+%parse-param {void* scanner} {std::pmr::memory_resource* resource} {Node** out}
+%lex-param   {void* scanner}
+
+%union {
+    long ival;
+    demo_ext::demo_node* node;
+}
+
+%token <ival> NUMBER
+%token KW_DEMO
+%type  <node> expr term factor
+
+%%
+
+input:
+    expr {
+        /* Wrap demo's own AST in an ExtensionNode envelope */
+        *out = make_extension_node(resource, "demo", $1);
+    }
+    ;
+
+expr:
+    expr '+' term       { $$ = demo_ext::make_binary(resource, demo_ext::demo_kind::add, $1, $3); }
+    | expr '-' term     { $$ = demo_ext::make_binary(resource, demo_ext::demo_kind::subtract, $1, $3); }
+    | term              { $$ = $1; }
+    ;
+
+term:
+    term '*' factor     { $$ = demo_ext::make_binary(resource, demo_ext::demo_kind::multiply, $1, $3); }
+    | term '/' factor   { $$ = demo_ext::make_binary(resource, demo_ext::demo_kind::divide, $1, $3); }
+    | factor            { $$ = $1; }
+    ;
+
+factor:
+    NUMBER              { $$ = demo_ext::make_number(resource, $1); }
+    | '(' expr ')'      { $$ = $2; }
+    ;
+
+%%
+
+void demo_yyerror(void*, std::pmr::memory_resource*, Node**, const char*) {
+    /* No errors for simplicity, they are reported via a non-zero demo_yyparse() return value */
+}

--- a/components/sql/demo_extension/demo_scan.l
+++ b/components/sql/demo_extension/demo_scan.l
@@ -1,0 +1,39 @@
+%{
+/*-------------------------------------------------------------------------
+ *
+ * demo_scan.l
+ *      Flex lexer for the arithmetic parser, used as part of example extension.
+ *
+ * A self-contained reentrant scanner with its own `demo_yy` prefix, isolated
+ * from the main `core_yy` scanner. It tokenizes integers, the `+ - * / ( )`
+ * operators and the `DEMO` keyword. flex generates the scanner API header itself
+ * (demo_scan.h, via the CMake DEFINES_FILE option), parse driver lives in demo_extension.cpp
+ *
+ *-------------------------------------------------------------------------
+ */
+#include <cstdlib>
+
+#include "demo_gram.hpp"
+%}
+
+%option reentrant
+%option bison-bridge
+%option noyywrap
+%option nounput
+%option noinput
+%option prefix="demo_yy"
+
+%%
+
+[ \t\r\n]+          { /* skip whitespace */ }
+[0-9]+              { yylval->ival = std::atol(yytext); return NUMBER; }
+[Dd][Ee][Mm][Oo]   { return KW_DEMO; }
+"+"                 { return '+'; }
+"-"                 { return '-'; }
+"*"                 { return '*'; }
+"/"                 { return '/'; }
+"("                 { return '('; }
+")"                 { return ')'; }
+.                   { return yytext[0]; } /* unknown char, let the parser error */
+
+%%

--- a/components/sql/parser/extension.cpp
+++ b/components/sql/parser/extension.cpp
@@ -1,0 +1,53 @@
+#include "extension.hpp"
+
+#include <algorithm>
+
+namespace components::sql::parser {
+    core::result_wrapper_t<const parser_extension_t*> parser_extension_registry_t::add(parser_extension_t extension) {
+        auto name = extension.name;
+        auto [it, inserted] = extensions_.try_emplace(std::move(name), std::move(extension));
+        if (!inserted) {
+            return core::error_t(core::error_code_t::already_exists,
+                                 std::pmr::string{
+                                     "parser extension '" + it->first + "' already registered",
+                                 });
+        }
+        return &it->second;
+    }
+
+    void parser_extension_registry_t::clear() { extensions_.clear(); }
+
+    bool parser_extension_registry_t::empty() const noexcept { return extensions_.empty(); }
+
+    const parser_extension_t* parser_extension_registry_t::find(std::string_view name) const {
+        auto it = extensions_.find(std::string{name});
+        return it != extensions_.end() ? &it->second : nullptr;
+    }
+
+    parse_extension_result_t parser_extension_registry_t::dispatch(std::pmr::memory_resource* resource,
+                                                                   const char* query) const {
+        const std::string query_str(query ? query : "");
+        // a successful parse claims the query, the first failure is kept as a best-effort diagnostic,
+        // surfaced only if nobody claims
+        parse_extension_result_t first_failure = NIL;
+        for (const auto& entry : extensions_) {
+            const parser_extension_t& extension = entry.second;
+            if (extension.parse == nullptr) {
+                continue;
+            }
+
+            parse_extension_result_t result = extension.parse(resource, query_str);
+            if (result.has_error()) {
+                if (!first_failure.has_error()) {
+                    first_failure = std::move(result);
+                }
+                continue;
+            }
+
+            if (result.value() != NIL) {
+                return result;
+            }
+        }
+        return first_failure;
+    }
+} // namespace components::sql::parser

--- a/components/sql/parser/extension.hpp
+++ b/components/sql/parser/extension.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <memory_resource>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+#include <components/logical_plan/node.hpp>
+#include <core/result_wrapper.hpp>
+
+#include "pg_std_list.h"
+
+struct ExtensionNode;
+
+namespace components::logical_plan {
+    class parameter_node_t;
+} // namespace components::logical_plan
+
+namespace components::sql::parser {
+    // only a successful parse claims the query:
+    //   value != NIL  — parsed, claims the query, tree in the core parser's form
+    //   has_error()   — failed, NOT a claim, surfaced as a diagnostic iff nobody claims
+    //   value == NIL  — not ours, try the next extension, no error is produced
+    using parse_extension_result_t = core::result_wrapper_t<List*>;
+
+    using parse_extension_fn = parse_extension_result_t (*)(std::pmr::memory_resource* resource,
+                                                            const std::string& query);
+
+    using transform_extension_fn = logical_plan::node_ptr (*)(std::pmr::memory_resource* resource,
+                                                              ExtensionNode* node,
+                                                              logical_plan::parameter_node_t* params);
+
+    struct parser_extension_t {
+        std::string name;
+        parse_extension_fn parse;
+        transform_extension_fn transform;
+
+        parser_extension_t(std::string name, parse_extension_fn parse, transform_extension_fn transform = nullptr)
+            : name(std::move(name))
+            , parse(parse)
+            , transform(transform) {}
+    };
+
+    class parser_extension_registry_t {
+    public:
+        // NOTE: extension names are unique: re-adding a name is rejected
+        [[nodiscard]] core::result_wrapper_t<const parser_extension_t*> add(parser_extension_t extension);
+
+        void clear();
+        [[nodiscard]] bool empty() const noexcept;
+
+        [[nodiscard]] const parser_extension_t* find(std::string_view name) const;
+
+        [[nodiscard]] parse_extension_result_t dispatch(std::pmr::memory_resource* resource, const char* query) const;
+
+    private:
+        std::unordered_map<std::string, parser_extension_t> extensions_;
+    };
+} // namespace components::sql::parser

--- a/components/sql/parser/flex_scanner_guard.hpp
+++ b/components/sql/parser/flex_scanner_guard.hpp
@@ -1,0 +1,79 @@
+#pragma once
+
+/*-------------------------------------------------------------------------
+ *
+ * flex_scanner_guard.hpp
+ *      RAII guard over a reentrant flex scanner, for parser extensions backed
+ *      by a flex+bison grammar.
+ *
+ * bison's yyparse() drives the scanner itself (it calls yylex), so an extension
+ * only needs to (1) stand a scanner up over the query string and (2) tear it
+ * down — including when yyparse throws. This guard does exactly that.
+ *
+ * Example usage:
+ *
+ *     using my_scanner = EXTENSION_FLEX_SCANNER(my_yy);   // my_yy is flex's %prefix
+ *     ...
+ *     my_scanner scanner(query.c_str());
+ *
+ *-------------------------------------------------------------------------
+ */
+
+namespace components::sql::parser {
+    namespace detail {
+        template<class ScanString, class Lex>
+        struct flex_scanner_types;
+
+        template<class Buffer, class Handle, class Value>
+        struct flex_scanner_types<Buffer (*)(const char*, Handle), int (*)(Value*, Handle)> {
+            using handle = Handle;
+            using buffer = Buffer;
+            using value = Value;
+        };
+    } // namespace detail
+
+    template<auto LexInit, auto LexDestroy, auto ScanString, auto DeleteBuffer, auto Lex>
+    class flex_scanner_guard {
+        using types = detail::flex_scanner_types<decltype(ScanString), decltype(Lex)>;
+        using handle_t = typename types::handle;
+        using buffer_t = typename types::buffer;
+
+    public:
+        using value_t = typename types::value;
+
+        explicit flex_scanner_guard(const char* query) {
+            if (LexInit(&handle_) == 0) {
+                buffer_ = ScanString(query, handle_);
+            }
+        }
+
+        ~flex_scanner_guard() {
+            if (handle_ != handle_t{}) {
+                if (buffer_ != buffer_t{}) {
+                    DeleteBuffer(buffer_, handle_);
+                }
+                LexDestroy(handle_);
+            }
+        }
+
+        flex_scanner_guard(const flex_scanner_guard&) = delete;
+        flex_scanner_guard& operator=(const flex_scanner_guard&) = delete;
+
+        [[nodiscard]] bool valid() const noexcept { return handle_ != handle_t{}; }
+        [[nodiscard]] handle_t handle() const noexcept { return handle_; }
+        int next_token(value_t* value) { return Lex(value, handle_); }
+
+    private:
+        handle_t handle_{};
+        buffer_t buffer_{};
+    };
+
+} // namespace components::sql::parser
+
+// expands to the flex_scanner_guard type for a reentrant scanner generated with %option prefix="<prefix>"
+#define EXTENSION_FLEX_SCANNER(prefix)                                                                                 \
+    ::components::sql::parser::flex_scanner_guard<&prefix##lex_init,                                                   \
+                                                  &prefix##lex_destroy,                                                \
+                                                  &prefix##_scan_string,                                               \
+                                                  &prefix##_delete_buffer,                                             \
+                                                  &prefix##lex>

--- a/components/sql/parser/nodes/makefuncs.cpp
+++ b/components/sql/parser/nodes/makefuncs.cpp
@@ -140,3 +140,14 @@ FuncCall* makeFuncCall(std::pmr::memory_resource* resource, List* name, List* ar
     n->location = location;
     return n;
 }
+
+/*
+ * make_extension_node -
+ *		build an otterbrix extension node, with payload and tagged by extension_id
+ */
+Node* make_extension_node(std::pmr::memory_resource* resource, const char* extension_id, void* data) {
+    ExtensionNode* node = makeNode(resource, ExtensionNode);
+    node->extension_id = extension_id;
+    node->data = data;
+    return reinterpret_cast<Node*>(node);
+}

--- a/components/sql/parser/nodes/nodes.h
+++ b/components/sql/parser/nodes/nodes.h
@@ -574,6 +574,8 @@ typedef enum NodeTag
     T_GpPolicy,                  /* in catalog/gp_policy.h */
     T_RetrieveStmt,
 
+    /* otterbrix: parser-extension AST node (components/sql/parser/extension.hpp) */
+    T_ExtensionNode,
 } NodeTag;
 
 /*

--- a/components/sql/parser/nodes/parsenodes.h
+++ b/components/sql/parser/nodes/parsenodes.h
@@ -20,6 +20,8 @@
 *-------------------------------------------------------------------------
 */
 #pragma once
+#include <string_view>
+
 #include "attrnum.h"
 #include "bitmapset.h"
 #include "nodes.h"
@@ -311,6 +313,39 @@ typedef struct A_Const {
     Value val;    /* value (includes type info, see value.h) */
     int location; /* token location, or -1 if unknown */
 } A_Const;
+
+/*
+* ExtensionNode - otterbrix parser-extension AST node
+*
+* A grammar extension (see components/sql/parser/extension.hpp) emits this for
+* its own, non-core syntax.
+*/
+typedef struct ExtensionNode {
+    NodeTag type;             /* T_ExtensionNode */
+    const char* extension_id; /* owning extension's name */
+    void* data;               /* extension payload, arena-allocated */
+} ExtensionNode;
+
+/*
+* make_extension_node - build the ExtensionNode envelope a grammar emits for its root
+*/
+Node* make_extension_node(std::pmr::memory_resource* resource, const char* extension_id, void* data);
+
+/*
+* extension_payload - the inverse of make_extension_node: read an extension's typed payload from a parse tree
+*/
+template<typename Payload>
+[[nodiscard]] Payload* extension_payload(List* tree, std::string_view extension_id) {
+    if (tree == NIL) {
+        return nullptr;
+    }
+    ExtensionNode* node = reinterpret_cast<ExtensionNode*>(linitial(tree));
+    if (node == nullptr || nodeTag(node) != T_ExtensionNode || node->extension_id == nullptr ||
+        extension_id != node->extension_id) {
+        return nullptr;
+    }
+    return static_cast<Payload*>(node->data);
+}
 
 /*
 * TypeCast - a CAST expression

--- a/components/sql/parser/parser.cpp
+++ b/components/sql/parser/parser.cpp
@@ -20,16 +20,21 @@
 */
 
 #include "parser.h"
+#include "extension.hpp"
 #include "gramparse.h"
 #include "pg_functions.h"
 
+#include <optional>
+
 /*
-* raw_parser
-*		Given a query in string form, do lexical and grammatical analysis.
+* base_raw_parser
+*		The core bison/flex parsing path — the "base" grammar layer that drives
+*		base_yyparse (cf. core_yylex / base_yylex). Reached when no registered
+*		parser extension claimed the query (see raw_parser below).
 *
 * Returns a list of raw (un-analyzed) parse trees.
 */
-List* raw_parser(std::pmr::memory_resource* resource, const char* str) {
+static List* base_raw_parser(std::pmr::memory_resource* resource, const char* str) {
     core_yyscan_t yyscanner;
     base_yy_extra_type yyextra;
     yyextra.core_yy_extra.resource = resource;
@@ -60,6 +65,50 @@ List* raw_parser(std::pmr::memory_resource* resource, const char* str) {
         return NIL;
 
     return yyextra.parsetree;
+}
+
+/*
+* raw_parser
+*		Core-only entry point: parses core SQL with no extensions condigured.
+*/
+List* raw_parser(std::pmr::memory_resource* resource, const char* str) {
+    const components::sql::parser::parser_extension_registry_t no_extensions;
+    return raw_parser(resource, str, no_extensions);
+}
+
+/*
+* raw_parser
+*		Primary entry point. The core bison/flex parser runs first, only
+*		syntax the core rejects is offered to `extensions`. If no extension
+*		claims it, the original core-parser error is surfaced.
+*/
+List* raw_parser(std::pmr::memory_resource* resource,
+                 const char* str,
+                 const components::sql::parser::parser_extension_registry_t& extensions) {
+    using namespace components::sql::parser;
+
+    std::optional<parser_exception_t> base_error_opt;
+    try {
+        List* tree = base_raw_parser(resource, str);
+        if (list_length(tree) > 0) {
+            return tree;
+        }
+    } catch (const parser_exception_t& error) {
+        base_error_opt = error;
+    }
+
+    parse_extension_result_t ext_result = extensions.dispatch(resource, str);
+    if (ext_result.has_error()) {
+        throw parser_exception_t(ext_result.error().what.c_str(), "");
+    }
+    if (ext_result.value() != NIL) {
+        return ext_result.value();
+    }
+
+    if (base_error_opt) {
+        throw *base_error_opt;
+    }
+    return NIL;
 }
 
 /*

--- a/components/sql/parser/parser.h
+++ b/components/sql/parser/parser.h
@@ -1,11 +1,23 @@
 #pragma once
 #include "nodes/parsenodes.h"
 
+namespace components::sql::parser {
+    class parser_extension_registry_t;
+} // namespace components::sql::parser
+
 /* Primary entry point for the raw parsing functions
  *
  * resource is a pointer to arena allocator and used for various objects,
- * lifetime of which exceeds parser scope */
+ * lifetime of which exceeds parser scope.
+ *
+ * The two-argument form parses core SQL only. The three-argument form also
+ * consults `extensions` for any syntax the core grammar rejects (see
+ * extension.hpp); pass the registry owned by the database instance, or a
+ * standalone one when using the parser as a component. */
 extern List* raw_parser(std::pmr::memory_resource* resource, const char* str);
+extern List* raw_parser(std::pmr::memory_resource* resource,
+                        const char* str,
+                        const components::sql::parser::parser_extension_registry_t& extensions);
 
 /* Utility functions exported by gram.y (perhaps these should be elsewhere) */
 extern List* SystemFuncName(std::pmr::memory_resource* resource, char* name);

--- a/components/sql/test/CMakeLists.txt
+++ b/components/sql/test/CMakeLists.txt
@@ -15,6 +15,7 @@ set(${PROJECT_NAME}_SOURCES
         test_parameter.cpp
         test_checkpoint.cpp
         test_constraints_ddl.cpp
+        test_parser_extension.cpp
 )
 
 add_executable(${PROJECT_NAME} main.cpp ${${PROJECT_NAME}_SOURCES})
@@ -22,6 +23,7 @@ add_executable(${PROJECT_NAME} main.cpp ${${PROJECT_NAME}_SOURCES})
 target_link_libraries(
     ${PROJECT_NAME} PRIVATE
     otterbrix::sql
+    otterbrix::demo_extension
     Catch2::Catch2
 )
 

--- a/components/sql/test/test_parser_extension.cpp
+++ b/components/sql/test/test_parser_extension.cpp
@@ -1,0 +1,125 @@
+#include <catch2/catch.hpp>
+
+#include <string>
+
+#include <components/sql/parser/extension.hpp>
+#include <components/sql/parser/parser.h>
+#include <components/sql/parser/pg_functions.h>
+#include <components/sql/transformer/transformer.hpp>
+
+#include <demo_ast.hpp>
+#include <demo_extension.hpp>
+
+using namespace components::sql::parser;
+
+namespace {
+    using demo_ext::demo_kind;
+
+    bool is_op(const demo_ext::demo_node* node, demo_kind kind) { return node != nullptr && node->kind == kind; }
+
+    long int_value(const demo_ext::demo_node* node) {
+        REQUIRE(node != nullptr);
+        REQUIRE(node->kind == demo_kind::number);
+        return node->value;
+    }
+
+    demo_ext::demo_node* demo_payload(List* tree) {
+        auto* root = extension_payload<demo_ext::demo_node>(tree, "demo");
+        REQUIRE(root != nullptr);
+        return root;
+    }
+
+    parser_extension_registry_t demo_registry() {
+        parser_extension_registry_t registry;
+        REQUIRE_FALSE(registry.add(make_demo_extension()).has_error());
+        return registry;
+    }
+} // namespace
+
+TEST_CASE("components::sql::correct_pg_query") {
+    auto registry = demo_registry();
+
+    std::pmr::monotonic_buffer_resource arena;
+    auto* tree = raw_parser(&arena, "SELECT * FROM t;", registry);
+    REQUIRE(nodeTag(linitial(tree)) == T_SelectStmt);
+}
+
+TEST_CASE("components::sql::extension_ast") {
+    auto registry = demo_registry();
+
+    std::pmr::monotonic_buffer_resource arena;
+
+    SECTION("single literal") {
+        auto* root = demo_payload(raw_parser(&arena, "DEMO 7", registry));
+        CHECK(int_value(root) == 7);
+    }
+
+    SECTION("'+' binds looser than '*'") {
+        auto* root = demo_payload(raw_parser(&arena, "DEMO 2 + 3 * 4", registry));
+        REQUIRE(is_op(root, demo_kind::add));
+        CHECK(int_value(root->lhs) == 2);
+        REQUIRE(is_op(root->rhs, demo_kind::multiply));
+        CHECK(int_value(root->rhs->lhs) == 3);
+        CHECK(int_value(root->rhs->rhs) == 4);
+    }
+
+    SECTION("parentheses override precedence") {
+        auto* root = demo_payload(raw_parser(&arena, "DEMO (2 + 3) * 4", registry));
+        REQUIRE(is_op(root, demo_kind::multiply));
+        REQUIRE(is_op(root->lhs, demo_kind::add));
+        CHECK(int_value(root->rhs) == 4);
+    }
+
+    SECTION("left-associativity of subtraction") {
+        // 10 - 3 - 2  ==  (10 - 3) - 2, i.e. the left operand is itself a '-'.
+        auto* root = demo_payload(raw_parser(&arena, "DEMO 10 - 3 - 2", registry));
+        REQUIRE(is_op(root, demo_kind::subtract));
+        REQUIRE(is_op(root->lhs, demo_kind::subtract));
+        CHECK(int_value(root->rhs) == 2);
+    }
+
+    SECTION("division is left-associative too") {
+        // 20 / 5 / 2  ==  (20 / 5) / 2
+        auto* root = demo_payload(raw_parser(&arena, "DEMO 20 / 5 / 2", registry));
+        REQUIRE(is_op(root, demo_kind::divide));
+        REQUIRE(is_op(root->lhs, demo_kind::divide));
+        CHECK(int_value(root->rhs) == 2);
+    }
+
+    SECTION("the DEMO keyword is case-insensitive") {
+        auto* root = demo_payload(raw_parser(&arena, "dEmO 7", registry));
+        CHECK(int_value(root) == 7);
+    }
+}
+
+TEST_CASE("components::sql::extension_transform") {
+    auto registry = demo_registry();
+
+    std::pmr::monotonic_buffer_resource arena;
+    auto* demo_node = reinterpret_cast<Node*>(linitial(raw_parser(&arena, "DEMO 2 + 3 * 4", registry)));
+    REQUIRE(nodeTag(demo_node) == T_ExtensionNode);
+
+    components::sql::transform::transformer tr(&arena, nullptr, &registry);
+    auto result = tr.transform(*demo_node);
+    REQUIRE_FALSE(result.has_error());
+    REQUIRE(result.node_ptr() != nullptr);
+    CHECK(result.node_ptr()->type() == components::logical_plan::node_type::data_t);
+}
+
+TEST_CASE("components::sql::extension_error") {
+    auto registry = demo_registry();
+
+    std::pmr::monotonic_buffer_resource arena;
+    CHECK_THROWS_AS(raw_parser(&arena, "DEMO 2 +", registry), parser_exception_t);
+    CHECK_THROWS_AS(raw_parser(&arena, "DEMO (1 + 2", registry), parser_exception_t);
+    CHECK_THROWS_AS(raw_parser(&arena, "DEMO", registry), parser_exception_t); // keyword, no expression
+}
+
+TEST_CASE("components::sql::extension_duplicate_rejected") {
+    parser_extension_registry_t registry;
+    REQUIRE_FALSE(registry.add(make_demo_extension()).has_error());
+
+    auto duplicate = registry.add(make_demo_extension());
+    REQUIRE(duplicate.has_error());
+    CHECK(duplicate.error().type == core::error_code_t::already_exists);
+}

--- a/components/sql/test/test_parser_extension.cpp
+++ b/components/sql/test/test_parser_extension.cpp
@@ -1,11 +1,15 @@
 #include <catch2/catch.hpp>
 
+#include <cctype>
+#include <stdexcept>
 #include <string>
 
+#include <components/logical_plan/node_data.hpp>
 #include <components/sql/parser/extension.hpp>
 #include <components/sql/parser/parser.h>
 #include <components/sql/parser/pg_functions.h>
 #include <components/sql/transformer/transformer.hpp>
+#include <components/types/logical_value.hpp>
 
 #include <demo_ast.hpp>
 #include <demo_extension.hpp>
@@ -29,9 +33,74 @@ namespace {
         return root;
     }
 
+    // a toy ECHO extension, accepts ECHO <integer>
+    struct echo_payload {
+        int64_t value;
+    };
+
+    size_t match_keyword(const std::string& query, std::string_view keyword) {
+        const size_t begin = query.find_first_not_of(" \t\r\n");
+        if (begin == std::string::npos || query.size() - begin < keyword.size()) {
+            return std::string::npos;
+        }
+        for (size_t i = 0; i < keyword.size(); ++i) {
+            if (std::tolower(static_cast<unsigned char>(query[begin + i])) != keyword[i]) {
+                return std::string::npos;
+            }
+        }
+        const size_t end = begin + keyword.size();
+        if (end < query.size() && (std::isalnum(static_cast<unsigned char>(query[end])) || query[end] == '_')) {
+            return std::string::npos;
+        }
+        return end;
+    }
+
+    parse_extension_result_t echo_parse(std::pmr::memory_resource* resource, const std::string& query) {
+        const size_t after_kw = match_keyword(query, "echo");
+        if (after_kw == std::string::npos) {
+            return NIL; // not ours, let the next extension win
+        }
+
+        const std::string arg = query.substr(after_kw);
+        try {
+            size_t consumed = 0;
+            const long long value = std::stoll(arg, &consumed);
+            if (arg.find_first_not_of(" \t\r\n", consumed) != std::string::npos) {
+                throw std::invalid_argument("trailing tokens");
+            }
+            auto* payload = static_cast<echo_payload*>(resource->allocate(sizeof(echo_payload)));
+            payload->value = static_cast<int64_t>(value);
+            return list_make1(resource, make_extension_node(resource, "echo", payload));
+        } catch (const std::exception&) {
+            return core::error_t(core::error_code_t::sql_parse_error,
+                                 std::pmr::string{"echo: expected a single integer argument", resource});
+        }
+    }
+
+    components::logical_plan::node_ptr echo_transform(std::pmr::memory_resource* resource,
+                                                      ExtensionNode* node,
+                                                      components::logical_plan::parameter_node_t* /*params*/) {
+        const auto* payload = static_cast<const echo_payload*>(node->data);
+        components::types::logical_value_t value(resource, payload->value);
+        components::vector::data_chunk_t chunk(resource, {}, 1);
+        chunk.set_cardinality(1);
+        chunk.data.emplace_back(resource, value.type(), chunk.capacity());
+        chunk.set_value(0, 0, std::move(value));
+        return components::logical_plan::make_node_raw_data(resource, std::move(chunk));
+    }
+
+    parser_extension_t make_echo_extension() { return parser_extension_t{"echo", &echo_parse, &echo_transform}; }
+
     parser_extension_registry_t demo_registry() {
         parser_extension_registry_t registry;
         REQUIRE_FALSE(registry.add(make_demo_extension()).has_error());
+        return registry;
+    }
+
+    parser_extension_registry_t demo_and_echo_registry() {
+        parser_extension_registry_t registry;
+        REQUIRE_FALSE(registry.add(make_demo_extension()).has_error());
+        REQUIRE_FALSE(registry.add(make_echo_extension()).has_error());
         return registry;
     }
 } // namespace
@@ -122,4 +191,84 @@ TEST_CASE("components::sql::extension_duplicate_rejected") {
     auto duplicate = registry.add(make_demo_extension());
     REQUIRE(duplicate.has_error());
     CHECK(duplicate.error().type == core::error_code_t::already_exists);
+}
+
+TEST_CASE("components::sql::two_extensions_route_by_keyword") {
+    auto registry = demo_and_echo_registry();
+    std::pmr::monotonic_buffer_resource arena;
+
+    SECTION("demo claims DEMO, echo does not") {
+        auto* tree = raw_parser(&arena, "DEMO 2 + 3", registry);
+        CHECK(extension_payload<demo_ext::demo_node>(tree, "demo") != nullptr);
+        CHECK(extension_payload<echo_payload>(tree, "echo") == nullptr);
+    }
+
+    SECTION("echo claims ECHO, demo does not") {
+        auto* tree = raw_parser(&arena, "ECHO 42", registry);
+        auto* payload = extension_payload<echo_payload>(tree, "echo");
+        REQUIRE(payload != nullptr);
+        CHECK(payload->value == 42);
+        CHECK(extension_payload<demo_ext::demo_node>(tree, "demo") == nullptr);
+    }
+
+    SECTION("keyword that only prefixes an identifier is not claimed") {
+        // "ECHOES" must not be mistaken for the ECHO keyword, this is parse error
+        CHECK_THROWS_AS(raw_parser(&arena, "ECHOES 1", registry), parser_exception_t);
+    }
+
+    SECTION("core SQL is claimed by neither extension") {
+        auto* tree = raw_parser(&arena, "SELECT * FROM t;", registry);
+        REQUIRE(nodeTag(linitial(tree)) == T_SelectStmt);
+    }
+
+    SECTION("a keyword nobody owns surfaces core parser error") {
+        CHECK_THROWS_AS(raw_parser(&arena, "FOOBAR 1", registry), parser_exception_t);
+    }
+}
+
+TEST_CASE("components::sql::two_extensions_error_handling") {
+    auto registry = demo_and_echo_registry();
+    std::pmr::monotonic_buffer_resource arena;
+
+    SECTION("demo parse error") {
+        CHECK_THROWS_AS(raw_parser(&arena, "DEMO 2 +", registry), parser_exception_t);
+        CHECK_THROWS_AS(raw_parser(&arena, "DEMO (1 + 2", registry), parser_exception_t);
+    }
+
+    SECTION("echo parse error") {
+        CHECK_THROWS_AS(raw_parser(&arena, "ECHO", registry), parser_exception_t);     // missing argument
+        CHECK_THROWS_AS(raw_parser(&arena, "ECHO abc", registry), parser_exception_t); // not an integer
+        CHECK_THROWS_AS(raw_parser(&arena, "ECHO 1 2", registry), parser_exception_t); // trailing tokens
+    }
+}
+
+TEST_CASE("components::sql::two_extensions_transform_routing") {
+    auto registry = demo_and_echo_registry();
+    std::pmr::monotonic_buffer_resource arena;
+
+    SECTION("echo node transform") {
+        auto* node = reinterpret_cast<Node*>(linitial(raw_parser(&arena, "ECHO 99", registry)));
+        REQUIRE(nodeTag(node) == T_ExtensionNode);
+        components::sql::transform::transformer tr(&arena, nullptr, &registry);
+        auto result = tr.transform(*node);
+        REQUIRE_FALSE(result.has_error());
+        REQUIRE(result.node_ptr() != nullptr);
+        CHECK(result.node_ptr()->type() == components::logical_plan::node_type::data_t);
+    }
+
+    SECTION("demo node transform") {
+        auto* node = reinterpret_cast<Node*>(linitial(raw_parser(&arena, "DEMO 2 + 3 * 4", registry)));
+        REQUIRE(nodeTag(node) == T_ExtensionNode);
+        components::sql::transform::transformer tr(&arena, nullptr, &registry);
+        auto result = tr.transform(*node);
+        REQUIRE_FALSE(result.has_error());
+        CHECK(result.node_ptr()->type() == components::logical_plan::node_type::data_t);
+    }
+
+    SECTION("an unknown extension node is a transform error") {
+        auto* ghost = make_extension_node(&arena, "unknown-and-unregistered-extension", nullptr);
+        components::sql::transform::transformer tr(&arena, nullptr, &registry);
+        auto result = tr.transform(*ghost);
+        REQUIRE(result.has_error());
+    }
 }

--- a/components/sql/transformer/transformer.cpp
+++ b/components/sql/transformer/transformer.cpp
@@ -2,6 +2,7 @@
 #include "utils.hpp"
 
 #include <components/logical_plan/node_aggregate.hpp>
+#include <components/sql/parser/extension.hpp>
 
 namespace components::sql::transform {
 
@@ -25,8 +26,7 @@ namespace components::sql::transform {
         }
     } // namespace
 
-    transform_result transformer::transform(Node& node) {
-        auto params = logical_plan::make_parameter_node(resource_);
+    logical_plan::node_ptr transformer::transform_statement(Node& node, logical_plan::parameter_node_t* params) {
         logical_plan::node_ptr log_node;
 
         switch (node.type) {
@@ -63,7 +63,7 @@ namespace components::sql::transform {
                 log_node = transform_create_enum_type(pg_cast<CreateEnumStmt>(node));
                 break;
             case T_SelectStmt: {
-                log_node = transform_select(pg_cast<SelectStmt>(node), params.get());
+                log_node = transform_select(pg_cast<SelectStmt>(node), params);
                 // Stamp the primary FROM-clause table as a catalog dependency.
                 // The transformer's aggregate wrapper at the root carries the
                 // (dbname, relname); a future patch can walk joins to add
@@ -75,13 +75,13 @@ namespace components::sql::transform {
                 break;
             }
             case T_UpdateStmt:
-                log_node = transform_update(pg_cast<UpdateStmt>(node), params.get());
+                log_node = transform_update(pg_cast<UpdateStmt>(node), params);
                 break;
             case T_InsertStmt:
-                log_node = transform_insert(pg_cast<InsertStmt>(node), params.get());
+                log_node = transform_insert(pg_cast<InsertStmt>(node), params);
                 break;
             case T_DeleteStmt:
-                log_node = transform_delete(pg_cast<DeleteStmt>(node), params.get());
+                log_node = transform_delete(pg_cast<DeleteStmt>(node), params);
                 break;
             case T_IndexStmt:
                 // TODO: CREATE INDEX needs the parent table resolved — pull
@@ -103,7 +103,7 @@ namespace components::sql::transform {
             case T_CreateTableAsStmt: {
                 auto& cs = pg_cast<CreateTableAsStmt>(node);
                 if (cs.relkind == OBJECT_MATVIEW) {
-                    log_node = transform_create_matview(cs, params.get());
+                    log_node = transform_create_matview(cs, params);
                 } else {
                     error_ = core::error_t(
                         core::error_code_t::sql_parse_error,
@@ -141,11 +141,31 @@ namespace components::sql::transform {
                 }
                 break;
             }
+            case T_ExtensionNode: {
+                // route to the owning extension's transform stage by extension_id
+                auto& ext_node = pg_cast<ExtensionNode>(node);
+                const std::string id = ext_node.extension_id ? ext_node.extension_id : "";
+                const auto* extension = extensions_ ? extensions_->find(id) : nullptr;
+                if (extension != nullptr && extension->transform != nullptr) {
+                    log_node = extension->transform(resource_, &ext_node, params);
+                } else {
+                    error_ = core::error_t(core::error_code_t::sql_parse_error,
+                                           std::pmr::string{"no transformer extension for '" + id + "'", resource_});
+                }
+                break;
+            }
             default:
                 error_ = core::error_t(
                     core::error_code_t::sql_parse_error,
                     std::pmr::string{"Unsupported node type: " + node_tag_to_string(node.type), resource_});
         }
+
+        return log_node;
+    }
+
+    transform_result transformer::transform(Node& node) {
+        auto params = logical_plan::make_parameter_node(resource_);
+        auto log_node = transform_statement(node, params.get());
 
         if (has_error()) {
             return {resource_, std::move(error_)};

--- a/components/sql/transformer/transformer.cpp
+++ b/components/sql/transformer/transformer.cpp
@@ -26,9 +26,25 @@ namespace components::sql::transform {
         }
     } // namespace
 
-    logical_plan::node_ptr transformer::transform_statement(Node& node, logical_plan::parameter_node_t* params) {
-        logical_plan::node_ptr log_node;
+    transform_result transformer::transform(Node& node) {
+        logical_plan::execution_plan_t plan(resource_);
 
+        plan.sub_queries.emplace_back(transform(node, &plan));
+
+        if (has_error()) {
+            return {resource_, std::move(error_)};
+        } else {
+            return {resource_,
+                    std::move(plan),
+                    std::move(parameter_map_),
+                    std::move(parameter_insert_map_),
+                    std::move(parameter_insert_rows_),
+                    std::move(deferred_limits_)};
+        }
+    }
+
+    logical_plan::node_ptr transformer::transform(Node& node, logical_plan::execution_plan_t* plan) {
+        logical_plan::node_ptr log_node = nullptr;
         switch (node.type) {
             case T_CreatedbStmt: {
                 auto& n = pg_cast<CreatedbStmt>(node);
@@ -63,7 +79,7 @@ namespace components::sql::transform {
                 log_node = transform_create_enum_type(pg_cast<CreateEnumStmt>(node));
                 break;
             case T_SelectStmt: {
-                log_node = transform_select(pg_cast<SelectStmt>(node), params);
+                log_node = transform_select(pg_cast<SelectStmt>(node), plan);
                 // Stamp the primary FROM-clause table as a catalog dependency.
                 // The transformer's aggregate wrapper at the root carries the
                 // (dbname, relname); a future patch can walk joins to add
@@ -75,13 +91,13 @@ namespace components::sql::transform {
                 break;
             }
             case T_UpdateStmt:
-                log_node = transform_update(pg_cast<UpdateStmt>(node), params);
+                log_node = transform_update(pg_cast<UpdateStmt>(node), plan);
                 break;
             case T_InsertStmt:
-                log_node = transform_insert(pg_cast<InsertStmt>(node), params);
+                log_node = transform_insert(pg_cast<InsertStmt>(node), plan);
                 break;
             case T_DeleteStmt:
-                log_node = transform_delete(pg_cast<DeleteStmt>(node), params);
+                log_node = transform_delete(pg_cast<DeleteStmt>(node), plan);
                 break;
             case T_IndexStmt:
                 // TODO: CREATE INDEX needs the parent table resolved — pull
@@ -103,7 +119,7 @@ namespace components::sql::transform {
             case T_CreateTableAsStmt: {
                 auto& cs = pg_cast<CreateTableAsStmt>(node);
                 if (cs.relkind == OBJECT_MATVIEW) {
-                    log_node = transform_create_matview(cs, params);
+                    log_node = transform_create_matview(cs, plan);
                 } else {
                     error_ = core::error_t(
                         core::error_code_t::sql_parse_error,
@@ -147,7 +163,7 @@ namespace components::sql::transform {
                 const std::string id = ext_node.extension_id ? ext_node.extension_id : "";
                 const auto* extension = extensions_ ? extensions_->find(id) : nullptr;
                 if (extension != nullptr && extension->transform != nullptr) {
-                    log_node = extension->transform(resource_, &ext_node, params);
+                    log_node = extension->transform(resource_, &ext_node, plan->parameters.get());
                 } else {
                     error_ = core::error_t(core::error_code_t::sql_parse_error,
                                            std::pmr::string{"no transformer extension for '" + id + "'", resource_});
@@ -161,23 +177,6 @@ namespace components::sql::transform {
         }
 
         return log_node;
-    }
-
-    transform_result transformer::transform(Node& node) {
-        auto params = logical_plan::make_parameter_node(resource_);
-        auto log_node = transform_statement(node, params.get());
-
-        if (has_error()) {
-            return {resource_, std::move(error_)};
-        } else {
-            return {resource_,
-                    std::move(log_node),
-                    std::move(params),
-                    std::move(parameter_map_),
-                    std::move(parameter_insert_map_),
-                    std::move(parameter_insert_rows_),
-                    std::move(deferred_limits_)};
-        }
     }
 
     bool transformer::has_error() const noexcept { return error_.contains_error(); }

--- a/components/sql/transformer/transformer.hpp
+++ b/components/sql/transformer/transformer.hpp
@@ -9,18 +9,30 @@
 #include <components/logical_plan/param_storage.hpp>
 #include <components/sql/parser/nodes/parsenodes.h>
 
+namespace components::sql::parser {
+    class parser_extension_registry_t;
+} // namespace components::sql::parser
+
 namespace components::sql::transform {
     class transformer {
     public:
-        explicit transformer(std::pmr::memory_resource* resource, const char* raw_sql = nullptr)
+        explicit transformer(std::pmr::memory_resource* resource,
+                             const char* raw_sql = nullptr,
+                             const parser::parser_extension_registry_t* extensions = nullptr)
             : resource_(resource)
             , raw_sql_(raw_sql)
+            , extensions_(extensions)
             , parameter_map_(resource_)
             , parameter_insert_map_(resource_)
             , parameter_insert_rows_(resource_, {})
             , error_(core::error_t::no_error()) {}
 
         transform_result transform(Node& node);
+
+        // Lower a single statement node to a plan node (the dispatch switch);
+        // transform() wraps the result with parameter bookkeeping. Sets the
+        // internal error and returns nullptr on failure.
+        logical_plan::node_ptr transform_statement(Node& node, logical_plan::parameter_node_t* params);
 
         // Parse a bare SQL expression string (e.g. "age > 0") as if it were a WHERE clause.
         // Used to compile stored CHECK constraint expressions for runtime evaluation.
@@ -143,9 +155,7 @@ namespace components::sql::transform {
         // column contributes its name) followed by every operator's key(s).
         // On a table-returning top operator (-> / #>) in this scalar position,
         // or any malformed operand, sets error_ and returns false.
-        bool resolve_jsonb_scalar_key(A_Expr* node,
-                                      const name_collection_t& names,
-                                      expressions::key_t& out_key);
+        bool resolve_jsonb_scalar_key(A_Expr* node, const name_collection_t& names, expressions::key_t& out_key);
         // Recursive worker: appends this chain's path segments (in order) and
         // sets `side` from the base operand. Accepts any nav operator.
         bool collect_jsonb_path(A_Expr* node,
@@ -173,9 +183,9 @@ namespace components::sql::transform {
         // Desugars each key to an IS NOT NULL test on the flattened path, then
         // combines with OR ('?'/'?|') or AND ('?&').
         expressions::expression_ptr transform_jsonb_exists(A_Expr* node,
-                                                          const name_collection_t& names,
-                                                          logical_plan::parameter_node_t* params,
-                                                          std::string_view op);
+                                                           const name_collection_t& names,
+                                                           logical_plan::parameter_node_t* params,
+                                                           std::string_view op);
 
         expressions::expression_ptr
         transform_null_test(NullTest* node, const name_collection_t& names, logical_plan::parameter_node_t* params);
@@ -200,6 +210,7 @@ namespace components::sql::transform {
 
         std::pmr::memory_resource* resource_;
         const char* raw_sql_;
+        const parser::parser_extension_registry_t* extensions_;
         std::pmr::unordered_map<size_t, core::parameter_id_t> parameter_map_;
         std::pmr::unordered_map<size_t, std::pmr::vector<insert_location_t>> parameter_insert_map_;
         vector::data_chunk_t parameter_insert_rows_;

--- a/components/sql/transformer/transformer.hpp
+++ b/components/sql/transformer/transformer.hpp
@@ -5,6 +5,7 @@
 
 #include <components/expressions/compare_expression.hpp>
 #include <components/logical_plan/node.hpp>
+#include <components/logical_plan/node_aggregate.hpp>
 #include <components/logical_plan/node_update.hpp>
 #include <components/logical_plan/param_storage.hpp>
 #include <components/sql/parser/nodes/parsenodes.h>
@@ -28,11 +29,11 @@ namespace components::sql::transform {
             , error_(core::error_t::no_error()) {}
 
         transform_result transform(Node& node);
-
         // Lower a single statement node to a plan node (the dispatch switch);
         // transform() wraps the result with parameter bookkeeping. Sets the
-        // internal error and returns nullptr on failure.
-        logical_plan::node_ptr transform_statement(Node& node, logical_plan::parameter_node_t* params);
+        // internal error and returns nullptr on failure. Subqueries are collected
+        // into plan->sub_queries; extension nodes route through plan->parameters.
+        logical_plan::node_ptr transform(Node& node, logical_plan::execution_plan_t* plan);
 
         // Parse a bare SQL expression string (e.g. "age > 0") as if it were a WHERE clause.
         // Used to compile stored CHECK constraint expressions for runtime evaluation.
@@ -53,10 +54,10 @@ namespace components::sql::transform {
         logical_plan::node_ptr transform_vacuum(VacuumStmt& node);
         logical_plan::node_ptr transform_create_table(CreateStmt& node);
         logical_plan::node_ptr transform_drop(DropStmt& node);
-        logical_plan::node_ptr transform_select(SelectStmt& node, logical_plan::parameter_node_t* params);
-        logical_plan::node_ptr transform_update(UpdateStmt& node, logical_plan::parameter_node_t* params);
-        logical_plan::node_ptr transform_insert(InsertStmt& node, logical_plan::parameter_node_t* params);
-        logical_plan::node_ptr transform_delete(DeleteStmt& node, logical_plan::parameter_node_t* params);
+        logical_plan::node_ptr transform_select(SelectStmt& node, logical_plan::execution_plan_t* plan);
+        logical_plan::node_ptr transform_update(UpdateStmt& node, logical_plan::execution_plan_t* plan);
+        logical_plan::node_ptr transform_insert(InsertStmt& node, logical_plan::execution_plan_t* plan);
+        logical_plan::node_ptr transform_delete(DeleteStmt& node, logical_plan::execution_plan_t* plan);
         logical_plan::node_ptr transform_create_index(IndexStmt& node);
         logical_plan::node_ptr transform_create_type(CompositeTypeStmt& node);
         logical_plan::node_ptr transform_create_enum_type(CreateEnumStmt& node);
@@ -67,7 +68,7 @@ namespace components::sql::transform {
         // is hoisted to the outer sequence_t front so Pass 1 stamps source's
         // pg_attribute. The planner reads body_plan + stamped source metadata to
         // derive output schema before lowering to physical operators.
-        logical_plan::node_ptr transform_create_matview(CreateTableAsStmt& cs, logical_plan::parameter_node_t* params);
+        logical_plan::node_ptr transform_create_matview(CreateTableAsStmt& cs, logical_plan::execution_plan_t* plan);
         // REFRESH MATERIALIZED VIEW [CONCURRENTLY] mv [WITH NO DATA].
         // Wrapped with catalog_resolve_table(mv) so Pass 1 stamps view_sql from
         // pg_rewrite.ev_action (already supported for relkind='m' by Phase A.A2).
@@ -90,7 +91,10 @@ namespace components::sql::transform {
         using insert_location_t = std::pair<size_t, std::string>; // position in vector + string key
 
         expressions::expression_ptr
-        transform_a_expr(A_Expr* node, const name_collection_t& names, logical_plan::parameter_node_t* params);
+        transform_a_expr(A_Expr* node, const name_collection_t& names, logical_plan::execution_plan_t* plan);
+
+        expressions::expression_ptr
+        transform_sublink_expr(SubLink* node, const name_collection_t& names, logical_plan::execution_plan_t* plan);
 
         // Arithmetic expression: returns scalar_expression_t
         expressions::expression_ptr transform_a_expr_arithmetic(A_Expr* node,
@@ -105,13 +109,13 @@ namespace components::sql::transform {
         void transform_select_a_expr(A_Expr* node,
                                      const char* alias,
                                      const name_collection_t& names,
-                                     logical_plan::parameter_node_t* params,
+                                     logical_plan::execution_plan_t* plan,
                                      logical_plan::node_ptr& group);
 
         // Resolve SELECT operand — aggregates become separate group expressions
         expressions::param_storage resolve_select_operand(Node* node,
                                                           const name_collection_t& names,
-                                                          logical_plan::parameter_node_t* params,
+                                                          logical_plan::execution_plan_t* plan,
                                                           logical_plan::node_ptr& group);
 
         expressions::expression_ptr
@@ -120,32 +124,32 @@ namespace components::sql::transform {
         // HAVING clause: resolve aggregate references to aliases from group node
         expressions::expression_ptr transform_having_expr(Node* node,
                                                           const name_collection_t& names,
-                                                          logical_plan::parameter_node_t* params,
+                                                          logical_plan::execution_plan_t* plan,
                                                           const logical_plan::node_ptr& group);
 
         // Handle T_CaseExpr in SELECT target list
         void transform_select_case_expr(CaseExpr* node,
                                         const char* alias,
                                         const name_collection_t& names,
-                                        logical_plan::parameter_node_t* params,
+                                        logical_plan::execution_plan_t* plan,
                                         logical_plan::node_ptr& group);
 
         // Build a scalar_expression_ptr (type=case_expr) from a CaseExpr
         expressions::expression_ptr case_expr_to_scalar(CaseExpr* node,
                                                         const char* alias,
                                                         const name_collection_t& names,
-                                                        logical_plan::parameter_node_t* params,
+                                                        logical_plan::execution_plan_t* plan,
                                                         logical_plan::node_ptr group);
 
         // Resolve a HAVING operand: FuncCall → aggregate alias key
         expressions::param_storage resolve_having_operand(Node* node,
                                                           const name_collection_t& names,
-                                                          logical_plan::parameter_node_t* params,
+                                                          logical_plan::execution_plan_t* plan,
                                                           const logical_plan::node_ptr& group);
 
         expressions::expression_ptr transform_a_indirection(A_Indirection* node,
                                                             const name_collection_t& names,
-                                                            logical_plan::parameter_node_t* params);
+                                                            logical_plan::execution_plan_t* plan);
 
         // --- JSONB navigation (-> ->> #> #>>) ----------------------------
         // Resolve a scalar (text-returning, ->> / #>>) jsonb navigation chain
@@ -195,11 +199,18 @@ namespace components::sql::transform {
         logical_plan::node_ptr
         transform_function(FuncCall& node, const name_collection_t& names, logical_plan::parameter_node_t* params);
 
+        // Build the logical node for a FROM-clause reference to a recursive CTE.
+        // Returns an aggregate wrapping either a cte_scan (inside recursive member) or
+        // a recursive_cte node (in the outer query). Returns nullptr on error.
+        logical_plan::node_aggregate_ptr build_recursive_cte_ref(const std::string& cte_name,
+                                                                 const std::string& effective_alias,
+                                                                 logical_plan::execution_plan_t* plan);
+
         void join_dfs(std::pmr::memory_resource* resource,
                       JoinExpr* join,
                       logical_plan::node_join_ptr& node_join,
                       name_collection_t& names,
-                      logical_plan::parameter_node_t* params);
+                      logical_plan::execution_plan_t* plan);
 
         expressions::update_expr_ptr
         transform_update_expr(Node* node, const name_collection_t& names, logical_plan::parameter_node_t* params);
@@ -217,6 +228,9 @@ namespace components::sql::transform {
         std::vector<deferred_limit_t> deferred_limits_;
         size_t aggregate_counter_{0};
         std::pmr::vector<expressions::expression_ptr> pending_internal_aggs_{resource_};
+        std::pmr::unordered_map<std::string_view, SelectStmt*> cte_queries_{resource_};
+        std::pmr::unordered_map<std::string, SelectStmt*> recursive_cte_queries_{resource_};
+        bool transforming_recursive_member_{false};
         core::error_t error_;
     };
 } // namespace components::sql::transform

--- a/components/table/CMakeLists.txt
+++ b/components/table/CMakeLists.txt
@@ -65,3 +65,11 @@ target_include_directories(
 if (DEV_MODE)
     add_subdirectory(test)
 endif ()
+
+install(TARGETS
+        otterbrix_${PROJECT_NAME}
+
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+)

--- a/components/table/column_state.hpp
+++ b/components/table/column_state.hpp
@@ -8,8 +8,8 @@
 
 #include <components/table/storage/buffer_handle.hpp>
 
-#include <expressions/forward.hpp>
-#include <types/logical_value.hpp>
+#include <components/expressions/forward.hpp>
+#include <components/types/logical_value.hpp>
 
 namespace components::table {
     class row_group_t;

--- a/integration/cpp/CMakeLists.txt
+++ b/integration/cpp/CMakeLists.txt
@@ -105,6 +105,6 @@ if (DEV_MODE OR ALLOW_BENCHMARK)
     )
 endif()
 
-#if (DEV_MODE)
+if (DEV_MODE)
     add_subdirectory(test)
-#endif()
+endif()

--- a/integration/cpp/test/CMakeLists.txt
+++ b/integration/cpp/test/CMakeLists.txt
@@ -24,6 +24,7 @@ set( ${PROJECT_NAME}_SOURCES
         test_column_projection.cpp
         test_computed_schema.cpp
         test_hash_join.cpp
+        test_parser_extension.cpp
 )
 
 add_executable(${PROJECT_NAME} main.cpp ${${PROJECT_NAME}_SOURCES})
@@ -34,6 +35,7 @@ target_link_libraries(
         cpp_otterbrix
         non_thread_scheduler
 
+        otterbrix::demo_extension
         otterbrix::test_generaty
         otterbrix::log
         otterbrix::cursor

--- a/integration/cpp/test/test_parser_extension.cpp
+++ b/integration/cpp/test/test_parser_extension.cpp
@@ -1,0 +1,69 @@
+#include "test_config.hpp"
+
+#include <catch2/catch.hpp>
+
+#include <demo_extension.hpp>
+
+using namespace components;
+using namespace components::cursor;
+
+TEST_CASE("integration::cpp::parser_extension_demo") {
+    auto config = test_create_config("/tmp/test_demo_extension");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    INFO("without the extension, DEMO is rejected") {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "DEMO 1 + 20");
+        REQUIRE_FALSE(cur->is_success());
+    }
+
+    REQUIRE_FALSE(dispatcher->add_parser_extension(make_demo_extension()).has_error());
+
+    INFO("with the extension registered, DEMO is OK") {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "DEMO 1 + 20");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        REQUIRE(cur->chunk_data().data[0].data<int64_t>()[0] == 21);
+    }
+
+    INFO("precedence") {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "DEMO 2 + 3 * 4");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        REQUIRE(cur->chunk_data().data[0].data<int64_t>()[0] == 14);
+    }
+}
+
+TEST_CASE("integration::cpp::parser_extension_is_per_instance") {
+    auto config_a = test_create_config("/tmp/test_demo_extension_a");
+    auto config_b = test_create_config("/tmp/test_demo_extension_b");
+    test_clear_directory(config_a);
+    test_clear_directory(config_b);
+    config_a.disk.on = false;
+    config_a.wal.on = false;
+    config_b.disk.on = false;
+    config_b.wal.on = false;
+    test_spaces space_a(config_a);
+    test_spaces space_b(config_b);
+
+    // register the extension on instance A
+    REQUIRE_FALSE(space_a.dispatcher()->add_parser_extension(make_demo_extension()).has_error());
+
+    auto session = otterbrix::session_id_t();
+    INFO("instance A (registered) correctly runs DEMO") {
+        auto cur = space_a.dispatcher()->execute_sql(session, "DEMO 1 + 20");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->chunk_data().data[0].data<int64_t>()[0] == 21);
+    }
+
+    INFO("instance B (no extension) rejects") {
+        auto cur = space_b.dispatcher()->execute_sql(session, "DEMO 1 + 20");
+        REQUIRE_FALSE(cur->is_success());
+    }
+}

--- a/integration/cpp/wrapper_dispatcher.cpp
+++ b/integration/cpp/wrapper_dispatcher.cpp
@@ -279,7 +279,7 @@ namespace otterbrix {
         std::pmr::monotonic_buffer_resource parser_arena(resource());
         void* parse_result;
         try {
-            parse_result = linitial(raw_parser(&parser_arena, query.c_str()));
+            parse_result = linitial(raw_parser(&parser_arena, query.c_str(), parser_extensions_));
         } catch (const std::exception& exception) {
             return make_cursor(
                 resource(),
@@ -291,7 +291,7 @@ namespace otterbrix {
                                core::error_t(core::error_code_t::sql_parse_error,
                                              std::pmr::string{"unknown parser error", resource()}));
         }
-        transformer local_transformer(resource(), query.c_str());
+        transformer local_transformer(resource(), query.c_str(), &parser_extensions_);
         if (auto result = local_transformer.transform(pg_cell_to_node_cast(parse_result)).finalize();
             result.has_error()) {
             return make_cursor(resource(), result.error());
@@ -312,7 +312,7 @@ namespace otterbrix {
         std::pmr::monotonic_buffer_resource parser_arena(resource());
         void* parse_result;
         try {
-            parse_result = linitial(raw_parser(&parser_arena, query.c_str()));
+            parse_result = linitial(raw_parser(&parser_arena, query.c_str(), parser_extensions_));
         } catch (const std::exception& exception) {
             return make_cursor(
                 resource(),
@@ -324,7 +324,7 @@ namespace otterbrix {
                                core::error_t(core::error_code_t::sql_parse_error,
                                              std::pmr::string{"unknown parser error", resource()}));
         }
-        transformer local_transformer(resource(), query.c_str());
+        transformer local_transformer(resource(), query.c_str(), &parser_extensions_);
         auto binder = local_transformer.transform(pg_cell_to_node_cast(parse_result));
         try {
             for (const auto& [id, value] : params) {
@@ -342,6 +342,11 @@ namespace otterbrix {
         }
         auto& view = std::move(finalized).value();
         return execute_plan(session, std::move(view.node), std::move(view.params));
+    }
+
+    auto wrapper_dispatcher_t::add_parser_extension(components::sql::parser::parser_extension_t extension)
+        -> core::result_wrapper_t<const components::sql::parser::parser_extension_t*> {
+        return parser_extensions_.add(std::move(extension));
     }
 
     auto wrapper_dispatcher_t::set_timezone(const session_id_t& session, std::string timezone_name) -> cursor_t_ptr {

--- a/integration/cpp/wrapper_dispatcher.hpp
+++ b/integration/cpp/wrapper_dispatcher.hpp
@@ -25,6 +25,7 @@
 #include <components/logical_plan/node_drop_index.hpp>
 #include <components/logical_plan/node_match.hpp>
 #include <components/session/session.hpp>
+#include <components/sql/parser/extension.hpp>
 #include <components/sql/transformer/transformer.hpp>
 #include <components/types/logical_value.hpp>
 
@@ -111,11 +112,15 @@ namespace otterbrix {
             -> components::cursor::cursor_t_ptr;
         auto set_timezone(const session_id_t& session, std::string timezone_name) -> components::cursor::cursor_t_ptr;
 
+        auto add_parser_extension(components::sql::parser::parser_extension_t extension)
+            -> core::result_wrapper_t<const components::sql::parser::parser_extension_t*>;
+
     private:
         std::pmr::memory_resource* resource_;
         services::dispatcher::manager_dispatcher_t* manager_dispatcher_;
         actor_zeta::scheduler_raw scheduler_;
         log_t log_;
+        components::sql::parser::parser_extension_registry_t parser_extensions_;
         std::atomic_int i = 0;
 
         std::mutex event_loop_mutex_;


### PR DESCRIPTION
Added parser extensions API, allowing to parse multiple independent grammars. Example extension is available at `components/sql/demo_extension` 