### PR TITLE
disk: make manager_disk a pure router/orchestrator; offload per-oid work to agent twins

### DIFF
--- a/components/catalog/results/resolve_result.hpp
+++ b/components/catalog/results/resolve_result.hpp
@@ -7,7 +7,6 @@
 #include <cstdint>
 #include <memory_resource>
 #include <string>
-#include <vector>
 
 namespace services::disk {
 
@@ -18,47 +17,6 @@ namespace services::disk {
 
         resolve_namespace_result_t() = default;
         explicit resolve_namespace_result_t(std::pmr::memory_resource* /*resource*/) {}
-    };
-
-    // Per-column metadata returned by resolve_table. Mirrors pg_attribute row layout so the
-    // dispatcher can reconstruct a column_definition_t with full type info
-    // (decoding atttypspec when present, falling back to atttypid → built-in type).
-    // Field order: strings → oid_t/int32_t → bool, to minimise padding.
-    struct column_info_t {
-        std::string attname;
-        std::string atttypspec; // serialized complex_logical_type (empty for built-ins)
-        std::string attdefspec; // serialized default value (empty if no default)
-        components::catalog::oid_t atttypid{components::catalog::INVALID_OID};
-        components::catalog::oid_t attoid{components::catalog::INVALID_OID};
-        std::int32_t attnum{0};
-        bool attnotnull{false};
-        bool atthasdefault{false};
-        bool attisdropped{false};
-    };
-    // Layout guard: libstdc++ sizeof(std::string)==32 → 112; libc++ sizeof==24 → 88.
-    static_assert(sizeof(column_info_t) <= 112, "column_info_t layout regression");
-
-    struct resolve_table_result_t {
-        bool found{false};
-        components::catalog::oid_t oid{components::catalog::INVALID_OID};
-        components::catalog::oid_t namespace_oid{components::catalog::INVALID_OID};
-        char relkind{'r'};
-        std::string name;
-        std::vector<column_info_t> columns;
-
-        resolve_table_result_t() = default;
-        explicit resolve_table_result_t(std::pmr::memory_resource* /*resource*/) {}
-    };
-
-    struct resolve_type_result_t {
-        bool found{false};
-        components::catalog::oid_t oid{components::catalog::INVALID_OID};
-        components::catalog::oid_t namespace_oid{components::catalog::INVALID_OID};
-        std::string name;
-        std::string typdefspec;
-
-        resolve_type_result_t() = default;
-        explicit resolve_type_result_t(std::pmr::memory_resource* /*resource*/) {}
     };
 
     // Field order: strings → uint64 → oid_t/int32 → bool.

--- a/components/context/context.hpp
+++ b/components/context/context.hpp
@@ -65,7 +65,7 @@ namespace components::pipeline {
         uint64_t dml_delete_txn_id{0};
         catalog::oid_t dml_table_oid{catalog::INVALID_OID};
         // DROP back-channel: operator_dynamic_cascade_delete_t records each
-        // storage oid it dropped (alongside the mark_storage_dropped send). The
+        // storage oid it dropped (alongside the mark_storage_dropped_many send). The
         // executor lifts these into execute_result_t.dropped_storage_oids and
         // ships them in the txn_accumulate payload so COMMIT's drain can drive
         // the DROP-GC value-space remap off the ACTUAL drops (decoupled from

--- a/components/physical_plan/operators/alter_validators.cpp
+++ b/components/physical_plan/operators/alter_validators.cpp
@@ -1,6 +1,7 @@
 #include "alter_validators.hpp"
 
 #include <components/catalog/system_table_schemas.hpp>
+#include <components/physical_plan/operators/operator_data.hpp>
 #include <components/types/logical_value.hpp>
 #include <components/vector/data_chunk.hpp>
 #include <services/disk/manager_disk.hpp>
@@ -30,7 +31,7 @@ namespace components::operators::alter_validators {
                                           exec_ctx,
                                           pg_attr_oid,
                                           std::move(keys),
-                                          std::move(vals));
+                                          components::operators::make_key_chunk(resource, std::move(vals)));
         std::pmr::vector<components::vector::data_chunk_t> batches = co_await std::move(fut);
 
         // pg_attribute column layout (system_table_schemas.cpp::pg_attribute_columns):
@@ -101,7 +102,7 @@ namespace components::operators::alter_validators {
                                           exec_ctx,
                                           pg_dep_oid,
                                           std::move(keys),
-                                          std::move(vals));
+                                          components::operators::make_key_chunk(resource, std::move(vals)));
         std::pmr::vector<components::vector::data_chunk_t> batches = co_await std::move(fut);
 
         std::pmr::vector<std::pair<int, catalog::oid_t>> out(resource);

--- a/components/physical_plan/operators/operator_abort_transaction.cpp
+++ b/components/physical_plan/operators/operator_abort_transaction.cpp
@@ -180,9 +180,9 @@ namespace components::operators {
         //     removed (their catalog rows are reverted by the swap_appends revert
         //     above, but the on-disk storage + index engine are not catalog rows).
         //     created_indexes drop_index per (table_oid, name); created_storage
-        //     oids unregister_collection THEN drop_storage per oid (index before
-        //     disk so no consumer references a freed collection — co_await the
-        //     unregister before the drop, two-phase per oid pair like the COMMIT
+        //     oids unregister_collection (ALL) THEN one drop_storage_many (index
+        //     before disk so no consumer references a freed collection — every
+        //     unregister is awaited before the batched disk drop, like the COMMIT
         //     teardown). drop_index / drop_storage tolerate an unknown target, so
         //     a CREATE that never fully materialized is safe to tear down.
         if (txn_data.transaction_id != 0) {
@@ -201,19 +201,40 @@ namespace components::operators {
                     co_await std::move(f);
                 }
             }
-            for (auto oid : created_storage_oids) {
+            // Batched CREATE-rollback removal: ALL unregister_collection
+            // (manager_index) THEN ONE drop_storage_many (manager_disk), awaiting
+            // every unregister before any disk drop so no index consumer references a
+            // collection whose backing storage the disk actor is about to free
+            // (index-before-disk, preserved GLOBALLY — strictly stronger than the
+            // previous per-oid interleave). unregister_collection acts on the index
+            // MANAGER's own maps, so the N sends pipeline onto one mailbox;
+            // drop_storage_many partitions the oids per disk agent and fans out in
+            // parallel. drop_storage tolerates an unknown target, so a CREATE that
+            // never fully materialized is still safe to tear down.
+            if (!created_storage_oids.empty()) {
                 if (ctx->index_address != actor_zeta::address_t::empty_address()) {
-                    auto [_u, uf] = actor_zeta::send(ctx->index_address,
-                                                     &services::index::manager_index_t::unregister_collection,
-                                                     ctx->session,
-                                                     oid);
-                    co_await std::move(uf);
+                    std::pmr::vector<actor_zeta::unique_future<void>> unregister_futures{resource()};
+                    unregister_futures.reserve(created_storage_oids.size());
+                    for (auto oid : created_storage_oids) {
+                        auto [_u, uf] = actor_zeta::send(ctx->index_address,
+                                                         &services::index::manager_index_t::unregister_collection,
+                                                         ctx->session,
+                                                         oid);
+                        unregister_futures.push_back(std::move(uf));
+                    }
+                    // Await EVERY unregister before any disk drop (index-before-disk).
+                    for (auto& uf : unregister_futures) {
+                        co_await std::move(uf);
+                    }
                 }
                 if (ctx->disk_address != actor_zeta::address_t::empty_address()) {
+                    std::pmr::vector<components::catalog::oid_t> drop_oids{created_storage_oids.begin(),
+                                                                          created_storage_oids.end(),
+                                                                          resource()};
                     auto [_d, df] = actor_zeta::send(ctx->disk_address,
-                                                     &services::disk::manager_disk_t::drop_storage,
+                                                     &services::disk::manager_disk_t::drop_storage_many,
                                                      ctx->session,
-                                                     oid);
+                                                     std::move(drop_oids));
                     co_await std::move(df);
                 }
             }

--- a/components/physical_plan/operators/operator_alter_column_add.cpp
+++ b/components/physical_plan/operators/operator_alter_column_add.cpp
@@ -71,7 +71,7 @@ namespace components::operators {
                                            exec_ctx,
                                            pg_attr_oid,
                                            std::move(pa_keys),
-                                           std::move(pa_vals));
+                                           components::operators::make_key_chunk(resource_, std::move(pa_vals)));
         std::pmr::vector<components::vector::data_chunk_t> attr_batches = co_await std::move(paf);
         std::int32_t next_attnum = 1;
         for (auto& chunk : attr_batches) {

--- a/components/physical_plan/operators/operator_alter_column_drop.cpp
+++ b/components/physical_plan/operators/operator_alter_column_drop.cpp
@@ -65,7 +65,7 @@ namespace components::operators {
                                            exec_ctx,
                                            pg_attr_oid,
                                            std::move(pa_keys),
-                                           std::move(pa_vals));
+                                           components::operators::make_key_chunk(resource_, std::move(pa_vals)));
         std::pmr::vector<components::vector::data_chunk_t> attr_batches = co_await std::move(paf);
 
         catalog::oid_t attoid = catalog::INVALID_OID;
@@ -125,7 +125,7 @@ namespace components::operators {
                                            exec_ctx,
                                            pg_dep_oid,
                                            std::move(pd_keys),
-                                           std::move(pd_vals));
+                                           components::operators::make_key_chunk(resource_, std::move(pd_vals)));
         std::pmr::vector<components::vector::data_chunk_t> dep_batches = co_await std::move(pdf);
 
         std::size_t dep_row_count = 0;

--- a/components/physical_plan/operators/operator_alter_column_rename.cpp
+++ b/components/physical_plan/operators/operator_alter_column_rename.cpp
@@ -64,7 +64,7 @@ namespace components::operators {
                                            exec_ctx,
                                            pg_attr,
                                            std::move(pa_keys),
-                                           std::move(pa_vals));
+                                           components::operators::make_key_chunk(resource_, std::move(pa_vals)));
         std::pmr::vector<components::vector::data_chunk_t> attr_batches = co_await std::move(paf);
 
         catalog::oid_t attoid = catalog::INVALID_OID;

--- a/components/physical_plan/operators/operator_commit_transaction.cpp
+++ b/components/physical_plan/operators/operator_commit_transaction.cpp
@@ -251,8 +251,13 @@ namespace components::operators {
         }
 
         // Flip MVCC state on the pg_catalog rows AND the base-table DML ranges
-        // drained above: one publish_commits / publish_deletes per category
-        // covers every table touched between BEGIN and COMMIT.
+        // drained above: ONE publish_commits + ONE publish_deletes cover every
+        // table touched between BEGIN and COMMIT. The swap (pg_catalog) and base
+        // (user-table DML) sets are merged into a single send each: the manager's
+        // storage_publish_commits / storage_publish_deletes partition their whole
+        // argument by pool_idx_for_oid internally and the per-agent inner handlers
+        // are idempotent for not-owned oids, so concatenation is value-correct and
+        // order-independent within one call (4 awaited sends → 2).
         // This in-memory MVCC flip happens BEFORE the WAL commit marker, yet
         // is crash-safe — durability of the flip comes from the WAL physical
         // records (already written by the DML operators) plus checkpoint, NOT from
@@ -264,37 +269,34 @@ namespace components::operators {
         if (txn_data.transaction_id != 0 && commit_id_ > 0 &&
             ctx->disk_address != actor_zeta::address_t::empty_address()) {
             components::execution_context_t swap_ctx{ctx->session, txn_data, {}};
-            if (!swap_appends.empty()) {
+            // Concatenate pg_catalog appends + base-table appends into one publish.
+            // Move both sources into a single ranges vector (both are
+            // std::vector<pg_catalog_append_range_t>, so a flat append preserves
+            // each range verbatim — the manager re-partitions per oid).
+            std::vector<components::pg_catalog_append_range_t> all_appends = std::move(swap_appends);
+            all_appends.insert(all_appends.end(),
+                               std::make_move_iterator(base_appends.begin()),
+                               std::make_move_iterator(base_appends.end()));
+            if (!all_appends.empty()) {
                 auto [_a, af] = actor_zeta::send(ctx->disk_address,
                                                  &services::disk::manager_disk_t::storage_publish_commits,
                                                  swap_ctx,
                                                  commit_id_,
-                                                 std::move(swap_appends));
+                                                 std::move(all_appends));
                 co_await std::move(af);
             }
-            if (!swap_deletes.empty()) {
+            // Concatenate pg_catalog deletes + base-table deletes into one publish
+            // (both are std::set<oid_t>; the union is the full set of dropped/
+            // deleted-from tables, deduped by the set, partitioned per oid).
+            std::set<components::catalog::oid_t> all_deletes = std::move(swap_deletes);
+            all_deletes.insert(base_delete_tables.begin(), base_delete_tables.end());
+            if (!all_deletes.empty()) {
                 auto [_d, df] = actor_zeta::send(ctx->disk_address,
                                                  &services::disk::manager_disk_t::storage_publish_deletes,
                                                  swap_ctx,
                                                  commit_id_,
-                                                 std::move(swap_deletes));
+                                                 std::move(all_deletes));
                 co_await std::move(df);
-            }
-            if (!base_appends.empty()) {
-                auto [_ba, baf] = actor_zeta::send(ctx->disk_address,
-                                                   &services::disk::manager_disk_t::storage_publish_commits,
-                                                   swap_ctx,
-                                                   commit_id_,
-                                                   std::move(base_appends));
-                co_await std::move(baf);
-            }
-            if (!base_delete_tables.empty()) {
-                auto [_bd, bdf] = actor_zeta::send(ctx->disk_address,
-                                                   &services::disk::manager_disk_t::storage_publish_deletes,
-                                                   swap_ctx,
-                                                   commit_id_,
-                                                   std::move(base_delete_tables));
-                co_await std::move(bdf);
             }
         }
 
@@ -337,36 +339,49 @@ namespace components::operators {
         // other sessions kept reading the table. Now that the txn is published —
         // the ProcArray barrier above has flipped every reader's snapshot past
         // this commit — physically tear them down. Per drained dropped oid:
-        // unregister_collection (manager_index) THEN drop_storage (manager_disk),
-        // in THAT order so no index consumer references a collection whose backing
-        // storage the disk actor is about to free. The two sends target distinct
-        // mailboxes, so FIFO gives no cross-mailbox ordering — we co_await the
-        // unregister BEFORE sending the drop to enforce index-before-disk per oid
-        // (two-phase per oid pair, acceptable: the pairs are independent so the
-        // serial per-pair await is the simplest correct shape). The DROP-GC remap
-        // (storage_dropped_committed / table_dropped_committed, above) already
-        // stamped the tombstones with commit_id so on_horizon_advanced reclaims
-        // any residue; this block does the eager removal of the now-committed drop.
+        // ALL unregister_collection (manager_index) THEN ONE drop_storage_many
+        // (manager_disk), in THAT order so no index consumer references a collection
+        // whose backing storage the disk actor is about to free. The two managers are
+        // distinct mailboxes, so FIFO gives no cross-mailbox ordering — we batch every
+        // unregister and AWAIT THEM ALL before issuing the batched disk drop. This is
+        // strictly stronger than the previous per-oid interleave: every index
+        // unregister completes BEFORE any disk drop, preserving the index-before-disk
+        // invariant globally. unregister_collection runs on the index MANAGER's own
+        // maps (not a per-oid router), so the N sends pipeline onto one mailbox;
+        // drop_storage_many partitions the oids per disk agent and fans out in
+        // parallel, collapsing N per-oid disk round-trips into one. The DROP-GC remap
+        // (storage_dropped_committed / table_dropped_committed, above) already stamped
+        // the tombstones with commit_id so on_horizon_advanced reclaims any residue;
+        // this block does the eager removal of the now-committed drop.
         // Gated on commit_id_ > 0 (mirrors the publish barrier / DROP-GC remap):
         // a DROP makes has_accumulated() true, so a txn with drops always gets a
         // real commit_id — but if commit_id_ is 0 (the empty-COMMIT abort, or a
         // missing txn) nothing committed, so nothing may be physically removed.
-        if (commit_id_ > 0) {
-            for (auto oid : dropped_storage_oids) {
-                if (ctx->index_address != actor_zeta::address_t::empty_address()) {
+        if (commit_id_ > 0 && !dropped_storage_oids.empty()) {
+            if (ctx->index_address != actor_zeta::address_t::empty_address()) {
+                std::pmr::vector<actor_zeta::unique_future<void>> unregister_futures{resource_};
+                unregister_futures.reserve(dropped_storage_oids.size());
+                for (auto oid : dropped_storage_oids) {
                     auto [_u, uf] = actor_zeta::send(ctx->index_address,
                                                      &services::index::manager_index_t::unregister_collection,
                                                      ctx->session,
                                                      oid);
+                    unregister_futures.push_back(std::move(uf));
+                }
+                // Await EVERY unregister before any disk drop (index-before-disk).
+                for (auto& uf : unregister_futures) {
                     co_await std::move(uf);
                 }
-                if (ctx->disk_address != actor_zeta::address_t::empty_address()) {
-                    auto [_d, df] = actor_zeta::send(ctx->disk_address,
-                                                     &services::disk::manager_disk_t::drop_storage,
-                                                     ctx->session,
-                                                     oid);
-                    co_await std::move(df);
-                }
+            }
+            if (ctx->disk_address != actor_zeta::address_t::empty_address()) {
+                std::pmr::vector<components::catalog::oid_t> drop_oids{dropped_storage_oids.begin(),
+                                                                      dropped_storage_oids.end(),
+                                                                      resource_};
+                auto [_d, df] = actor_zeta::send(ctx->disk_address,
+                                                 &services::disk::manager_disk_t::drop_storage_many,
+                                                 ctx->session,
+                                                 std::move(drop_oids));
+                co_await std::move(df);
             }
         }
 

--- a/components/physical_plan/operators/operator_computed_field_register.cpp
+++ b/components/physical_plan/operators/operator_computed_field_register.cpp
@@ -84,7 +84,7 @@ namespace components::operators {
                                              exec_ctx,
                                              pg_computed_column,
                                              std::move(r_keys),
-                                             std::move(r_vals));
+                                             components::operators::make_key_chunk(resource_, std::move(r_vals)));
             auto batches = co_await std::move(rf);
 
             std::int64_t max_version = -1;
@@ -141,7 +141,7 @@ namespace components::operators {
                                                      exec_ctx,
                                                      pg_type,
                                                      std::move(t_keys),
-                                                     std::move(t_vals));
+                                                     components::operators::make_key_chunk(resource_, std::move(t_vals)));
                     auto type_batches = co_await std::move(tf);
                     if (!type_batches.empty() && type_batches[0].size() != 0 &&
                         type_batches[0].column_count() > 0) {

--- a/components/physical_plan/operators/operator_computed_field_unregister.cpp
+++ b/components/physical_plan/operators/operator_computed_field_unregister.cpp
@@ -70,7 +70,7 @@ namespace components::operators {
                                          exec_ctx,
                                          pg_computed_column,
                                          std::move(r_keys),
-                                         std::move(r_vals));
+                                         components::operators::make_key_chunk(resource_, std::move(r_vals)));
         auto batches = co_await std::move(rf);
 
         // pick the latest live row matching attoid_ (max attversion AND attrefcount > 0).

--- a/components/physical_plan/operators/operator_data.cpp
+++ b/components/physical_plan/operators/operator_data.cpp
@@ -121,4 +121,49 @@ namespace components::operators {
         return out;
     }
 
+    vector::data_chunk_t make_key_chunk(std::pmr::memory_resource* resource,
+                                        std::pmr::vector<types::logical_value_t> values) {
+        // Column j carries the value's own complex_logical_type, so the cell is written
+        // without a cast. Capacity is at least 1 because set_cardinality(1) below requires
+        // capacity_ >= 1 even when there are no key columns.
+        std::pmr::vector<types::complex_logical_type> types(resource);
+        types.reserve(values.size());
+        for (const auto& v : values) {
+            types.emplace_back(v.type());
+        }
+        vector::data_chunk_t chunk(resource, types, 1);
+        for (std::size_t j = 0; j < values.size(); ++j) {
+            // set_value already leaves the cell invalid for a null logical_value_t.
+            chunk.set_value(static_cast<uint64_t>(j), 0, values[j]);
+        }
+        chunk.set_cardinality(1);
+        return chunk;
+    }
+
+    vector::data_chunk_t make_keys_chunk(std::pmr::memory_resource* resource,
+                                         const std::pmr::vector<std::pmr::vector<types::logical_value_t>>& rows) {
+        // Column types are taken from the first key-tuple; every other tuple must be
+        // positionally aligned to the same key columns (same arity, same per-column type).
+        // Capacity is at least 1 because set_cardinality requires capacity_ >= 1 even when
+        // there are no rows.
+        std::pmr::vector<types::complex_logical_type> types(resource);
+        if (!rows.empty()) {
+            types.reserve(rows.front().size());
+            for (const auto& v : rows.front()) {
+                types.emplace_back(v.type());
+            }
+        }
+        const std::size_t nrows = rows.size();
+        vector::data_chunk_t chunk(resource, types, nrows == 0 ? 1 : nrows);
+        for (std::size_t i = 0; i < nrows; ++i) {
+            const auto& row = rows[i];
+            for (std::size_t j = 0; j < row.size(); ++j) {
+                // set_value already leaves the cell invalid for a null logical_value_t.
+                chunk.set_value(static_cast<uint64_t>(j), static_cast<uint64_t>(i), row[j]);
+            }
+        }
+        chunk.set_cardinality(static_cast<uint64_t>(nrows));
+        return chunk;
+    }
+
 } // namespace components::operators

--- a/components/physical_plan/operators/operator_data.hpp
+++ b/components/physical_plan/operators/operator_data.hpp
@@ -68,4 +68,30 @@ namespace components::operators {
         return {new operator_data_t(resource, std::move(chunks))};
     }
 
+    // Builds the 1-row columnar key carrier used to call manager_disk_t::read_chunks_by_key
+    // (and mirrors the scan_by_keys columnar contract). Column j of the returned chunk has
+    // type values[j].type() and cell (j, 0) holds values[j] (null cells stay invalid). The
+    // result has exactly one row (cardinality 1) and one column per value.
+    //
+    // The chunk carries no column NAMES: callers pass key column names separately
+    // (key_col_names), so values[] must be ordered POSITIONALLY to match key_col_names[] —
+    // values[j] is the key for key_col_names[j]. The agent resolves names to storage column
+    // indices independently and reads keys.value(ki, 0) by the same positional index ki.
+    vector::data_chunk_t make_key_chunk(std::pmr::memory_resource* resource,
+                                        std::pmr::vector<types::logical_value_t> values);
+
+    // Builds the N-row columnar key carrier used to call manager_disk_t::read_chunks_by_keys
+    // (and mirrors the scan_by_keys columnar contract for a multi-key batch). Row i of the
+    // returned chunk is the i-th key-tuple: cell (j, i) holds rows[i][j] (null cells stay
+    // invalid). The result has exactly rows.size() rows and one column per key field.
+    //
+    // Column types come from rows[0]: every key-tuple MUST be positionally aligned to the same
+    // key_col_names[] and use the same column types, so rows[i][j].type() == rows[0][j].type()
+    // for all i. The chunk carries no column NAMES; callers pass key_col_names separately and
+    // the agent resolves names to storage indices once, then reads keys.value(ki, i) by the
+    // same positional index ki. An empty rows[] yields a 0-row, 0-column chunk (the read then
+    // returns an empty per-key result, matching read_chunks_by_keys' invariant).
+    vector::data_chunk_t make_keys_chunk(std::pmr::memory_resource* resource,
+                                         const std::pmr::vector<std::pmr::vector<types::logical_value_t>>& rows);
+
 } // namespace components::operators

--- a/components/physical_plan/operators/operator_dynamic_cascade_delete.cpp
+++ b/components/physical_plan/operators/operator_dynamic_cascade_delete.cpp
@@ -136,7 +136,7 @@ namespace components::operators {
                                                exec_ctx,
                                                kPgDepend,
                                                std::move(rd_keys),
-                                               std::move(rd_vals));
+                                               components::operators::make_key_chunk(resource_, std::move(rd_vals)));
             auto dep_batches = co_await std::move(rdf);
 
             std::pmr::vector<catalog::dependency_t> deps(resource_);
@@ -208,39 +208,52 @@ namespace components::operators {
 
         // pg_class relkind probe: each storage step's read is keyed by its own
         // step.objid and only decides whether the oid is storage-backed, so no read
-        // feeds another iteration's read (probes are independent).
+        // feeds another iteration's read (probes are independent). plan.steps is fixed
+        // before this loop, so the probe oids are all known up front — gather the
+        // pg_class-keyed step oids in step order and run ONE batched read_chunks_by_keys
+        // keyed on "oid", then map result[i] back to the i-th probed step.
+        std::pmr::vector<catalog::oid_t> probe_oids(resource_);
+        std::pmr::vector<std::pmr::vector<types::logical_value_t>> probe_key_rows(resource_);
         for (const auto& step : plan.steps) {
             if (step.classid != catalog::well_known_oid::pg_class_table)
                 continue;
-
-            // Read pg_class row for this oid to inspect relkind: (oid, relname, relnamespace, relkind, ...)
-            // Storage routing is by table_oid only — relname/nspname are no longer needed.
-            types::logical_value_t pcoid_lv(resource_, step.objid);
+            probe_oids.push_back(step.objid);
+            std::pmr::vector<types::logical_value_t> row(resource_);
+            row.emplace_back(types::logical_value_t(resource_, step.objid));
+            probe_key_rows.push_back(std::move(row));
+        }
+        if (!probe_oids.empty()) {
+            // Read pg_class rows for these oids to inspect relkind: (oid, relname, relnamespace,
+            // relkind, ...). Storage routing is by table_oid only — relname/nspname are no longer
+            // needed. result[i] = matched chunks for probe_oids[i], in input order.
             std::pmr::vector<std::string> pc_keys(resource_);
             pc_keys.emplace_back("oid");
-            std::pmr::vector<types::logical_value_t> pc_vals(resource_);
-            pc_vals.emplace_back(pcoid_lv);
             auto [_pc, pcf] = actor_zeta::send(ctx->disk_address,
-                                               &services::disk::manager_disk_t::read_chunks_by_key,
+                                               &services::disk::manager_disk_t::read_chunks_by_keys,
                                                exec_ctx,
                                                kPgClass,
                                                std::move(pc_keys),
-                                               std::move(pc_vals));
-            std::pmr::vector<components::vector::data_chunk_t> pc_batches = co_await std::move(pcf);
-            if (pc_batches.empty() || pc_batches[0].size() == 0 || pc_batches[0].column_count() < 4)
-                continue;
+                                               components::operators::make_keys_chunk(resource_, probe_key_rows));
+            std::pmr::vector<std::pmr::vector<components::vector::data_chunk_t>> pc_results =
+                co_await std::move(pcf);
 
-            const auto rk = pc_batches[0].value(3, 0);
-            const auto rkv = rk.is_null() ? std::string_view{"r"} : rk.value<std::string_view>();
-            const char relkind = rkv.empty() ? catalog::relkind::regular : rkv[0];
+            for (std::size_t k = 0; k < probe_oids.size() && k < pc_results.size(); ++k) {
+                const auto& pc_batches = pc_results[k];
+                if (pc_batches.empty() || pc_batches[0].size() == 0 || pc_batches[0].column_count() < 4)
+                    continue;
 
-            // Only regular and computing tables back actual storage. Index/
-            // sequence/view/macro/composite-type entries are pure catalog
-            // bookkeeping: deleting the pg_class row is sufficient.
-            if (relkind != catalog::relkind::regular && relkind != catalog::relkind::computed)
-                continue;
+                const auto rk = pc_batches[0].value(3, 0);
+                const auto rkv = rk.is_null() ? std::string_view{"r"} : rk.value<std::string_view>();
+                const char relkind = rkv.empty() ? catalog::relkind::regular : rkv[0];
 
-            pending_storage_drops.push_back({step.objid});
+                // Only regular and computing tables back actual storage. Index/
+                // sequence/view/macro/composite-type entries are pure catalog
+                // bookkeeping: deleting the pg_class row is sufficient.
+                if (relkind != catalog::relkind::regular && relkind != catalog::relkind::computed)
+                    continue;
+
+                pending_storage_drops.push_back({probe_oids[k]});
+            }
         }
 
         // execute the catalog-row deletes in the planned order.
@@ -267,7 +280,7 @@ namespace components::operators {
         }
 
         // Mark the storage + index entry dropped per table, but DO NOT physically
-        // tear them down here. The mark_table_dropped / mark_storage_dropped
+        // tear them down here. The mark_table_dropped / mark_storage_dropped_many
         // tombstones record (oid, dropped_at) for the next horizon-advance GC
         // sweep; the actual drop_storage + unregister_collection now fire only at
         // COMMIT time (operator_commit_transaction, after the txn_publish barrier).
@@ -287,13 +300,17 @@ namespace components::operators {
         // txn=0 (auto-commit/bootstrap) records 0, matching catalog-scan rebuild.
         const uint64_t dropped_at = ctx->txn.transaction_id;
         bool any_storage_drop = false;
-        // Two-phase fan-out: send both mark messages per storage drop without
-        // awaiting in the loop, then await every future afterwards. No
-        // intra-target drop ordering is required (the marks have no ordered
-        // follow-up here; the physical drop_storage / unregister_collection run
-        // at COMMIT), so awaiting below is completion-sync only.
+        // Two-phase fan-out: send the per-table index mark (mark_table_dropped) without
+        // awaiting in the loop and collect the dropped storage oids; then issue ONE
+        // batched disk mark (mark_storage_dropped_many — every oid in this cascade shares
+        // the same dropped_at) and await every future afterwards. No intra-target drop
+        // ordering is required (the marks have no ordered follow-up here; the physical
+        // drop_storage / unregister_collection run at COMMIT), so awaiting below is
+        // completion-sync only and batching the disk mark cannot reorder anything.
         std::pmr::vector<actor_zeta::unique_future<void>> drop_futures(resource_);
-        drop_futures.reserve(pending_storage_drops.size() * 2);
+        drop_futures.reserve(pending_storage_drops.size() + 1);
+        std::pmr::vector<catalog::oid_t> dropped_storage_oids(resource_);
+        dropped_storage_oids.reserve(pending_storage_drops.size());
         for (auto& sd : pending_storage_drops) {
             any_storage_drop = true;
             // DROP back-channel: record the dropped storage oid for the COMMIT
@@ -311,10 +328,13 @@ namespace components::operators {
                                                      dropped_at);
                 drop_futures.push_back(std::move(mtif));
             }
+            dropped_storage_oids.push_back(sd.table_oid);
+        }
+        if (!dropped_storage_oids.empty()) {
             auto [_msd, msdf] = actor_zeta::send(ctx->disk_address,
-                                                 &services::disk::manager_disk_t::mark_storage_dropped,
+                                                 &services::disk::manager_disk_t::mark_storage_dropped_many,
                                                  ctx->session,
-                                                 sd.table_oid,
+                                                 std::move(dropped_storage_oids),
                                                  dropped_at);
             drop_futures.push_back(std::move(msdf));
         }

--- a/components/physical_plan/operators/operator_fk_cascade.cpp
+++ b/components/physical_plan/operators/operator_fk_cascade.cpp
@@ -134,83 +134,79 @@ namespace components::operators {
             }
             case 'n':   // SET NULL
             case 'd': { // SET DEFAULT
-                // Two-phase: fetch every referencing child row first, then update.
-                // Carry each fetch's source row index so the per-row child_ids stay
-                // paired with that row's fetched chunk when building the update.
-                std::pmr::vector<actor_zeta::unique_future<std::unique_ptr<components::vector::data_chunk_t>>>
-                    fetch_futures(resource_);
-                std::pmr::vector<std::size_t> fetch_rows(resource_);
-                fetch_futures.reserve(per_row_child_ids.size());
-                fetch_rows.reserve(per_row_child_ids.size());
-                for (std::size_t row = 0; row < per_row_child_ids.size(); ++row) {
-                    const auto& child_ids = per_row_child_ids[row];
-                    if (child_ids.empty())
-                        continue;
-                    components::vector::vector_t fetch_ids(resource_, types::logical_type::BIGINT, child_ids.size());
-                    for (std::size_t i = 0; i < child_ids.size(); ++i) {
-                        fetch_ids.data<int64_t>()[i] = child_ids[i];
+                // Mirror the CASCADE branch's flattening: aggregate EVERY referencing
+                // child row_id across all parent rows into ONE set, then do a single
+                // fetch + single update against the SAME child_table_oid (one owning
+                // agent). The SET NULL / SET DEFAULT transform is uniform across rows
+                // — it keys off per-COLUMN child_col_schema_indices / per-COLUMN
+                // child_col_default_specs, never off the parent row — so a single
+                // combined update chunk is value-correct. Each child row_id stays
+                // paired with its fetched chunk position because storage_fetch returns
+                // rows positionally aligned with the requested row_ids, and
+                // storage_update applies data[i] to row_ids[i] positionally.
+                std::pmr::vector<int64_t> all_child_ids(resource_);
+                for (const auto& child_ids : per_row_child_ids) {
+                    for (auto id : child_ids) {
+                        all_child_ids.push_back(id);
                     }
-                    auto [_f, ffut] = actor_zeta::send(ctx->disk_address,
-                                                       &services::disk::manager_disk_t::storage_fetch,
-                                                       ctx->session,
-                                                       fk_.child_table_oid,
-                                                       std::move(fetch_ids),
-                                                       static_cast<uint64_t>(child_ids.size()));
-                    fetch_futures.push_back(std::move(ffut));
-                    fetch_rows.push_back(row);
                 }
+                if (all_child_ids.empty())
+                    break;
+
+                // Single fetch for the whole set.
+                components::vector::vector_t fetch_ids(resource_, types::logical_type::BIGINT, all_child_ids.size());
+                for (std::size_t i = 0; i < all_child_ids.size(); ++i) {
+                    fetch_ids.data<int64_t>()[i] = all_child_ids[i];
+                }
+                auto [_f, ffut] = actor_zeta::send(ctx->disk_address,
+                                                   &services::disk::manager_disk_t::storage_fetch,
+                                                   ctx->session,
+                                                   fk_.child_table_oid,
+                                                   std::move(fetch_ids),
+                                                   static_cast<uint64_t>(all_child_ids.size()));
+                auto fetched = co_await std::move(ffut);
+                if (!fetched || fetched->size() == 0)
+                    break;
 
                 const bool is_set_null = (fk_.del_action == 'n');
-                // Await each fetch, build that row's update from the fetched chunk,
-                // and send all storage_update calls; await them in the final phase.
-                std::pmr::vector<actor_zeta::unique_future<std::pair<int64_t, uint64_t>>> update_futures(resource_);
-                update_futures.reserve(fetch_futures.size());
-                for (std::size_t fi = 0; fi < fetch_futures.size(); ++fi) {
-                    auto fetched = co_await std::move(fetch_futures[fi]);
-                    if (!fetched || fetched->size() == 0)
+                // Apply the uniform per-column transform to every fetched row.
+                for (std::size_t ci = 0; ci < fk_.child_col_schema_indices.size(); ++ci) {
+                    const auto schema_idx = fk_.child_col_schema_indices[ci];
+                    if (schema_idx == absent || schema_idx >= fetched->column_count())
                         continue;
-                    const auto& child_ids = per_row_child_ids[fetch_rows[fi]];
-
-                    for (std::size_t ci = 0; ci < fk_.child_col_schema_indices.size(); ++ci) {
-                        const auto schema_idx = fk_.child_col_schema_indices[ci];
-                        if (schema_idx == absent || schema_idx >= fetched->column_count())
-                            continue;
-                        if (is_set_null) {
-                            for (uint64_t r = 0; r < fetched->size(); ++r) {
+                    if (is_set_null) {
+                        for (uint64_t r = 0; r < fetched->size(); ++r) {
+                            fetched->data[schema_idx].validity().set_invalid(r);
+                        }
+                    } else {
+                        // SET DEFAULT: decode attdefspec; NULL default → same as SET NULL.
+                        const auto& spec = ci < fk_.child_col_default_specs.size() ? fk_.child_col_default_specs[ci]
+                                                                                   : std::string{};
+                        auto default_val =
+                            spec.empty() ? std::nullopt : components::catalog::decode_default_spec(resource_, spec);
+                        for (uint64_t r = 0; r < fetched->size(); ++r) {
+                            if (default_val.has_value()) {
+                                fetched->set_value(schema_idx, r, *default_val);
+                            } else {
                                 fetched->data[schema_idx].validity().set_invalid(r);
-                            }
-                        } else {
-                            // SET DEFAULT: decode attdefspec; NULL default → same as SET NULL.
-                            const auto& spec = ci < fk_.child_col_default_specs.size() ? fk_.child_col_default_specs[ci]
-                                                                                       : std::string{};
-                            auto default_val =
-                                spec.empty() ? std::nullopt : components::catalog::decode_default_spec(resource_, spec);
-                            for (uint64_t r = 0; r < fetched->size(); ++r) {
-                                if (default_val.has_value()) {
-                                    fetched->set_value(schema_idx, r, *default_val);
-                                } else {
-                                    fetched->data[schema_idx].validity().set_invalid(r);
-                                }
                             }
                         }
                     }
+                }
 
-                    components::vector::vector_t upd_ids(resource_, types::logical_type::BIGINT, child_ids.size());
-                    for (std::size_t i = 0; i < child_ids.size(); ++i) {
-                        upd_ids.data<int64_t>()[i] = child_ids[i];
-                    }
-                    execution_context_t upd_ctx{ctx->session, {}, {}};
-                    auto [_u, ufut] = actor_zeta::send(ctx->disk_address,
-                                                       &services::disk::manager_disk_t::storage_update,
-                                                       upd_ctx,
-                                                       fk_.child_table_oid,
-                                                       std::move(upd_ids),
-                                                       std::move(fetched));
-                    update_futures.push_back(std::move(ufut));
+                // Single update for the whole set.
+                components::vector::vector_t upd_ids(resource_, types::logical_type::BIGINT, all_child_ids.size());
+                for (std::size_t i = 0; i < all_child_ids.size(); ++i) {
+                    upd_ids.data<int64_t>()[i] = all_child_ids[i];
                 }
-                for (auto& ufut : update_futures) {
-                    co_await std::move(ufut);
-                }
+                execution_context_t upd_ctx{ctx->session, {}, {}};
+                auto [_u, ufut] = actor_zeta::send(ctx->disk_address,
+                                                   &services::disk::manager_disk_t::storage_update,
+                                                   upd_ctx,
+                                                   fk_.child_table_oid,
+                                                   std::move(upd_ids),
+                                                   std::move(fetched));
+                co_await std::move(ufut);
                 break;
             }
             default:

--- a/components/physical_plan/operators/operator_resolve_constraint.cpp
+++ b/components/physical_plan/operators/operator_resolve_constraint.cpp
@@ -85,8 +85,27 @@ namespace components::operators {
                                               exec_ctx,
                                               kPgConstraint,
                                               std::move(con_keys),
-                                              std::move(con_vals));
+                                              components::operators::make_key_chunk(resource_, std::move(con_vals)));
         auto con_batches = co_await std::move(fut_con);
+
+        // PASS 1: decode every pg_constraint row. FK rows ('f') build a partially-filled
+        // fk_info_t plus the child/parent attoid CSVs needed to resolve column names; CHECK
+        // rows ('c', outgoing only) emit check_exprs directly. The per-FK child/parent
+        // pg_attribute reads below are independent (each keys on a table oid known here from
+        // the constraint row, their results feed disjoint fk fields, and nothing in this
+        // operator WRITES the catalog), so they are deferred and issued as two batched
+        // read_chunks_by_keys calls after this pass — one key per FK, in FK order. The order
+        // of `fks` is preserved: every FK candidate keeps its slot in pending_fks and is
+        // pushed (if valid) during pass 2 in the same order it was decoded here.
+        struct pending_fk_t {
+            catalog::fk_info_t fk;
+            // parse_oid_csv returns std::vector (not pmr), so these mirror that type.
+            std::vector<catalog::oid_t> child_attoids;
+            std::vector<catalog::oid_t> parent_attoids;
+        };
+        std::pmr::vector<pending_fk_t> pending_fks(resource_);
+        std::pmr::vector<std::pmr::vector<types::logical_value_t>> child_key_rows(resource_);
+        std::pmr::vector<std::pmr::vector<types::logical_value_t>> parent_key_rows(resource_);
 
         for (auto& con_chunk : con_batches) {
             if (con_chunk.column_count() <= catalog::pg_constraint_col::confupdtype)
@@ -104,7 +123,8 @@ namespace components::operators {
                 const char contype = contype_sv[0];
 
                 if (contype == 'f') {
-                    catalog::fk_info_t fk;
+                    pending_fk_t pending;
+                    catalog::fk_info_t& fk = pending.fk;
                     fk.constraint_oid = static_cast<catalog::oid_t>(
                         con_chunk.value(catalog::pg_constraint_col::oid, ci).value<std::uint32_t>());
                     if (direction == direction_t::outgoing) {
@@ -129,201 +149,27 @@ namespace components::operators {
                             ? 'a'
                             : con_chunk.value(catalog::pg_constraint_col::confupdtype, ci).value<std::string_view>()[0];
 
-                    const auto child_attoids = catalog::parse_oid_csv(
+                    pending.child_attoids = catalog::parse_oid_csv(
                         con_chunk.value(catalog::pg_constraint_col::conkey, ci).is_null()
                             ? std::string{}
                             : std::string(
                                   con_chunk.value(catalog::pg_constraint_col::conkey, ci).value<std::string_view>()));
-                    const auto parent_attoids = catalog::parse_oid_csv(
+                    pending.parent_attoids = catalog::parse_oid_csv(
                         con_chunk.value(catalog::pg_constraint_col::confkey, ci).is_null()
                             ? std::string{}
                             : std::string(
                                   con_chunk.value(catalog::pg_constraint_col::confkey, ci).value<std::string_view>()));
 
-                    // Two-phase: the child-attr and parent-attr pg_attribute reads
-                    // are independent (both key on a table oid known up front, and
-                    // their results feed disjoint fk fields), so send both before
-                    // awaiting either. Child is awaited first because the schema-
-                    // position logic below consumes it; the parent await is purely
-                    // completion-sync after.
-                    types::logical_value_t child_lv(resource_, fk.child_table_oid);
-                    std::pmr::vector<std::string> attr_c_keys(resource_);
-                    attr_c_keys.emplace_back("attrelid");
-                    std::pmr::vector<types::logical_value_t> attr_c_vals(resource_);
-                    attr_c_vals.emplace_back(child_lv);
-                    auto [_a, fut_attr_c] = actor_zeta::send(ctx->disk_address,
-                                                             &services::disk::manager_disk_t::read_chunks_by_key,
-                                                             exec_ctx,
-                                                             kPgAttribute,
-                                                             std::move(attr_c_keys),
-                                                             std::move(attr_c_vals));
+                    // One key row per FK, positionally aligned to pending_fks — child by
+                    // child_table_oid, parent by parent_table_oid (both keyed "attrelid").
+                    std::pmr::vector<types::logical_value_t> child_row(resource_);
+                    child_row.emplace_back(types::logical_value_t(resource_, fk.child_table_oid));
+                    child_key_rows.push_back(std::move(child_row));
+                    std::pmr::vector<types::logical_value_t> parent_row(resource_);
+                    parent_row.emplace_back(types::logical_value_t(resource_, fk.parent_table_oid));
+                    parent_key_rows.push_back(std::move(parent_row));
 
-                    types::logical_value_t parent_lv(resource_, fk.parent_table_oid);
-                    std::pmr::vector<std::string> attr_p_keys(resource_);
-                    attr_p_keys.emplace_back("attrelid");
-                    std::pmr::vector<types::logical_value_t> attr_p_vals(resource_);
-                    attr_p_vals.emplace_back(parent_lv);
-                    auto [_b, fut_attr_p] = actor_zeta::send(ctx->disk_address,
-                                                             &services::disk::manager_disk_t::read_chunks_by_key,
-                                                             exec_ctx,
-                                                             kPgAttribute,
-                                                             std::move(attr_p_keys),
-                                                             std::move(attr_p_vals));
-
-                    auto child_attr = co_await std::move(fut_attr_c);
-                    {
-                        std::vector<std::string> names;
-                        names.reserve(child_attoids.size());
-                        for (const auto& wanted_oid : child_attoids) {
-                            for (auto& attr_chunk : child_attr) {
-                                if (attr_chunk.column_count() <= catalog::pg_attribute_col::attname)
-                                    continue;
-                                bool found = false;
-                                for (uint64_t ai = 0; ai < attr_chunk.size(); ++ai) {
-                                    auto row_attoid = static_cast<catalog::oid_t>(
-                                        attr_chunk.value(catalog::pg_attribute_col::attoid, ai).value<std::uint32_t>());
-                                    if (row_attoid == wanted_oid) {
-                                        names.emplace_back(std::string(
-                                            attr_chunk.value(catalog::pg_attribute_col::attname, ai)
-                                                .value<std::string_view>()));
-                                        found = true;
-                                        break;
-                                    }
-                                }
-                                if (found)
-                                    break;
-                            }
-                        }
-                        fk.child_col_names = std::move(names);
-                    }
-
-                    // Also resolve child schema positions + defspec for each FK
-                    // column (used by operator_fk_cascade_t SET NULL / SET DEFAULT).
-                    if (direction == direction_t::referencing) {
-                        // Build (attname → attnum-1, attdefspec) over child's
-                        // pg_attribute rows sorted by attnum.
-                        struct row_meta_t {
-                            std::int32_t attnum{0};
-                            std::string attname;
-                            std::string attdefspec;
-                        };
-                        std::vector<row_meta_t> ordered;
-                        constexpr std::uint64_t kAttnum = 4;
-                        constexpr std::uint64_t kAttisdropped = 7;
-                        constexpr std::uint64_t kAttdefspec = 9;
-                        for (auto& attr_chunk : child_attr) {
-                            if (attr_chunk.column_count() <= kAttisdropped)
-                                continue;
-                            for (uint64_t ai = 0; ai < attr_chunk.size(); ++ai) {
-                                if (!attr_chunk.value(kAttisdropped, ai).is_null() &&
-                                    attr_chunk.value(kAttisdropped, ai).value<bool>())
-                                    continue;
-                                row_meta_t r;
-                                if (!attr_chunk.value(catalog::pg_attribute_col::attname, ai).is_null()) {
-                                    r.attname.assign(
-                                        attr_chunk.value(catalog::pg_attribute_col::attname, ai).value<std::string_view>());
-                                }
-                                r.attnum = attr_chunk.value(kAttnum, ai).is_null()
-                                               ? 0
-                                               : attr_chunk.value(kAttnum, ai).value<std::int32_t>();
-                                if (attr_chunk.column_count() > kAttdefspec &&
-                                    !attr_chunk.value(kAttdefspec, ai).is_null()) {
-                                    r.attdefspec.assign(attr_chunk.value(kAttdefspec, ai).value<std::string_view>());
-                                }
-                                ordered.push_back(std::move(r));
-                            }
-                        }
-                        std::sort(ordered.begin(), ordered.end(), [](const row_meta_t& a, const row_meta_t& b) {
-                            return a.attnum < b.attnum;
-                        });
-                        for (const auto& col_name : fk.child_col_names) {
-                            std::size_t pos = std::numeric_limits<std::size_t>::max();
-                            std::string def_spec;
-                            for (std::size_t i = 0; i < ordered.size(); ++i) {
-                                if (ordered[i].attname == col_name) {
-                                    pos = i;
-                                    def_spec = ordered[i].attdefspec;
-                                    break;
-                                }
-                            }
-                            fk.child_col_schema_indices.push_back(pos);
-                            fk.child_col_default_specs.push_back(std::move(def_spec));
-                        }
-                    }
-
-                    auto parent_attr = co_await std::move(fut_attr_p);
-                    {
-                        std::vector<std::string> names;
-                        names.reserve(parent_attoids.size());
-                        for (const auto& wanted_oid : parent_attoids) {
-                            for (auto& attr_chunk : parent_attr) {
-                                if (attr_chunk.column_count() <= catalog::pg_attribute_col::attname)
-                                    continue;
-                                bool found = false;
-                                for (uint64_t ai = 0; ai < attr_chunk.size(); ++ai) {
-                                    auto row_attoid = static_cast<catalog::oid_t>(
-                                        attr_chunk.value(catalog::pg_attribute_col::attoid, ai).value<std::uint32_t>());
-                                    if (row_attoid == wanted_oid) {
-                                        names.emplace_back(std::string(
-                                            attr_chunk.value(catalog::pg_attribute_col::attname, ai)
-                                                .value<std::string_view>()));
-                                        found = true;
-                                        break;
-                                    }
-                                }
-                                if (found)
-                                    break;
-                            }
-                        }
-                        fk.parent_col_names = std::move(names);
-                    }
-
-                    if (direction == direction_t::referencing) {
-                        // For DELETE FK cascade we also need the child's table name
-                        // + schema (so operator_fk_cascade_t can locate the
-                        // descendant collection without a back-resolve).
-                        types::logical_value_t child_oid_lv(resource_, fk.child_table_oid);
-                        std::pmr::vector<std::string> cls_keys(resource_);
-                        cls_keys.emplace_back("oid");
-                        std::pmr::vector<types::logical_value_t> cls_vals(resource_);
-                        cls_vals.emplace_back(child_oid_lv);
-                        auto [_cls, fut_cls] = actor_zeta::send(ctx->disk_address,
-                                                                &services::disk::manager_disk_t::read_chunks_by_key,
-                                                                exec_ctx,
-                                                                kPgClass,
-                                                                std::move(cls_keys),
-                                                                std::move(cls_vals));
-                        auto cls_batches = co_await std::move(fut_cls);
-                        if (!cls_batches.empty() && cls_batches[0].size() != 0 &&
-                            cls_batches[0].column_count() > catalog::pg_class_col::relname) {
-                            fk.child_collection_name = std::string(
-                                cls_batches[0].value(catalog::pg_class_col::relname, 0).value<std::string_view>());
-                            fk.child_database = "";
-                            const auto ns_oid = static_cast<catalog::oid_t>(
-                                cls_batches[0].value(catalog::pg_class_col::relnamespace, 0).value<std::uint32_t>());
-                            types::logical_value_t ns_oid_lv(resource_, ns_oid);
-                            std::pmr::vector<std::string> ns_keys(resource_);
-                            ns_keys.emplace_back("oid");
-                            std::pmr::vector<types::logical_value_t> ns_vals(resource_);
-                            ns_vals.emplace_back(ns_oid_lv);
-                            auto [_ns, fut_ns] = actor_zeta::send(ctx->disk_address,
-                                                                  &services::disk::manager_disk_t::read_chunks_by_key,
-                                                                  exec_ctx,
-                                                                  kPgNamespace,
-                                                                  std::move(ns_keys),
-                                                                  std::move(ns_vals));
-                            auto ns_batches = co_await std::move(fut_ns);
-                            if (!ns_batches.empty() && ns_batches[0].size() != 0 &&
-                                ns_batches[0].column_count() > catalog::pg_namespace_col::nspname) {
-                                fk.child_schema = std::string(
-                                    ns_batches[0].value(catalog::pg_namespace_col::nspname, 0).value<std::string_view>());
-                            }
-                        }
-                    }
-
-                    if (!fk.child_col_names.empty() && !fk.parent_col_names.empty()) {
-                        fks.push_back(std::move(fk));
-                    }
+                    pending_fks.push_back(std::move(pending));
                 } else if (contype == 'c' && direction == direction_t::outgoing) {
                     // Named locals required here too (see contype dangle note above).
                     const auto conexpr_cell = con_chunk.value(catalog::pg_constraint_col::conexpr, ci);
@@ -338,6 +184,204 @@ namespace components::operators {
                         name = std::string(conname_cell.value<std::string_view>());
                     }
                     check_exprs.emplace_back(std::move(name), std::string(conexpr_sv));
+                }
+            }
+        }
+
+        if (!pending_fks.empty()) {
+            // Batched child + parent pg_attribute reads, one key per FK in FK order. The two
+            // batches are mutually independent (disjoint key columns / disjoint fk fields), so
+            // issue both before awaiting either — same independence the prior per-FK code relied
+            // on, now amortised across the whole constraint set in two mailbox hops total.
+            // child_results[k] / parent_results[k] correspond to pending_fks[k].
+            std::pmr::vector<std::string> attr_c_keys(resource_);
+            attr_c_keys.emplace_back("attrelid");
+            auto [_a, fut_attr_c] = actor_zeta::send(ctx->disk_address,
+                                                     &services::disk::manager_disk_t::read_chunks_by_keys,
+                                                     exec_ctx,
+                                                     kPgAttribute,
+                                                     std::move(attr_c_keys),
+                                                     components::operators::make_keys_chunk(resource_, child_key_rows));
+
+            std::pmr::vector<std::string> attr_p_keys(resource_);
+            attr_p_keys.emplace_back("attrelid");
+            auto [_b, fut_attr_p] = actor_zeta::send(ctx->disk_address,
+                                                     &services::disk::manager_disk_t::read_chunks_by_keys,
+                                                     exec_ctx,
+                                                     kPgAttribute,
+                                                     std::move(attr_p_keys),
+                                                     components::operators::make_keys_chunk(resource_, parent_key_rows));
+
+            std::pmr::vector<std::pmr::vector<components::vector::data_chunk_t>> child_results =
+                co_await std::move(fut_attr_c);
+            std::pmr::vector<std::pmr::vector<components::vector::data_chunk_t>> parent_results =
+                co_await std::move(fut_attr_p);
+
+            // PASS 2: per-FK column-name resolution + (for referencing) the chained
+            // pg_class / pg_namespace reads. Identical extraction logic to the prior
+            // per-FK code, just driven off the batched results indexed by FK slot k.
+            for (std::size_t k = 0; k < pending_fks.size(); ++k) {
+                catalog::fk_info_t fk = std::move(pending_fks[k].fk);
+                const auto& child_attoids = pending_fks[k].child_attoids;
+                const auto& parent_attoids = pending_fks[k].parent_attoids;
+                std::pmr::vector<components::vector::data_chunk_t> empty_child(resource_);
+                std::pmr::vector<components::vector::data_chunk_t> empty_parent(resource_);
+                auto& child_attr = k < child_results.size() ? child_results[k] : empty_child;
+                auto& parent_attr = k < parent_results.size() ? parent_results[k] : empty_parent;
+
+                {
+                    std::vector<std::string> names;
+                    names.reserve(child_attoids.size());
+                    for (const auto& wanted_oid : child_attoids) {
+                        for (auto& attr_chunk : child_attr) {
+                            if (attr_chunk.column_count() <= catalog::pg_attribute_col::attname)
+                                continue;
+                            bool found = false;
+                            for (uint64_t ai = 0; ai < attr_chunk.size(); ++ai) {
+                                auto row_attoid = static_cast<catalog::oid_t>(
+                                    attr_chunk.value(catalog::pg_attribute_col::attoid, ai).value<std::uint32_t>());
+                                if (row_attoid == wanted_oid) {
+                                    names.emplace_back(std::string(
+                                        attr_chunk.value(catalog::pg_attribute_col::attname, ai)
+                                            .value<std::string_view>()));
+                                    found = true;
+                                    break;
+                                }
+                            }
+                            if (found)
+                                break;
+                        }
+                    }
+                    fk.child_col_names = std::move(names);
+                }
+
+                // Also resolve child schema positions + defspec for each FK
+                // column (used by operator_fk_cascade_t SET NULL / SET DEFAULT).
+                if (direction == direction_t::referencing) {
+                    // Build (attname → attnum-1, attdefspec) over child's
+                    // pg_attribute rows sorted by attnum.
+                    struct row_meta_t {
+                        std::int32_t attnum{0};
+                        std::string attname;
+                        std::string attdefspec;
+                    };
+                    std::vector<row_meta_t> ordered;
+                    constexpr std::uint64_t kAttnum = 4;
+                    constexpr std::uint64_t kAttisdropped = 7;
+                    constexpr std::uint64_t kAttdefspec = 9;
+                    for (auto& attr_chunk : child_attr) {
+                        if (attr_chunk.column_count() <= kAttisdropped)
+                            continue;
+                        for (uint64_t ai = 0; ai < attr_chunk.size(); ++ai) {
+                            if (!attr_chunk.value(kAttisdropped, ai).is_null() &&
+                                attr_chunk.value(kAttisdropped, ai).value<bool>())
+                                continue;
+                            row_meta_t r;
+                            if (!attr_chunk.value(catalog::pg_attribute_col::attname, ai).is_null()) {
+                                r.attname.assign(
+                                    attr_chunk.value(catalog::pg_attribute_col::attname, ai).value<std::string_view>());
+                            }
+                            r.attnum = attr_chunk.value(kAttnum, ai).is_null()
+                                           ? 0
+                                           : attr_chunk.value(kAttnum, ai).value<std::int32_t>();
+                            if (attr_chunk.column_count() > kAttdefspec &&
+                                !attr_chunk.value(kAttdefspec, ai).is_null()) {
+                                r.attdefspec.assign(attr_chunk.value(kAttdefspec, ai).value<std::string_view>());
+                            }
+                            ordered.push_back(std::move(r));
+                        }
+                    }
+                    std::sort(ordered.begin(), ordered.end(), [](const row_meta_t& a, const row_meta_t& b) {
+                        return a.attnum < b.attnum;
+                    });
+                    for (const auto& col_name : fk.child_col_names) {
+                        std::size_t pos = std::numeric_limits<std::size_t>::max();
+                        std::string def_spec;
+                        for (std::size_t i = 0; i < ordered.size(); ++i) {
+                            if (ordered[i].attname == col_name) {
+                                pos = i;
+                                def_spec = ordered[i].attdefspec;
+                                break;
+                            }
+                        }
+                        fk.child_col_schema_indices.push_back(pos);
+                        fk.child_col_default_specs.push_back(std::move(def_spec));
+                    }
+                }
+
+                {
+                    std::vector<std::string> names;
+                    names.reserve(parent_attoids.size());
+                    for (const auto& wanted_oid : parent_attoids) {
+                        for (auto& attr_chunk : parent_attr) {
+                            if (attr_chunk.column_count() <= catalog::pg_attribute_col::attname)
+                                continue;
+                            bool found = false;
+                            for (uint64_t ai = 0; ai < attr_chunk.size(); ++ai) {
+                                auto row_attoid = static_cast<catalog::oid_t>(
+                                    attr_chunk.value(catalog::pg_attribute_col::attoid, ai).value<std::uint32_t>());
+                                if (row_attoid == wanted_oid) {
+                                    names.emplace_back(std::string(
+                                        attr_chunk.value(catalog::pg_attribute_col::attname, ai)
+                                            .value<std::string_view>()));
+                                    found = true;
+                                    break;
+                                }
+                            }
+                            if (found)
+                                break;
+                        }
+                    }
+                    fk.parent_col_names = std::move(names);
+                }
+
+                if (direction == direction_t::referencing) {
+                    // For DELETE FK cascade we also need the child's table name
+                    // + schema (so operator_fk_cascade_t can locate the
+                    // descendant collection without a back-resolve). The pg_namespace
+                    // read keys on an oid DERIVED from the pg_class read result, so
+                    // this remains a 2-hop chained read per FK (NOT batchable).
+                    types::logical_value_t child_oid_lv(resource_, fk.child_table_oid);
+                    std::pmr::vector<std::string> cls_keys(resource_);
+                    cls_keys.emplace_back("oid");
+                    std::pmr::vector<types::logical_value_t> cls_vals(resource_);
+                    cls_vals.emplace_back(child_oid_lv);
+                    auto [_cls, fut_cls] = actor_zeta::send(ctx->disk_address,
+                                                            &services::disk::manager_disk_t::read_chunks_by_key,
+                                                            exec_ctx,
+                                                            kPgClass,
+                                                            std::move(cls_keys),
+                                                            components::operators::make_key_chunk(resource_, std::move(cls_vals)));
+                    auto cls_batches = co_await std::move(fut_cls);
+                    if (!cls_batches.empty() && cls_batches[0].size() != 0 &&
+                        cls_batches[0].column_count() > catalog::pg_class_col::relname) {
+                        fk.child_collection_name = std::string(
+                            cls_batches[0].value(catalog::pg_class_col::relname, 0).value<std::string_view>());
+                        fk.child_database = "";
+                        const auto ns_oid = static_cast<catalog::oid_t>(
+                            cls_batches[0].value(catalog::pg_class_col::relnamespace, 0).value<std::uint32_t>());
+                        types::logical_value_t ns_oid_lv(resource_, ns_oid);
+                        std::pmr::vector<std::string> ns_keys(resource_);
+                        ns_keys.emplace_back("oid");
+                        std::pmr::vector<types::logical_value_t> ns_vals(resource_);
+                        ns_vals.emplace_back(ns_oid_lv);
+                        auto [_ns, fut_ns] = actor_zeta::send(ctx->disk_address,
+                                                              &services::disk::manager_disk_t::read_chunks_by_key,
+                                                              exec_ctx,
+                                                              kPgNamespace,
+                                                              std::move(ns_keys),
+                                                              components::operators::make_key_chunk(resource_, std::move(ns_vals)));
+                        auto ns_batches = co_await std::move(fut_ns);
+                        if (!ns_batches.empty() && ns_batches[0].size() != 0 &&
+                            ns_batches[0].column_count() > catalog::pg_namespace_col::nspname) {
+                            fk.child_schema = std::string(
+                                ns_batches[0].value(catalog::pg_namespace_col::nspname, 0).value<std::string_view>());
+                        }
+                    }
+                }
+
+                if (!fk.child_col_names.empty() && !fk.parent_col_names.empty()) {
+                    fks.push_back(std::move(fk));
                 }
             }
         }

--- a/components/physical_plan/operators/operator_resolve_database.cpp
+++ b/components/physical_plan/operators/operator_resolve_database.cpp
@@ -77,7 +77,7 @@ namespace components::operators {
                                            exec_ctx,
                                            kPgDatabase,
                                            std::move(db_keys),
-                                           std::move(db_vals));
+                                           components::operators::make_key_chunk(resource_, std::move(db_vals)));
         auto db_batches = co_await std::move(dbf);
 
         bool resolved = false;

--- a/components/physical_plan/operators/operator_resolve_function.cpp
+++ b/components/physical_plan/operators/operator_resolve_function.cpp
@@ -113,7 +113,7 @@ namespace components::operators {
                                           exec_ctx,
                                           kPgProc,
                                           std::move(pr_keys),
-                                          std::move(pr_vals));
+                                          components::operators::make_key_chunk(resource_, std::move(pr_vals)));
         auto batches = co_await std::move(fut);
 
         // Materialise the matched rows into a fresh chunk. Capacity is sized to

--- a/components/physical_plan/operators/operator_resolve_namespace.cpp
+++ b/components/physical_plan/operators/operator_resolve_namespace.cpp
@@ -90,7 +90,7 @@ namespace components::operators {
                                            exec_ctx,
                                            kPgNamespace,
                                            std::move(ns_keys),
-                                           std::move(ns_vals));
+                                           components::operators::make_key_chunk(resource_, std::move(ns_vals)));
         auto ns_batches = co_await std::move(nsf);
 
         bool resolved = false;

--- a/components/physical_plan/operators/operator_resolve_table.cpp
+++ b/components/physical_plan/operators/operator_resolve_table.cpp
@@ -137,7 +137,7 @@ namespace components::operators {
                                                         exec_ctx,
                                                         kPgClass,
                                                         std::move(key_cols),
-                                                        std::move(key_vals));
+                                                        components::operators::make_key_chunk(resource_, std::move(key_vals)));
             auto lookup_batches = co_await std::move(lookup_f);
             if (lookup_batches.empty() || lookup_batches[0].size() == 0 || lookup_batches[0].column_count() == 0 ||
                 lookup_batches[0].value(0, 0).is_null()) {
@@ -164,7 +164,7 @@ namespace components::operators {
                                                exec_ctx,
                                                kPgClass,
                                                std::move(pc_keys),
-                                               std::move(pc_vals));
+                                               components::operators::make_key_chunk(resource_, std::move(pc_vals)));
             auto pc_batches = co_await std::move(pcf);
             if (!pc_batches.empty() && pc_batches[0].size() != 0 && pc_batches[0].column_count() >= 4) {
                 found_ = true;
@@ -215,7 +215,7 @@ namespace components::operators {
                                                exec_ctx,
                                                kPgRewrite,
                                                std::move(pr_keys),
-                                               std::move(pr_vals));
+                                               components::operators::make_key_chunk(resource_, std::move(pr_vals)));
             auto pr_batches = co_await std::move(prf);
             if (!pr_batches.empty() && pr_batches[0].size() != 0 && pr_batches[0].column_count() >= 5) {
                 auto ev_action = pr_batches[0].value(4, 0);
@@ -263,7 +263,7 @@ namespace components::operators {
                                                exec_ctx,
                                                kPgComputedColumn,
                                                std::move(cc_keys),
-                                               std::move(cc_vals));
+                                               components::operators::make_key_chunk(resource_, std::move(cc_vals)));
             auto cc_batches = co_await std::move(ccf);
 
             struct cc_candidate_t {
@@ -389,7 +389,7 @@ namespace components::operators {
                                                exec_ctx,
                                                kPgAttribute,
                                                std::move(pa_keys),
-                                               std::move(pa_vals));
+                                               components::operators::make_key_chunk(resource_, std::move(pa_vals)));
             auto pa_batches = co_await std::move(paf);
 
             // Column visible to this snapshot iff added_at_commit_id <= start_time

--- a/components/physical_plan/operators/operator_resolve_type.cpp
+++ b/components/physical_plan/operators/operator_resolve_type.cpp
@@ -99,7 +99,7 @@ namespace components::operators {
                                                  exec_ctx,
                                                  kPgNamespace,
                                                  std::move(ns_keys),
-                                                 std::move(ns_vals));
+                                                 components::operators::make_key_chunk(resource_, std::move(ns_vals)));
                 auto ns_batches = co_await std::move(nf);
                 if (!ns_batches.empty() && ns_batches[0].size() != 0 && ns_batches[0].column_count() >= 1) {
                     auto ns_oid_v = ns_batches[0].value(0, 0);
@@ -126,7 +126,7 @@ namespace components::operators {
                                              exec_ctx,
                                              kPgType,
                                              std::move(typ_keys),
-                                             std::move(typ_vals));
+                                             components::operators::make_key_chunk(resource_, std::move(typ_vals)));
             auto batches = co_await std::move(tf);
 
             if (!batches.empty() && batches.front().size() != 0 && batches.front().column_count() >= 4) {

--- a/components/physical_plan/operators/operator_vacuum.cpp
+++ b/components/physical_plan/operators/operator_vacuum.cpp
@@ -202,7 +202,7 @@ namespace components::operators {
                                                    cc_ctx,
                                                    kPgComputedColumn,
                                                    std::move(cc_keys),
-                                                   std::move(cc_vals));
+                                                   components::operators::make_key_chunk(resource_, std::move(cc_vals)));
                 auto cc_batches = co_await std::move(ccf);
 
                 // Both GC passes below delete by (kPgComputedColumn, col 1=attoid)
@@ -307,7 +307,7 @@ namespace components::operators {
                                                          cc_ctx,
                                                          kPgComputedColumn,
                                                          std::move(cc2_keys),
-                                                         std::move(cc2_vals));
+                                                         components::operators::make_key_chunk(resource_, std::move(cc2_vals)));
                     auto live_cc = co_await std::move(ccf2);
 
                     std::set<std::string> live_attnames;

--- a/integration/cpp/test/test_clean_break_startup.cpp
+++ b/integration/cpp/test/test_clean_break_startup.cpp
@@ -18,6 +18,7 @@
 #include <components/types/types.hpp>
 #include <core/non_thread_scheduler/scheduler_test.hpp>
 #include <services/disk/manager_disk.hpp>
+#include <services/disk/tests/catalog_probe.hpp>
 #include <services/disk/tests/disk_test_helpers.hpp>
 
 #include <filesystem>
@@ -120,7 +121,7 @@ TEST_CASE("integration::clean_break_startup::existing_pg_catalog_loads") {
     }
     {
         fresh_disk fd2(dir);
-        REQUIRE_NOTHROW(fd2.manager->load_system_tables_sync());
+        REQUIRE_NOTHROW(fd2.manager->bootstrap_system_tables_sync());
         REQUIRE_NOTHROW(fd2.manager->restore_oid_generator_sync());
     }
     std::filesystem::remove_all(dir);
@@ -149,7 +150,7 @@ TEST_CASE("integration::clean_break_startup::oid_generator_seeded_max_plus_1") {
     }
     {
         fresh_disk fd2(dir);
-        fd2.manager->load_system_tables_sync();
+        fd2.manager->bootstrap_system_tables_sync();
         fd2.manager->restore_oid_generator_sync();
         auto new_ns_oid = test_create_namespace(fd2, "after_restart");
         REQUIRE(new_ns_oid > high_oid);
@@ -176,7 +177,7 @@ TEST_CASE("integration::clean_break_startup::namespace_round_trip") {
     }
     {
         fresh_disk fd2(dir);
-        fd2.manager->load_system_tables_sync();
+        fd2.manager->bootstrap_system_tables_sync();
         fd2.manager->restore_oid_generator_sync();
         components::table::transaction_data _td_open(0, 0);
         _td_open.snapshot_horizon = std::numeric_limits<uint64_t>::max();
@@ -217,7 +218,7 @@ TEST_CASE("integration::clean_break_startup::table_round_trip_with_columns") {
     }
     {
         fresh_disk fd2(dir);
-        fd2.manager->load_system_tables_sync();
+        fd2.manager->bootstrap_system_tables_sync();
         fd2.manager->restore_oid_generator_sync();
         components::table::transaction_data _td_open(0, 0);
         _td_open.snapshot_horizon = std::numeric_limits<uint64_t>::max();
@@ -231,14 +232,7 @@ TEST_CASE("integration::clean_break_startup::table_round_trip_with_columns") {
         auto rns = std::move(nfut).take_ready();
         REQUIRE(rns.found);
 
-        auto [__, tfut] = actor_zeta::otterbrix::send(fd2.manager->address(),
-                                                      &manager_disk_t::resolve_table,
-                                                      ctx,
-                                                      rns.oid,
-                                                      std::string("tbl"),
-                                                      std::uint64_t{0});
-        poll_ready(fd2.scheduler, tfut);
-        auto rt = std::move(tfut).take_ready();
+        auto rt = test_probe::probe_table(fd2, ctx, rns.oid, std::string("tbl"));
         REQUIRE(rt.found);
         REQUIRE(rt.oid == tbl_oid);
         REQUIRE(rt.columns.size() == 1);
@@ -247,7 +241,7 @@ TEST_CASE("integration::clean_break_startup::table_round_trip_with_columns") {
 }
 
 // 6. index_round_trip — ddl_create_index writes pg_class (relkind='i') + pg_index +
-// pg_depend. After restart, the index entry survives via load_system_tables_sync and is
+// pg_depend. After restart, the index entry survives via bootstrap_system_tables_sync and is
 // observable via resolve_table by name (relkind 'i' shares the pg_class namespace with 'r').
 TEST_CASE("integration::clean_break_startup::index_round_trip") {
     auto dir = clean_break_dir() + "/idx_rt";
@@ -273,20 +267,13 @@ TEST_CASE("integration::clean_break_startup::index_round_trip") {
     }
     {
         fresh_disk fd2(dir);
-        fd2.manager->load_system_tables_sync();
+        fd2.manager->bootstrap_system_tables_sync();
         fd2.manager->restore_oid_generator_sync();
         components::table::transaction_data _td_open(0, 0);
         _td_open.snapshot_horizon = std::numeric_limits<uint64_t>::max();
         components::execution_context_t ctx{session_id_t{}, _td_open, {}};
         // Index lives in pg_class with relkind='i'; resolve_table finds it by name.
-        auto [_, ifut] = actor_zeta::otterbrix::send(fd2.manager->address(),
-                                                     &manager_disk_t::resolve_table,
-                                                     ctx,
-                                                     ns_oid,
-                                                     std::string("tbl_idx"),
-                                                     std::uint64_t{0});
-        poll_ready(fd2.scheduler, ifut);
-        auto ri = std::move(ifut).take_ready();
+        auto ri = test_probe::probe_table(fd2, ctx, ns_oid, std::string("tbl_idx"));
         REQUIRE(ri.found);
         REQUIRE(ri.oid == idx_oid);
         REQUIRE(ri.relkind == 'i');
@@ -315,7 +302,7 @@ TEST_CASE("integration::clean_break_startup::resolve_after_restart") {
     }
     {
         fresh_disk fd2(dir);
-        fd2.manager->load_system_tables_sync();
+        fd2.manager->bootstrap_system_tables_sync();
         fd2.manager->restore_oid_generator_sync();
         components::table::transaction_data _td_open(0, 0);
         _td_open.snapshot_horizon = std::numeric_limits<uint64_t>::max();
@@ -357,7 +344,7 @@ TEST_CASE("integration::clean_break_startup::sequence_view_macro_via_pg_class") 
     }
     {
         fresh_disk fd2(dir);
-        fd2.manager->load_system_tables_sync();
+        fd2.manager->bootstrap_system_tables_sync();
         fd2.manager->restore_oid_generator_sync();
         // A new namespace creation uses an OID strictly above the persisted SVM OIDs.
         auto after_oid = test_create_namespace(fd2, "after");

--- a/integration/cpp/test/test_index.cpp
+++ b/integration/cpp/test/test_index.cpp
@@ -1,15 +1,28 @@
 #include "test_config.hpp"
+#include <components/catalog/catalog_oids.hpp>
+#include <components/compute/function.hpp>
 #include <components/expressions/compare_expression.hpp>
 #include <components/expressions/scalar_expression.hpp>
+#include <components/log/log.hpp>
 #include <components/logical_plan/node_delete.hpp>
 #include <components/logical_plan/node_drop_index.hpp>
 #include <components/logical_plan/node_insert.hpp>
+#include <components/logical_plan/node_primitive_delete.hpp>
+#include <components/logical_plan/node_sequence.hpp>
 #include <components/logical_plan/node_update.hpp>
+#include <components/physical_plan/operators/operator.hpp>
+#include <components/physical_plan_generator/create_plan.hpp>
 #include <components/sql/transformer/utils.hpp>
 #include <components/tests/generaty.hpp>
+#include <services/collection/context_storage.hpp>
 
 #include <catch2/catch.hpp>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <memory_resource>
 #include <sstream>
+#include <tuple>
 #include <unistd.h>
 
 using components::expressions::compare_type;
@@ -550,4 +563,110 @@ TEST_CASE("integration::cpp::test_index::vacuum_rebuild_visible") {
     // Deleted multiples of 3 stay gone via the rebuilt index.
     CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE count = 0;", 0);
     CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE count = 48;", 0);
+}
+
+// ----------------------------------------------------------------------------
+// DROP INDEX catalog-delete folding (physical-plan-generator unit test).
+//
+// rewrite_drop_index emits sequence_t(primitive_delete × N, drop_index_t) — N=4:
+// pg_index ×1, pg_depend ×2, pg_class ×1. create_plan_sequence's drop_index_t
+// branch must FOLD all N primitive_delete leaves into the single
+// operator_drop_index_t's catalog_deletes_ vector, so the operator can issue ONE
+// batched delete_pg_catalog_rows_many at runtime instead of N singular
+// delete_pg_catalog_rows sends.
+//
+// Observable invariant of a correct fold (no production accessor needed):
+//   - the lowered plan is a SINGLE leaf operator (no children) tagged
+//     operator_type::create_collection — the tag operator_drop_index_t reuses;
+//   - NO operator_type::primitive_delete operator survives anywhere in the tree.
+// A regression that drops the fold makes the N leaves fall through to the generic
+// left-child chain, where each leaf lowers to a standalone
+// operator_primitive_delete_t (type primitive_delete) linked via left_. The
+// control sub-case below builds the SAME leaves WITHOUT the trailing drop_index_t
+// and asserts they DO produce N standalone primitive_delete operators, so the
+// fold is exactly what collapses them.
+// ----------------------------------------------------------------------------
+namespace {
+
+    // Counts operators of a given type across the whole left_/right_ tree.
+    std::size_t count_ops_of_type(const components::operators::operator_ptr& op,
+                                  components::operators::operator_type type) {
+        if (!op) {
+            return 0;
+        }
+        std::size_t n = (op->type() == type) ? 1u : 0u;
+        n += count_ops_of_type(op->left(), type);
+        n += count_ops_of_type(op->right(), type);
+        return n;
+    }
+
+} // namespace
+
+TEST_CASE("integration::cpp::test_index::drop_index_folds_catalog_deletes") {
+    std::pmr::monotonic_buffer_resource arena;
+    auto* res = &arena;
+
+    services::context_storage_t context(res, log_t{}, core::date::timezone_offset_t{});
+    components::compute::function_registry_t registry(res);
+
+    namespace lp = components::logical_plan;
+    namespace ops = components::operators;
+    using components::catalog::oid_t;
+    constexpr oid_t index_oid = 9001; // any non-INVALID oid
+
+    constexpr oid_t pg_index = components::catalog::well_known_oid::pg_index_table;
+    constexpr oid_t pg_depend = components::catalog::well_known_oid::pg_depend_table;
+    constexpr oid_t pg_class = components::catalog::well_known_oid::pg_class_table;
+
+    // The exact N=4 primitive_delete spec set rewrite_drop_index emits:
+    // pg_index(objid col 0), pg_depend(objid col 1), pg_depend(refobjid col 3),
+    // pg_class(oid col 0). Same order so the test fails loudly if that contract drifts.
+    const std::array<std::tuple<oid_t, std::int64_t>, 4> delete_specs = {{
+        {pg_index, std::int64_t{0}},
+        {pg_depend, std::int64_t{1}},
+        {pg_depend, std::int64_t{3}},
+        {pg_class, std::int64_t{0}},
+    }};
+
+    auto append_delete_leaves = [&](const lp::node_sequence_ptr& seq) {
+        for (const auto& [catalog_oid, col] : delete_specs) {
+            seq->append_child(
+                boost::intrusive_ptr(new lp::node_primitive_delete_t(res, catalog_oid, col, index_oid)));
+        }
+    };
+
+    INFO("trailing drop_index_t folds all N delete leaves into one operator_drop_index_t") {
+        auto seq = boost::intrusive_ptr(new lp::node_sequence_t(res));
+        append_delete_leaves(seq);
+        auto di = lp::make_node_drop_index(res);
+        di->set_index_oid(index_oid);
+        di->set_runtime_index_name("idx_folded");
+        seq->append_child(di); // trailing drop_index_t marker
+
+        auto plan = services::planner::create_plan(context, registry, seq, lp::limit_t::unlimit(), nullptr);
+        REQUIRE(plan);
+
+        // Folded → a single leaf operator, NOT a chain. operator_drop_index_t
+        // reuses operator_type::create_collection as its tag and absorbs the
+        // delete leaves into catalog_deletes_ (one batched send at runtime).
+        CHECK(plan->type() == ops::operator_type::create_collection);
+        CHECK(plan->left() == nullptr);
+        CHECK(plan->right() == nullptr);
+
+        // None of the N delete leaves leaked out as a standalone operator —
+        // they were folded into the single drop_index operator's vector.
+        CHECK(count_ops_of_type(plan, ops::operator_type::primitive_delete) == 0u);
+    }
+
+    INFO("control: same delete leaves with NO trailing drop_index_t stay N standalone operators") {
+        // Without the drop_index_t marker the leaves fall through to the generic
+        // left-child chain and each lowers to its own operator_primitive_delete_t.
+        // This is the un-folded baseline the drop_index branch collapses.
+        auto seq = boost::intrusive_ptr(new lp::node_sequence_t(res));
+        append_delete_leaves(seq);
+
+        auto plan = services::planner::create_plan(context, registry, seq, lp::limit_t::unlimit(), nullptr);
+        REQUIRE(plan);
+        CHECK(count_ops_of_type(plan, ops::operator_type::primitive_delete) == delete_specs.size());
+    }
 }

--- a/integration/cpp/test/test_persistence.cpp
+++ b/integration/cpp/test/test_persistence.cpp
@@ -1266,7 +1266,7 @@ TEST_CASE("integration::cpp::test_persistence::disk_drop_gc_removes_storage_file
     //   PRIMARY — drop_storage during the DROP statement removes .otbx +
     //   sidecars immediately (a surviving file would let WAL replay
     //   synthesise a phantom storage);
-    //   SECONDARY — mark_storage_dropped parks a tombstone keyed by the
+    //   SECONDARY — mark_storage_dropped_many parks a tombstone keyed by the
     //   dropping TXN-ID, the commit operator remaps it to the real commit_id
     //   (storage_dropped_committed), and the next commit's horizon broadcast
     //   (on_horizon_advanced, commit-id space) drains the queue. The drain is

--- a/services/disk/agent_disk.cpp
+++ b/services/disk/agent_disk.cpp
@@ -1,5 +1,6 @@
 #include "agent_disk.hpp"
 #include "manager_disk.hpp"
+#include "inline_scan.hpp" // services::disk::detail::inline_scan (catalog DDL on the agent)
 #include <services/dispatcher/dispatcher.hpp>
 #include <fstream>
 #include <unordered_set>
@@ -44,42 +45,6 @@ namespace services::disk {
 
     bool agent_disk_t::has_storage_sync(components::catalog::oid_t oid) const noexcept {
         return storages_.find(oid) != storages_.end();
-    }
-
-    uint64_t agent_disk_t::total_rows_inner_sync(components::catalog::oid_t oid) const noexcept {
-        auto it = storages_.find(oid);
-        if (it == storages_.end()) {
-            return 0;
-        }
-        const auto& entry = it->second;
-        if (entry == nullptr) {
-            return 0;
-        }
-        return entry->table_storage.table().calculate_size();
-    }
-
-    wal::id_t agent_disk_t::checkpoint_wal_id_inner_sync(components::catalog::oid_t oid) const noexcept {
-        auto it = storages_.find(oid);
-        if (it == storages_.end()) {
-            return wal::id_t{0};
-        }
-        const auto& entry = it->second;
-        if (entry == nullptr) {
-            return wal::id_t{0};
-        }
-        return entry->table_storage.checkpoint_wal_id();
-    }
-
-    bool agent_disk_t::has_in_memory_inner_sync() const noexcept {
-        for (const auto& [oid, entry] : storages_) {
-            if (entry == nullptr) {
-                continue;
-            }
-            if (entry->table_storage.mode() == storage_mode_t::IN_MEMORY) {
-                return true;
-            }
-        }
-        return false;
     }
 
     // Borrowed pointer — see header. nullptr when the OID isn't owned.
@@ -150,38 +115,67 @@ namespace services::disk {
         return storages_.try_emplace(oid, std::move(entry)).second;
     }
 
+    // Runtime CREATE mailbox handlers (see header). The entry is built on the AGENT's
+    // OWN resource() here on the agent thread, then emplaced via the existing
+    // bootstrap_*_inner_sync helpers (now called intra-actor). Each returns false on
+    // duplicate key, mirroring the helpers' contract.
+    agent_disk_t::unique_future<bool> agent_disk_t::create_storage_inner(components::catalog::oid_t oid) {
+        auto entry = std::make_unique<collection_storage_entry_t>(resource());
+        const bool ok = bootstrap_inner_sync(oid, std::move(entry));
+        if (!ok) {
+            trace(log_,
+                  "agent_disk[{}]::create_storage_inner: oid {} already owned — duplicate",
+                  pool_idx_,
+                  static_cast<unsigned>(oid));
+        }
+        co_return ok;
+    }
+
+    agent_disk_t::unique_future<bool>
+    agent_disk_t::create_storage_with_columns_inner(components::catalog::oid_t oid,
+                                                    std::vector<components::table::column_definition_t> columns) {
+        auto entry = std::make_unique<collection_storage_entry_t>(resource(), std::move(columns));
+        const bool ok = bootstrap_inner_sync(oid, std::move(entry));
+        if (!ok) {
+            trace(log_,
+                  "agent_disk[{}]::create_storage_with_columns_inner: oid {} already owned — duplicate",
+                  pool_idx_,
+                  static_cast<unsigned>(oid));
+        }
+        co_return ok;
+    }
+
+    agent_disk_t::unique_future<bool>
+    agent_disk_t::create_storage_disk_inner(components::catalog::oid_t oid,
+                                            std::vector<components::table::column_definition_t> columns,
+                                            std::filesystem::path otbx_path) {
+        // create_directories runs on the AGENT thread (manager builds nothing). The SFBM
+        // is then constructed by bootstrap_create_disk_inner_sync, which holds the
+        // exclusive posix WRITE_LOCK on the .otbx — agent-only, so no construction race.
+        std::error_code ec;
+        std::filesystem::create_directories(otbx_path.parent_path(), ec);
+        if (ec) {
+            warn(log_,
+                 "agent_disk[{}]::create_storage_disk_inner: create_directories {} failed: {}",
+                 pool_idx_,
+                 otbx_path.parent_path().string(),
+                 ec.message());
+        }
+        const bool ok = bootstrap_create_disk_inner_sync(oid, std::move(columns), otbx_path);
+        if (!ok) {
+            trace(log_,
+                  "agent_disk[{}]::create_storage_disk_inner: oid {} already owned (path={}) — duplicate",
+                  pool_idx_,
+                  static_cast<unsigned>(oid),
+                  otbx_path.string());
+        }
+        co_return ok;
+    }
+
     // WAL-replay direct_* helpers (see header). Mutation logic is intentionally
     // minimal: schema-adoption / column-expansion / type-promotion run upstream in
     // the mailbox body, and replay records arrive pre-aligned with the table schema,
-    // so a direct append/delete/update against the entry's storage adapter is correct.
-    void agent_disk_t::direct_append_sync(components::catalog::oid_t table_oid,
-                                          components::vector::data_chunk_t& data,
-                                          core::date::timezone_offset_t /*session_tz*/,
-                                          const components::table::transaction_data& txn) {
-        auto it = storages_.find(table_oid);
-        if (it == storages_.end()) {
-            trace(log_,
-                  "agent_disk[{}]::direct_append_sync: oid {} not owned by this agent — no-op",
-                  pool_idx_,
-                  static_cast<unsigned>(table_oid));
-            return;
-        }
-        auto& entry = it->second;
-        if (entry == nullptr) {
-            // Defensive: null entries (legacy record-only markers) are unreachable
-            // now that every DISK OID owns a live SFBM.
-            trace(log_,
-                  "agent_disk[{}]::direct_append_sync: oid {} has null entry (unreachable post-§8.1.B/C) — no-op",
-                  pool_idx_,
-                  static_cast<unsigned>(table_oid));
-            return;
-        }
-        if (data.size() == 0 || entry->storage == nullptr) {
-            return;
-        }
-        entry->storage->append(data, txn);
-    }
-
+    // so a direct delete/update against the entry's storage adapter is correct.
     void agent_disk_t::direct_delete_sync(components::catalog::oid_t table_oid,
                                           const std::pmr::vector<int64_t>& row_ids,
                                           uint64_t count,
@@ -254,8 +248,6 @@ namespace services::disk {
         entry->storage->update(ids_vec, local);
     }
 
-    auto agent_disk_t::make_type() const noexcept -> const char* { return "agent_disk"; }
-
     actor_zeta::behavior_t agent_disk_t::behavior(actor_zeta::mailbox::message* msg) {
         switch (msg->command()) {
             case actor_zeta::msg_id<agent_disk_t, &agent_disk_t::fix_wal_id>: {
@@ -286,10 +278,6 @@ namespace services::disk {
                 co_await actor_zeta::dispatch(this, &agent_disk_t::storage_revert_appends_inner, msg);
                 break;
             }
-            case actor_zeta::msg_id<agent_disk_t, &agent_disk_t::storage_revert_append_inner>: {
-                co_await actor_zeta::dispatch(this, &agent_disk_t::storage_revert_append_inner, msg);
-                break;
-            }
             case actor_zeta::msg_id<agent_disk_t, &agent_disk_t::storage_update_inner>: {
                 co_await actor_zeta::dispatch(this, &agent_disk_t::storage_update_inner, msg);
                 break;
@@ -314,12 +302,16 @@ namespace services::disk {
                 co_await actor_zeta::dispatch(this, &agent_disk_t::scan_by_keys_inner, msg);
                 break;
             }
-            case actor_zeta::msg_id<agent_disk_t, &agent_disk_t::storage_types_inner>: {
-                co_await actor_zeta::dispatch(this, &agent_disk_t::storage_types_inner, msg);
+            case actor_zeta::msg_id<agent_disk_t, &agent_disk_t::read_chunks_by_key_inner>: {
+                co_await actor_zeta::dispatch(this, &agent_disk_t::read_chunks_by_key_inner, msg);
                 break;
             }
-            case actor_zeta::msg_id<agent_disk_t, &agent_disk_t::storage_column_names_inner>: {
-                co_await actor_zeta::dispatch(this, &agent_disk_t::storage_column_names_inner, msg);
+            case actor_zeta::msg_id<agent_disk_t, &agent_disk_t::read_chunks_by_keys_inner>: {
+                co_await actor_zeta::dispatch(this, &agent_disk_t::read_chunks_by_keys_inner, msg);
+                break;
+            }
+            case actor_zeta::msg_id<agent_disk_t, &agent_disk_t::storage_types_inner>: {
+                co_await actor_zeta::dispatch(this, &agent_disk_t::storage_types_inner, msg);
                 break;
             }
             case actor_zeta::msg_id<agent_disk_t, &agent_disk_t::storage_total_rows_inner>: {
@@ -350,16 +342,40 @@ namespace services::disk {
                 co_await actor_zeta::dispatch(this, &agent_disk_t::storage_drop_aborted_inner, msg);
                 break;
             }
-            case actor_zeta::msg_id<agent_disk_t, &agent_disk_t::register_dropped_storage_inner>: {
-                co_await actor_zeta::dispatch(this, &agent_disk_t::register_dropped_storage_inner, msg);
+            case actor_zeta::msg_id<agent_disk_t, &agent_disk_t::drop_storage_many_inner>: {
+                co_await actor_zeta::dispatch(this, &agent_disk_t::drop_storage_many_inner, msg);
                 break;
             }
-            case actor_zeta::msg_id<agent_disk_t, &agent_disk_t::drop_storage_inner>: {
-                co_await actor_zeta::dispatch(this, &agent_disk_t::drop_storage_inner, msg);
+            case actor_zeta::msg_id<agent_disk_t, &agent_disk_t::append_pg_catalog_row_inner>: {
+                co_await actor_zeta::dispatch(this, &agent_disk_t::append_pg_catalog_row_inner, msg);
                 break;
             }
-            case actor_zeta::msg_id<agent_disk_t, &agent_disk_t::drop_column_inner>: {
-                co_await actor_zeta::dispatch(this, &agent_disk_t::drop_column_inner, msg);
+            case actor_zeta::msg_id<agent_disk_t, &agent_disk_t::delete_pg_catalog_rows_inner>: {
+                co_await actor_zeta::dispatch(this, &agent_disk_t::delete_pg_catalog_rows_inner, msg);
+                break;
+            }
+            case actor_zeta::msg_id<agent_disk_t, &agent_disk_t::update_pg_attribute_commit_id_field_inner>: {
+                co_await actor_zeta::dispatch(this, &agent_disk_t::update_pg_attribute_commit_id_field_inner, msg);
+                break;
+            }
+            case actor_zeta::msg_id<agent_disk_t, &agent_disk_t::compact_relkind_g_storage_inner>: {
+                co_await actor_zeta::dispatch(this, &agent_disk_t::compact_relkind_g_storage_inner, msg);
+                break;
+            }
+            case actor_zeta::msg_id<agent_disk_t, &agent_disk_t::mark_storage_dropped_many_inner>: {
+                co_await actor_zeta::dispatch(this, &agent_disk_t::mark_storage_dropped_many_inner, msg);
+                break;
+            }
+            case actor_zeta::msg_id<agent_disk_t, &agent_disk_t::create_storage_inner>: {
+                co_await actor_zeta::dispatch(this, &agent_disk_t::create_storage_inner, msg);
+                break;
+            }
+            case actor_zeta::msg_id<agent_disk_t, &agent_disk_t::create_storage_with_columns_inner>: {
+                co_await actor_zeta::dispatch(this, &agent_disk_t::create_storage_with_columns_inner, msg);
+                break;
+            }
+            case actor_zeta::msg_id<agent_disk_t, &agent_disk_t::create_storage_disk_inner>: {
+                co_await actor_zeta::dispatch(this, &agent_disk_t::create_storage_disk_inner, msg);
                 break;
             }
             default:
@@ -716,33 +732,6 @@ namespace services::disk {
         co_return;
     }
 
-    agent_disk_t::unique_future<void>
-    agent_disk_t::storage_revert_append_inner(components::catalog::oid_t table_oid,
-                                              int64_t row_start,
-                                              uint64_t count) {
-        auto it = storages_.find(table_oid);
-        if (it == storages_.end()) {
-            trace(log_,
-                  "agent_disk[{}]::storage_revert_append_inner: oid {} not owned by this agent — no-op",
-                  pool_idx_,
-                  static_cast<unsigned>(table_oid));
-            co_return;
-        }
-        auto& entry = it->second;
-        if (entry == nullptr) {
-            trace(log_,
-                  "agent_disk[{}]::storage_revert_append_inner: oid {} has null entry — no-op",
-                  pool_idx_,
-                  static_cast<unsigned>(table_oid));
-            co_return;
-        }
-        if (entry->storage == nullptr || count == 0) {
-            co_return;
-        }
-        entry->storage->revert_append(row_start, count);
-        co_return;
-    }
-
     agent_disk_t::unique_future<std::pair<int64_t, uint64_t>>
     agent_disk_t::storage_update_inner(components::catalog::oid_t table_oid,
                                        components::vector::vector_t row_ids,
@@ -829,33 +818,43 @@ namespace services::disk {
         co_return std::move(result);
     }
 
+    std::pmr::vector<components::vector::data_chunk_t>
+    agent_disk_t::scan_batched_local(components::catalog::oid_t table_oid,
+                                     components::table::table_filter_t* filter,
+                                     int64_t limit,
+                                     const std::vector<std::size_t>* projected_cols,
+                                     const components::table::transaction_data& txn) {
+        std::pmr::vector<components::vector::data_chunk_t> batches{resource()};
+        auto it = storages_.find(table_oid);
+        if (it == storages_.end()) {
+            trace(log_,
+                  "agent_disk[{}]::scan_batched_local: oid {} not owned by this agent",
+                  pool_idx_,
+                  static_cast<unsigned>(table_oid));
+            return batches;
+        }
+        auto& entry = it->second;
+        if (entry == nullptr || entry->storage == nullptr) {
+            trace(log_,
+                  "agent_disk[{}]::scan_batched_local: oid {} is a DISK record-only marker",
+                  pool_idx_,
+                  static_cast<unsigned>(table_oid));
+            return batches;
+        }
+        entry->storage->scan_batched(batches, filter, limit, projected_cols, txn);
+        return batches;
+    }
+
+    // Thin mailbox wrapper over scan_batched_local (D6: same-actor callers use the local
+    // helper directly; this exists for the manager→agent mailbox route).
     agent_disk_t::unique_future<std::pmr::vector<components::vector::data_chunk_t>>
     agent_disk_t::storage_scan_batched_inner(components::catalog::oid_t table_oid,
                                              std::unique_ptr<components::table::table_filter_t> filter,
                                              int64_t limit,
                                              std::vector<size_t> projected_cols,
                                              components::table::transaction_data txn) {
-        std::pmr::vector<components::vector::data_chunk_t> batches{resource()};
-        auto it = storages_.find(table_oid);
-        if (it == storages_.end()) {
-            trace(log_,
-                  "agent_disk[{}]::storage_scan_batched_inner: oid {} not owned by this agent — fallback to manager",
-                  pool_idx_,
-                  static_cast<unsigned>(table_oid));
-            co_return std::move(batches);
-        }
-        auto& entry = it->second;
-        if (entry == nullptr || entry->storage == nullptr) {
-            trace(log_,
-                  "agent_disk[{}]::storage_scan_batched_inner: oid {} is a DISK record-only marker — "
-                  "fallback to manager",
-                  pool_idx_,
-                  static_cast<unsigned>(table_oid));
-            co_return std::move(batches);
-        }
         const std::vector<size_t>* projected_ptr = projected_cols.empty() ? nullptr : &projected_cols;
-        entry->storage->scan_batched(batches, filter.get(), limit, projected_ptr, txn);
-        co_return std::move(batches);
+        co_return scan_batched_local(table_oid, filter.get(), limit, projected_ptr, txn);
     }
 
     agent_disk_t::unique_future<std::unique_ptr<components::vector::data_chunk_t>>
@@ -967,6 +966,131 @@ namespace services::disk {
         co_return std::move(result);
     }
 
+    agent_disk_t::unique_future<std::pmr::vector<components::vector::data_chunk_t>>
+    agent_disk_t::read_chunks_by_key_inner(components::catalog::oid_t table_oid,
+                                           std::pmr::vector<std::string> key_col_names,
+                                           components::vector::data_chunk_t keys,
+                                           components::table::transaction_data txn) {
+        // Single key-tuple (keys has exactly one row): resolve the key column NAMES to
+        // storage indices, build an eq-AND filter and scan its own slice directly via
+        // scan_batched_local (D6: no self-send). Empty result on any degenerate input.
+        std::pmr::vector<components::vector::data_chunk_t> empty{resource()};
+        auto it = storages_.find(table_oid);
+        if (it == storages_.end() || it->second == nullptr || it->second->storage == nullptr ||
+            key_col_names.empty() || keys.size() == 0) {
+            co_return std::move(empty);
+        }
+        auto& entry = it->second;
+
+        // Resolve each key column NAME to a storage column index; an unknown column voids
+        // the whole call (empty result).
+        const auto& cols = entry->storage->columns();
+        std::pmr::vector<std::uint64_t> key_col_indices{resource()};
+        key_col_indices.reserve(key_col_names.size());
+        for (const auto& kname : key_col_names) {
+            std::size_t col_idx = cols.size();
+            for (std::size_t ci = 0; ci < cols.size(); ++ci) {
+                if (cols[ci].name() == kname) {
+                    col_idx = ci;
+                    break;
+                }
+            }
+            if (col_idx == cols.size()) {
+                co_return std::move(empty);
+            }
+            key_col_indices.push_back(static_cast<std::uint64_t>(col_idx));
+        }
+
+        // Each filter constant is keys.value(ki, 0) — a logical_value_t materialized only
+        // here for the filter API (the irreducible floor, same as scan_by_keys_inner). No
+        // row-major key crosses the mailbox; the carrier is the columnar `keys` chunk.
+        auto filter = std::make_unique<components::table::conjunction_and_filter_t>();
+        for (std::size_t ki = 0; ki < key_col_indices.size(); ++ki) {
+            std::pmr::vector<std::uint64_t> idx_vec{resource()};
+            idx_vec.push_back(key_col_indices[ki]);
+            filter->child_filters.push_back(
+                std::make_unique<components::table::constant_filter_t>(components::expressions::compare_type::eq,
+                                                                      keys.value(ki, 0),
+                                                                      std::move(idx_vec)));
+        }
+
+        // All columns (projected = nullptr), no row limit (-1) — same as the prior
+        // manager-side storage_scan_batched_inner call (it passed an empty projected list).
+        co_return scan_batched_local(table_oid, filter.get(), int64_t{-1}, nullptr, txn);
+    }
+
+    agent_disk_t::unique_future<std::pmr::vector<std::pmr::vector<components::vector::data_chunk_t>>>
+    agent_disk_t::read_chunks_by_keys_inner(components::catalog::oid_t table_oid,
+                                            std::pmr::vector<std::string> key_col_names,
+                                            components::vector::data_chunk_t keys,
+                                            components::table::transaction_data txn) {
+        // result[i] = matched chunks for key-tuple i; one (possibly empty) entry per key,
+        // preserving input order. Name→index resolution runs once for the whole batch, then
+        // each key gets an eq-AND filtered scan via scan_batched_local (D6: no self-send).
+        std::pmr::vector<std::pmr::vector<components::vector::data_chunk_t>> result{resource()};
+        result.reserve(keys.size());
+
+        auto it = storages_.find(table_oid);
+        if (it == storages_.end() || it->second == nullptr || it->second->storage == nullptr ||
+            key_col_names.empty()) {
+            // Not owned / record-only marker / no key columns: one empty entry per key.
+            for (std::size_t i = 0; i < keys.size(); ++i) {
+                result.emplace_back();
+            }
+            co_return std::move(result);
+        }
+        auto& entry = it->second;
+
+        // Resolve key column NAMES to storage indices once (same column set for every key).
+        // Any unknown column degrades the whole batch to empty entries.
+        const auto& cols = entry->storage->columns();
+        std::pmr::vector<std::uint64_t> key_col_indices{resource()};
+        key_col_indices.reserve(key_col_names.size());
+        for (const auto& kname : key_col_names) {
+            std::size_t col_idx = cols.size();
+            for (std::size_t ci = 0; ci < cols.size(); ++ci) {
+                if (cols[ci].name() == kname) {
+                    col_idx = ci;
+                    break;
+                }
+            }
+            if (col_idx == cols.size()) {
+                for (std::size_t i = 0; i < keys.size(); ++i) {
+                    result.emplace_back();
+                }
+                co_return std::move(result);
+            }
+            key_col_indices.push_back(static_cast<std::uint64_t>(col_idx));
+        }
+
+        // Columnar keys: column j == key_col_names[j], row i == key-tuple i. Arity is uniform
+        // across the chunk, so a mismatch (chunk column count != resolved key columns) voids the
+        // whole batch with one empty entry per key. Each filter constant is the single
+        // materialization of a key cell (keys.value(ki, i)): the filter API requires a
+        // logical_value_t, so this is the irreducible floor — no row-major keys cross the mailbox.
+        const std::uint64_t nkeys = keys.size();
+        if (keys.column_count() != key_col_indices.size()) {
+            for (std::uint64_t i = 0; i < nkeys; ++i) {
+                result.emplace_back();
+            }
+            co_return std::move(result);
+        }
+        for (std::uint64_t i = 0; i < nkeys; ++i) {
+            auto filter = std::make_unique<components::table::conjunction_and_filter_t>();
+            for (std::size_t ki = 0; ki < key_col_indices.size(); ++ki) {
+                std::pmr::vector<std::uint64_t> idx_vec{resource()};
+                idx_vec.push_back(key_col_indices[ki]);
+                filter->child_filters.push_back(
+                    std::make_unique<components::table::constant_filter_t>(components::expressions::compare_type::eq,
+                                                                          keys.value(ki, i),
+                                                                          std::move(idx_vec)));
+            }
+            // All columns (projected = nullptr), no row limit (-1) — same as read_chunks_by_key_inner.
+            result.emplace_back(scan_batched_local(table_oid, filter.get(), int64_t{-1}, nullptr, txn));
+        }
+        co_return std::move(result);
+    }
+
     agent_disk_t::unique_future<std::pmr::vector<components::types::complex_logical_type>>
     agent_disk_t::storage_types_inner(components::catalog::oid_t table_oid) {
         auto it = storages_.find(table_oid);
@@ -986,34 +1110,6 @@ namespace services::disk {
             co_return std::pmr::vector<components::types::complex_logical_type>{resource()};
         }
         co_return entry->storage->types();
-    }
-
-    agent_disk_t::unique_future<std::pmr::vector<std::string>>
-    agent_disk_t::storage_column_names_inner(components::catalog::oid_t table_oid) {
-        auto it = storages_.find(table_oid);
-        if (it == storages_.end()) {
-            trace(log_,
-                  "agent_disk[{}]::storage_column_names_inner: oid {} not owned by this agent — fallback to manager",
-                  pool_idx_,
-                  static_cast<unsigned>(table_oid));
-            co_return std::pmr::vector<std::string>{resource()};
-        }
-        auto& entry = it->second;
-        if (entry == nullptr || entry->storage == nullptr) {
-            trace(log_,
-                  "agent_disk[{}]::storage_column_names_inner: oid {} is a DISK record-only marker — "
-                  "fallback to manager",
-                  pool_idx_,
-                  static_cast<unsigned>(table_oid));
-            co_return std::pmr::vector<std::string>{resource()};
-        }
-        const auto& cols = entry->storage->columns();
-        std::pmr::vector<std::string> names{resource()};
-        names.reserve(cols.size());
-        for (const auto& col : cols) {
-            names.push_back(col.name());
-        }
-        co_return std::move(names);
     }
 
     agent_disk_t::unique_future<uint64_t>
@@ -1045,8 +1141,8 @@ namespace services::disk {
         co_return;
     }
 
-    agent_disk_t::unique_future<wal::id_t> agent_disk_t::checkpoint_inner(session_id_t /*session*/,
-                                                                          wal::id_t current_wal_id) {
+    agent_disk_t::unique_future<checkpoint_result_t> agent_disk_t::checkpoint_inner(session_id_t /*session*/,
+                                                                                   wal::id_t current_wal_id) {
         trace(log_,
               "agent_disk[{}]::checkpoint_inner: {} entries in local slice",
               pool_idx_,
@@ -1055,11 +1151,17 @@ namespace services::disk {
         //   backup .otbx → .prev, compact + checkpoint(wal_id), persist the
         //   .wal_id sidecar via tmp+rename, then delete the .prev backup on success.
         //   Tally min(prev_checkpoint_wal_id_) for the manager's cross-agent std::min.
-        // IN_MEMORY twins and null entries are skipped.
+        // IN_MEMORY twins and null entries are skipped for checkpointing, but an
+        // IN_MEMORY twin flips has_in_memory so checkpoint_all can gate WAL-floor
+        // sealing without a separate sync slice read (folded from has_in_memory_inner_sync).
         wal::id_t min_prev_id = std::numeric_limits<wal::id_t>::max();
+        bool has_in_memory = false;
         for (auto& [tbl_oid, entry] : storages_) {
             if (entry == nullptr) {
                 continue;
+            }
+            if (entry->table_storage.mode() == storage_mode_t::IN_MEMORY) {
+                has_in_memory = true;
             }
             if (entry->table_storage.mode() != storage_mode_t::DISK) {
                 continue;
@@ -1126,7 +1228,7 @@ namespace services::disk {
 
             min_prev_id = std::min(min_prev_id, entry->table_storage.prev_checkpoint_wal_id());
         }
-        co_return min_prev_id;
+        co_return checkpoint_result_t{min_prev_id, has_in_memory};
     }
 
     agent_disk_t::unique_future<void> agent_disk_t::vacuum_inner(session_id_t /*session*/,
@@ -1302,7 +1404,13 @@ namespace services::disk {
         manager_dispatcher_addr_ = std::move(address);
     }
 
-    // Bootstrap-only push-back (see header); runtime DROP uses the mailbox overload below.
+    // See header. Bootstrap-only; after scheduler.start the address is read-only.
+    void agent_disk_t::set_manager_wal_sync(actor_zeta::address_t address) {
+        manager_wal_addr_ = std::move(address);
+    }
+
+    // GC-slice push-back (see header). Called pre-scheduler-start by base_spaces
+    // catalog rebuild and at runtime by mark_storage_dropped_many_inner.
     void agent_disk_t::register_dropped_storage_inner_sync(components::catalog::oid_t oid,
                                                             uint64_t dropped_at_commit_id,
                                                             std::filesystem::path path,
@@ -1313,26 +1421,14 @@ namespace services::disk {
                                                              std::move(sidecar_paths)});
     }
 
-    // Runtime DROP path. The mailbox serializes this push_back w.r.t.
-    // on_horizon_advanced_inner.
-    agent_disk_t::unique_future<void>
-    agent_disk_t::register_dropped_storage_inner(components::catalog::oid_t oid,
-                                                  uint64_t dropped_at_commit_id,
-                                                  std::filesystem::path path,
-                                                  std::pmr::vector<std::filesystem::path> sidecar_paths) {
-        register_dropped_storage_inner_sync(oid,
-                                             dropped_at_commit_id,
-                                             std::move(path),
-                                             std::move(sidecar_paths));
-        co_return;
-    }
-
     // Canonical erase + .otbx removal (see header). Idempotent on a missing key;
     // the erase drops the unique_ptr, closing the file_handle_t once. The mailbox
     // serializes this against the only other slice writers (bootstrap pre-start;
     // runtime storage_*_inner handlers only read).
-    agent_disk_t::unique_future<void>
-    agent_disk_t::drop_storage_inner(components::catalog::oid_t oid) {
+    // Canonical single-oid erase + .otbx removal. Used by drop_storage_many_inner,
+    // which loops it over its oid slice. Synchronous (no co_await) — the caller runs
+    // on the agent thread.
+    void agent_disk_t::drop_storage_one_local(components::catalog::oid_t oid) {
         // Read otbx_path BEFORE the erase, while the unique_ptr is still live. Empty
         // path (IN_MEMORY twins) skips the remove block. Remove sequence: .otbx +
         // .wal_id + .prev sidecars + per-oid directory, all via std::error_code
@@ -1345,15 +1441,16 @@ namespace services::disk {
         }
         const auto erased = storages_.erase(oid);
         if (erased == 0) {
-            // Trace, not warn: drop_storage routes to a single agent, so this path
-            // is only hit for a truly-missing OID — benign (idempotent DROP).
+            // Trace, not warn: drop_storage_many over-routes idempotently, so this
+            // path is hit for a truly-missing / not-owned OID — benign (idempotent
+            // DROP).
             trace(log_,
-                  "agent_disk[{}]::drop_storage_inner: oid {} not in local slice (no-op)",
+                  "agent_disk[{}]::drop_storage_one_local: oid {} not in local slice (no-op)",
                   pool_idx_,
                   static_cast<unsigned>(oid));
         } else {
             trace(log_,
-                  "agent_disk[{}]::drop_storage_inner: erased oid {} from local slice",
+                  "agent_disk[{}]::drop_storage_one_local: erased oid {} from local slice",
                   pool_idx_,
                   static_cast<unsigned>(oid));
         }
@@ -1372,46 +1469,425 @@ namespace services::disk {
             std::filesystem::remove(prev, ec);
             std::filesystem::remove(otbx_path.parent_path(), ec);
         }
+    }
+
+    // Batched DROP: one message per agent carries that agent's whole oid slice
+    // (manager partitioned by pool_idx_for_oid). Loops the canonical singular erase;
+    // each oid is idempotent on a missing key, so an over-routed oid is a no-op.
+    agent_disk_t::unique_future<void>
+    agent_disk_t::drop_storage_many_inner(std::pmr::vector<components::catalog::oid_t> oids) {
+        for (auto oid : oids) {
+            drop_storage_one_local(oid);
+        }
         co_return;
     }
 
-    // Mutation half of compact_relkind_g_storage (see header). drop_column is
-    // non-const: it rebuilds the storage_t adapter against the agent's arena because
-    // the adapter holds a data_table_t& that dangles after the rebuild.
-    agent_disk_t::unique_future<void>
-    agent_disk_t::drop_column_inner(components::catalog::oid_t table_oid,
-                                     std::pmr::string column_name) {
+    // ---------------------------------------------------------------------------
+    // Catalog DDL handlers (Track A). These moved off the manager loop: the catalog
+    // scan + mutation now run on this (CATALOG / agent-0) thread against the agent's
+    // OWN slice, so the manager no longer borrows the agent's storage_entry across
+    // the actor boundary. WAL goes through manager_wal_addr_ (plain actor_zeta::send +
+    // co_await; the WAL manager self-schedules, so NO scheduler_disk_->enqueue here).
+    // ---------------------------------------------------------------------------
+
+    // Crash-safe pg_catalog row append: WAL physical_insert is written first so a
+    // crash before the storage update can be replayed on restart, then storage is
+    // updated on this agent's own slice. The preprocessing body applies only schema
+    // adoption + alias-keyed column expansion + numeric/string cast rather than the
+    // heavier storage_append_inner pipeline — storage_append_inner adds NOT NULL
+    // rejection, _id dedup, default-value / positional fallback, and broader
+    // is_convertable_to casting, none of which the catalog-append path applied, so
+    // this lighter path keeps WAL-time semantics faithful.
+    agent_disk_t::unique_future<components::pg_catalog_append_range_t>
+    agent_disk_t::append_pg_catalog_row_inner(execution_context_t ctx,
+                                              components::catalog::oid_t table_oid,
+                                              components::vector::data_chunk_t row) {
+        if (manager_wal_addr_ != actor_zeta::address_t::empty_address()) {
+            auto wal_chunk =
+                std::make_unique<components::vector::data_chunk_t>(resource(), row.types(), row.size());
+            wal_chunk->set_cardinality(row.size());
+            for (uint64_t col = 0; col < row.column_count(); col++) {
+                for (uint64_t r = 0; r < row.size(); r++) {
+                    wal_chunk->data[col].set_value(r, row.data[col].value(r));
+                }
+            }
+            // pg_catalog writes route to main_database (ctx.database_oid is always
+            // INVALID_OID for catalog writes).
+            constexpr auto db_oid = components::catalog::well_known_oid::main_database;
+            auto [_w, wf] = actor_zeta::send(manager_wal_addr_,
+                                             &wal::manager_wal_replicate_t::write_physical_insert,
+                                             ctx.session,
+                                             table_oid,
+                                             std::move(wal_chunk),
+                                             std::uint64_t{0},
+                                             static_cast<std::uint64_t>(row.size()),
+                                             ctx.txn.transaction_id,
+                                             db_oid);
+            if (auto wal_id = co_await std::move(wf); wal_id == wal::id_t{}) {
+                trace(log_,
+                      "agent_disk[{}]::append_pg_catalog_row_inner: WAL write returned zero id for oid={}",
+                      pool_idx_,
+                      static_cast<unsigned>(table_oid));
+            }
+        }
+
+        const auto count = static_cast<std::uint64_t>(row.size());
+        uint64_t start_row = 0;
+
+        // Append on this agent's own slice.
         auto it = storages_.find(table_oid);
-        if (it == storages_.end()) {
+        if (it != storages_.end() && it->second != nullptr && it->second->storage != nullptr &&
+            row.size() != 0) {
+            auto* s = it->second->storage.get();
+
+            // rebuild onto this agent's resource (row arrives on the mailbox resource).
+            auto types = row.types();
+            const uint64_t n = row.size();
+            components::vector::data_chunk_t local(resource(), types, n > 0 ? n : 1);
+            local.set_cardinality(0);
+            row.copy(local, 0);
+
+            if (!s->has_schema() && local.column_count() > 0) {
+                s->adopt_schema(local.types());
+            }
+
+            const auto& table_columns = s->columns();
+            if (!table_columns.empty() && local.column_count() < table_columns.size()) {
+                std::pmr::vector<components::types::complex_logical_type> full_types(resource());
+                for (const auto& col_def : table_columns) {
+                    full_types.push_back(col_def.type());
+                }
+
+                std::vector<components::vector::vector_t> expanded_data;
+                expanded_data.reserve(table_columns.size());
+                for (size_t t = 0; t < table_columns.size(); t++) {
+                    bool found = false;
+                    for (uint64_t col = 0; col < local.column_count(); col++) {
+                        if (local.data[col].type().has_alias() &&
+                            local.data[col].type().alias() == table_columns[t].name()) {
+                            expanded_data.push_back(std::move(local.data[col]));
+                            found = true;
+                            break;
+                        }
+                    }
+                    if (!found) {
+                        expanded_data.emplace_back(resource(), full_types[t], local.size());
+                        expanded_data.back().validity().set_all_invalid(local.size());
+                    }
+                }
+                local.data = std::move(expanded_data);
+            }
+
+            if (s->has_schema() && !table_columns.empty()) {
+                using components::types::is_numeric;
+                using components::types::logical_type;
+                for (size_t i = 0; i < table_columns.size() && i < local.column_count(); i++) {
+                    auto src_type = local.data[i].type().type();
+                    auto tgt_type = table_columns[i].type().type();
+                    if (src_type != tgt_type &&
+                        (is_numeric(src_type) || src_type == logical_type::STRING_LITERAL) &&
+                        (is_numeric(tgt_type) || tgt_type == logical_type::STRING_LITERAL)) {
+                        auto& src_vec = local.data[i];
+                        auto target_type = table_columns[i].type();
+                        if (src_vec.type().has_alias()) {
+                            target_type.set_alias(src_vec.type().alias());
+                        }
+                        components::vector::vector_t casted(resource(), target_type, local.size());
+                        for (uint64_t r = 0; r < local.size(); r++) {
+                            if (src_vec.validity().row_is_valid(r)) {
+                                casted.set_value(r, src_vec.value(r).cast_as(target_type, ctx.session_tz));
+                            } else {
+                                casted.validity().set_invalid(r);
+                            }
+                        }
+                        local.data[i] = std::move(casted);
+                    }
+                }
+            }
+
+            start_row = s->append(local, ctx.txn);
+        } else {
             trace(log_,
-                  "agent_disk[{}]::drop_column_inner: oid {} not owned by this agent — no-op",
+                  "agent_disk[{}]::append_pg_catalog_row_inner: oid {} not owned/empty — no storage append",
                   pool_idx_,
                   static_cast<unsigned>(table_oid));
+        }
+
+        if (ctx.txn.transaction_id == 0 || count == 0) {
+            co_return components::pg_catalog_append_range_t{table_oid, static_cast<int64_t>(start_row), 0};
+        }
+        co_return components::pg_catalog_append_range_t{table_oid, static_cast<int64_t>(start_row), count};
+    }
+
+    agent_disk_t::unique_future<void>
+    agent_disk_t::delete_pg_catalog_rows_inner(execution_context_t ctx,
+                                               components::catalog::oid_t table_oid,
+                                               std::int64_t oid_col_idx,
+                                               components::catalog::oid_t target_oid) {
+        // Read the slice directly. Bind entry NON-const so inline_scan binds the
+        // non-const data_table_t& overload (no const_cast).
+        auto it = storages_.find(table_oid);
+        if (it == storages_.end() || it->second == nullptr || it->second->storage == nullptr) {
             co_return;
         }
         auto& entry = it->second;
-        if (entry == nullptr) {
-            trace(log_,
-                  "agent_disk[{}]::drop_column_inner: oid {} has null entry — no-op",
-                  pool_idx_,
-                  static_cast<unsigned>(table_oid));
+
+        std::pmr::synchronized_pool_resource scan_resource;
+        std::pmr::vector<std::int64_t> row_ids(resource());
+        detail::inline_scan(entry->table_storage.table(),
+                            {oid_col_idx},
+                            &scan_resource,
+                            [&, oid_col_idx](components::vector::data_chunk_t& chunk, uint64_t i) {
+                                auto v = chunk.value(static_cast<uint64_t>(oid_col_idx), i);
+                                if (v.is_null())
+                                    return true;
+                                if (static_cast<components::catalog::oid_t>(v.value<std::uint32_t>()) ==
+                                    target_oid) {
+                                    row_ids.push_back(chunk.row_ids.data<std::int64_t>()[i]);
+                                }
+                                return true;
+                            });
+        if (row_ids.empty()) {
             co_return;
         }
-        // drop_column takes std::string; the mailbox payload is pmr::string.
-        const std::string attname{column_name.data(), column_name.size()};
-        const bool dropped = entry->drop_column(attname, resource());
-        if (!dropped) {
+        if (manager_wal_addr_ != actor_zeta::address_t::empty_address()) {
+            std::pmr::vector<std::int64_t> wal_ids(row_ids.begin(), row_ids.end(), resource());
+            auto [_w, wf] = actor_zeta::send(manager_wal_addr_,
+                                             &wal::manager_wal_replicate_t::write_physical_delete,
+                                             ctx.session,
+                                             table_oid,
+                                             std::move(wal_ids),
+                                             static_cast<std::uint64_t>(row_ids.size()),
+                                             ctx.txn.transaction_id,
+                                             components::catalog::well_known_oid::main_database);
+            if (auto wal_id = co_await std::move(wf); wal_id == wal::id_t{}) {
+                trace(log_,
+                      "agent_disk[{}]::delete_pg_catalog_rows_inner: WAL write returned zero id for oid={}",
+                      pool_idx_,
+                      static_cast<unsigned>(table_oid));
+            }
+        }
+        direct_delete_sync(table_oid, row_ids, static_cast<std::uint64_t>(row_ids.size()), ctx.txn);
+        co_return;
+    }
+
+    // Implementation pitfall (preserved from the manager body): data_table_t::update()
+    // rewrites EVERY column in the target row (it builds column_ids = [0..count)
+    // unconditionally), so a "patch one column" chunk would NULL out the others. We
+    // read the full row, mutate the target field in the read-back chunk, and write the
+    // whole chunk back.
+    agent_disk_t::unique_future<void> agent_disk_t::update_pg_attribute_commit_id_field_inner(
+        execution_context_t ctx,
+        components::catalog::oid_t attoid,
+        components::pg_attribute_commit_id_backfill_t::kind_t kind,
+        std::uint64_t commit_id) {
+        constexpr auto pg_attr_oid = components::catalog::well_known_oid::pg_attribute_table;
+        auto it = storages_.find(pg_attr_oid);
+        if (it == storages_.end() || it->second == nullptr || it->second->storage == nullptr) {
+            co_return;
+        }
+        auto& entry = it->second;
+
+        // Scan all columns for the attoid row, capturing row_id + a snapshot of
+        // every column value. attoid is never reused, so at most one row matches.
+        auto& tbl = entry->table_storage.table();
+        const std::size_t col_count = tbl.column_count();
+        std::vector<std::int64_t> all_col_indices;
+        all_col_indices.reserve(col_count);
+        for (std::size_t i = 0; i < col_count; ++i) {
+            all_col_indices.push_back(static_cast<std::int64_t>(i));
+        }
+
+        std::pmr::synchronized_pool_resource scan_resource;
+        std::pmr::vector<std::int64_t> row_ids(resource());
+        std::pmr::vector<components::types::logical_value_t> row_values(resource());
+        row_values.reserve(col_count);
+
+        detail::inline_scan(tbl,
+                            all_col_indices,
+                            &scan_resource,
+                            [&](components::vector::data_chunk_t& chunk, uint64_t i) {
+                                auto v0 = chunk.value(0, i);
+                                if (v0.is_null())
+                                    return true;
+                                if (static_cast<components::catalog::oid_t>(v0.value<std::uint32_t>()) !=
+                                    attoid)
+                                    return true;
+                                row_ids.push_back(chunk.row_ids.data<std::int64_t>()[i]);
+                                for (std::size_t c = 0; c < col_count; ++c) {
+                                    row_values.push_back(chunk.value(static_cast<uint64_t>(c), i));
+                                }
+                                return false; // single-row identity — short-circuit
+                            });
+        if (row_ids.empty()) {
             trace(log_,
-                  "agent_disk[{}]::drop_column_inner: oid {} column '{}' not found / DISK no-op",
+                  "agent_disk[{}]::update_pg_attribute_commit_id_field_inner: attoid={} not found (skipping)",
                   pool_idx_,
-                  static_cast<unsigned>(table_oid),
-                  attname);
-        } else {
+                  static_cast<unsigned>(attoid));
+            co_return;
+        }
+
+        // Patch the target column: 10 = added_at_commit_id, 11 = dropped_at_commit_id.
+        const std::size_t patch_col_idx =
+            (kind == components::pg_attribute_commit_id_backfill_t::kind_t::added_at) ? 10u : 11u;
+        if (patch_col_idx >= row_values.size()) {
             trace(log_,
-                  "agent_disk[{}]::drop_column_inner: oid {} dropped column '{}'",
+                  "agent_disk[{}]::update_pg_attribute_commit_id_field_inner: patch_col_idx={} out of range "
+                  "(col_count={})",
                   pool_idx_,
-                  static_cast<unsigned>(table_oid),
-                  attname);
+                  patch_col_idx,
+                  col_count);
+            co_return;
+        }
+        row_values[patch_col_idx] =
+            components::types::logical_value_t(resource(), static_cast<std::int64_t>(commit_id));
+
+        // Build a full-width update chunk: every column keeps its scanned value, only
+        // patch_col_idx gets the new commit_id. Aliases mirror the table's column names
+        // so direct_update_sync's name-match routing lands each vector on the correct
+        // storage column.
+        const auto& table_columns = entry->table_storage.table().columns();
+        std::pmr::vector<components::types::complex_logical_type> chunk_types(resource());
+        chunk_types.reserve(table_columns.size());
+        for (const auto& col_def : table_columns) {
+            auto t = col_def.type();
+            t.set_alias(col_def.name());
+            chunk_types.push_back(std::move(t));
+        }
+        components::vector::data_chunk_t patch(resource(), chunk_types, 1);
+        patch.set_cardinality(1);
+        for (std::size_t c = 0; c < table_columns.size() && c < row_values.size(); ++c) {
+            if (row_values[c].is_null()) {
+                patch.data[c].validity().set_invalid(0);
+            } else {
+                patch.data[c].set_value(0, row_values[c]);
+            }
+        }
+
+        // WAL physical_update: the chunk mirrors the patch chunk full-width so replay's
+        // direct_update_sync takes the same alias-matching path.
+        if (manager_wal_addr_ != actor_zeta::address_t::empty_address()) {
+            auto wal_chunk = std::make_unique<components::vector::data_chunk_t>(resource(), chunk_types, 1);
+            wal_chunk->set_cardinality(1);
+            for (std::size_t c = 0; c < table_columns.size() && c < row_values.size(); ++c) {
+                if (row_values[c].is_null()) {
+                    wal_chunk->data[c].validity().set_invalid(0);
+                } else {
+                    wal_chunk->data[c].set_value(0, row_values[c]);
+                }
+            }
+            std::pmr::vector<std::int64_t> wal_row_ids(row_ids.begin(), row_ids.end(), resource());
+            auto [_w, wf] = actor_zeta::send(manager_wal_addr_,
+                                             &wal::manager_wal_replicate_t::write_physical_update,
+                                             ctx.session,
+                                             pg_attr_oid,
+                                             std::move(wal_row_ids),
+                                             std::move(wal_chunk),
+                                             static_cast<std::uint64_t>(row_ids.size()),
+                                             ctx.txn.transaction_id,
+                                             components::catalog::well_known_oid::main_database);
+            if (auto wal_id = co_await std::move(wf); wal_id == wal::id_t{}) {
+                trace(log_,
+                      "agent_disk[{}]::update_pg_attribute_commit_id_field_inner: WAL write returned zero id "
+                      "for attoid={}",
+                      pool_idx_,
+                      static_cast<unsigned>(attoid));
+            }
+        }
+
+        direct_update_sync(pg_attr_oid, row_ids, patch);
+        co_return;
+    }
+
+    // Whole-op intra-agent compaction: read own slice (mode + columns), compute the
+    // columns NOT in live_attnames, drop each via entry->drop_column on its own slice,
+    // and return the dropped count. This eliminates the per-column manager↔agent
+    // round-trips the former manager body did.
+    agent_disk_t::unique_future<std::uint64_t>
+    agent_disk_t::compact_relkind_g_storage_inner(components::catalog::oid_t table_oid,
+                                                  std::set<std::string> live_attnames) {
+        auto it = storages_.find(table_oid);
+        if (it == storages_.end() || it->second == nullptr || it->second->storage == nullptr) {
+            co_return 0;
+        }
+        auto& entry = it->second;
+        if (entry->table_storage.mode() != storage_mode_t::IN_MEMORY) {
+            trace(log_,
+                  "agent_disk[{}]::compact_relkind_g_storage_inner: skip DISK-backed oid={} (out of scope)",
+                  pool_idx_,
+                  static_cast<unsigned>(table_oid));
+            co_return 0;
+        }
+
+        std::vector<std::string> to_drop;
+        {
+            const auto& cols = entry->table_storage.table().columns();
+            to_drop.reserve(cols.size());
+            for (const auto& c : cols) {
+                if (live_attnames.find(c.name()) == live_attnames.end()) {
+                    to_drop.push_back(c.name());
+                }
+            }
+        }
+
+        std::uint64_t dropped = 0;
+        for (const auto& attname : to_drop) {
+            if (entry->drop_column(attname, resource())) {
+                ++dropped;
+            } else {
+                trace(log_,
+                      "agent_disk[{}]::compact_relkind_g_storage_inner: oid {} column '{}' not "
+                      "found / DISK no-op",
+                      pool_idx_,
+                      static_cast<unsigned>(table_oid),
+                      attname);
+            }
+        }
+        co_return dropped;
+    }
+
+    // Runtime DROP path, canonical per-oid mark: read otbx_path + derive .wal_id/.prev
+    // sidecars from the own slice, then record the GC entry via
+    // register_dropped_storage_inner_sync. Replaces the manager-side storage_entry borrow
+    // at mark_storage_dropped_many. Synchronous (no co_await) — the caller runs on the
+    // agent thread.
+    void agent_disk_t::mark_storage_dropped_one_local(components::catalog::oid_t table_oid,
+                                                      uint64_t dropped_at_commit_id) {
+        trace(log_,
+              "agent_disk[{}]::mark_storage_dropped_one_local: oid {} commit_id {}",
+              pool_idx_,
+              static_cast<unsigned>(table_oid),
+              dropped_at_commit_id);
+        std::filesystem::path otbx_path;
+        std::pmr::vector<std::filesystem::path> sidecars{resource()};
+        if (auto it = storages_.find(table_oid); it != storages_.end() && it->second != nullptr) {
+            otbx_path = it->second->otbx_path;
+            if (!otbx_path.empty()) {
+                auto wal_id_sidecar = otbx_path;
+                wal_id_sidecar += ".wal_id";
+                sidecars.push_back(std::move(wal_id_sidecar));
+                auto prev_sidecar = otbx_path;
+                prev_sidecar += ".prev";
+                sidecars.push_back(std::move(prev_sidecar));
+            }
+        }
+        // IN_MEMORY storages leave otbx_path/sidecars empty, but we still record a GC
+        // entry so disk_has_dropped_ bookkeeping is uniform (sweep no-ops on empty path).
+        register_dropped_storage_inner_sync(table_oid,
+                                            dropped_at_commit_id,
+                                            std::move(otbx_path),
+                                            std::move(sidecars));
+    }
+
+    // Batched DROP-mark: one message per agent carries that agent's whole oid slice
+    // (manager partitioned by pool_idx_for_oid) plus the shared dropped_at_commit_id.
+    // Loops the canonical per-oid mark; an over-routed / not-owned oid records an empty
+    // GC entry (no-op sweep), matching the IN_MEMORY case.
+    agent_disk_t::unique_future<void>
+    agent_disk_t::mark_storage_dropped_many_inner(std::pmr::vector<components::catalog::oid_t> table_oids,
+                                                  uint64_t dropped_at_commit_id) {
+        for (auto table_oid : table_oids) {
+            mark_storage_dropped_one_local(table_oid, dropped_at_commit_id);
         }
         co_return;
     }

--- a/services/disk/agent_disk.hpp
+++ b/services/disk/agent_disk.hpp
@@ -18,7 +18,9 @@
 #include <filesystem>
 #include <memory>
 #include <memory_resource>
+#include <set>
 #include <string>
+#include <components/context/execution_context.hpp>
 #include <components/context/pg_catalog_swap.hpp>
 #include <services/wal/base.hpp>
 #include <services/wal/manager_wal_replicate.hpp>
@@ -32,6 +34,8 @@ namespace services::disk {
     class manager_disk_t;
     using name_t = std::string;
     using session_id_t = ::components::session::session_id_t;
+    // Catalog-DDL _inner handlers take the same by-value context the manager routers do.
+    using execution_context_t = ::components::execution_context_t;
 
     class base_manager_disk_t;
 
@@ -40,6 +44,19 @@ namespace services::disk {
     // destructor in agent_disk.cpp defers template instantiation past this header.
     struct collection_storage_entry_t;
     struct dropped_storage_entry_t;
+
+    // Plain cross-mailbox result for checkpoint_inner. Folds the IN_MEMORY-twin
+    // signal (formerly read post-await via has_in_memory_inner_sync) into the
+    // fan-out return so checkpoint_all needs no synchronous slice read afterwards.
+    // Plain std fields only (no pmr) — safe to copy across the mailbox by value.
+    //   min_prev_checkpoint_wal_id — min(prev_checkpoint_wal_id_) over this agent's
+    //     DISK entries, or wal::id_t max() sentinel when it owns no DISK entry.
+    //   has_in_memory — true iff this agent owns >= 1 IN_MEMORY storage entry (the
+    //     same predicate has_in_memory_inner_sync computed); gates WAL-floor sealing.
+    struct checkpoint_result_t {
+        wal::id_t min_prev_checkpoint_wal_id;
+        bool has_in_memory;
+    };
 
     /// Agent role / storages_ partition. agent 0 = CATALOG (pg_* tables + oid_gen_ +
     /// stored_catalog_ + file_wal_id_); agents 1..N-1 = USER_POOL (user tables hashed
@@ -69,8 +86,6 @@ namespace services::disk {
 
         ~agent_disk_t();
 
-        auto make_type() const noexcept -> const char*;
-
         // storages_ slice: this agent is the SOLE owner of its DISK SFBMs; the
         // manager is a pure router.
 
@@ -78,20 +93,6 @@ namespace services::disk {
         /// NOT a mailbox handler — after scheduler.start, callers must go through
         /// the storage_* mailbox handlers.
         [[nodiscard]] bool has_storage_sync(components::catalog::oid_t oid) const noexcept;
-
-        // Sync probes for the manager_disk_t public accessors (has_storage /
-        // total_rows_sync / checkpoint_wal_id_sync). Safe because every call site is
-        // single-threaded bootstrap or already inside the manager's mailbox lock.
-        // Not-owned OIDs return 0 / wal::id_t{0}.
-        [[nodiscard]] uint64_t total_rows_inner_sync(components::catalog::oid_t oid) const noexcept;
-        [[nodiscard]] wal::id_t checkpoint_wal_id_inner_sync(components::catalog::oid_t oid) const noexcept;
-
-        // checkpoint_all must NOT seal the WAL ID floor while any IN_MEMORY entry
-        // exists (those tables still need replay records), but checkpoint_inner skips
-        // IN_MEMORY twins, so the min(prev_checkpoint_wal_id_) tally can't detect
-        // them. This mailbox-free slice walk returns the missing signal. Same
-        // sync-read safety as the other *_inner_sync probes.
-        [[nodiscard]] bool has_in_memory_inner_sync() const noexcept;
 
         // Const raw-pointer accessor into the storages_ slice; nullptr when the OID
         // isn't owned. The unique_ptr gives the entry a stable address and the agent
@@ -129,18 +130,29 @@ namespace services::disk {
                                           std::vector<components::table::column_definition_t> columns,
                                           const std::filesystem::path& otbx_path) noexcept;
 
-        /// Read-only role/pool introspection. Not a mailbox handler.
-        [[nodiscard]] agent_role_t role() const noexcept { return role_; }
-        [[nodiscard]] std::size_t pool_idx() const noexcept { return pool_idx_; }
+        // Runtime CREATE mailbox handlers. The manager routers forward by oid (+ columns
+        // by value / path as string) so the entry is built with the AGENT's OWN
+        // resource() on the agent thread — no entry crosses the mailbox and the manager
+        // touches no storage state. Each returns a plain bool: false on duplicate key,
+        // mirroring the bootstrap helpers' contract. The bodies reuse the existing
+        // bootstrap_*_inner_sync helpers (now called intra-actor).
+        //   create_storage_inner               — IN_MEMORY schema-less entry.
+        //   create_storage_with_columns_inner  — IN_MEMORY entry with columns.
+        //   create_storage_disk_inner          — create_directories(parent) on the agent
+        //     thread, then construct the new .otbx SFBM entry.
+        unique_future<bool> create_storage_inner(components::catalog::oid_t oid);
+        unique_future<bool>
+        create_storage_with_columns_inner(components::catalog::oid_t oid,
+                                          std::vector<components::table::column_definition_t> columns);
+        unique_future<bool>
+        create_storage_disk_inner(components::catalog::oid_t oid,
+                                  std::vector<components::table::column_definition_t> columns,
+                                  std::filesystem::path otbx_path);
 
         // WAL-replay direct_* helpers: the manager-side direct_*_sync routers forward
         // here to apply the mutation against the local slice (missing OIDs no-op).
         // Bootstrap-only — base_spaces WAL replay runs synchronously before
         // scheduler.start; post-start mutations use the storage_* mailbox handlers.
-        void direct_append_sync(components::catalog::oid_t table_oid,
-                                components::vector::data_chunk_t& data,
-                                core::date::timezone_offset_t session_tz,
-                                const components::table::transaction_data& txn);
         void direct_delete_sync(components::catalog::oid_t table_oid,
                                 const std::pmr::vector<int64_t>& row_ids,
                                 uint64_t count,
@@ -203,11 +215,6 @@ namespace services::disk {
         unique_future<void>
         storage_revert_appends_inner(std::pmr::vector<components::pg_catalog_append_range_t> ranges);
 
-        // storage_revert_append_inner — single-OID abort (lone INSERT rollback).
-        unique_future<void> storage_revert_append_inner(components::catalog::oid_t table_oid,
-                                                        int64_t row_start,
-                                                        uint64_t count);
-
         // storage_update_inner — single-OID UPDATE mutation against the
         //   agent twin. Returns storage_t::update's (updated, appended)
         //   pair; (0, 0) on no-op.
@@ -264,16 +271,40 @@ namespace services::disk {
                            components::vector::data_chunk_t keys,
                            components::table::transaction_data txn);
 
+        // read_chunks_by_key_inner — columnar row-data scan for ONE key-tuple on one owned
+        //   table. `keys` is a single-row data_chunk whose column j holds key_col_names[j];
+        //   the handler resolves the key column NAMES to storage indices, builds an eq-AND
+        //   filter (constant = keys.value(j, 0)) and returns the matching rows as batched
+        //   data_chunk_t (<= DEFAULT_VECTOR_CAPACITY rows each), all columns, no row limit.
+        //   The filter constant is a logical_value_t — the irreducible filter-API floor,
+        //   same as scan_by_keys_inner; it never crosses the mailbox. A not-owned OID /
+        //   record-only marker / unknown column / empty keys yields an empty vector.
+        unique_future<std::pmr::vector<components::vector::data_chunk_t>>
+        read_chunks_by_key_inner(components::catalog::oid_t table_oid,
+                                 std::pmr::vector<std::string> key_col_names,
+                                 components::vector::data_chunk_t keys,
+                                 components::table::transaction_data txn);
+
+        // read_chunks_by_keys_inner — batched multi-key columnar row-data scan for one owned
+        //   table. `keys` is an N-row data_chunk whose column j holds key_col_names[j] and whose
+        //   row i is the i-th key-tuple. The handler resolves the key column NAMES to storage
+        //   indices ONCE, then for each key row builds an eq-AND filter (constant = keys.value(j, i))
+        //   and scans, returning the matching rows as batched data_chunk_t (all columns, no row
+        //   limit). result[i] == matched chunks for key-tuple i; the outer vector always has one
+        //   (possibly empty) entry per key in input order, so result.size() == keys.size() on
+        //   EVERY path — mirroring scan_by_keys_inner. A not-owned OID / record-only marker /
+        //   unknown column / arity mismatch yields a same-length vector of empty entries (or empty
+        //   when keys is empty). The filter constant is a logical_value_t — the irreducible
+        //   filter-API floor, same as read_chunks_by_key_inner; it never crosses the mailbox.
+        unique_future<std::pmr::vector<std::pmr::vector<components::vector::data_chunk_t>>>
+        read_chunks_by_keys_inner(components::catalog::oid_t table_oid,
+                                  std::pmr::vector<std::string> key_col_names,
+                                  components::vector::data_chunk_t keys,
+                                  components::table::transaction_data txn);
+
         // storage_types_inner — schema metadata accessor.
         unique_future<std::pmr::vector<components::types::complex_logical_type>>
         storage_types_inner(components::catalog::oid_t table_oid);
-
-        // storage_column_names_inner — names in storage-column order (vector index ==
-        //   storage column index), so the manager can resolve name-keyed filters to
-        //   indices without borrowing the agent's columns() across the boundary.
-        //   Empty vector means "not owned" / record-only marker.
-        unique_future<std::pmr::vector<std::string>>
-        storage_column_names_inner(components::catalog::oid_t table_oid);
 
         // storage_total_rows_inner — row-count metadata accessor. 0 means
         //   either "not owned" or "empty twin" — both equivalent for callers.
@@ -283,9 +314,12 @@ namespace services::disk {
         // each agent iterates its own storages_ slice in parallel.
         //
         // checkpoint_inner — (compact + checkpoint(wal_id) + sidecar) per DISK entry.
-        //   Returns min(prev_checkpoint_wal_id_) over the agent's DISK entries, or
-        //   max() sentinel when it owns none. IN_MEMORY entries are skipped.
-        unique_future<wal::id_t> checkpoint_inner(session_id_t session, wal::id_t current_wal_id);
+        //   Returns a checkpoint_result_t whose min_prev_checkpoint_wal_id is
+        //   min(prev_checkpoint_wal_id_) over the agent's DISK entries (max() sentinel
+        //   when it owns none, IN_MEMORY entries skipped) and whose has_in_memory flags
+        //   whether this agent owns >= 1 IN_MEMORY entry — folding the signal
+        //   checkpoint_all formerly read via has_in_memory_inner_sync into the fan-out.
+        unique_future<checkpoint_result_t> checkpoint_inner(session_id_t session, wal::id_t current_wal_id);
 
         // vacuum_inner — cleanup_versions + compact per entry.
         unique_future<void> vacuum_inner(session_id_t session, uint64_t lowest_active_start_time);
@@ -310,7 +344,7 @@ namespace services::disk {
         unique_future<void> on_horizon_advanced_inner(uint64_t new_horizon);
 
         // storage_dropped_committed_inner — DROP-GC value-space remap. A GC entry
-        //   recorded by register_dropped_storage_inner carries dropped_at_commit_id
+        //   recorded by register_dropped_storage_inner_sync carries dropped_at_commit_id
         //   in TXN-ID space (>= 2^62) because the cascade-delete operator only knew
         //   the in-flight txn_id. on_horizon_advanced_inner compares against a
         //   commit-id horizon, so the TXN-ID placeholder would never be reclaimed.
@@ -324,39 +358,76 @@ namespace services::disk {
         //   dropped_at_commit_id into commit-id space, it ERASES every
         //   dropped_storages_ entry whose dropped_at_commit_id == txn_id. A DROP
         //   TABLE inside a transaction records its GC entry in TXN-ID space via
-        //   register_dropped_storage_inner; if the transaction ABORTS the table must
+        //   register_dropped_storage_inner_sync; if the transaction ABORTS the table must
         //   survive, so manager_disk fans this out to every agent and each removes
         //   the matching entries so on_horizon_advanced never reclaims the live .otbx.
         unique_future<void> storage_drop_aborted_inner(uint64_t txn_id);
 
-        // Pre-scheduler-start helper: push-back into dropped_storages_ (base_spaces
-        // catalog rebuild via register_dropped_storage_sync). Not a mailbox handler.
+        // GC-slice push-back into dropped_storages_. Not a mailbox handler. Called
+        // pre-scheduler-start by base_spaces catalog rebuild and at runtime by
+        // mark_storage_dropped_many_inner (single-threaded on the agent at both sites).
         void register_dropped_storage_inner_sync(components::catalog::oid_t oid,
                                                   uint64_t dropped_at_commit_id,
                                                   std::filesystem::path path,
                                                   std::pmr::vector<std::filesystem::path> sidecar_paths);
 
-        // Runtime DROP path mailbox handler. manager_disk_t::mark_storage_dropped
-        // forwards here so the per-agent slice gets the entry without sharing
-        // mutable state across the actor boundary. Internally delegates to
-        // register_dropped_storage_inner_sync.
-        unique_future<void> register_dropped_storage_inner(components::catalog::oid_t oid,
-                                                            uint64_t dropped_at_commit_id,
-                                                            std::filesystem::path path,
-                                                            std::pmr::vector<std::filesystem::path> sidecar_paths);
+        // Batched DROP: one message per agent, looping the canonical singular erase
+        // over this agent's oid slice (manager partitioned by pool_idx_for_oid). Each
+        // oid is idempotent on a missing key (over-routed oid = no-op).
+        unique_future<void> drop_storage_many_inner(std::pmr::vector<components::catalog::oid_t> oids);
 
-        // Runtime DROP TABLE storages_ erase (sole owner of the canonical erase +
-        // .otbx removal). Idempotent on a missing key; the SFBM WRITE_LOCK is
-        // released exactly once when erase drops the unique_ptr.
-        unique_future<void> drop_storage_inner(components::catalog::oid_t oid);
+        // Catalog DDL handlers (Track A): the manager-side append_pg_catalog_row /
+        // delete_pg_catalog_rows / update_pg_attribute_commit_id_fields /
+        // compact_relkind_g_storage / mark_storage_dropped_many bodies move HERE so the
+        // catalog scan + mutation run on this (agent-0 / CATALOG) thread instead of
+        // the manager loop borrowing the agent's slice. All catalog OIDs route to
+        // agents_[0] via pool_idx_for_oid. WAL is written via manager_wal_addr_
+        // (empty in WAL-disabled fixtures, guarded). Not-owned OIDs no-op.
+        //
+        // append_pg_catalog_row_inner — crash-safe single-row append: WAL physical_insert
+        //   first (so a crash before storage update can be replayed), then append on this
+        //   agent's own slice. Returns (table_oid, start_row, count); count is 0 when
+        //   txn.transaction_id == 0 or the append wrote nothing.
+        unique_future<components::pg_catalog_append_range_t>
+        append_pg_catalog_row_inner(execution_context_t ctx,
+                                    components::catalog::oid_t table_oid,
+                                    components::vector::data_chunk_t row);
 
-        // Physical column compaction. The mutation half
-        // (collection_storage_entry_t::drop_column) is non-const — it rewrites
-        // table_storage and recreates the storage adapter on the agent's arena.
-        // Idempotent re-issue logs "not found"; DISK is out-of-scope
-        // (table_storage_t::drop_column returns false on DISK).
-        unique_future<void> drop_column_inner(components::catalog::oid_t table_oid,
-                                              std::pmr::string column_name);
+        // delete_pg_catalog_rows_inner — scan this agent's slice for rows whose
+        //   column[oid_col_idx] == target_oid, WAL physical_delete, then delete via the
+        //   agent's own direct_delete_sync. No-op if not owned or no match.
+        unique_future<void> delete_pg_catalog_rows_inner(execution_context_t ctx,
+                                                         components::catalog::oid_t table_oid,
+                                                         std::int64_t oid_col_idx,
+                                                         components::catalog::oid_t target_oid);
+
+        // update_pg_attribute_commit_id_field_inner — patch the pg_attribute row keyed
+        //   by attoid: read the full row, mutate col 10 (added_at) or 11 (dropped_at) to
+        //   commit_id, WAL physical_update full-width, then write back via the agent's
+        //   own direct_update_sync.
+        unique_future<void>
+        update_pg_attribute_commit_id_field_inner(execution_context_t ctx,
+                                                  components::catalog::oid_t attoid,
+                                                  components::pg_attribute_commit_id_backfill_t::kind_t kind,
+                                                  std::uint64_t commit_id);
+
+        // compact_relkind_g_storage_inner — whole-op intra-agent: read own slice
+        //   (mode + columns), compute the columns NOT in live_attnames, drop each via
+        //   entry->drop_column on its own slice, return the dropped count. DISK-mode /
+        //   missing / already-compact returns 0.
+        unique_future<std::uint64_t> compact_relkind_g_storage_inner(components::catalog::oid_t table_oid,
+                                                                     std::set<std::string> live_attnames);
+
+        // mark_storage_dropped_many_inner — batched DROP-mark: one message per agent
+        //   carries that agent's whole oid slice (manager partitioned by pool_idx_for_oid)
+        //   plus the shared dropped_at_commit_id. Loops the canonical per-oid mark body
+        //   (mark_storage_dropped_one_local) over the slice. Each oid reads its otbx_path
+        //   + derives .wal_id/.prev sidecars from this agent's own slice, then records the
+        //   GC entry via register_dropped_storage_inner_sync. IN_MEMORY storages leave the
+        //   path empty (uniform GC bookkeeping, no-op sweep). Over-routed oids no-op.
+        unique_future<void>
+        mark_storage_dropped_many_inner(std::pmr::vector<components::catalog::oid_t> table_oids,
+                                        uint64_t dropped_at_commit_id);
 
         // Bootstrap-only: base_spaces wires the manager_dispatcher_t address into
         // every agent before scheduler.start. on_horizon_advanced_inner uses it to
@@ -365,6 +436,14 @@ namespace services::disk {
         // mailbox handler; single-threaded at the bootstrap call site.
         void set_manager_dispatcher_sync(actor_zeta::address_t address);
 
+        // Bootstrap-only: base_spaces wires the WAL manager's address into every agent
+        // (via manager_disk_t::sync fan-out) before scheduler.start. The CATALOG agent
+        // (agent 0) uses it to write physical WAL records for catalog DDL directly
+        // (append/delete/update pg_* rows), so that work runs on the agent thread instead
+        // of the manager loop. A mailbox handle (not mutable state), safe to copy. Not a
+        // mailbox handler; single-threaded at the bootstrap call site.
+        void set_manager_wal_sync(actor_zeta::address_t address);
+
         using dispatch_traits = actor_zeta::dispatch_traits<&agent_disk_t::fix_wal_id,
                                                             &agent_disk_t::storage_scan,
                                                             &agent_disk_t::storage_append_inner,
@@ -372,15 +451,15 @@ namespace services::disk {
                                                             &agent_disk_t::storage_publish_deletes_inner,
                                                             &agent_disk_t::storage_revert_deletes_inner,
                                                             &agent_disk_t::storage_revert_appends_inner,
-                                                            &agent_disk_t::storage_revert_append_inner,
                                                             &agent_disk_t::storage_update_inner,
                                                             &agent_disk_t::storage_delete_rows_inner,
                                                             &agent_disk_t::storage_fetch_inner,
                                                             &agent_disk_t::storage_scan_batched_inner,
                                                             &agent_disk_t::storage_scan_segment_inner,
                                                             &agent_disk_t::scan_by_keys_inner,
+                                                            &agent_disk_t::read_chunks_by_key_inner,
+                                                            &agent_disk_t::read_chunks_by_keys_inner,
                                                             &agent_disk_t::storage_types_inner,
-                                                            &agent_disk_t::storage_column_names_inner,
                                                             &agent_disk_t::storage_total_rows_inner,
                                                             &agent_disk_t::checkpoint_inner,
                                                             &agent_disk_t::vacuum_inner,
@@ -388,13 +467,42 @@ namespace services::disk {
                                                             &agent_disk_t::on_horizon_advanced_inner,
                                                             &agent_disk_t::storage_dropped_committed_inner,
                                                             &agent_disk_t::storage_drop_aborted_inner,
-                                                            &agent_disk_t::register_dropped_storage_inner,
-                                                            &agent_disk_t::drop_storage_inner,
-                                                            &agent_disk_t::drop_column_inner>;
+                                                            &agent_disk_t::drop_storage_many_inner,
+                                                            &agent_disk_t::append_pg_catalog_row_inner,
+                                                            &agent_disk_t::delete_pg_catalog_rows_inner,
+                                                            &agent_disk_t::update_pg_attribute_commit_id_field_inner,
+                                                            &agent_disk_t::compact_relkind_g_storage_inner,
+                                                            &agent_disk_t::mark_storage_dropped_many_inner,
+                                                            &agent_disk_t::create_storage_inner,
+                                                            &agent_disk_t::create_storage_with_columns_inner,
+                                                            &agent_disk_t::create_storage_disk_inner>;
 
         actor_zeta::behavior_t behavior(actor_zeta::mailbox::message* msg);
 
     private:
+        // Non-mailbox committed-scan over an OWNED slice entry (D6: callers on the agent
+        // thread — storage_scan_batched_inner and read_chunks_by_keys_inner — read their own
+        // slice directly here, never by self-sending a mailbox message). Returns empty when
+        // the oid isn't owned or is a record-only marker. `filter` may be nullptr;
+        // `projected_cols` may be nullptr for all columns.
+        std::pmr::vector<components::vector::data_chunk_t>
+        scan_batched_local(components::catalog::oid_t table_oid,
+                           components::table::table_filter_t* filter,
+                           int64_t limit,
+                           const std::vector<std::size_t>* projected_cols,
+                           const components::table::transaction_data& txn);
+
+        // Canonical single-oid erase + .otbx removal, used by
+        // drop_storage_many_inner. Synchronous; agent-thread callers only.
+        void drop_storage_one_local(components::catalog::oid_t oid);
+
+        // Canonical single-oid DROP-mark: read otbx_path + derive .wal_id/.prev
+        // sidecars from this agent's own slice, then record the GC entry via
+        // register_dropped_storage_inner_sync. Used by mark_storage_dropped_many_inner,
+        // which loops it over its oid slice. Synchronous; agent-thread callers only.
+        void mark_storage_dropped_one_local(components::catalog::oid_t table_oid,
+                                            uint64_t dropped_at_commit_id);
+
         const name_t name_;
         log_t log_;
         path_t path_;
@@ -409,7 +517,7 @@ namespace services::disk {
         std::pmr::unordered_map<components::catalog::oid_t, std::unique_ptr<collection_storage_entry_t>> storages_;
 
         // Per-agent GC slice — sole owner of GC state. Populated by
-        // register_dropped_storage_inner; on_horizon_advanced_inner removes entries
+        // register_dropped_storage_inner_sync; on_horizon_advanced_inner removes entries
         // whose dropped_at_commit_id < new_horizon and acks on_subscriber_empty
         // (DISK_KIND) once it drains.
         std::pmr::vector<dropped_storage_entry_t> dropped_storages_;
@@ -417,6 +525,10 @@ namespace services::disk {
         // Empty by default; the ack path in on_horizon_advanced_inner is gated on
         // != empty_address() so test fixtures without a dispatcher pass cleanly.
         actor_zeta::address_t manager_dispatcher_addr_{actor_zeta::address_t::empty_address()};
+
+        // WAL manager address for CATALOG-agent DDL (set via set_manager_wal_sync at
+        // bootstrap). Empty by default so WAL-disabled fixtures skip the WAL write.
+        actor_zeta::address_t manager_wal_addr_{actor_zeta::address_t::empty_address()};
     };
 
     using agent_disk_ptr = std::unique_ptr<agent_disk_t, actor_zeta::pmr::deleter_t>;

--- a/services/disk/disk_contract.hpp
+++ b/services/disk/disk_contract.hpp
@@ -59,18 +59,6 @@ namespace services::disk {
 
         actor_zeta::unique_future<resolve_namespace_result_t>
         resolve_namespace(execution_context_t ctx, std::string name, std::uint64_t since_version);
-        actor_zeta::unique_future<resolve_table_result_t> resolve_table(execution_context_t ctx,
-                                                                        components::catalog::oid_t namespace_oid,
-                                                                        std::string name,
-                                                                        std::uint64_t since_version);
-        actor_zeta::unique_future<resolve_type_result_t> resolve_type(execution_context_t ctx,
-                                                                      components::catalog::oid_t namespace_oid,
-                                                                      std::string name,
-                                                                      std::uint64_t since_version);
-        actor_zeta::unique_future<resolve_function_result_t> resolve_function(execution_context_t ctx,
-                                                                              components::catalog::oid_t namespace_oid,
-                                                                              std::string name,
-                                                                              std::uint64_t since_version);
         actor_zeta::unique_future<std::pmr::vector<resolve_function_result_t>>
         resolve_function_by_name(execution_context_t ctx, std::string name, std::uint64_t since_version);
         actor_zeta::unique_future<std::pmr::vector<std::string>> list_namespaces(execution_context_t ctx);
@@ -113,15 +101,29 @@ namespace services::disk {
                      std::pmr::vector<std::string> key_col_names,
                      components::vector::data_chunk_t keys);
 
-        // Columnar row-data scan: returns the txn-visible rows for key_col_names[i] ==
-        // key_values[i] as batched data_chunk_t (each chunk <= DEFAULT_VECTOR_CAPACITY
-        // rows). Callers read cells via chunk.value(col_idx, row_idx) without
-        // materializing a row-major vector.
+        // Columnar row-data scan for ONE key-tuple: returns the txn-visible rows where
+        // key_col_names[j] == keys.value(j, 0) as batched data_chunk_t (each chunk <=
+        // DEFAULT_VECTOR_CAPACITY rows). `keys` is a 1-row columnar carrier (column j ==
+        // key_col_names[j]), so no row-major logical_value_t crosses the boundary. Callers
+        // read cells via chunk.value(col_idx, row_idx).
         actor_zeta::unique_future<std::pmr::vector<components::vector::data_chunk_t>>
         read_chunks_by_key(execution_context_t ctx,
                            components::catalog::oid_t table_oid,
                            std::pmr::vector<std::string> key_col_names,
-                           std::pmr::vector<components::types::logical_value_t> key_values);
+                           components::vector::data_chunk_t keys);
+
+        // Batched multi-key columnar row-data scan for one table: result[i] = matched chunks
+        // for key-tuple i (each chunk <= DEFAULT_VECTOR_CAPACITY rows). `keys` is an N-row
+        // columnar carrier (column j == key_col_names[j], row i == i-th key-tuple), so no
+        // row-major logical_value_t crosses the boundary. All keys share `table_oid` (one owning
+        // agent), so the per-key loop runs intra-agent via a single read_chunks_by_keys_inner
+        // message. The outer vector always has one (possibly empty) entry per key in input
+        // order, so result.size() == keys.size(). Callers read cells via chunk.value(col, row).
+        actor_zeta::unique_future<std::pmr::vector<std::pmr::vector<components::vector::data_chunk_t>>>
+        read_chunks_by_keys(execution_context_t ctx,
+                            components::catalog::oid_t table_oid,
+                            std::pmr::vector<std::string> key_col_names,
+                            components::vector::data_chunk_t keys);
 
         // Physical column compaction for an IN_MEMORY relkind='g'
         // table_storage_t.
@@ -143,7 +145,9 @@ namespace services::disk {
                             components::catalog::oid_t table_oid,
                             components::catalog::oid_t database_oid,
                             std::vector<components::table::column_definition_t> columns);
-        actor_zeta::unique_future<void> drop_storage(session_id_t session, components::catalog::oid_t table_oid);
+        // Batched DROP: partition oids per agent, fan out one inner per agent.
+        actor_zeta::unique_future<void> drop_storage_many(session_id_t session,
+                                                          std::pmr::vector<components::catalog::oid_t> table_oids);
 
         // Storage queries
         actor_zeta::unique_future<std::pmr::vector<components::types::complex_logical_type>>
@@ -190,19 +194,6 @@ namespace services::disk {
                                                                 components::vector::vector_t row_ids,
                                                                 uint64_t count);
 
-        // MVCC commit/revert
-        actor_zeta::unique_future<void> storage_publish_commit(execution_context_t ctx,
-                                                              components::catalog::oid_t table_oid,
-                                                              uint64_t commit_id,
-                                                              int64_t row_start,
-                                                              uint64_t count);
-        actor_zeta::unique_future<void> storage_revert_append(execution_context_t ctx,
-                                                              components::catalog::oid_t table_oid,
-                                                              int64_t row_start,
-                                                              uint64_t count);
-        actor_zeta::unique_future<void>
-        storage_publish_delete(execution_context_t ctx, components::catalog::oid_t table_oid, uint64_t commit_id);
-
         // Batched MVCC swap. Each range carries its own table_oid.
         actor_zeta::unique_future<void>
         storage_publish_commits(execution_context_t ctx,
@@ -230,13 +221,18 @@ namespace services::disk {
         // Runtime DROP TABLE path — operator_dynamic_cascade_delete sends this
         // from inside the executor actor so the manager_disk side records a
         // pending GC entry (path + sidecars derived from the live storages_
-        // map) before the file is removed by drop_storage. Pair with
+        // map) before the file is removed by drop_storage_many. Pair with
         // manager_dispatcher_t::on_drop_resource_marked(DISK_KIND).
-        actor_zeta::unique_future<void> mark_storage_dropped(session_id_t session,
-                                                             components::catalog::oid_t table_oid,
-                                                             uint64_t dropped_at_commit_id);
+        // Batched: one call marks every storage dropped in a cascade with the
+        // SAME dropped_at_commit_id (the cascade operator computes a single
+        // txn_id upper bound for the whole DROP). Partitioned per owning agent
+        // (pool_idx_for_oid) and fanned out in parallel, mirroring drop_storage_many.
+        actor_zeta::unique_future<void>
+        mark_storage_dropped_many(session_id_t session,
+                                  std::pmr::vector<components::catalog::oid_t> table_oids,
+                                  uint64_t dropped_at_commit_id);
 
-        // DROP-GC value-space remap. mark_storage_dropped records
+        // DROP-GC value-space remap. mark_storage_dropped_many records
         // dropped_at_commit_id in TXN-ID space (>= 2^62) because the cascade-delete
         // operator only knows the in-flight txn_id at the time. Once the transaction
         // commits and a real commit_id is allocated, operator_commit_transaction
@@ -250,7 +246,7 @@ namespace services::disk {
 
         // DROP-rollback un-mark. The mirror of storage_dropped_committed for the
         // abort path: a DROP TABLE inside a transaction records its GC entry with
-        // dropped_at_commit_id in TXN-ID space via mark_storage_dropped, but if the
+        // dropped_at_commit_id in TXN-ID space via mark_storage_dropped_many, but if the
         // transaction ABORTS the table must survive. operator_abort_transaction sends
         // this so the manager fans out to every agent, and each agent ERASES (not
         // remaps) its own dropped_storages_ entries whose dropped_at_commit_id == txn_id,
@@ -265,7 +261,7 @@ namespace services::disk {
                                                             &disk_contract::create_storage,
                                                             &disk_contract::create_storage_with_columns,
                                                             &disk_contract::create_storage_disk,
-                                                            &disk_contract::drop_storage,
+                                                            &disk_contract::drop_storage_many,
                                                             // Storage queries
                                                             &disk_contract::storage_types,
                                                             &disk_contract::storage_total_rows,
@@ -278,18 +274,12 @@ namespace services::disk {
                                                             &disk_contract::storage_update,
                                                             &disk_contract::storage_delete_rows,
                                                             // MVCC commit/revert
-                                                            &disk_contract::storage_publish_commit,
-                                                            &disk_contract::storage_revert_append,
-                                                            &disk_contract::storage_publish_delete,
                                                             &disk_contract::storage_publish_commits,
                                                             &disk_contract::storage_publish_deletes,
                                                             &disk_contract::storage_revert_appends,
                                                             &disk_contract::storage_revert_deletes,
                                                             // resolve + invalidation pull
                                                             &disk_contract::resolve_namespace,
-                                                            &disk_contract::resolve_table,
-                                                            &disk_contract::resolve_type,
-                                                            &disk_contract::resolve_function,
                                                             &disk_contract::resolve_function_by_name,
                                                             &disk_contract::list_namespaces,
                                                             &disk_contract::allocate_oids_batch,
@@ -299,9 +289,10 @@ namespace services::disk {
                                                             &disk_contract::update_pg_attribute_commit_id_fields,
                                                             &disk_contract::scan_by_keys,
                                                             &disk_contract::read_chunks_by_key,
+                                                            &disk_contract::read_chunks_by_keys,
                                                             &disk_contract::compact_relkind_g_storage,
                                                             &disk_contract::on_horizon_advanced,
-                                                            &disk_contract::mark_storage_dropped,
+                                                            &disk_contract::mark_storage_dropped_many,
                                                             &disk_contract::storage_dropped_committed,
                                                             &disk_contract::storage_drop_aborted>;
 

--- a/services/disk/inline_scan.hpp
+++ b/services/disk/inline_scan.hpp
@@ -1,0 +1,107 @@
+#pragma once
+
+// Shared committed-row scan helper for the disk service. Extracted from
+// manager_disk_impl.hpp so BOTH the manager TUs and agent_disk.cpp can use it
+// (agent-side catalog DDL handlers scan their own slice on the agent thread).
+
+#include <components/table/column_state.hpp>   // storage_index_t
+#include <components/table/data_table.hpp>     // data_table_t
+#include <components/table/table_state.hpp>    // table_scan_state
+#include <components/vector/data_chunk.hpp>    // data_chunk_t
+#include <components/vector/indexing_vector.hpp> // DEFAULT_VECTOR_CAPACITY
+
+#include <initializer_list>
+#include <iterator>
+#include <memory_resource>
+#include <vector>
+
+namespace services::disk::detail {
+
+    // ---------------------------------------------------------------------------
+    // inline_scan: scan all committed rows of a data_table_t, projecting the given
+    // column indices.  Calls fn(chunk, row_index) for every row; returning false
+    // from fn stops the scan early.
+    // ---------------------------------------------------------------------------
+
+    namespace detail_impl_ {
+        template<typename Range, typename Fn>
+        void inline_scan_range(components::table::data_table_t& table,
+                               const Range& col_indices,
+                               std::pmr::memory_resource* resource,
+                               Fn&& fn) {
+            std::vector<components::table::storage_index_t> col_ids;
+            const auto& all_cols = table.columns();
+            // row_group_t::scan_committed writes to result.data[column.primary_index()] —
+            // i.e. it indexes by storage column position, not by row in `col_ids`. So the
+            // chunk must have a slot at every storage column index that appears in
+            // col_indices. Use the projected_cols ctor to allocate buffers only for the
+            // requested columns (other slots are placeholders, no data buffer).
+            std::pmr::vector<components::types::complex_logical_type> all_types(resource);
+            all_types.reserve(all_cols.size());
+            for (const auto& c : all_cols) {
+                all_types.push_back(c.type());
+            }
+            std::vector<size_t> projected;
+            projected.reserve(
+                static_cast<std::size_t>(std::distance(std::begin(col_indices), std::end(col_indices))));
+            for (auto idx : col_indices) {
+                col_ids.emplace_back(static_cast<uint64_t>(idx));
+                projected.push_back(static_cast<std::size_t>(idx));
+            }
+
+            components::table::table_scan_state state(resource);
+            table.initialize_scan(state, col_ids);
+
+            while (true) {
+                components::vector::data_chunk_t chunk(resource,
+                                                       all_types,
+                                                       projected,
+                                                       components::vector::DEFAULT_VECTOR_CAPACITY);
+                table.scan(chunk, state);
+                if (chunk.size() == 0)
+                    break;
+                for (uint64_t i = 0; i < chunk.size(); ++i) {
+                    if (!fn(chunk, i))
+                        return;
+                }
+            }
+        }
+    } // namespace detail_impl_
+
+    template<typename Fn>
+    void inline_scan(components::table::data_table_t& table,
+                     std::initializer_list<std::int64_t> col_indices,
+                     std::pmr::memory_resource* resource,
+                     Fn&& fn) {
+        detail_impl_::inline_scan_range(table, col_indices, resource, std::forward<Fn>(fn));
+    }
+
+    template<typename Fn>
+    void inline_scan(components::table::data_table_t& table,
+                     const std::vector<std::int64_t>& col_indices,
+                     std::pmr::memory_resource* resource,
+                     Fn&& fn) {
+        detail_impl_::inline_scan_range(table, col_indices, resource, std::forward<Fn>(fn));
+    }
+
+    // const overload: data_table_t::scan is read-only but not declared const,
+    // so the const_cast is safe.
+    template<typename Fn>
+    void inline_scan(const components::table::data_table_t& table,
+                     std::initializer_list<std::int64_t> col_indices,
+                     std::pmr::memory_resource* resource,
+                     Fn&& fn) {
+        detail_impl_::inline_scan_range(const_cast<components::table::data_table_t&>(table),
+                                        col_indices, resource, std::forward<Fn>(fn));
+    }
+
+    template<typename Fn>
+    void inline_scan(const components::table::data_table_t& table,
+                     const std::vector<std::int64_t>& col_indices,
+                     std::pmr::memory_resource* resource,
+                     Fn&& fn) {
+        detail_impl_::inline_scan_range(const_cast<components::table::data_table_t&>(table),
+                                        col_indices, resource, std::forward<Fn>(fn));
+    }
+
+} // namespace services::disk::detail

--- a/services/disk/manager_disk.cpp
+++ b/services/disk/manager_disk.cpp
@@ -44,7 +44,7 @@ namespace services::disk {
             actor_zeta::msg_id<manager_disk_t, &manager_disk_t::create_storage>,
             actor_zeta::msg_id<manager_disk_t, &manager_disk_t::create_storage_with_columns>,
             actor_zeta::msg_id<manager_disk_t, &manager_disk_t::create_storage_disk>,
-            actor_zeta::msg_id<manager_disk_t, &manager_disk_t::drop_storage>,
+            actor_zeta::msg_id<manager_disk_t, &manager_disk_t::drop_storage_many>,
             actor_zeta::msg_id<manager_disk_t, &manager_disk_t::storage_types>,
             actor_zeta::msg_id<manager_disk_t, &manager_disk_t::storage_total_rows>,
             actor_zeta::msg_id<manager_disk_t, &manager_disk_t::storage_scan>,
@@ -54,17 +54,11 @@ namespace services::disk {
             actor_zeta::msg_id<manager_disk_t, &manager_disk_t::storage_append>,
             actor_zeta::msg_id<manager_disk_t, &manager_disk_t::storage_update>,
             actor_zeta::msg_id<manager_disk_t, &manager_disk_t::storage_delete_rows>,
-            actor_zeta::msg_id<manager_disk_t, &manager_disk_t::storage_publish_commit>,
-            actor_zeta::msg_id<manager_disk_t, &manager_disk_t::storage_revert_append>,
-            actor_zeta::msg_id<manager_disk_t, &manager_disk_t::storage_publish_delete>,
             actor_zeta::msg_id<manager_disk_t, &manager_disk_t::storage_publish_commits>,
             actor_zeta::msg_id<manager_disk_t, &manager_disk_t::storage_publish_deletes>,
             actor_zeta::msg_id<manager_disk_t, &manager_disk_t::storage_revert_appends>,
             actor_zeta::msg_id<manager_disk_t, &manager_disk_t::storage_revert_deletes>,
             actor_zeta::msg_id<manager_disk_t, &manager_disk_t::resolve_namespace>,
-            actor_zeta::msg_id<manager_disk_t, &manager_disk_t::resolve_table>,
-            actor_zeta::msg_id<manager_disk_t, &manager_disk_t::resolve_type>,
-            actor_zeta::msg_id<manager_disk_t, &manager_disk_t::resolve_function>,
             actor_zeta::msg_id<manager_disk_t, &manager_disk_t::resolve_function_by_name>,
             actor_zeta::msg_id<manager_disk_t, &manager_disk_t::list_namespaces>,
             actor_zeta::msg_id<manager_disk_t, &manager_disk_t::allocate_oids_batch>,
@@ -74,9 +68,10 @@ namespace services::disk {
             actor_zeta::msg_id<manager_disk_t, &manager_disk_t::update_pg_attribute_commit_id_fields>,
             actor_zeta::msg_id<manager_disk_t, &manager_disk_t::scan_by_keys>,
             actor_zeta::msg_id<manager_disk_t, &manager_disk_t::read_chunks_by_key>,
+            actor_zeta::msg_id<manager_disk_t, &manager_disk_t::read_chunks_by_keys>,
             actor_zeta::msg_id<manager_disk_t, &manager_disk_t::compact_relkind_g_storage>,
             actor_zeta::msg_id<manager_disk_t, &manager_disk_t::on_horizon_advanced>,
-            actor_zeta::msg_id<manager_disk_t, &manager_disk_t::mark_storage_dropped>,
+            actor_zeta::msg_id<manager_disk_t, &manager_disk_t::mark_storage_dropped_many>,
             actor_zeta::msg_id<manager_disk_t, &manager_disk_t::storage_dropped_committed>,
             actor_zeta::msg_id<manager_disk_t, &manager_disk_t::storage_drop_aborted>,
         };
@@ -372,8 +367,8 @@ namespace services::disk {
                 co_await actor_zeta::dispatch(this, &manager_disk_t::create_storage_disk, msg);
                 break;
             }
-            case actor_zeta::msg_id<manager_disk_t, &manager_disk_t::drop_storage>: {
-                co_await actor_zeta::dispatch(this, &manager_disk_t::drop_storage, msg);
+            case actor_zeta::msg_id<manager_disk_t, &manager_disk_t::drop_storage_many>: {
+                co_await actor_zeta::dispatch(this, &manager_disk_t::drop_storage_many, msg);
                 break;
             }
             // Storage queries
@@ -415,18 +410,6 @@ namespace services::disk {
                 break;
             }
             // MVCC commit/revert
-            case actor_zeta::msg_id<manager_disk_t, &manager_disk_t::storage_publish_commit>: {
-                co_await actor_zeta::dispatch(this, &manager_disk_t::storage_publish_commit, msg);
-                break;
-            }
-            case actor_zeta::msg_id<manager_disk_t, &manager_disk_t::storage_revert_append>: {
-                co_await actor_zeta::dispatch(this, &manager_disk_t::storage_revert_append, msg);
-                break;
-            }
-            case actor_zeta::msg_id<manager_disk_t, &manager_disk_t::storage_publish_delete>: {
-                co_await actor_zeta::dispatch(this, &manager_disk_t::storage_publish_delete, msg);
-                break;
-            }
             case actor_zeta::msg_id<manager_disk_t, &manager_disk_t::storage_publish_commits>: {
                 co_await actor_zeta::dispatch(this, &manager_disk_t::storage_publish_commits, msg);
                 break;
@@ -446,18 +429,6 @@ namespace services::disk {
             // resolve + invalidation pull
             case actor_zeta::msg_id<manager_disk_t, &manager_disk_t::resolve_namespace>: {
                 co_await actor_zeta::dispatch(this, &manager_disk_t::resolve_namespace, msg);
-                break;
-            }
-            case actor_zeta::msg_id<manager_disk_t, &manager_disk_t::resolve_table>: {
-                co_await actor_zeta::dispatch(this, &manager_disk_t::resolve_table, msg);
-                break;
-            }
-            case actor_zeta::msg_id<manager_disk_t, &manager_disk_t::resolve_type>: {
-                co_await actor_zeta::dispatch(this, &manager_disk_t::resolve_type, msg);
-                break;
-            }
-            case actor_zeta::msg_id<manager_disk_t, &manager_disk_t::resolve_function>: {
-                co_await actor_zeta::dispatch(this, &manager_disk_t::resolve_function, msg);
                 break;
             }
             case actor_zeta::msg_id<manager_disk_t, &manager_disk_t::resolve_function_by_name>: {
@@ -484,6 +455,10 @@ namespace services::disk {
                 co_await actor_zeta::dispatch(this, &manager_disk_t::read_chunks_by_key, msg);
                 break;
             }
+            case actor_zeta::msg_id<manager_disk_t, &manager_disk_t::read_chunks_by_keys>: {
+                co_await actor_zeta::dispatch(this, &manager_disk_t::read_chunks_by_keys, msg);
+                break;
+            }
             case actor_zeta::msg_id<manager_disk_t, &manager_disk_t::delete_pg_catalog_rows>: {
                 co_await actor_zeta::dispatch(this, &manager_disk_t::delete_pg_catalog_rows, msg);
                 break;
@@ -504,8 +479,8 @@ namespace services::disk {
                 co_await actor_zeta::dispatch(this, &manager_disk_t::on_horizon_advanced, msg);
                 break;
             }
-            case actor_zeta::msg_id<manager_disk_t, &manager_disk_t::mark_storage_dropped>: {
-                co_await actor_zeta::dispatch(this, &manager_disk_t::mark_storage_dropped, msg);
+            case actor_zeta::msg_id<manager_disk_t, &manager_disk_t::mark_storage_dropped_many>: {
+                co_await actor_zeta::dispatch(this, &manager_disk_t::mark_storage_dropped_many, msg);
                 break;
             }
             case actor_zeta::msg_id<manager_disk_t, &manager_disk_t::storage_dropped_committed>: {
@@ -558,7 +533,7 @@ namespace services::disk {
                                                        std::filesystem::path path,
                                                        std::pmr::vector<std::filesystem::path> sidecar_paths) {
         // Bootstrap-only (base_spaces catalog scan rebuild); runtime DROP uses the
-        // mark_storage_dropped mailbox handler below. Forwards an independent
+        // mark_storage_dropped_many mailbox handler below. Forwards an independent
         // deep-copy of path + sidecars into the owning agent's slice.
         if (!agents_.empty()) {
             const auto idx = pool_idx_for_oid(oid, agents_.size());
@@ -575,60 +550,57 @@ namespace services::disk {
     }
 
     manager_disk_t::unique_future<void>
-    manager_disk_t::mark_storage_dropped(session_id_t /*session*/,
-                                         components::catalog::oid_t table_oid,
-                                         uint64_t dropped_at_commit_id) {
-        // Must run BEFORE the drop_storage send: it reads the still-live storage
-        // entry to derive the .otbx path + sidecars. The borrowed storage_entry_sync
-        // pointer is valid for this handler only (the agent mailbox serializes
-        // writes against this read); the GC entry is then fanned into the agent's
-        // slice via mailbox send.
+    manager_disk_t::mark_storage_dropped_many(session_id_t /*session*/,
+                                              std::pmr::vector<components::catalog::oid_t> table_oids,
+                                              uint64_t dropped_at_commit_id) {
+        // Partition oids per owning agent (pool_idx_for_oid), then fan out one
+        // mark_storage_dropped_many_inner per agent in PARALLEL (send all → await
+        // all) — N per-oid singular marks would cost N round-trips; here they cost
+        // one (at most num_agents parallel sends). The owning agent derives each
+        // .otbx path + sidecars from its OWN still-live slice and records the GC
+        // entry in mark_storage_dropped_many_inner — the manager no longer borrows
+        // the agent's storage_entry across the actor boundary. Every oid in one
+        // cascade shares the SAME dropped_at_commit_id (txn_id upper bound). Awaiting
+        // all keeps this handler ordered w.r.t. operator_dynamic_cascade_delete's
+        // subsequent drop_storage_many / cascade sends. Same partition-by-agent shape
+        // as drop_storage_many.
         trace(log_,
-              "manager_disk_t::mark_storage_dropped , oid : {} , commit_id : {}",
-              static_cast<unsigned>(table_oid),
+              "manager_disk_t::mark_storage_dropped_many , oids : {} , commit_id : {}",
+              table_oids.size(),
               dropped_at_commit_id);
-        std::filesystem::path otbx_path;
-        std::pmr::vector<std::filesystem::path> sidecars{resource()};
-        if (!agents_.empty()) {
-            const auto idx = pool_idx_for_oid(table_oid, agents_.size());
-            if (agents_[idx] != nullptr) {
-                if (const auto* entry = agents_[idx]->storage_entry_sync(table_oid);
-                    entry != nullptr) {
-                    otbx_path = entry->otbx_path;
-                    if (!otbx_path.empty()) {
-                        auto wal_id_sidecar = otbx_path;
-                        wal_id_sidecar += ".wal_id";
-                        sidecars.push_back(std::move(wal_id_sidecar));
-                        auto prev_sidecar = otbx_path;
-                        prev_sidecar += ".prev";
-                        sidecars.push_back(std::move(prev_sidecar));
-                    }
-                }
-            }
+        if (agents_.empty()) {
+            co_return;
         }
-        // IN_MEMORY storages leave otbx_path/sidecars empty, but we still record a
-        // GC entry so disk_has_dropped_ bookkeeping is uniform (agent sweep no-ops
-        // on the empty path).
-
-        // Deep-copy path + sidecars so the agent owns them independently; co_await
-        // keeps this handler ordered w.r.t. subsequent cascade-delete sends.
-        if (!agents_.empty()) {
-            const auto idx = pool_idx_for_oid(table_oid, agents_.size());
-            std::pmr::vector<std::filesystem::path> agent_sidecars{resource()};
-            agent_sidecars.reserve(sidecars.size());
-            for (const auto& sidecar : sidecars) {
-                agent_sidecars.push_back(sidecar);
+        std::pmr::vector<std::pmr::vector<components::catalog::oid_t>> per_agent{resource()};
+        per_agent.reserve(agents_.size());
+        for (std::size_t i = 0; i < agents_.size(); ++i) {
+            per_agent.emplace_back();
+        }
+        for (auto oid : table_oids) {
+            const std::size_t pool_idx = pool_idx_for_oid(oid, agents_.size());
+            per_agent[pool_idx].push_back(oid);
+        }
+        std::pmr::vector<unique_future<void>> agent_futures{resource()};
+        agent_futures.reserve(per_agent.size());
+        for (std::size_t i = 0; i < per_agent.size(); ++i) {
+            if (per_agent[i].empty()) {
+                continue;
             }
-            auto [needs_sched, fut] = actor_zeta::otterbrix::send(agents_[idx]->address(),
-                                                                   &agent_disk_t::register_dropped_storage_inner,
-                                                                   table_oid,
-                                                                   dropped_at_commit_id,
-                                                                   std::move(otbx_path),
-                                                                   std::move(agent_sidecars));
+            auto& agent = agents_[i];
+            if (agent == nullptr) {
+                continue;
+            }
+            auto [needs_sched, fut] = actor_zeta::otterbrix::send(agent->address(),
+                                                                   &agent_disk_t::mark_storage_dropped_many_inner,
+                                                                   std::move(per_agent[i]),
+                                                                   dropped_at_commit_id);
             if (needs_sched) {
-                scheduler_disk_->enqueue(agents_[idx].get());
+                scheduler_disk_->enqueue(agent.get());
             }
-            co_await std::move(fut);
+            agent_futures.emplace_back(std::move(fut));
+        }
+        for (auto& f : agent_futures) {
+            co_await std::move(f);
         }
         co_return;
     }

--- a/services/disk/manager_disk.hpp
+++ b/services/disk/manager_disk.hpp
@@ -78,7 +78,6 @@ namespace services::disk {
         table_storage_t(std::pmr::memory_resource* resource, const std::filesystem::path& otbx_path);
 
         components::table::data_table_t& table() { return *table_; }
-        const components::table::data_table_t& table() const { return *table_; }
         storage_mode_t mode() const { return mode_; }
 
         /// Checkpoint (disk mode only, no-op for in-memory).
@@ -135,8 +134,8 @@ namespace services::disk {
         table_storage_t table_storage;
         std::unique_ptr<components::storage::storage_t> storage;
         // Actual on-disk path for DISK-mode tables. Empty for IN_MEMORY entries.
-        // Used by checkpoint_all (sidecar lands next to .otbx) and drop_storage
-        // (physical file removal).
+        // Used by checkpoint_all (sidecar lands next to .otbx) and
+        // drop_storage_one_local (physical file removal).
         std::filesystem::path otbx_path;
         // Computing (relkind='g', dynamic-schema) table, created schema-less. Only
         // these may hold several columns with the same name but different types
@@ -264,27 +263,6 @@ namespace services::disk {
                 return false;
             return agents_[idx]->has_storage_sync(table_oid);
         }
-        // Sync row-count probe used by base_spaces WAL replay to avoid duplicating already-
-        // checkpointed records. Returns 0 for unknown OIDs.
-        uint64_t total_rows_sync(components::catalog::oid_t table_oid) const noexcept {
-            if (agents_.empty())
-                return 0;
-            const std::size_t idx = pool_idx_for_oid(table_oid, agents_.size());
-            if (idx >= agents_.size() || agents_[idx] == nullptr)
-                return 0;
-            return agents_[idx]->total_rows_inner_sync(table_oid);
-        }
-        // Returns the persisted checkpoint_wal_id for `table_oid` (0 if never
-        // checkpointed or unknown).
-        wal::id_t checkpoint_wal_id_sync(components::catalog::oid_t table_oid) const noexcept {
-            if (agents_.empty())
-                return wal::id_t{0};
-            const std::size_t idx = pool_idx_for_oid(table_oid, agents_.size());
-            if (idx >= agents_.size() || agents_[idx] == nullptr)
-                return wal::id_t{0};
-            return agents_[idx]->checkpoint_wal_id_inner_sync(table_oid);
-        }
-
         // Read the .otbx.wal_id sidecar directly from disk without loading the storage.
         wal::id_t peek_checkpoint_wal_id_from_disk(components::catalog::oid_t table_oid,
                                                    components::catalog::oid_t database_oid) const noexcept;
@@ -298,12 +276,11 @@ namespace services::disk {
         void create_storage_with_columns_sync(components::catalog::oid_t table_oid,
                                               components::catalog::oid_t database_oid,
                                               std::vector<components::table::column_definition_t> columns);
-        // System catalog (pg_*) bootstrap and load. Called from base_spaces during PHASE 1
-        // before any actor is spawned. bootstrap creates the 9 .otbx files for the system
-        // tables; load picks them up on subsequent starts. Both are idempotent w.r.t. the
+        // System catalog (pg_*) bootstrap. Called from base_spaces during PHASE 1
+        // before any actor is spawned. Creates the system-table .otbx files on a fresh
+        // start and picks up existing ones on subsequent starts; idempotent w.r.t. the
         // resulting `storages_` map — collections are keyed by `pg_catalog.<name>`.
         void bootstrap_system_tables_sync();
-        void load_system_tables_sync();
         // Walk config_.path looking for user-table .otbx files
         // (${db_oid}/${tbl_oid}/table.otbx where tbl_oid >= FIRST_USER_OID) and
         // load each into storages_ via load_storage_disk_sync. Called by
@@ -380,33 +357,12 @@ namespace services::disk {
         // Synchronous — called at startup before actor schedulers start.
         std::string read_setting_sync(std::string_view name);
 
-        // Public accessor — ddl_* methods take their OIDs from this generator.
-        components::catalog::oid_generator& oid_gen() noexcept { return oid_gen_; }
-
         // Per-item resolve methods. Each method scans the corresponding pg_* table
         // on the disk actor thread and returns the found object (or {found=false}).
         // The since_version parameter is kept for message-dispatch compatibility
         // (always ignored — versioning is no longer used).
         unique_future<resolve_namespace_result_t>
         resolve_namespace(execution_context_t ctx, std::string name, std::uint64_t since_version);
-        unique_future<resolve_table_result_t> resolve_table(execution_context_t ctx,
-                                                            components::catalog::oid_t namespace_oid,
-                                                            std::string name,
-                                                            std::uint64_t since_version);
-        unique_future<resolve_type_result_t> resolve_type(execution_context_t ctx,
-                                                          components::catalog::oid_t namespace_oid,
-                                                          std::string name,
-                                                          std::uint64_t since_version);
-        // Internal: pg_type → pg_class fallback. Self-recurses for composite STRUCT
-        // field references (UNKNOWN-by-name). Reads route through the agent-0 mailbox
-        // via storage_scan_batched_inner, so this is a coroutine (co_await at the
-        // recursion site and at the resolve_type call site).
-        unique_future<resolve_type_result_t> resolve_type_sync(components::catalog::oid_t namespace_oid,
-                                                               const std::string& name);
-        unique_future<resolve_function_result_t> resolve_function(execution_context_t ctx,
-                                                                  components::catalog::oid_t namespace_oid,
-                                                                  std::string name,
-                                                                  std::uint64_t since_version);
 
         // Cross-namespace function lookup: returns ALL pg_proc rows whose proname matches
         // `name`, regardless of pronamespace. Used by the UDF admin paths (#41 Path 2/4):
@@ -470,14 +426,28 @@ namespace services::disk {
                      std::pmr::vector<std::string> key_col_names,
                      components::vector::data_chunk_t keys);
 
-        // Columnar row-data scan: returns the txn-visible rows where key_col_names[i] ==
-        // key_values[i] as batched data_chunk_t (each <= DEFAULT_VECTOR_CAPACITY rows)
-        // instead of materializing a row-major vector.
+        // Columnar row-data scan for ONE key-tuple: returns the txn-visible rows where
+        // key_col_names[j] == keys.value(j, 0) as batched data_chunk_t (each <=
+        // DEFAULT_VECTOR_CAPACITY rows). `keys` is a 1-row columnar carrier (column j ==
+        // key_col_names[j]), so no row-major logical_value_t crosses the boundary. Thin
+        // router: one read_chunks_by_key_inner message to the owning agent.
         unique_future<std::pmr::vector<components::vector::data_chunk_t>>
         read_chunks_by_key(execution_context_t ctx,
                            components::catalog::oid_t table_oid,
                            std::pmr::vector<std::string> key_col_names,
-                           std::pmr::vector<components::types::logical_value_t> key_values);
+                           components::vector::data_chunk_t keys);
+
+        // Batched multi-key columnar row-data scan: result[i] = matched chunks for key-tuple i
+        // (each <= DEFAULT_VECTOR_CAPACITY rows). `keys` is an N-row columnar carrier (column j =
+        // key_col_names[j], row i = i-th key-tuple), so no row-major logical_value_t crosses the
+        // boundary. All keys share `table_oid` (one owning agent), so the per-key loop runs
+        // intra-agent via a single read_chunks_by_keys_inner message. result.size() ==
+        // keys.size() (one possibly-empty entry per key, in input order). Thin router.
+        unique_future<std::pmr::vector<std::pmr::vector<components::vector::data_chunk_t>>>
+        read_chunks_by_keys(execution_context_t ctx,
+                            components::catalog::oid_t table_oid,
+                            std::pmr::vector<std::string> key_col_names,
+                            components::vector::data_chunk_t keys);
 
         // Physical column compaction. For an IN_MEMORY relkind='g' storage,
         // drop every physical column whose name is NOT in `live_attnames`. Called by
@@ -497,17 +467,9 @@ namespace services::disk {
         uint64_t direct_append_sync(components::catalog::oid_t table_oid,
                                     components::vector::data_chunk_t& data,
                                     core::date::timezone_offset_t session_tz);
-        uint64_t direct_append_sync(components::catalog::oid_t table_oid,
-                                    components::vector::data_chunk_t& data,
-                                    core::date::timezone_offset_t session_tz,
-                                    const components::table::transaction_data& txn);
         void direct_delete_sync(components::catalog::oid_t table_oid,
                                 const std::pmr::vector<int64_t>& row_ids,
                                 uint64_t count);
-        void direct_delete_sync(components::catalog::oid_t table_oid,
-                                const std::pmr::vector<int64_t>& row_ids,
-                                uint64_t count,
-                                const components::table::transaction_data& txn);
         void direct_update_sync(components::catalog::oid_t table_oid,
                                 const std::pmr::vector<int64_t>& row_ids,
                                 components::vector::data_chunk_t& new_data);
@@ -545,26 +507,32 @@ namespace services::disk {
         // the dispatcher on slice drain so the selective-broadcast flag clears.
         unique_future<void> on_horizon_advanced(uint64_t new_horizon);
 
-        /// Bootstrap helper — catalog scan rebuild populates this. Also called
-        /// internally by the mark_storage_dropped mailbox handler once it has
-        /// derived path + sidecars from the live storage entry.
-        /// NOT a mailbox handler — single-threaded callers only.
+        /// Bootstrap-only helper — the crash-recovery catalog scan rebuild populates the
+        /// per-agent dropped_storages_ slices through this (base_spaces, pre-scheduler-start).
+        /// The RUNTIME DROP path does NOT use this: it goes mark_storage_dropped_many
+        /// (mailbox) -> agent mark_storage_dropped_many_inner -> register_dropped_storage_inner_sync
+        /// on the agent's own thread. NOT a mailbox handler — single-threaded callers only.
         void register_dropped_storage_sync(components::catalog::oid_t oid,
                                            uint64_t dropped_at_commit_id,
                                            std::filesystem::path path,
                                            std::pmr::vector<std::filesystem::path> sidecar_paths);
 
         /// Runtime DROP TABLE path — sent from operator_dynamic_cascade_delete
-        /// BEFORE the drop_storage send, so it can still read the live storage entry
-        /// to derive the .otbx path + sidecars (wal_id, prev) and record them via
-        /// register_dropped_storage_sync. Touches no files (drop_storage does the
-        /// removal); the GC entry lets on_horizon_advanced reconcile leftovers and
-        /// flips dispatcher disk_has_dropped_ via on_drop_resource_marked.
-        unique_future<void> mark_storage_dropped(session_id_t session,
-                                                 components::catalog::oid_t table_oid,
-                                                 uint64_t dropped_at_commit_id);
+        /// BEFORE the drop_storage_many send, so the owning agents can still read the
+        /// live storage entries to derive the .otbx path + sidecars (wal_id, prev) and
+        /// record them via register_dropped_storage_inner_sync. Touches no files
+        /// (drop_storage_many does the removal); the GC entry lets on_horizon_advanced
+        /// reconcile leftovers and flips dispatcher disk_has_dropped_ via
+        /// on_drop_resource_marked. Batched: a single cascade DROP marks every storage
+        /// with the SAME dropped_at_commit_id, so we partition the oids per owning
+        /// agent (pool_idx_for_oid) and fan out one mark_storage_dropped_many_inner per
+        /// agent in parallel — N per-oid manager round-trips collapse to one (at most
+        /// num_agents parallel sends), mirroring drop_storage_many.
+        unique_future<void> mark_storage_dropped_many(session_id_t session,
+                                                      std::pmr::vector<components::catalog::oid_t> table_oids,
+                                                      uint64_t dropped_at_commit_id);
 
-        /// DROP-GC value-space remap. mark_storage_dropped recorded the GC entry's
+        /// DROP-GC value-space remap. mark_storage_dropped_many recorded the GC entry's
         /// dropped_at_commit_id in TXN-ID space (>= 2^62, the only id the cascade
         /// operator had). After the transaction commits and a real commit_id is
         /// allocated, operator_commit_transaction sends this; the manager fans out
@@ -574,7 +542,7 @@ namespace services::disk {
         unique_future<void> storage_dropped_committed(session_id_t session, uint64_t txn_id, uint64_t commit_id);
 
         /// DROP-rollback un-mark — the abort mirror of storage_dropped_committed.
-        /// mark_storage_dropped recorded the GC entry's dropped_at_commit_id in TXN-ID
+        /// mark_storage_dropped_many recorded the GC entry's dropped_at_commit_id in TXN-ID
         /// space (>= 2^62). If the transaction ABORTS instead of committing, the table
         /// must remain live, so operator_abort_transaction sends this; the manager fans
         /// out storage_drop_aborted_inner(txn_id) to EVERY agent so the owning slice can
@@ -601,7 +569,13 @@ namespace services::disk {
                                                 components::catalog::oid_t table_oid,
                                                 components::catalog::oid_t database_oid,
                                                 std::vector<components::table::column_definition_t> columns);
-        unique_future<void> drop_storage(session_id_t session, components::catalog::oid_t table_oid);
+        // Batched DROP: partition the oids per owning agent (pool_idx_for_oid) and
+        // fan out one drop_storage_many_inner per agent in parallel — N per-oid
+        // manager round-trips collapse to one (at most num_agents parallel sends).
+        // Each agent's inner is idempotent for not-owned oids. Caller MUST ensure
+        // all index unregisters complete BEFORE invoking this (cross-manager order).
+        unique_future<void> drop_storage_many(session_id_t session,
+                                              std::pmr::vector<components::catalog::oid_t> table_oids);
 
         // Storage queries
         unique_future<std::pmr::vector<components::types::complex_logical_type>>
@@ -646,19 +620,6 @@ namespace services::disk {
                                                     components::catalog::oid_t table_oid,
                                                     components::vector::vector_t row_ids,
                                                     uint64_t count);
-        // MVCC commit/revert
-        unique_future<void> storage_publish_commit(execution_context_t ctx,
-                                                  components::catalog::oid_t table_oid,
-                                                  uint64_t commit_id,
-                                                  int64_t row_start,
-                                                  uint64_t count);
-        unique_future<void> storage_revert_append(execution_context_t ctx,
-                                                  components::catalog::oid_t table_oid,
-                                                  int64_t row_start,
-                                                  uint64_t count);
-        unique_future<void>
-        storage_publish_delete(execution_context_t ctx, components::catalog::oid_t table_oid, uint64_t commit_id);
-
         // Batched MVCC swap. Each range carries its own table_oid.
         unique_future<void> storage_publish_commits(execution_context_t ctx,
                                                    uint64_t commit_id,
@@ -683,7 +644,7 @@ namespace services::disk {
                                                        &manager_disk_t::create_storage,
                                                        &manager_disk_t::create_storage_with_columns,
                                                        &manager_disk_t::create_storage_disk,
-                                                       &manager_disk_t::drop_storage,
+                                                       &manager_disk_t::drop_storage_many,
                                                        // Storage queries
                                                        &manager_disk_t::storage_types,
                                                        &manager_disk_t::storage_total_rows,
@@ -696,18 +657,12 @@ namespace services::disk {
                                                        &manager_disk_t::storage_update,
                                                        &manager_disk_t::storage_delete_rows,
                                                        // MVCC commit/revert
-                                                       &manager_disk_t::storage_publish_commit,
-                                                       &manager_disk_t::storage_revert_append,
-                                                       &manager_disk_t::storage_publish_delete,
                                                        &manager_disk_t::storage_publish_commits,
                                                        &manager_disk_t::storage_publish_deletes,
                                                        &manager_disk_t::storage_revert_appends,
                                                        &manager_disk_t::storage_revert_deletes,
                                                        // resolve + invalidation pull
                                                        &manager_disk_t::resolve_namespace,
-                                                       &manager_disk_t::resolve_table,
-                                                       &manager_disk_t::resolve_type,
-                                                       &manager_disk_t::resolve_function,
                                                        &manager_disk_t::resolve_function_by_name,
                                                        &manager_disk_t::list_namespaces,
                                                        &manager_disk_t::allocate_oids_batch,
@@ -717,27 +672,14 @@ namespace services::disk {
                                                        &manager_disk_t::update_pg_attribute_commit_id_fields,
                                                        &manager_disk_t::scan_by_keys,
                                                        &manager_disk_t::read_chunks_by_key,
+                                                       &manager_disk_t::read_chunks_by_keys,
                                                        &manager_disk_t::compact_relkind_g_storage,
                                                        &manager_disk_t::on_horizon_advanced,
-                                                       &manager_disk_t::mark_storage_dropped,
+                                                       &manager_disk_t::mark_storage_dropped_many,
                                                        &manager_disk_t::storage_dropped_committed,
                                                        &manager_disk_t::storage_drop_aborted>;
 
     private:
-        // Shared per-item bodies for the singular + batched pg_catalog mutators.
-        // Each is the canonical inner logic (WAL write + direct_*_sync) for a single
-        // request; the public singular handler and the batched handler both co_await
-        // it so the two paths emit identical WAL records. Not mailbox handlers.
-        unique_future<void> delete_pg_catalog_rows_one_(execution_context_t ctx,
-                                                        components::catalog::oid_t table_oid,
-                                                        std::int64_t oid_col_idx,
-                                                        components::catalog::oid_t target_oid);
-        unique_future<void>
-        update_pg_attribute_commit_id_field_one_(execution_context_t ctx,
-                                                 components::catalog::oid_t attoid,
-                                                 components::pg_attribute_commit_id_backfill_t::kind_t kind,
-                                                 std::uint64_t commit_id);
-
         // Disk storage helpers — used only by bootstrap / io / recovery paths
         // inside services/disk/. Not part of the actor's public interface.
         void create_storage_disk_sync(components::catalog::oid_t table_oid,

--- a/services/disk/manager_disk_bootstrap.cpp
+++ b/services/disk/manager_disk_bootstrap.cpp
@@ -303,39 +303,6 @@ namespace services::disk {
         }
     }
 
-    void manager_disk_t::load_system_tables_sync() {
-        // Walks sys_dir and re-hydrates every pg_* catalog table via
-        // load_storage_disk_sync, which constructs the SFBM on agents_[0]
-        // (catalog agent). Skip-if-present probe via has_storage_sync
-        // prevents double-load.
-        if (config_.path.empty()) {
-            return;
-        }
-        const auto sys_db_oid = catalog::well_known_oid::main_database;
-        auto sys_dir = config_.path / std::to_string(static_cast<unsigned>(sys_db_oid));
-        if (!std::filesystem::exists(sys_dir)) {
-            return;
-        }
-        for (const auto& def : components::catalog::all_system_tables()) {
-            const auto tbl_oid = well_known_oid_for_system_table(def.name);
-            if (tbl_oid == catalog::INVALID_OID)
-                continue;
-            if (!agents_.empty() && agents_[0] != nullptr) {
-                if (agents_[0]->has_storage_sync(tbl_oid))
-                    continue;
-            }
-            auto otbx = sys_dir / std::to_string(static_cast<unsigned>(tbl_oid)) / "table.otbx";
-            if (!std::filesystem::exists(otbx)) {
-                continue;
-            }
-            trace(log_,
-                  "manager_disk_t::load_system_tables_sync loading : {} oid={}",
-                  std::string(def.name),
-                  static_cast<unsigned>(tbl_oid));
-            load_storage_disk_sync(tbl_oid, sys_db_oid, otbx);
-        }
-    }
-
     void manager_disk_t::restore_oid_generator_sync() {
         // agents_[0] (catalog agent) owns all catalog SFBM entries.
         // Pre-scheduler-start, single-threaded.

--- a/services/disk/manager_disk_ddl.cpp
+++ b/services/disk/manager_disk_ddl.cpp
@@ -6,120 +6,87 @@ namespace services::disk {
     namespace catalog = components::catalog;
     using namespace detail;
 
-    // Crash-safe pg_catalog row append: WAL is written first so a crash before the
-    // storage update can be replayed on restart, then storage is updated.
+    // Catalog DDL routers. The crash-safe WAL write + catalog scan + storage mutation
+    // now run on the owning agent (agent-0 / CATALOG) in append_pg_catalog_row_inner /
+    // delete_pg_catalog_rows_inner / update_pg_attribute_commit_id_field_inner /
+    // compact_relkind_g_storage_inner, so the manager no longer borrows the agent's
+    // slice across the actor boundary. Every catalog OID routes to agents_[0] via
+    // pool_idx_for_oid. Routers mirror storage_append: pool_idx_for_oid → otterbrix::send
+    // → if needs_sched enqueue → co_return co_await.
+
     manager_disk_t::unique_future<components::pg_catalog_append_range_t>
     manager_disk_t::append_pg_catalog_row(execution_context_t ctx,
                                           components::catalog::oid_t table_oid,
                                           components::vector::data_chunk_t row) {
-        const bool wal_available = (manager_wal_ != actor_zeta::address_t::empty_address());
-        if (wal_available) {
-            auto wal_chunk = std::make_unique<components::vector::data_chunk_t>(resource(), row.types(), row.size());
-            wal_chunk->set_cardinality(row.size());
-            for (uint64_t col = 0; col < row.column_count(); col++) {
-                for (uint64_t r = 0; r < row.size(); r++) {
-                    wal_chunk->data[col].set_value(r, row.data[col].value(r));
+        if (!agents_.empty()) {
+            const std::size_t idx = pool_idx_for_oid(table_oid, agents_.size());
+            auto& agent = agents_[idx];
+            if (agent != nullptr) {
+                auto [needs_sched, fut] = actor_zeta::otterbrix::send(agent->address(),
+                                                                       &agent_disk_t::append_pg_catalog_row_inner,
+                                                                       ctx,
+                                                                       table_oid,
+                                                                       std::move(row));
+                if (needs_sched) {
+                    scheduler_disk_->enqueue(agent.get());
                 }
-            }
-            // pg_catalog writes route to main_database (ctx.database_oid is always
-            // INVALID_OID for catalog writes).
-            constexpr auto db_oid = components::catalog::well_known_oid::main_database;
-            auto [_w, wf] = actor_zeta::send(manager_wal_,
-                                             &wal::manager_wal_replicate_t::write_physical_insert,
-                                             ctx.session,
-                                             table_oid,
-                                             std::move(wal_chunk),
-                                             std::uint64_t{0},
-                                             static_cast<std::uint64_t>(row.size()),
-                                             ctx.txn.transaction_id,
-                                             db_oid);
-            if (auto wal_id = co_await std::move(wf); wal_id == wal::id_t{}) {
-                trace(log_,
-                      "pg_catalog insert WAL write returned zero id for oid={}",
-                      static_cast<unsigned>(table_oid));
+                co_return co_await std::move(fut);
             }
         }
-        const auto count = static_cast<std::uint64_t>(row.size());
-        const auto start_row = direct_append_sync(table_oid, row, ctx.session_tz, ctx.txn);
-        if (ctx.txn.transaction_id == 0 || count == 0) {
-            co_return components::pg_catalog_append_range_t{table_oid, static_cast<int64_t>(start_row), 0};
-        }
-        co_return components::pg_catalog_append_range_t{table_oid, static_cast<int64_t>(start_row), count};
+        co_return components::pg_catalog_append_range_t{table_oid, 0, 0};
     }
 
     manager_disk_t::unique_future<void> manager_disk_t::delete_pg_catalog_rows(execution_context_t ctx,
                                                                                components::catalog::oid_t table_oid,
                                                                                std::int64_t oid_col_idx,
                                                                                components::catalog::oid_t target_oid) {
-        // Thin wrapper over the shared per-item body (also looped by
-        // delete_pg_catalog_rows_many) so both paths emit identical WAL records.
-        co_await delete_pg_catalog_rows_one_(ctx, table_oid, oid_col_idx, target_oid);
+        // Single route to the agent inner body (the same body delete_pg_catalog_rows_many
+        // loops, so both paths emit identical WAL records).
+        if (!agents_.empty()) {
+            const std::size_t idx = pool_idx_for_oid(table_oid, agents_.size());
+            auto& agent = agents_[idx];
+            if (agent != nullptr) {
+                auto [needs_sched, fut] = actor_zeta::otterbrix::send(agent->address(),
+                                                                       &agent_disk_t::delete_pg_catalog_rows_inner,
+                                                                       ctx,
+                                                                       table_oid,
+                                                                       oid_col_idx,
+                                                                       target_oid);
+                if (needs_sched) {
+                    scheduler_disk_->enqueue(agent.get());
+                }
+                co_await std::move(fut);
+            }
+        }
         co_return;
     }
 
     manager_disk_t::unique_future<void>
     manager_disk_t::delete_pg_catalog_rows_many(execution_context_t ctx,
                                                 std::pmr::vector<pg_catalog_delete_spec_t> specs) {
-        // Loop the singular inner logic per spec; each spec emits the same WAL +
-        // storage records as one singular delete_pg_catalog_rows call. Serialized
-        // (co_await per spec) so the WAL ordering matches N successive singular calls.
+        // Loop-route per spec; each spec emits the same WAL + storage records as one
+        // singular delete_pg_catalog_rows call. Serialized (co_await per spec) so the
+        // WAL ordering matches N successive singular calls.
+        if (agents_.empty()) {
+            co_return;
+        }
         for (const auto& spec : specs) {
-            co_await delete_pg_catalog_rows_one_(ctx, spec.table_oid, spec.oid_col_idx, spec.target_oid);
-        }
-        co_return;
-    }
-
-    manager_disk_t::unique_future<void>
-    manager_disk_t::delete_pg_catalog_rows_one_(execution_context_t ctx,
-                                                components::catalog::oid_t table_oid,
-                                                std::int64_t oid_col_idx,
-                                                components::catalog::oid_t target_oid) {
-        // Catalog OIDs only (all route to agents_[0]). Null storage_entry_sync is a
-        // terminal "no entry"; the mutation half (direct_delete_sync) routes to the agent.
-        const collection_storage_entry_t* entry = nullptr;
-        if (!agents_.empty()) {
-            const std::size_t idx = pool_idx_for_oid(table_oid, agents_.size());
-            if (agents_[idx] != nullptr) {
-                entry = agents_[idx]->storage_entry_sync(table_oid);
+            const std::size_t idx = pool_idx_for_oid(spec.table_oid, agents_.size());
+            auto& agent = agents_[idx];
+            if (agent == nullptr) {
+                continue;
             }
-        }
-        if (entry == nullptr) {
-            co_return;
-        }
-        std::pmr::synchronized_pool_resource scan_resource;
-        std::pmr::vector<std::int64_t> row_ids(resource());
-        inline_scan(entry->table_storage.table(),
-                    {oid_col_idx},
-                    &scan_resource,
-                    [&, oid_col_idx](components::vector::data_chunk_t& chunk, uint64_t i) {
-                        auto v = chunk.value(static_cast<uint64_t>(oid_col_idx), i);
-                        if (v.is_null())
-                            return true;
-                        if (static_cast<components::catalog::oid_t>(v.value<std::uint32_t>()) == target_oid) {
-                            row_ids.push_back(chunk.row_ids.data<std::int64_t>()[i]);
-                        }
-                        return true;
-                    });
-        if (row_ids.empty()) {
-            co_return;
-        }
-        if (manager_wal_ != actor_zeta::address_t::empty_address()) {
-            std::pmr::vector<std::int64_t> wal_ids(row_ids.begin(), row_ids.end(), resource());
-            auto [_w, wf] = actor_zeta::send(manager_wal_,
-                                             &wal::manager_wal_replicate_t::write_physical_delete,
-                                             ctx.session,
-                                             table_oid,
-                                             std::move(wal_ids),
-                                             static_cast<std::uint64_t>(row_ids.size()),
-                                             ctx.txn.transaction_id,
-                                             components::catalog::well_known_oid::main_database);
-            if (auto wal_id = co_await std::move(wf); wal_id == wal::id_t{}) {
-                trace(log_,
-                      "pg_catalog delete WAL write returned zero id for oid={}",
-                      static_cast<unsigned>(table_oid));
+            auto [needs_sched, fut] = actor_zeta::otterbrix::send(agent->address(),
+                                                                   &agent_disk_t::delete_pg_catalog_rows_inner,
+                                                                   ctx,
+                                                                   spec.table_oid,
+                                                                   spec.oid_col_idx,
+                                                                   spec.target_oid);
+            if (needs_sched) {
+                scheduler_disk_->enqueue(agent.get());
             }
+            co_await std::move(fut);
         }
-        direct_delete_sync(table_oid, row_ids, static_cast<std::uint64_t>(row_ids.size()), ctx.txn);
         co_return;
     }
 
@@ -128,142 +95,32 @@ namespace services::disk {
         execution_context_t ctx,
         std::pmr::vector<components::pg_attribute_commit_id_backfill_t> backfills,
         std::uint64_t commit_id) {
-        // Loop the singular inner body per backfill with the shared commit_id; each
-        // emits its own physical_update WAL record. Serialized (co_await per item) so
-        // the per-backfill WAL records are emitted in order.
-        for (const auto& b : backfills) {
-            co_await update_pg_attribute_commit_id_field_one_(ctx, b.attoid, b.kind, commit_id);
-        }
-        co_return;
-    }
-
-    // See header for the contract. Implementation pitfall: data_table_t::update()
-    // rewrites EVERY column in the target row (it builds column_ids = [0..count)
-    // unconditionally in components/table/data_table.cpp), so a "patch one column"
-    // chunk would NULL out the other ten. We read the full row, mutate the target
-    // field in the read-back chunk, and write the whole chunk back.
-    manager_disk_t::unique_future<void> manager_disk_t::update_pg_attribute_commit_id_field_one_(
-        execution_context_t ctx,
-        components::catalog::oid_t attoid,
-        components::pg_attribute_commit_id_backfill_t::kind_t kind,
-        std::uint64_t commit_id) {
+        // Loop-route per backfill with the shared commit_id; each emits its own
+        // physical_update WAL record. pg_attribute always routes to agents_[0].
+        // Serialized (co_await per item) so the per-backfill WAL records are emitted
+        // in order.
         constexpr auto pg_attr_oid = components::catalog::well_known_oid::pg_attribute_table;
-        // pg_attribute routes to agents_[0]. Null storage_entry_sync is a terminal
-        // "no entry"; the mutation half (direct_update_sync) routes to the agent.
-        const collection_storage_entry_t* entry = nullptr;
-        if (!agents_.empty()) {
-            const std::size_t idx = pool_idx_for_oid(pg_attr_oid, agents_.size());
-            if (agents_[idx] != nullptr) {
-                entry = agents_[idx]->storage_entry_sync(pg_attr_oid);
-            }
-        }
-        if (entry == nullptr) {
+        if (agents_.empty()) {
             co_return;
         }
-
-        // Scan all columns for the attoid row, capturing row_id + a snapshot of
-        // every column value. attoid is never reused, so at most one row matches.
-        auto& tbl = entry->table_storage.table();
-        const std::size_t col_count = tbl.column_count();
-        std::vector<std::int64_t> all_col_indices;
-        all_col_indices.reserve(col_count);
-        for (std::size_t i = 0; i < col_count; ++i) {
-            all_col_indices.push_back(static_cast<std::int64_t>(i));
-        }
-
-        std::pmr::synchronized_pool_resource scan_resource;
-        std::pmr::vector<std::int64_t> row_ids(resource());
-        std::pmr::vector<components::types::logical_value_t> row_values(resource());
-        row_values.reserve(col_count);
-
-        inline_scan(tbl,
-                    all_col_indices,
-                    &scan_resource,
-                    [&](components::vector::data_chunk_t& chunk, uint64_t i) {
-                        auto v0 = chunk.value(0, i);
-                        if (v0.is_null())
-                            return true;
-                        if (static_cast<components::catalog::oid_t>(v0.value<std::uint32_t>()) != attoid)
-                            return true;
-                        row_ids.push_back(chunk.row_ids.data<std::int64_t>()[i]);
-                        for (std::size_t c = 0; c < col_count; ++c) {
-                            row_values.push_back(chunk.value(static_cast<uint64_t>(c), i));
-                        }
-                        return false; // single-row identity — short-circuit
-                    });
-        if (row_ids.empty()) {
-            trace(log_,
-                  "update_pg_attribute_commit_id_field: attoid={} not found (skipping backfill)",
-                  static_cast<unsigned>(attoid));
+        const std::size_t idx = pool_idx_for_oid(pg_attr_oid, agents_.size());
+        auto& agent = agents_[idx];
+        if (agent == nullptr) {
             co_return;
         }
-
-        // Patch the target column: 10 = added_at_commit_id, 11 = dropped_at_commit_id
-        // (see system_table_schemas.cpp pg_attribute_columns()).
-        const std::size_t patch_col_idx =
-            (kind == components::pg_attribute_commit_id_backfill_t::kind_t::added_at) ? 10u : 11u;
-        if (patch_col_idx >= row_values.size()) {
-            trace(log_,
-                  "update_pg_attribute_commit_id_field: patch_col_idx={} out of range (col_count={})",
-                  patch_col_idx,
-                  col_count);
-            co_return;
-        }
-        row_values[patch_col_idx] =
-            components::types::logical_value_t(resource(), static_cast<std::int64_t>(commit_id));
-
-        // Build a full-width update chunk: every column keeps its scanned value,
-        // only patch_col_idx gets the new commit_id. Aliases mirror the table's
-        // column names so direct_update_sync's name-match routing lands each vector
-        // on the correct storage column.
-        const auto& table_columns = entry->table_storage.table().columns();
-        std::pmr::vector<components::types::complex_logical_type> chunk_types(resource());
-        chunk_types.reserve(table_columns.size());
-        for (const auto& col_def : table_columns) {
-            auto t = col_def.type();
-            t.set_alias(col_def.name());
-            chunk_types.push_back(std::move(t));
-        }
-        components::vector::data_chunk_t patch(resource(), chunk_types, 1);
-        patch.set_cardinality(1);
-        for (std::size_t c = 0; c < table_columns.size() && c < row_values.size(); ++c) {
-            if (row_values[c].is_null()) {
-                patch.data[c].validity().set_invalid(0);
-            } else {
-                patch.data[c].set_value(0, row_values[c]);
+        for (const auto& b : backfills) {
+            auto [needs_sched, fut] =
+                actor_zeta::otterbrix::send(agent->address(),
+                                             &agent_disk_t::update_pg_attribute_commit_id_field_inner,
+                                             ctx,
+                                             b.attoid,
+                                             b.kind,
+                                             commit_id);
+            if (needs_sched) {
+                scheduler_disk_->enqueue(agent.get());
             }
+            co_await std::move(fut);
         }
-
-        // WAL physical_update: the chunk mirrors the patch chunk full-width so
-        // replay's direct_update_sync takes the same alias-matching path.
-        if (manager_wal_ != actor_zeta::address_t::empty_address()) {
-            auto wal_chunk = std::make_unique<components::vector::data_chunk_t>(resource(), chunk_types, 1);
-            wal_chunk->set_cardinality(1);
-            for (std::size_t c = 0; c < table_columns.size() && c < row_values.size(); ++c) {
-                if (row_values[c].is_null()) {
-                    wal_chunk->data[c].validity().set_invalid(0);
-                } else {
-                    wal_chunk->data[c].set_value(0, row_values[c]);
-                }
-            }
-            std::pmr::vector<std::int64_t> wal_row_ids(row_ids.begin(), row_ids.end(), resource());
-            auto [_w, wf] = actor_zeta::send(manager_wal_,
-                                             &wal::manager_wal_replicate_t::write_physical_update,
-                                             ctx.session,
-                                             pg_attr_oid,
-                                             std::move(wal_row_ids),
-                                             std::move(wal_chunk),
-                                             static_cast<std::uint64_t>(row_ids.size()),
-                                             ctx.txn.transaction_id,
-                                             components::catalog::well_known_oid::main_database);
-            if (auto wal_id = co_await std::move(wf); wal_id == wal::id_t{}) {
-                trace(log_,
-                      "update_pg_attribute_commit_id_field: WAL write returned zero id for attoid={}",
-                      static_cast<unsigned>(attoid));
-            }
-        }
-
-        direct_update_sync(pg_attr_oid, row_ids, patch);
         co_return;
     }
 
@@ -271,51 +128,24 @@ namespace services::disk {
     manager_disk_t::compact_relkind_g_storage(execution_context_t /*ctx*/,
                                               components::catalog::oid_t table_oid,
                                               std::set<std::string> live_attnames) {
-        // Read the column list via storage_entry_sync (borrow safe while the agent
-        // mailbox is idle), then forward each drop via mailbox to drop_column_inner.
-        if (agents_.empty())
-            co_return 0;
-        const std::size_t pool_idx = pool_idx_for_oid(table_oid, agents_.size());
-        if (agents_[pool_idx] == nullptr)
-            co_return 0;
-        const collection_storage_entry_t* read_entry = agents_[pool_idx]->storage_entry_sync(table_oid);
-        if (read_entry == nullptr)
-            co_return 0;
-        if (read_entry->table_storage.mode() != storage_mode_t::IN_MEMORY) {
-            trace(log_,
-                  "compact_relkind_g_storage: skip DISK-backed oid={} (out of scope)",
-                  static_cast<unsigned>(table_oid));
-            co_return 0;
-        }
-
-        std::vector<std::string> to_drop;
-        {
-            const auto& cols = read_entry->table_storage.table().columns();
-            to_drop.reserve(cols.size());
-            for (const auto& c : cols) {
-                if (live_attnames.find(c.name()) == live_attnames.end()) {
-                    to_drop.push_back(c.name());
+        // Single route: the whole compaction (read mode + columns, compute to_drop,
+        // drop each, count) runs intra-agent in compact_relkind_g_storage_inner —
+        // no per-column manager↔agent round-trips.
+        if (!agents_.empty()) {
+            const std::size_t idx = pool_idx_for_oid(table_oid, agents_.size());
+            auto& agent = agents_[idx];
+            if (agent != nullptr) {
+                auto [needs_sched, fut] = actor_zeta::otterbrix::send(agent->address(),
+                                                                       &agent_disk_t::compact_relkind_g_storage_inner,
+                                                                       table_oid,
+                                                                       std::move(live_attnames));
+                if (needs_sched) {
+                    scheduler_disk_->enqueue(agent.get());
                 }
+                co_return co_await std::move(fut);
             }
         }
-
-        // drop_column_inner returns void, but the dropped count equals to_drop.size()
-        // because this manager handler is the sole writer for the OID — to_drop came
-        // from a fresh read of the agent's own twin a few lines above.
-        auto& agent = agents_[pool_idx];
-        for (const auto& attname : to_drop) {
-            std::pmr::string column_name{attname.data(), attname.size(), resource()};
-            auto [needs_sched, fut] =
-                actor_zeta::otterbrix::send(agent->address(),
-                                             &agent_disk_t::drop_column_inner,
-                                             table_oid,
-                                             std::move(column_name));
-            if (needs_sched) {
-                scheduler_disk_->enqueue(agent.get());
-            }
-            co_await std::move(fut);
-        }
-        co_return static_cast<std::uint64_t>(to_drop.size());
+        co_return 0;
     }
 
 } // namespace services::disk

--- a/services/disk/manager_disk_impl.hpp
+++ b/services/disk/manager_disk_impl.hpp
@@ -4,6 +4,7 @@
 // Centralises includes and exposes the shared helpers that all TUs need.
 
 #include "manager_disk.hpp"
+#include "inline_scan.hpp" // services::disk::detail::inline_scan (shared with agent_disk)
 
 #include <actor-zeta/spawn.hpp>
 #include <algorithm>
@@ -42,18 +43,6 @@ namespace services::disk {
             return components::types::logical_value_t(r, std::move(v));
         }
 
-        inline components::types::logical_value_t lv_i32(std::pmr::memory_resource* r, std::int32_t v) {
-            return components::types::logical_value_t(r, v);
-        }
-
-        inline components::types::logical_value_t lv_i64(std::pmr::memory_resource* r, std::int64_t v) {
-            return components::types::logical_value_t(r, v);
-        }
-
-        inline components::types::logical_value_t lv_bool(std::pmr::memory_resource* r, bool v) {
-            return components::types::logical_value_t(r, v);
-        }
-
         // ---------------------------------------------------------------------------
         // make_row: allocate a single-row data_chunk_t and fill it via a lambda.
         // Usage: make_row(resource, def->columns, [&](data_chunk_t& chunk, auto* res) { ... })
@@ -84,92 +73,8 @@ namespace services::disk {
             return v.value<std::string_view>() == std::string_view(s);
         }
 
-        // ---------------------------------------------------------------------------
-        // inline_scan: scan all committed rows of a data_table_t, projecting the given
-        // column indices.  Calls fn(chunk, row_index) for every row; returning false
-        // from fn stops the scan early.
-        // ---------------------------------------------------------------------------
-
-        namespace detail_impl_ {
-            template<typename Range, typename Fn>
-            void inline_scan_range(components::table::data_table_t& table,
-                                   const Range& col_indices,
-                                   std::pmr::memory_resource* resource,
-                                   Fn&& fn) {
-                std::vector<components::table::storage_index_t> col_ids;
-                const auto& all_cols = table.columns();
-                // row_group_t::scan_committed writes to result.data[column.primary_index()] —
-                // i.e. it indexes by storage column position, not by row in `col_ids`. So the
-                // chunk must have a slot at every storage column index that appears in
-                // col_indices. Use the projected_cols ctor to allocate buffers only for the
-                // requested columns (other slots are placeholders, no data buffer).
-                std::pmr::vector<components::types::complex_logical_type> all_types(resource);
-                all_types.reserve(all_cols.size());
-                for (const auto& c : all_cols) {
-                    all_types.push_back(c.type());
-                }
-                std::vector<size_t> projected;
-                projected.reserve(
-                    static_cast<std::size_t>(std::distance(std::begin(col_indices), std::end(col_indices))));
-                for (auto idx : col_indices) {
-                    col_ids.emplace_back(static_cast<uint64_t>(idx));
-                    projected.push_back(static_cast<std::size_t>(idx));
-                }
-
-                components::table::table_scan_state state(resource);
-                table.initialize_scan(state, col_ids);
-
-                while (true) {
-                    components::vector::data_chunk_t chunk(resource,
-                                                           all_types,
-                                                           projected,
-                                                           components::vector::DEFAULT_VECTOR_CAPACITY);
-                    table.scan(chunk, state);
-                    if (chunk.size() == 0)
-                        break;
-                    for (uint64_t i = 0; i < chunk.size(); ++i) {
-                        if (!fn(chunk, i))
-                            return;
-                    }
-                }
-            }
-        } // namespace detail_impl_
-
-        template<typename Fn>
-        void inline_scan(components::table::data_table_t& table,
-                         std::initializer_list<std::int64_t> col_indices,
-                         std::pmr::memory_resource* resource,
-                         Fn&& fn) {
-            detail_impl_::inline_scan_range(table, col_indices, resource, std::forward<Fn>(fn));
-        }
-
-        template<typename Fn>
-        void inline_scan(components::table::data_table_t& table,
-                         const std::vector<std::int64_t>& col_indices,
-                         std::pmr::memory_resource* resource,
-                         Fn&& fn) {
-            detail_impl_::inline_scan_range(table, col_indices, resource, std::forward<Fn>(fn));
-        }
-
-        // const overload: data_table_t::scan is read-only but not declared const,
-        // so the const_cast is safe.
-        template<typename Fn>
-        void inline_scan(const components::table::data_table_t& table,
-                         std::initializer_list<std::int64_t> col_indices,
-                         std::pmr::memory_resource* resource,
-                         Fn&& fn) {
-            detail_impl_::inline_scan_range(const_cast<components::table::data_table_t&>(table),
-                                            col_indices, resource, std::forward<Fn>(fn));
-        }
-
-        template<typename Fn>
-        void inline_scan(const components::table::data_table_t& table,
-                         const std::vector<std::int64_t>& col_indices,
-                         std::pmr::memory_resource* resource,
-                         Fn&& fn) {
-            detail_impl_::inline_scan_range(const_cast<components::table::data_table_t&>(table),
-                                            col_indices, resource, std::forward<Fn>(fn));
-        }
+        // inline_scan(...) lives in services/disk/inline_scan.hpp (shared with agent_disk);
+        // it is in namespace services::disk::detail, so "using namespace detail" exposes it here.
 
         // ---------------------------------------------------------------------------
         // rebuild_chunk: copy a data_chunk_t into a new one backed by `resource`.

--- a/services/disk/manager_disk_io.cpp
+++ b/services/disk/manager_disk_io.cpp
@@ -6,7 +6,17 @@ namespace services::disk {
     namespace catalog = components::catalog;
     using namespace detail;
 
-    void manager_disk_t::sync(disk_sync_pack_t pack) { manager_wal_ = pack.wal; }
+    void manager_disk_t::sync(disk_sync_pack_t pack) {
+        manager_wal_ = pack.wal;
+        // Fan the WAL address into every agent so the CATALOG agent can write physical
+        // WAL records for catalog DDL on its own thread. Bootstrap-only (single-threaded,
+        // agents already spawned in the ctor). No-op when no agents (empty config path).
+        for (auto& agent : agents_) {
+            if (agent != nullptr) {
+                agent->set_manager_wal_sync(pack.wal);
+            }
+        }
+    }
 
     void manager_disk_t::create_agent(int count_agents) {
         // Roles align with pool_idx_for_oid: slot 0 = CATALOG (pg_* system
@@ -31,10 +41,12 @@ namespace services::disk {
                                                                             wal::id_t current_wal_id) {
         trace(log_, "manager_disk_t::checkpoint_all , session : {} , wal_id : {}", session.data(), current_wal_id);
 
-        // Fan checkpoint_inner to every agent; each returns
-        // min(prev_checkpoint_wal_id_) over its DISK entries, or max() sentinel when
-        // it owns no DISK entry.
-        std::pmr::vector<unique_future<wal::id_t>> agent_futures{resource()};
+        // Fan checkpoint_inner to every agent; each returns a checkpoint_result_t with
+        // min(prev_checkpoint_wal_id_) over its DISK entries (max() sentinel when it owns
+        // none) AND a has_in_memory flag — folding the former post-await
+        // has_in_memory_inner_sync read into the fan-out so no synchronous cross-actor
+        // slice read remains.
+        std::pmr::vector<unique_future<checkpoint_result_t>> agent_futures{resource()};
         agent_futures.reserve(agents_.size());
         for (auto& agent_ptr : agents_) {
             auto [needs_sched, fut] = actor_zeta::otterbrix::send(agent_ptr->address(),
@@ -47,26 +59,21 @@ namespace services::disk {
             agent_futures.emplace_back(std::move(fut));
         }
 
+        // Aggregate: min over min_prev_checkpoint_wal_id AND OR over has_in_memory.
         wal::id_t min_prev_id = std::numeric_limits<wal::id_t>::max();
+        bool any_in_memory = false;
         for (auto& f : agent_futures) {
-            auto agent_min = co_await std::move(f);
-            min_prev_id = std::min(min_prev_id, agent_min);
+            auto agent_result = co_await std::move(f);
+            min_prev_id = std::min(min_prev_id, agent_result.min_prev_checkpoint_wal_id);
+            any_in_memory = any_in_memory || agent_result.has_in_memory;
         }
 
         if (!agents_.empty()) {
             // IN_MEMORY-twin WAL-seal suppression. The min() tally can't tell "no
             // DISK entry + no IN_MEMORY twin" (safe to seal) from "no DISK entry +
             // IN_MEMORY twin" (must NOT seal — those tables still need replay
-            // records). has_in_memory_inner_sync supplies the missing signal. The
-            // mailbox-free sync read is legal here: we just awaited every agent's
-            // mailbox, so agents are idle and the manager is their only writer.
-            bool any_in_memory = false;
-            for (const auto& agent_ptr : agents_) {
-                if (agent_ptr != nullptr && agent_ptr->has_in_memory_inner_sync()) {
-                    any_in_memory = true;
-                    break;
-                }
-            }
+            // records). any_in_memory comes from the checkpoint_inner fan-out above,
+            // so no synchronous slice read is needed here.
 
             // Seal only when some agent actually checkpointed a DISK entry (min_prev_id
             // still max() => none did) AND no IN_MEMORY twin exists anywhere.

--- a/services/disk/manager_disk_resolve.cpp
+++ b/services/disk/manager_disk_resolve.cpp
@@ -11,9 +11,9 @@ namespace services::disk {
     // storage_entry_sync pointer — serialises against agent-0's compact path
     // (checkpoint/vacuum/maybe_cleanup_inner) running on the scheduler_disk_
     // threads, avoiding a borrowed-pointer race. transaction_data{} = "see all
-    // committed". read_chunks_by_key adds one hop:
-    // storage_column_names_inner resolves column NAMES to indices, then the
-    // filter is built manager-side and shipped to storage_scan_batched_inner.
+    // committed". read_chunks_by_key is a thin router: the column NAME→index
+    // resolution and the eq-AND filtered scan both run intra-agent in
+    // read_chunks_by_key_inner.
 
     manager_disk_t::unique_future<resolve_namespace_result_t>
     manager_disk_t::resolve_namespace(execution_context_t /*ctx*/, std::string name, std::uint64_t /*since_version*/) {
@@ -45,482 +45,6 @@ namespace services::disk {
                     out.found = true;
                     out.oid = static_cast<components::catalog::oid_t>(oid_v.value<std::uint32_t>());
                     out.name = name;
-                    stop = true;
-                    break;
-                }
-                if (stop)
-                    break;
-            }
-        }
-        co_return out;
-    }
-
-    manager_disk_t::unique_future<resolve_table_result_t>
-    manager_disk_t::resolve_table(execution_context_t ctx,
-                                  components::catalog::oid_t namespace_oid,
-                                  std::string name,
-                                  std::uint64_t /*since_version*/) {
-        resolve_table_result_t out(resource());
-        out.namespace_oid = namespace_oid;
-
-        if (!agents_.empty() && agents_[0] != nullptr) {
-            const std::size_t idx = pool_idx_for_oid(pg_class_oid, agents_.size());
-            std::vector<size_t> projected{0, 1, 2, 3};
-            auto [needs_sched, fut] = actor_zeta::otterbrix::send(agents_[idx]->address(),
-                                                                  &agent_disk_t::storage_scan_batched_inner,
-                                                                  pg_class_oid,
-                                                                  std::unique_ptr<components::table::table_filter_t>{},
-                                                                  int64_t{-1},
-                                                                  std::move(projected),
-                                                                  components::table::transaction_data{});
-            if (needs_sched) {
-                scheduler_disk_->enqueue(agents_[idx].get());
-            }
-            auto batches = co_await std::move(fut);
-            for (auto& chunk : batches) {
-                bool stop = false;
-                for (uint64_t i = 0; i < chunk.size(); ++i) {
-                    auto ns_v = chunk.value(2, i);
-                    if (ns_v.is_null())
-                        continue;
-                    if (static_cast<components::catalog::oid_t>(ns_v.value<std::uint32_t>()) != namespace_oid)
-                        continue;
-                    auto name_v = chunk.value(1, i);
-                    if (name_v.is_null() || name_v.value<std::string_view>() != name)
-                        continue;
-                    out.found = true;
-                    out.oid = static_cast<components::catalog::oid_t>(chunk.value(0, i).value<std::uint32_t>());
-                    out.name = name;
-                    auto kind_v = chunk.value(3, i);
-                    if (!kind_v.is_null()) {
-                        auto ks = kind_v.value<std::string_view>();
-                        if (!ks.empty())
-                            out.relkind = ks.front();
-                    }
-                    stop = true;
-                    break;
-                }
-                if (stop)
-                    break;
-            }
-        }
-
-        if (!out.found) {
-            co_return out;
-        }
-
-        if (out.relkind == catalog::relkind::computed) {
-            if (!agents_.empty() && agents_[0] != nullptr) {
-                struct cc_row_t {
-                    components::catalog::oid_t attoid;
-                    std::string attname;
-                    components::catalog::oid_t atttypid;
-                    std::int64_t attversion;
-                };
-                std::unordered_map<std::string, cc_row_t> latest;
-                // Collect ALL rows (including tombstones with rc=0) and pick
-                // max-version per attname. Then drop entries whose chosen
-                // (max-version) row is a tombstone. Skipping tombstones early
-                // would let a lower-version live row survive a DROP COLUMN whose
-                // tombstone has version=N+1.
-                // Read atttypspec (column 4) for complex types — attversion /
-                // attrefcount live at columns 5 / 6.
-                struct cc_row_with_rc_t {
-                    cc_row_t base;
-                    std::string atttypspec;
-                    std::int64_t attrefcount;
-                };
-                std::unordered_map<std::string, cc_row_with_rc_t> latest_any;
-                const std::size_t cc_idx = pool_idx_for_oid(pg_computed_column_oid, agents_.size());
-                std::vector<size_t> cc_projected{0, 1, 2, 3, 4, 5, 6};
-                auto [cc_needs_sched, cc_fut] =
-                    actor_zeta::otterbrix::send(agents_[cc_idx]->address(),
-                                                &agent_disk_t::storage_scan_batched_inner,
-                                                pg_computed_column_oid,
-                                                std::unique_ptr<components::table::table_filter_t>{},
-                                                int64_t{-1},
-                                                std::move(cc_projected),
-                                                components::table::transaction_data{});
-                if (cc_needs_sched) {
-                    scheduler_disk_->enqueue(agents_[cc_idx].get());
-                }
-                auto cc_batches = co_await std::move(cc_fut);
-                for (auto& chunk : cc_batches) {
-                    for (uint64_t i = 0; i < chunk.size(); ++i) {
-                        auto rel = chunk.value(0, i);
-                        if (rel.is_null())
-                            continue;
-                        if (static_cast<components::catalog::oid_t>(rel.value<std::uint32_t>()) != out.oid)
-                            continue;
-                        cc_row_with_rc_t row;
-                        row.base.attoid =
-                            static_cast<components::catalog::oid_t>(chunk.value(1, i).value<std::uint32_t>());
-                        row.base.attname = std::string(chunk.value(2, i).value<std::string_view>());
-                        row.base.atttypid = chunk.value(3, i).is_null()
-                                                ? components::catalog::INVALID_OID
-                                                : static_cast<components::catalog::oid_t>(
-                                                      chunk.value(3, i).value<std::uint32_t>());
-                        auto spec_v = chunk.value(4, i);
-                        if (!spec_v.is_null())
-                            row.atttypspec = std::string(spec_v.value<std::string_view>());
-                        row.base.attversion = chunk.value(5, i).value<std::int64_t>();
-                        auto rc_v = chunk.value(6, i);
-                        row.attrefcount = rc_v.is_null() ? 0 : rc_v.value<std::int64_t>();
-                        auto it = latest_any.find(row.base.attname);
-                        if (it == latest_any.end() || it->second.base.attversion < row.base.attversion) {
-                            latest_any[row.base.attname] = std::move(row);
-                        }
-                    }
-                }
-                // Filter: column is live iff its max-version row has rc > 0.
-                std::unordered_map<std::string, std::string> typspec_by_name;
-                for (auto& [name, full] : latest_any) {
-                    if (full.attrefcount > 0) {
-                        typspec_by_name[name] = std::move(full.atttypspec);
-                        latest[name] = std::move(full.base);
-                    }
-                }
-                // Order by attoid ASC: attoid is allocated monotonically in
-                // operator_computed_field_register::await_async_and_resume by iterating
-                // columns_ vector in order, so attoid order == register order ==
-                // storage's adopt_schema(local.types()) order. Without this sort the
-                // unordered_map's bucket-order would produce indices that don't match
-                // the storage chunk's column layout, breaking WHERE-filter routing
-                // (filter applied to the wrong column → 0 rows).
-                std::vector<cc_row_t> ordered;
-                ordered.reserve(latest.size());
-                for (auto& [_, row] : latest) ordered.push_back(std::move(row));
-                std::sort(ordered.begin(), ordered.end(), [](const cc_row_t& a, const cc_row_t& b) {
-                    return a.attoid < b.attoid;
-                });
-                std::int32_t synthetic_attnum = 1;
-                for (auto& row : ordered) {
-                    column_info_t info;
-                    info.attoid = row.attoid;
-                    info.attname = row.attname; // copy: typspec lookup below needs name
-                    info.atttypid = row.atttypid;
-                    auto ts_it = typspec_by_name.find(info.attname);
-                    if (ts_it != typspec_by_name.end())
-                        info.atttypspec = std::move(ts_it->second);
-                    info.attnum = synthetic_attnum++;
-                    info.attnotnull = false;
-                    info.atthasdefault = false;
-                    info.attisdropped = false;
-                    out.columns.push_back(std::move(info));
-                }
-            }
-            co_return out;
-        }
-
-        if (!agents_.empty() && agents_[0] != nullptr) {
-            std::vector<column_info_t> rows;
-            // Column MVCC: read added_at_commit_id (col 10) + dropped_at_commit_id
-            // (col 11), filter by ctx.txn.start_time.
-            const auto snapshot_start_time = ctx.txn.start_time;
-            const std::size_t att_idx = pool_idx_for_oid(pg_attribute_oid, agents_.size());
-            std::vector<size_t> att_projected{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
-            auto [att_needs_sched, att_fut] =
-                actor_zeta::otterbrix::send(agents_[att_idx]->address(),
-                                            &agent_disk_t::storage_scan_batched_inner,
-                                            pg_attribute_oid,
-                                            std::unique_ptr<components::table::table_filter_t>{},
-                                            int64_t{-1},
-                                            std::move(att_projected),
-                                            components::table::transaction_data{});
-            if (att_needs_sched) {
-                scheduler_disk_->enqueue(agents_[att_idx].get());
-            }
-            auto att_batches = co_await std::move(att_fut);
-            for (auto& chunk : att_batches) {
-                for (uint64_t i = 0; i < chunk.size(); ++i) {
-                    auto rel = chunk.value(1, i);
-                    if (rel.is_null())
-                        continue;
-                    if (static_cast<components::catalog::oid_t>(rel.value<std::uint32_t>()) != out.oid)
-                        continue;
-                    auto dropped = chunk.value(7, i);
-                    const bool is_dropped = !dropped.is_null() && dropped.value<bool>();
-                    if (is_dropped)
-                        continue;
-                    // MVCC visibility — column added after snapshot is hidden;
-                    // column dropped before snapshot is hidden.
-                    auto added_at_v = chunk.value(10, i);
-                    if (!added_at_v.is_null()) {
-                        auto added_at = static_cast<uint64_t>(added_at_v.value<std::int64_t>());
-                        if (added_at > snapshot_start_time)
-                            continue;
-                    }
-                    auto dropped_at_v = chunk.value(11, i);
-                    if (!dropped_at_v.is_null()) {
-                        auto dropped_at = static_cast<uint64_t>(dropped_at_v.value<std::int64_t>());
-                        if (dropped_at != 0 && dropped_at <= snapshot_start_time)
-                            continue;
-                    }
-                    column_info_t info;
-                    info.attoid =
-                        static_cast<components::catalog::oid_t>(chunk.value(0, i).value<std::uint32_t>());
-                    auto name_v = chunk.value(2, i);
-                    if (!name_v.is_null())
-                        info.attname = std::string(name_v.value<std::string_view>());
-                    auto typid_v = chunk.value(3, i);
-                    if (!typid_v.is_null())
-                        info.atttypid = static_cast<components::catalog::oid_t>(typid_v.value<std::uint32_t>());
-                    info.attnum = chunk.value(4, i).value<std::int32_t>();
-                    auto nn_v = chunk.value(5, i);
-                    info.attnotnull = !nn_v.is_null() && nn_v.value<bool>();
-                    auto def_v = chunk.value(6, i);
-                    info.atthasdefault = !def_v.is_null() && def_v.value<bool>();
-                    info.attisdropped = false;
-                    auto typspec_v = chunk.value(8, i);
-                    if (!typspec_v.is_null())
-                        info.atttypspec = std::string(typspec_v.value<std::string_view>());
-                    auto defspec_v = chunk.value(9, i);
-                    if (!defspec_v.is_null())
-                        info.attdefspec = std::string(defspec_v.value<std::string_view>());
-                    rows.push_back(std::move(info));
-                }
-            }
-            std::sort(rows.begin(), rows.end(), [](const column_info_t& a, const column_info_t& b) {
-                return a.attnum < b.attnum;
-            });
-            out.columns = std::move(rows);
-            trace(log_, "resolve_table: oid={} found {} columns", out.oid, out.columns.size());
-            for (const auto& c : out.columns) {
-                trace(log_,
-                      "  col={} atttypid={} atttypspec='{}'",
-                      c.attname,
-                      static_cast<unsigned>(c.atttypid),
-                      c.atttypspec);
-            }
-        }
-        co_return out;
-    }
-
-    manager_disk_t::unique_future<resolve_type_result_t>
-    manager_disk_t::resolve_type_sync(components::catalog::oid_t namespace_oid, const std::string& name) {
-        resolve_type_result_t out(resource());
-        out.namespace_oid = namespace_oid;
-
-        if (!agents_.empty() && agents_[0] != nullptr) {
-            const std::size_t type_idx = pool_idx_for_oid(pg_type_oid, agents_.size());
-            std::vector<size_t> type_projected{0, 1, 2, 3};
-            auto [type_needs_sched, type_fut] =
-                actor_zeta::otterbrix::send(agents_[type_idx]->address(),
-                                            &agent_disk_t::storage_scan_batched_inner,
-                                            pg_type_oid,
-                                            std::unique_ptr<components::table::table_filter_t>{},
-                                            int64_t{-1},
-                                            std::move(type_projected),
-                                            components::table::transaction_data{});
-            if (type_needs_sched) {
-                scheduler_disk_->enqueue(agents_[type_idx].get());
-            }
-            auto type_batches = co_await std::move(type_fut);
-            for (auto& chunk : type_batches) {
-                bool stop = false;
-                for (uint64_t i = 0; i < chunk.size(); ++i) {
-                    auto ns = chunk.value(2, i);
-                    if (ns.is_null())
-                        continue;
-                    if (static_cast<components::catalog::oid_t>(ns.value<std::uint32_t>()) != namespace_oid)
-                        continue;
-                    if (!str_equals(chunk.value(1, i), name))
-                        continue;
-                    out.found = true;
-                    out.oid = static_cast<components::catalog::oid_t>(chunk.value(0, i).value<std::uint32_t>());
-                    out.name = name;
-                    auto def_v = chunk.value(3, i);
-                    if (!def_v.is_null())
-                        out.typdefspec = std::string(def_v.value<std::string_view>());
-                    stop = true;
-                    break;
-                }
-                if (stop)
-                    break;
-            }
-        }
-        if (out.found) {
-            co_return out;
-        }
-        if (agents_.empty() || agents_[0] == nullptr) {
-            co_return out;
-        }
-        components::catalog::oid_t composite_oid = components::catalog::INVALID_OID;
-        {
-            const std::size_t cls_idx = pool_idx_for_oid(pg_class_oid, agents_.size());
-            std::vector<size_t> cls_projected{0, 1, 2, 3};
-            auto [cls_needs_sched, cls_fut] =
-                actor_zeta::otterbrix::send(agents_[cls_idx]->address(),
-                                            &agent_disk_t::storage_scan_batched_inner,
-                                            pg_class_oid,
-                                            std::unique_ptr<components::table::table_filter_t>{},
-                                            int64_t{-1},
-                                            std::move(cls_projected),
-                                            components::table::transaction_data{});
-            if (cls_needs_sched) {
-                scheduler_disk_->enqueue(agents_[cls_idx].get());
-            }
-            auto cls_batches = co_await std::move(cls_fut);
-            for (auto& chunk : cls_batches) {
-                bool stop = false;
-                for (uint64_t i = 0; i < chunk.size(); ++i) {
-                    auto rns_v = chunk.value(2, i);
-                    if (rns_v.is_null())
-                        continue;
-                    if (static_cast<components::catalog::oid_t>(rns_v.value<std::uint32_t>()) != namespace_oid)
-                        continue;
-                    auto kind_v = chunk.value(3, i);
-                    if (kind_v.is_null())
-                        continue;
-                    auto kind_s = kind_v.value<std::string_view>();
-                    if (kind_s.empty() || kind_s.front() != catalog::relkind::composite_type)
-                        continue;
-                    if (!str_equals(chunk.value(1, i), name))
-                        continue;
-                    composite_oid =
-                        static_cast<components::catalog::oid_t>(chunk.value(0, i).value<std::uint32_t>());
-                    stop = true;
-                    break;
-                }
-                if (stop)
-                    break;
-            }
-        }
-        if (composite_oid == components::catalog::INVALID_OID) {
-            co_return out;
-        }
-        struct field_row {
-            std::string attname;
-            components::catalog::oid_t atttypid{components::catalog::INVALID_OID};
-            std::int32_t attnum{0};
-            std::string atttypspec;
-        };
-        std::vector<field_row> fields;
-        {
-            const std::size_t att_idx = pool_idx_for_oid(pg_attribute_oid, agents_.size());
-            std::vector<size_t> att_projected{1, 2, 3, 4, 7, 8};
-            auto [att_needs_sched, att_fut] =
-                actor_zeta::otterbrix::send(agents_[att_idx]->address(),
-                                            &agent_disk_t::storage_scan_batched_inner,
-                                            pg_attribute_oid,
-                                            std::unique_ptr<components::table::table_filter_t>{},
-                                            int64_t{-1},
-                                            std::move(att_projected),
-                                            components::table::transaction_data{});
-            if (att_needs_sched) {
-                scheduler_disk_->enqueue(agents_[att_idx].get());
-            }
-            auto att_batches = co_await std::move(att_fut);
-            for (auto& chunk : att_batches) {
-                for (uint64_t i = 0; i < chunk.size(); ++i) {
-                    auto rel = chunk.value(0, i);
-                    if (rel.is_null())
-                        continue;
-                    if (static_cast<components::catalog::oid_t>(rel.value<std::uint32_t>()) != composite_oid)
-                        continue;
-                    auto dropped = chunk.value(4, i);
-                    if (!dropped.is_null() && dropped.value<bool>())
-                        continue;
-                    field_row r;
-                    auto name_v = chunk.value(1, i);
-                    if (!name_v.is_null())
-                        r.attname = std::string(name_v.value<std::string_view>());
-                    auto typid_v = chunk.value(2, i);
-                    if (!typid_v.is_null())
-                        r.atttypid = static_cast<components::catalog::oid_t>(typid_v.value<std::uint32_t>());
-                    r.attnum = chunk.value(3, i).value<std::int32_t>();
-                    auto spec_v = chunk.value(5, i);
-                    if (!spec_v.is_null())
-                        r.atttypspec = std::string(spec_v.value<std::string_view>());
-                    fields.push_back(std::move(r));
-                }
-            }
-        }
-        std::sort(fields.begin(), fields.end(), [](const field_row& a, const field_row& b) {
-            return a.attnum < b.attnum;
-        });
-        std::pmr::vector<components::types::complex_logical_type> child_types(resource());
-        child_types.reserve(fields.size());
-        for (auto& f : fields) {
-            components::types::complex_logical_type ft =
-                f.atttypspec.empty()
-                    ? components::types::complex_logical_type{components::catalog::oid_to_builtin_type(f.atttypid)}
-                    : components::catalog::decode_type_spec(resource(), f.atttypspec);
-            if (ft.type() == components::types::logical_type::UNKNOWN) {
-                std::string ref_name(ft.type_name());
-                if (!ref_name.empty()) {
-                    auto nested = co_await resolve_type_sync(namespace_oid, ref_name);
-                    if (nested.found && !nested.typdefspec.empty()) {
-                        ft = components::catalog::decode_type_spec(resource(), nested.typdefspec);
-                    }
-                }
-            }
-            ft.set_alias(f.attname);
-            child_types.push_back(std::move(ft));
-        }
-        auto struct_t = components::types::complex_logical_type::create_struct(name, child_types);
-        out.found = true;
-        out.oid = composite_oid;
-        out.name = name;
-        out.typdefspec = components::catalog::encode_type_spec(struct_t);
-        co_return out;
-    }
-
-    manager_disk_t::unique_future<resolve_type_result_t>
-    manager_disk_t::resolve_type(execution_context_t /*ctx*/,
-                                 components::catalog::oid_t namespace_oid,
-                                 std::string name,
-                                 std::uint64_t /*since_version*/) {
-        co_return co_await resolve_type_sync(namespace_oid, name);
-    }
-
-    manager_disk_t::unique_future<resolve_function_result_t>
-    manager_disk_t::resolve_function(execution_context_t /*ctx*/,
-                                     components::catalog::oid_t namespace_oid,
-                                     std::string name,
-                                     std::uint64_t /*since_version*/) {
-        resolve_function_result_t out(resource());
-        out.namespace_oid = namespace_oid;
-
-        if (!agents_.empty() && agents_[0] != nullptr) {
-            const std::size_t idx = pool_idx_for_oid(pg_proc_oid, agents_.size());
-            std::vector<size_t> projected{0, 1, 2, 3, 4, 5, 6};
-            auto [needs_sched, fut] = actor_zeta::otterbrix::send(agents_[idx]->address(),
-                                                                  &agent_disk_t::storage_scan_batched_inner,
-                                                                  pg_proc_oid,
-                                                                  std::unique_ptr<components::table::table_filter_t>{},
-                                                                  int64_t{-1},
-                                                                  std::move(projected),
-                                                                  components::table::transaction_data{});
-            if (needs_sched) {
-                scheduler_disk_->enqueue(agents_[idx].get());
-            }
-            auto batches = co_await std::move(fut);
-            for (auto& chunk : batches) {
-                bool stop = false;
-                for (uint64_t i = 0; i < chunk.size(); ++i) {
-                    auto ns = chunk.value(2, i);
-                    if (ns.is_null())
-                        continue;
-                    if (static_cast<components::catalog::oid_t>(ns.value<std::uint32_t>()) != namespace_oid)
-                        continue;
-                    if (!str_equals(chunk.value(1, i), name))
-                        continue;
-                    out.found = true;
-                    out.oid = static_cast<components::catalog::oid_t>(chunk.value(0, i).value<std::uint32_t>());
-                    out.name = name;
-                    auto nargs_v = chunk.value(3, i);
-                    if (!nargs_v.is_null())
-                        out.pronargs = nargs_v.value<std::int32_t>();
-                    auto uid_v = chunk.value(4, i);
-                    if (!uid_v.is_null())
-                        out.prouid = uid_v.value<std::uint64_t>();
-                    auto args_v = chunk.value(5, i);
-                    if (!args_v.is_null())
-                        out.proargmatchers = std::string(args_v.value<std::string_view>());
-                    auto ret_v = chunk.value(6, i);
-                    if (!ret_v.is_null())
-                        out.prorettype = std::string(ret_v.value<std::string_view>());
                     stop = true;
                     break;
                 }
@@ -678,12 +202,13 @@ namespace services::disk {
     manager_disk_t::read_chunks_by_key(execution_context_t ctx,
                                        components::catalog::oid_t table_oid,
                                        std::pmr::vector<std::string> key_col_names,
-                                       std::pmr::vector<components::types::logical_value_t> key_values) {
-        // Name→index resolution + filtered scan, with the storage_scan_batched_inner
-        // chunks returned as-is (no row-major flatten). Callers read cells via
-        // chunk.value(col_idx, row_idx).
+                                       components::vector::data_chunk_t keys) {
+        // Thin router: name→index resolution + the eq-AND filtered scan now run
+        // intra-agent in read_chunks_by_key_inner (no row-major flatten, no
+        // separate column-name resolution hop). Callers read cells via
+        // chunk.value(col, row).
         std::pmr::vector<components::vector::data_chunk_t> empty(resource());
-        if (key_col_names.size() != key_values.size() || key_col_names.empty())
+        if (key_col_names.empty())
             co_return empty;
 
         if (agents_.empty())
@@ -693,47 +218,64 @@ namespace services::disk {
         if (agent == nullptr)
             co_return empty;
 
-        auto [names_ns, names_fut] = actor_zeta::otterbrix::send(agent->address(),
-                                                                  &agent_disk_t::storage_column_names_inner,
-                                                                  table_oid);
-        if (names_ns) {
+        auto [needs_sched, fut] = actor_zeta::otterbrix::send(agent->address(),
+                                                              &agent_disk_t::read_chunks_by_key_inner,
+                                                              table_oid,
+                                                              std::move(key_col_names),
+                                                              std::move(keys),
+                                                              ctx.txn);
+        if (needs_sched) {
             scheduler_disk_->enqueue(agent.get());
         }
-        auto all_names = co_await std::move(names_fut);
-        if (all_names.empty())
-            co_return empty;
+        co_return co_await std::move(fut);
+    }
 
-        auto filter = std::make_unique<components::table::conjunction_and_filter_t>();
-        for (std::size_t ki = 0; ki < key_col_names.size(); ++ki) {
-            std::size_t col_idx = all_names.size();
-            for (std::size_t ci = 0; ci < all_names.size(); ++ci) {
-                if (all_names[ci] == key_col_names[ki]) {
-                    col_idx = ci;
-                    break;
-                }
+    manager_disk_t::unique_future<std::pmr::vector<std::pmr::vector<components::vector::data_chunk_t>>>
+    manager_disk_t::read_chunks_by_keys(execution_context_t ctx,
+                                        components::catalog::oid_t table_oid,
+                                        std::pmr::vector<std::string> key_col_names,
+                                        components::vector::data_chunk_t keys) {
+        // Thin router for the multi-key batch: name→index resolution + the per-key eq-AND
+        // filtered scans run intra-agent in read_chunks_by_keys_inner (one mailbox hop for the
+        // whole batch). INVARIANT: result.size() == keys.size() on EVERY path — one (possibly
+        // empty) entry per input key, in input order, so result[i] always maps to keys[i].
+        // Consumers index result[i] positionally, so the no-key-columns / no-agents / null-agent
+        // paths still emit keys.size() empty entries rather than a 0-size vector. (Per-key arity
+        // / unknown column is handled agent-side, also yielding empty entries in result order.)
+        std::pmr::vector<std::pmr::vector<components::vector::data_chunk_t>> out(resource());
+        auto fill_empty_entries = [&]() {
+            for (std::size_t i = 0; i < keys.size(); ++i) {
+                // Nested pmr vector: bare emplace_back() lets uses-allocator construction
+                // propagate `out`'s resource to the inner vector. emplace_back(resource())
+                // would resolve to the 2-arg (resource, allocator) form — no such ctor.
+                out.emplace_back();
             }
-            if (col_idx == all_names.size())
-                co_return empty;
-            std::pmr::vector<uint64_t> idx_vec(resource());
-            idx_vec.push_back(static_cast<uint64_t>(col_idx));
-            filter->child_filters.push_back(
-                std::make_unique<components::table::constant_filter_t>(components::expressions::compare_type::eq,
-                                                                       key_values[ki],
-                                                                       std::move(idx_vec)));
+        };
+        if (keys.empty() || key_col_names.empty()) {
+            fill_empty_entries();
+            co_return out;
+        }
+        if (agents_.empty()) {
+            fill_empty_entries();
+            co_return out;
+        }
+        const std::size_t idx = pool_idx_for_oid(table_oid, agents_.size());
+        auto& agent = agents_[idx];
+        if (agent == nullptr) {
+            fill_empty_entries();
+            co_return out;
         }
 
-        auto [scan_ns, scan_fut] =
-            actor_zeta::otterbrix::send(agent->address(),
-                                        &agent_disk_t::storage_scan_batched_inner,
-                                        table_oid,
-                                        std::unique_ptr<components::table::table_filter_t>{std::move(filter)},
-                                        int64_t{-1},
-                                        std::vector<size_t>{},
-                                        ctx.txn);
-        if (scan_ns) {
+        auto [needs_sched, fut] = actor_zeta::otterbrix::send(agent->address(),
+                                                              &agent_disk_t::read_chunks_by_keys_inner,
+                                                              table_oid,
+                                                              std::move(key_col_names),
+                                                              std::move(keys),
+                                                              ctx.txn);
+        if (needs_sched) {
             scheduler_disk_->enqueue(agent.get());
         }
-        co_return co_await std::move(scan_fut);
+        co_return co_await std::move(fut);
     }
 
 } // namespace services::disk

--- a/services/disk/manager_disk_storage.cpp
+++ b/services/disk/manager_disk_storage.cpp
@@ -9,15 +9,10 @@ namespace services::disk {
     uint64_t manager_disk_t::direct_append_sync(catalog::oid_t table_oid,
                                                 components::vector::data_chunk_t& data,
                                                 core::date::timezone_offset_t session_tz) {
-        return direct_append_sync(table_oid, data, session_tz, components::table::transaction_data{0, 0});
-    }
-
-    uint64_t manager_disk_t::direct_append_sync(catalog::oid_t table_oid,
-                                                components::vector::data_chunk_t& data,
-                                                core::date::timezone_offset_t session_tz,
-                                                const components::table::transaction_data& txn) {
-        // The storage_entry_sync borrow is safe here: direct_append_sync runs only
-        // pre-scheduler-start (WAL replay / bootstrap) or inside the manager mailbox.
+        // Bootstrap / WAL-replay only (pre-scheduler-start). Replay records carry no
+        // MVCC txn, so the append commits under transaction_data{0, 0}. The
+        // storage_entry_sync borrow is safe in this single-threaded window.
+        const components::table::transaction_data txn{0, 0};
         components::storage::storage_t* s = nullptr;
         if (!agents_.empty()) {
             const std::size_t pool_idx = pool_idx_for_oid(table_oid, agents_.size());
@@ -96,16 +91,12 @@ namespace services::disk {
     void manager_disk_t::direct_delete_sync(catalog::oid_t table_oid,
                                             const std::pmr::vector<int64_t>& row_ids,
                                             uint64_t count) {
-        direct_delete_sync(table_oid, row_ids, count, components::table::transaction_data{0, 0});
-    }
-
-    void manager_disk_t::direct_delete_sync(catalog::oid_t table_oid,
-                                            const std::pmr::vector<int64_t>& row_ids,
-                                            uint64_t count,
-                                            const components::table::transaction_data& txn) {
+        // Bootstrap / WAL-replay only; routes the physical delete to the owning agent
+        // under transaction_data{0, 0} (replay carries no MVCC txn).
         if (!agents_.empty()) {
             const std::size_t pool_idx = pool_idx_for_oid(table_oid, agents_.size());
-            agents_[pool_idx]->direct_delete_sync(table_oid, row_ids, count, txn);
+            agents_[pool_idx]->direct_delete_sync(
+                table_oid, row_ids, count, components::table::transaction_data{0, 0});
         }
     }
 
@@ -128,16 +119,20 @@ namespace services::disk {
               "manager_disk_t::create_storage , session : {} , oid : {}",
               session.data(),
               static_cast<unsigned>(table_oid));
-        // Route CREATE through the agent slice. Safety contract:
-        //   1. No agent mailbox handler MUTATES storages_ (find-only).
-        //   2. The new OID is not yet visible to any router: this handler
-        //      publishes it.
-        //   3. The manager actor processes one message at a time.
+        // Pure router: the IN_MEMORY entry is built with the AGENT's own resource() on
+        // the agent thread (create_storage_inner). Only the oid crosses the mailbox; no
+        // entry is constructed on the manager thread.
         if (!agents_.empty()) {
             const std::size_t pool_idx = pool_idx_for_oid(table_oid, agents_.size());
             auto& agent = agents_[pool_idx];
-            auto twin = std::make_unique<collection_storage_entry_t>(agent->resource());
-            const bool ok = agent->bootstrap_inner_sync(table_oid, std::move(twin));
+            auto [needs_sched, fut] =
+                actor_zeta::otterbrix::send(agent->address(), &agent_disk_t::create_storage_inner, table_oid);
+            if (needs_sched) {
+                scheduler_disk_->enqueue(agent.get());
+            }
+            // Await so the storage exists before the future resolves; the bool result
+            // signals dup-key — drop it (the agent already logged the duplicate).
+            const bool ok = co_await std::move(fut);
             if (!ok) {
                 trace(log_,
                       "manager_disk_t::create_storage: agent[{}] already owned oid {}",
@@ -157,13 +152,20 @@ namespace services::disk {
               "manager_disk_t::create_storage_with_columns , session : {} , oid : {}",
               session.data(),
               static_cast<unsigned>(table_oid));
-        // Route CREATE through the agent slice. Safety contract: see
-        // create_storage above.
+        // Pure router: columns cross the mailbox by value (same as today's by-value
+        // parameter); the entry is built on the agent thread via
+        // create_storage_with_columns_inner. No entry on the manager thread.
         if (!agents_.empty()) {
             const std::size_t pool_idx = pool_idx_for_oid(table_oid, agents_.size());
             auto& agent = agents_[pool_idx];
-            auto twin = std::make_unique<collection_storage_entry_t>(agent->resource(), std::move(columns));
-            const bool ok = agent->bootstrap_inner_sync(table_oid, std::move(twin));
+            auto [needs_sched, fut] = actor_zeta::otterbrix::send(agent->address(),
+                                                                   &agent_disk_t::create_storage_with_columns_inner,
+                                                                   table_oid,
+                                                                   std::move(columns));
+            if (needs_sched) {
+                scheduler_disk_->enqueue(agent.get());
+            }
+            const bool ok = co_await std::move(fut);
             if (!ok) {
                 trace(log_,
                       "manager_disk_t::create_storage_with_columns: agent[{}] already owned oid {}",
@@ -183,15 +185,12 @@ namespace services::disk {
               "manager_disk_t::create_storage_disk , session : {} , oid : {}",
               session.data(),
               static_cast<unsigned>(table_oid));
+        // Pure router for runtime CREATE TABLE … DISK. The manager only derives the
+        // path string; create_directories + SFBM construction (which holds the
+        // exclusive posix WRITE_LOCK) both run on the agent thread via
+        // create_storage_disk_inner. Only oid/columns(by value)/path cross the mailbox.
         auto otbx_path = config_.path / std::to_string(static_cast<unsigned>(database_oid)) /
                          std::to_string(static_cast<unsigned>(table_oid)) / "table.otbx";
-        std::filesystem::create_directories(otbx_path.parent_path());
-        // Runtime CREATE TABLE … DISK. The SFBM is constructed on the routed agent
-        // via bootstrap_create_disk_inner_sync; the manager never opens .otbx
-        // (single_file_block_manager_t holds an exclusive posix WRITE_LOCK, so only
-        // the agent path may emplace). Same sync-call safety contract as
-        // create_storage above. The helper is noexcept and probes storages_ before
-        // constructing the SFBM, so the dup-key path is observable-but-non-fatal.
         if (!agents_.empty()) {
             const std::size_t pool_idx = pool_idx_for_oid(table_oid, agents_.size());
             auto& agent = agents_[pool_idx];
@@ -200,37 +199,66 @@ namespace services::disk {
                   static_cast<unsigned>(table_oid),
                   pool_idx,
                   otbx_path.string());
-            const bool ok = agent->bootstrap_create_disk_inner_sync(table_oid, std::move(columns), otbx_path);
+            auto [needs_sched, fut] = actor_zeta::otterbrix::send(agent->address(),
+                                                                   &agent_disk_t::create_storage_disk_inner,
+                                                                   table_oid,
+                                                                   std::move(columns),
+                                                                   std::move(otbx_path));
+            if (needs_sched) {
+                scheduler_disk_->enqueue(agent.get());
+            }
+            const bool ok = co_await std::move(fut);
             if (!ok) {
                 trace(log_,
-                      "manager_disk_t::create_storage_disk: agent[{}] already owns oid {} (path={})",
+                      "manager_disk_t::create_storage_disk: agent[{}] already owns oid {}",
                       pool_idx,
-                      static_cast<unsigned>(table_oid),
-                      otbx_path.string());
+                      static_cast<unsigned>(table_oid));
             }
         }
         co_return;
     }
 
-    manager_disk_t::unique_future<void> manager_disk_t::drop_storage(session_id_t session, catalog::oid_t table_oid) {
-        trace(log_,
-              "manager_disk_t::drop_storage , session : {} , oid : {}",
-              session.data(),
-              static_cast<unsigned>(table_oid));
-        // The agent owns the canonical erase + filesystem-remove in
-        // drop_storage_inner, idempotent on a missing key (DROP IF EXISTS / WAL
-        // re-drop / not-routed-here all log a no-op). co_await preserves ordering
-        // w.r.t. operator_dynamic_cascade_delete's subsequent sends.
-        if (!agents_.empty()) {
-            const std::size_t pool_idx = pool_idx_for_oid(table_oid, agents_.size());
-            auto& agent = agents_[pool_idx];
+    manager_disk_t::unique_future<void>
+    manager_disk_t::drop_storage_many(session_id_t /*session*/,
+                                      std::pmr::vector<components::catalog::oid_t> table_oids) {
+        // Partition oids per owning agent (pool_idx_for_oid), then fan out one
+        // drop_storage_many_inner per agent in PARALLEL — a per-oid singular drop
+        // would route one agent per oid with a co_await each, so N drops cost N
+        // round-trips; here they cost one (at most num_agents parallel sends). Each
+        // agent's inner loops the same idempotent erase, so an over-routed oid no-ops.
+        // Same partition-by-agent shape as storage_publish_commits.
+        if (agents_.empty()) {
+            co_return;
+        }
+        std::pmr::vector<std::pmr::vector<components::catalog::oid_t>> per_agent{resource()};
+        per_agent.reserve(agents_.size());
+        for (std::size_t i = 0; i < agents_.size(); ++i) {
+            per_agent.emplace_back();
+        }
+        for (auto oid : table_oids) {
+            const std::size_t pool_idx = pool_idx_for_oid(oid, agents_.size());
+            per_agent[pool_idx].push_back(oid);
+        }
+        std::pmr::vector<unique_future<void>> agent_futures{resource()};
+        agent_futures.reserve(per_agent.size());
+        for (std::size_t i = 0; i < per_agent.size(); ++i) {
+            if (per_agent[i].empty()) {
+                continue;
+            }
+            auto& agent = agents_[i];
+            if (agent == nullptr) {
+                continue;
+            }
             auto [needs_sched, fut] = actor_zeta::otterbrix::send(agent->address(),
-                                                                   &agent_disk_t::drop_storage_inner,
-                                                                   table_oid);
+                                                                   &agent_disk_t::drop_storage_many_inner,
+                                                                   std::move(per_agent[i]));
             if (needs_sched) {
                 scheduler_disk_->enqueue(agent.get());
             }
-            co_await std::move(fut);
+            agent_futures.emplace_back(std::move(fut));
+        }
+        for (auto& f : agent_futures) {
+            co_await std::move(f);
         }
         co_return;
     }
@@ -442,76 +470,6 @@ namespace services::disk {
     }
 
     // MVCC commit/revert methods
-
-    manager_disk_t::unique_future<void> manager_disk_t::storage_publish_commit(execution_context_t /*ctx*/,
-                                                                              catalog::oid_t table_oid,
-                                                                              uint64_t commit_id,
-                                                                              int64_t row_start,
-                                                                              uint64_t count) {
-        // Wraps the single range into the plural storage_publish_commits_inner payload.
-        if (agents_.empty())
-            co_return;
-        const std::size_t idx = pool_idx_for_oid(table_oid, agents_.size());
-        auto& agent = agents_[idx];
-        if (agent == nullptr)
-            co_return;
-        std::pmr::vector<components::pg_catalog_append_range_t> ranges{resource()};
-        ranges.push_back(components::pg_catalog_append_range_t{table_oid, row_start, count});
-        auto [needs_sched, fut] = actor_zeta::otterbrix::send(agent->address(),
-                                                               &agent_disk_t::storage_publish_commits_inner,
-                                                               commit_id,
-                                                               std::move(ranges));
-        if (needs_sched) {
-            scheduler_disk_->enqueue(agent.get());
-        }
-        co_await std::move(fut);
-        co_return;
-    }
-
-    manager_disk_t::unique_future<void> manager_disk_t::storage_revert_append(execution_context_t /*ctx*/,
-                                                                              catalog::oid_t table_oid,
-                                                                              int64_t row_start,
-                                                                              uint64_t count) {
-        if (!agents_.empty()) {
-            const std::size_t pool_idx = pool_idx_for_oid(table_oid, agents_.size());
-            auto& agent = agents_[pool_idx];
-            auto [needs_sched, fut] = actor_zeta::otterbrix::send(agent->address(),
-                                                                   &agent_disk_t::storage_revert_append_inner,
-                                                                   table_oid,
-                                                                   row_start,
-                                                                   count);
-            if (needs_sched) {
-                scheduler_disk_->enqueue(agent.get());
-            }
-            co_await std::move(fut);
-        }
-        co_return;
-    }
-
-    manager_disk_t::unique_future<void>
-    manager_disk_t::storage_publish_delete(execution_context_t ctx, catalog::oid_t table_oid, uint64_t commit_id) {
-        // Wraps the single oid into the plural storage_publish_deletes_inner payload.
-        // txn_id 0 (no real transaction) short-circuits, matching the twin's guard.
-        const auto txn_id = ctx.txn.transaction_id;
-        if (txn_id == 0 || agents_.empty())
-            co_return;
-        const std::size_t idx = pool_idx_for_oid(table_oid, agents_.size());
-        auto& agent = agents_[idx];
-        if (agent == nullptr)
-            co_return;
-        std::pmr::vector<components::catalog::oid_t> tables{resource()};
-        tables.push_back(table_oid);
-        auto [needs_sched, fut] = actor_zeta::otterbrix::send(agent->address(),
-                                                               &agent_disk_t::storage_publish_deletes_inner,
-                                                               txn_id,
-                                                               commit_id,
-                                                               std::move(tables));
-        if (needs_sched) {
-            scheduler_disk_->enqueue(agent.get());
-        }
-        co_await std::move(fut);
-        co_return;
-    }
 
     manager_disk_t::unique_future<void>
     manager_disk_t::storage_publish_commits(execution_context_t /*ctx*/,

--- a/services/disk/tests/catalog_probe.hpp
+++ b/services/disk/tests/catalog_probe.hpp
@@ -1,0 +1,535 @@
+#pragma once
+
+// Test-only catalog-read oracle.
+//
+// Production resolves catalog objects via physical-plan operators that call
+// manager_disk_t::read_chunks_by_key. The disk-layer methods resolve_table /
+// resolve_type / resolve_function used to provide the same lookups as a single
+// mailbox call and were kept ONLY because disk tests used them as a convenient
+// read oracle. Those methods have been deleted; this header reproduces the exact
+// lookup logic they performed, but issues every catalog read through the live
+// read_chunks_by_key path (the same boundary production uses).
+//
+// Each probe_* function mirrors a former resolve_*_result_t (plain std fields the
+// tests assert) and reproduces the former filtering rules:
+//   - probe_table  : pg_class scan by (relnamespace, relname); then pg_attribute
+//                    columns with the same MVCC visibility filter (added_at /
+//                    dropped_at vs ctx.txn.start_time) + attnum sort, OR the
+//                    pg_computed_column branch (max-version-per-name, refcount>0,
+//                    attoid-ASC order) for relkind='g' tables.
+//   - probe_type   : pg_type scan by (typnamespace, typname); composite fallback
+//                    via pg_class (relkind='c') + pg_attribute fields.
+//   - probe_function : pg_proc scan by (pronamespace, proname).
+//
+// Reads route through the fixture's invoke mechanism (fx.invoke / fx.invoke_async),
+// so this header is fixture-agnostic: both the disk-test `fixture` and the
+// integration `fresh_disk` expose a compatible invoke template.
+
+#include <components/catalog/catalog_codes.hpp>
+#include <components/catalog/catalog_oids.hpp>
+#include <components/catalog/system_table_schemas.hpp>
+#include <components/context/execution_context.hpp>
+#include <components/types/types.hpp>
+#include <components/vector/data_chunk.hpp>
+#include <services/disk/manager_disk.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <memory_resource>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace services::disk::test_probe {
+
+    namespace catalog = components::catalog;
+
+    // --- test-local result structs (mirror the deleted resolve_*_result_t) ---
+
+    struct probe_column_info_t {
+        std::string attname;
+        std::string atttypspec;
+        std::string attdefspec;
+        catalog::oid_t atttypid{catalog::INVALID_OID};
+        catalog::oid_t attoid{catalog::INVALID_OID};
+        std::int32_t attnum{0};
+        bool attnotnull{false};
+        bool atthasdefault{false};
+        bool attisdropped{false};
+    };
+
+    struct probe_table_result_t {
+        bool found{false};
+        catalog::oid_t oid{catalog::INVALID_OID};
+        catalog::oid_t namespace_oid{catalog::INVALID_OID};
+        char relkind{'r'};
+        std::string name;
+        std::vector<probe_column_info_t> columns;
+    };
+
+    struct probe_type_result_t {
+        bool found{false};
+        catalog::oid_t oid{catalog::INVALID_OID};
+        catalog::oid_t namespace_oid{catalog::INVALID_OID};
+        std::string name;
+        std::string typdefspec;
+    };
+
+    struct probe_function_result_t {
+        std::string name;
+        std::string proargmatchers;
+        std::string prorettype;
+        std::uint64_t prouid{0};
+        catalog::oid_t oid{catalog::INVALID_OID};
+        catalog::oid_t namespace_oid{catalog::INVALID_OID};
+        std::int32_t pronargs{0};
+        bool found{false};
+    };
+
+    // --- local key-chunk builder (mirrors components::operators::make_key_chunk) ---
+    //
+    // Disk tests do not link physical_plan/operators, so the 1-row columnar key
+    // carrier for read_chunks_by_key is built here. Column j carries values[j]'s own
+    // type so the cell is written without a cast; cardinality is set to 1.
+    inline components::vector::data_chunk_t
+    build_key_chunk(std::pmr::memory_resource* resource,
+                    std::pmr::vector<components::types::logical_value_t> values) {
+        std::pmr::vector<components::types::complex_logical_type> types(resource);
+        types.reserve(values.size());
+        for (const auto& v : values) {
+            types.emplace_back(v.type());
+        }
+        components::vector::data_chunk_t chunk(resource, types, 1);
+        for (std::size_t j = 0; j < values.size(); ++j) {
+            chunk.set_value(static_cast<std::uint64_t>(j), 0, values[j]);
+        }
+        chunk.set_cardinality(1);
+        return chunk;
+    }
+
+    // Issue a single-key read against `table_oid` filtering key_cols[j] == key_vals[j].
+    // Returns the batched data chunks the owning agent's slice yields (txn-visible
+    // rows per ctx.txn), exactly as the production read path would observe them.
+    template<typename Fx>
+    std::pmr::vector<components::vector::data_chunk_t>
+    probe_read(Fx& fx,
+               components::execution_context_t ctx,
+               catalog::oid_t table_oid,
+               std::pmr::vector<std::string> key_cols,
+               std::pmr::vector<components::types::logical_value_t> key_vals,
+               bool committed_scan = true) {
+        auto keys = build_key_chunk(&fx.resource, std::move(key_vals));
+        // committed_scan=true (default) mirrors the deleted resolve_* disk path: scan the
+        // catalog committed-only (transaction_data{}) so a txn's own uncommitted catalog
+        // writes are invisible; the caller still filters by ctx.txn.start_time.
+        // committed_scan=false uses the caller's REAL ctx.txn — the PRODUCTION
+        // operator_resolve_* semantics (read-your-own-uncommitted-catalog-writes).
+        if (committed_scan) {
+            ctx.txn = components::table::transaction_data{};
+        }
+        return fx.invoke(&manager_disk_t::read_chunks_by_key,
+                         ctx,
+                         table_oid,
+                         std::move(key_cols),
+                         std::move(keys));
+    }
+
+    // --- probe_table ---------------------------------------------------------
+    //
+    // pg_class layout: oid(0), relname(1), relnamespace(2), relkind(3).
+    // pg_attribute layout: attoid(0), attrelid(1), attname(2), atttypid(3),
+    //   attnum(4), attnotnull(5), atthasdefault(6), attisdropped(7), atttypspec(8),
+    //   attdefspec(9), added_at_commit_id(10), dropped_at_commit_id(11).
+    // pg_computed_column layout: relid(0), attoid(1), attname(2), atttypid(3),
+    //   atttypspec(4), attversion(5), attrefcount(6).
+    template<typename Fx>
+    probe_table_result_t probe_table(Fx& fx,
+                                     components::execution_context_t ctx,
+                                     catalog::oid_t namespace_oid,
+                                     std::string name,
+                                     bool committed_scan = true) {
+        probe_table_result_t out;
+        out.namespace_oid = namespace_oid;
+
+        constexpr catalog::oid_t pg_class = catalog::well_known_oid::pg_class_table;
+        constexpr catalog::oid_t pg_attribute = catalog::well_known_oid::pg_attribute_table;
+        constexpr catalog::oid_t pg_computed_column = catalog::well_known_oid::pg_computed_column_table;
+
+        // pg_class scan by (relnamespace, relname).
+        {
+            std::pmr::vector<std::string> keys{&fx.resource};
+            keys.emplace_back("relnamespace");
+            keys.emplace_back("relname");
+            std::pmr::vector<components::types::logical_value_t> vals{&fx.resource};
+            vals.emplace_back(&fx.resource, namespace_oid);
+            vals.emplace_back(&fx.resource, name);
+            auto batches = probe_read(fx, ctx, pg_class, std::move(keys), std::move(vals), committed_scan);
+            for (const auto& chunk : batches) {
+                bool stop = false;
+                for (std::uint64_t i = 0; i < chunk.size(); ++i) {
+                    auto oid_v = chunk.value(0, i);
+                    if (oid_v.is_null())
+                        continue;
+                    out.found = true;
+                    out.oid = static_cast<catalog::oid_t>(oid_v.template value<std::uint32_t>());
+                    out.name = name;
+                    auto kind_v = chunk.value(3, i);
+                    if (!kind_v.is_null()) {
+                        const auto kind_cell = kind_v;
+                        const auto ks = kind_cell.template value<std::string_view>();
+                        if (!ks.empty())
+                            out.relkind = ks.front();
+                    }
+                    stop = true;
+                    break;
+                }
+                if (stop)
+                    break;
+            }
+        }
+
+        if (!out.found)
+            return out;
+
+        if (out.relkind == catalog::relkind::computed) {
+            // pg_computed_column: collect ALL rows for relid (incl. tombstones),
+            // pick max-version per attname, drop names whose max-version row has
+            // refcount<=0, then order surviving columns by attoid ASC.
+            struct cc_row_t {
+                catalog::oid_t attoid{catalog::INVALID_OID};
+                std::string attname;
+                catalog::oid_t atttypid{catalog::INVALID_OID};
+                std::string atttypspec;
+                std::int64_t attversion{0};
+                std::int64_t attrefcount{0};
+            };
+            std::unordered_map<std::string, cc_row_t> latest_any;
+
+            std::pmr::vector<std::string> keys{&fx.resource};
+            keys.emplace_back("relid");
+            std::pmr::vector<components::types::logical_value_t> vals{&fx.resource};
+            vals.emplace_back(&fx.resource, out.oid);
+            auto batches = probe_read(fx, ctx, pg_computed_column, std::move(keys), std::move(vals), committed_scan);
+            for (const auto& chunk : batches) {
+                if (chunk.column_count() < 7)
+                    continue;
+                for (std::uint64_t i = 0; i < chunk.size(); ++i) {
+                    cc_row_t row;
+                    auto attoid_v = chunk.value(1, i);
+                    row.attoid = attoid_v.is_null()
+                                     ? catalog::INVALID_OID
+                                     : static_cast<catalog::oid_t>(attoid_v.template value<std::uint32_t>());
+                    auto name_v = chunk.value(2, i);
+                    if (!name_v.is_null()) {
+                        const auto name_cell = name_v;
+                        row.attname = std::string(name_cell.template value<std::string_view>());
+                    }
+                    auto typid_v = chunk.value(3, i);
+                    row.atttypid = typid_v.is_null()
+                                       ? catalog::INVALID_OID
+                                       : static_cast<catalog::oid_t>(typid_v.template value<std::uint32_t>());
+                    auto spec_v = chunk.value(4, i);
+                    if (!spec_v.is_null()) {
+                        const auto spec_cell = spec_v;
+                        row.atttypspec = std::string(spec_cell.template value<std::string_view>());
+                    }
+                    row.attversion = chunk.value(5, i).template value<std::int64_t>();
+                    auto rc_v = chunk.value(6, i);
+                    row.attrefcount = rc_v.is_null() ? 0 : rc_v.template value<std::int64_t>();
+                    auto it = latest_any.find(row.attname);
+                    if (it == latest_any.end() || it->second.attversion < row.attversion) {
+                        latest_any[row.attname] = std::move(row);
+                    }
+                }
+            }
+            std::vector<cc_row_t> ordered;
+            ordered.reserve(latest_any.size());
+            for (auto& [_, row] : latest_any) {
+                if (row.attrefcount > 0)
+                    ordered.push_back(std::move(row));
+            }
+            std::sort(ordered.begin(), ordered.end(), [](const cc_row_t& a, const cc_row_t& b) {
+                return a.attoid < b.attoid;
+            });
+            std::int32_t synthetic_attnum = 1;
+            for (auto& row : ordered) {
+                probe_column_info_t info;
+                info.attoid = row.attoid;
+                info.attname = std::move(row.attname);
+                info.atttypid = row.atttypid;
+                info.atttypspec = std::move(row.atttypspec);
+                info.attnum = synthetic_attnum++;
+                info.attnotnull = false;
+                info.atthasdefault = false;
+                info.attisdropped = false;
+                out.columns.push_back(std::move(info));
+            }
+            return out;
+        }
+
+        // pg_attribute: columns for attrelid == out.oid, with column-level MVCC
+        // visibility (added_at / dropped_at vs ctx.txn.start_time) + attnum sort.
+        {
+            const auto snapshot_start_time = ctx.txn.start_time;
+            std::vector<probe_column_info_t> rows;
+            std::pmr::vector<std::string> keys{&fx.resource};
+            keys.emplace_back("attrelid");
+            std::pmr::vector<components::types::logical_value_t> vals{&fx.resource};
+            vals.emplace_back(&fx.resource, out.oid);
+            auto batches = probe_read(fx, ctx, pg_attribute, std::move(keys), std::move(vals), committed_scan);
+            for (const auto& chunk : batches) {
+                for (std::uint64_t i = 0; i < chunk.size(); ++i) {
+                    auto dropped = chunk.value(7, i);
+                    if (!dropped.is_null() && dropped.template value<bool>())
+                        continue;
+                    auto added_at_v = chunk.value(10, i);
+                    if (!added_at_v.is_null()) {
+                        const auto added_at = static_cast<std::uint64_t>(added_at_v.template value<std::int64_t>());
+                        if (added_at > snapshot_start_time)
+                            continue;
+                    }
+                    auto dropped_at_v = chunk.value(11, i);
+                    if (!dropped_at_v.is_null()) {
+                        const auto dropped_at = static_cast<std::uint64_t>(dropped_at_v.template value<std::int64_t>());
+                        if (dropped_at != 0 && dropped_at <= snapshot_start_time)
+                            continue;
+                    }
+                    probe_column_info_t info;
+                    info.attoid = static_cast<catalog::oid_t>(chunk.value(0, i).template value<std::uint32_t>());
+                    auto name_v = chunk.value(2, i);
+                    if (!name_v.is_null()) {
+                        const auto name_cell = name_v;
+                        info.attname = std::string(name_cell.template value<std::string_view>());
+                    }
+                    auto typid_v = chunk.value(3, i);
+                    if (!typid_v.is_null())
+                        info.atttypid = static_cast<catalog::oid_t>(typid_v.template value<std::uint32_t>());
+                    info.attnum = chunk.value(4, i).template value<std::int32_t>();
+                    auto nn_v = chunk.value(5, i);
+                    info.attnotnull = !nn_v.is_null() && nn_v.template value<bool>();
+                    auto def_v = chunk.value(6, i);
+                    info.atthasdefault = !def_v.is_null() && def_v.template value<bool>();
+                    info.attisdropped = false;
+                    auto typspec_v = chunk.value(8, i);
+                    if (!typspec_v.is_null()) {
+                        const auto typspec_cell = typspec_v;
+                        info.atttypspec = std::string(typspec_cell.template value<std::string_view>());
+                    }
+                    auto defspec_v = chunk.value(9, i);
+                    if (!defspec_v.is_null()) {
+                        const auto defspec_cell = defspec_v;
+                        info.attdefspec = std::string(defspec_cell.template value<std::string_view>());
+                    }
+                    rows.push_back(std::move(info));
+                }
+            }
+            std::sort(rows.begin(), rows.end(), [](const probe_column_info_t& a, const probe_column_info_t& b) {
+                return a.attnum < b.attnum;
+            });
+            out.columns.assign(std::make_move_iterator(rows.begin()), std::make_move_iterator(rows.end()));
+        }
+        return out;
+    }
+
+    // --- probe_type ----------------------------------------------------------
+    //
+    // pg_type layout: oid(0), typname(1), typnamespace(2), typdefspec(3).
+    // Composite fallback: pg_class (relkind='c') by (relnamespace, relname), then
+    // pg_attribute fields by attrelid, encoded as a STRUCT type spec.
+    template<typename Fx>
+    probe_type_result_t probe_type(Fx& fx,
+                                   components::execution_context_t ctx,
+                                   catalog::oid_t namespace_oid,
+                                   std::string name) {
+        probe_type_result_t out;
+        out.namespace_oid = namespace_oid;
+
+        constexpr catalog::oid_t pg_type = catalog::well_known_oid::pg_type_table;
+        constexpr catalog::oid_t pg_class = catalog::well_known_oid::pg_class_table;
+        constexpr catalog::oid_t pg_attribute = catalog::well_known_oid::pg_attribute_table;
+
+        // pg_type scan by (typnamespace, typname).
+        {
+            std::pmr::vector<std::string> keys{&fx.resource};
+            keys.emplace_back("typnamespace");
+            keys.emplace_back("typname");
+            std::pmr::vector<components::types::logical_value_t> vals{&fx.resource};
+            vals.emplace_back(&fx.resource, namespace_oid);
+            vals.emplace_back(&fx.resource, name);
+            auto batches = probe_read(fx, ctx, pg_type, std::move(keys), std::move(vals));
+            for (const auto& chunk : batches) {
+                bool stop = false;
+                for (std::uint64_t i = 0; i < chunk.size(); ++i) {
+                    auto oid_v = chunk.value(0, i);
+                    if (oid_v.is_null())
+                        continue;
+                    out.found = true;
+                    out.oid = static_cast<catalog::oid_t>(oid_v.template value<std::uint32_t>());
+                    out.name = name;
+                    auto def_v = chunk.value(3, i);
+                    if (!def_v.is_null()) {
+                        const auto def_cell = def_v;
+                        out.typdefspec = std::string(def_cell.template value<std::string_view>());
+                    }
+                    stop = true;
+                    break;
+                }
+                if (stop)
+                    break;
+            }
+        }
+        if (out.found)
+            return out;
+
+        // Composite fallback via pg_class relkind='c'.
+        catalog::oid_t composite_oid = catalog::INVALID_OID;
+        {
+            std::pmr::vector<std::string> keys{&fx.resource};
+            keys.emplace_back("relnamespace");
+            keys.emplace_back("relname");
+            std::pmr::vector<components::types::logical_value_t> vals{&fx.resource};
+            vals.emplace_back(&fx.resource, namespace_oid);
+            vals.emplace_back(&fx.resource, name);
+            auto batches = probe_read(fx, ctx, pg_class, std::move(keys), std::move(vals));
+            for (const auto& chunk : batches) {
+                bool stop = false;
+                for (std::uint64_t i = 0; i < chunk.size(); ++i) {
+                    auto kind_v = chunk.value(3, i);
+                    if (kind_v.is_null())
+                        continue;
+                    const auto kind_cell = kind_v;
+                    const auto kind_s = kind_cell.template value<std::string_view>();
+                    if (kind_s.empty() || kind_s.front() != catalog::relkind::composite_type)
+                        continue;
+                    composite_oid = static_cast<catalog::oid_t>(chunk.value(0, i).template value<std::uint32_t>());
+                    stop = true;
+                    break;
+                }
+                if (stop)
+                    break;
+            }
+        }
+        if (composite_oid == catalog::INVALID_OID)
+            return out;
+
+        struct field_row {
+            std::string attname;
+            catalog::oid_t atttypid{catalog::INVALID_OID};
+            std::int32_t attnum{0};
+            std::string atttypspec;
+        };
+        std::vector<field_row> fields;
+        {
+            std::pmr::vector<std::string> keys{&fx.resource};
+            keys.emplace_back("attrelid");
+            std::pmr::vector<components::types::logical_value_t> vals{&fx.resource};
+            vals.emplace_back(&fx.resource, composite_oid);
+            auto batches = probe_read(fx, ctx, pg_attribute, std::move(keys), std::move(vals));
+            for (const auto& chunk : batches) {
+                for (std::uint64_t i = 0; i < chunk.size(); ++i) {
+                    auto dropped = chunk.value(7, i);
+                    if (!dropped.is_null() && dropped.template value<bool>())
+                        continue;
+                    field_row r;
+                    auto name_v = chunk.value(2, i);
+                    if (!name_v.is_null()) {
+                        const auto name_cell = name_v;
+                        r.attname = std::string(name_cell.template value<std::string_view>());
+                    }
+                    auto typid_v = chunk.value(3, i);
+                    if (!typid_v.is_null())
+                        r.atttypid = static_cast<catalog::oid_t>(typid_v.template value<std::uint32_t>());
+                    r.attnum = chunk.value(4, i).template value<std::int32_t>();
+                    auto spec_v = chunk.value(8, i);
+                    if (!spec_v.is_null()) {
+                        const auto spec_cell = spec_v;
+                        r.atttypspec = std::string(spec_cell.template value<std::string_view>());
+                    }
+                    fields.push_back(std::move(r));
+                }
+            }
+        }
+        std::sort(fields.begin(), fields.end(), [](const field_row& a, const field_row& b) {
+            return a.attnum < b.attnum;
+        });
+        std::pmr::vector<components::types::complex_logical_type> child_types(&fx.resource);
+        child_types.reserve(fields.size());
+        for (auto& f : fields) {
+            components::types::complex_logical_type ft =
+                f.atttypspec.empty()
+                    ? components::types::complex_logical_type{catalog::oid_to_builtin_type(f.atttypid)}
+                    : catalog::decode_type_spec(&fx.resource, f.atttypspec);
+            if (ft.type() == components::types::logical_type::UNKNOWN) {
+                std::string ref_name(ft.type_name());
+                if (!ref_name.empty()) {
+                    auto nested = probe_type(fx, ctx, namespace_oid, ref_name);
+                    if (nested.found && !nested.typdefspec.empty())
+                        ft = catalog::decode_type_spec(&fx.resource, nested.typdefspec);
+                }
+            }
+            ft.set_alias(f.attname);
+            child_types.push_back(std::move(ft));
+        }
+        auto struct_t = components::types::complex_logical_type::create_struct(name, child_types);
+        out.found = true;
+        out.oid = composite_oid;
+        out.name = name;
+        out.typdefspec = catalog::encode_type_spec(struct_t);
+        return out;
+    }
+
+    // --- probe_function ------------------------------------------------------
+    //
+    // pg_proc layout: oid(0), proname(1), pronamespace(2), pronargs(3), prouid(4),
+    //   proargmatchers(5), prorettype(6).
+    template<typename Fx>
+    probe_function_result_t probe_function(Fx& fx,
+                                           components::execution_context_t ctx,
+                                           catalog::oid_t namespace_oid,
+                                           std::string name) {
+        probe_function_result_t out;
+        out.namespace_oid = namespace_oid;
+
+        constexpr catalog::oid_t pg_proc = catalog::well_known_oid::pg_proc_table;
+        std::pmr::vector<std::string> keys{&fx.resource};
+        keys.emplace_back("pronamespace");
+        keys.emplace_back("proname");
+        std::pmr::vector<components::types::logical_value_t> vals{&fx.resource};
+        vals.emplace_back(&fx.resource, namespace_oid);
+        vals.emplace_back(&fx.resource, name);
+        auto batches = probe_read(fx, ctx, pg_proc, std::move(keys), std::move(vals));
+        for (const auto& chunk : batches) {
+            bool stop = false;
+            for (std::uint64_t i = 0; i < chunk.size(); ++i) {
+                auto oid_v = chunk.value(0, i);
+                if (oid_v.is_null())
+                    continue;
+                out.found = true;
+                out.oid = static_cast<catalog::oid_t>(oid_v.template value<std::uint32_t>());
+                out.name = name;
+                auto nargs_v = chunk.value(3, i);
+                if (!nargs_v.is_null())
+                    out.pronargs = nargs_v.template value<std::int32_t>();
+                auto uid_v = chunk.value(4, i);
+                if (!uid_v.is_null())
+                    out.prouid = uid_v.template value<std::uint64_t>();
+                auto args_v = chunk.value(5, i);
+                if (!args_v.is_null()) {
+                    const auto args_cell = args_v;
+                    out.proargmatchers = std::string(args_cell.template value<std::string_view>());
+                }
+                auto ret_v = chunk.value(6, i);
+                if (!ret_v.is_null()) {
+                    const auto ret_cell = ret_v;
+                    out.prorettype = std::string(ret_cell.template value<std::string_view>());
+                }
+                stop = true;
+                break;
+            }
+            if (stop)
+                break;
+        }
+        return out;
+    }
+
+} // namespace services::disk::test_probe

--- a/services/disk/tests/disk_test_helpers.hpp
+++ b/services/disk/tests/disk_test_helpers.hpp
@@ -11,6 +11,8 @@
 #include <components/vector/data_chunk.hpp>
 #include <services/disk/manager_disk.hpp>
 
+#include "catalog_probe.hpp"
+
 #include <limits>
 #include <set>
 #include <string>
@@ -422,8 +424,11 @@ namespace disk_test_helpers {
         std::pmr::vector<components::types::logical_value_t> reg_vals{&fx.resource};
         reg_vals.emplace_back(toid_lv);
         reg_vals.emplace_back(name_lv);
-        auto batches =
-            fx.invoke(&manager_disk_t::read_chunks_by_key, auto_ctx(), pg_cc, std::move(reg_keys), std::move(reg_vals));
+        auto batches = fx.invoke(&manager_disk_t::read_chunks_by_key,
+                                 auto_ctx(),
+                                 pg_cc,
+                                 std::move(reg_keys),
+                                 services::disk::test_probe::build_key_chunk(&fx.resource, std::move(reg_vals)));
 
         std::int64_t max_version = -1;
         catalog::oid_t latest_atttypid = catalog::INVALID_OID;
@@ -491,7 +496,7 @@ namespace disk_test_helpers {
                                  auto_ctx(),
                                  pg_cc,
                                  std::move(unreg_keys),
-                                 std::move(unreg_vals));
+                                 services::disk::test_probe::build_key_chunk(&fx.resource, std::move(unreg_vals)));
 
         std::int64_t max_version = -1;
         catalog::oid_t live_attoid = catalog::INVALID_OID;

--- a/services/disk/tests/test_d4_lazy_load.cpp
+++ b/services/disk/tests/test_d4_lazy_load.cpp
@@ -11,6 +11,7 @@
 #include <services/disk/manager_disk.hpp>
 #include <services/wal/base.hpp>
 
+#include "catalog_probe.hpp"
 #include "disk_test_helpers.hpp"
 
 #include <filesystem>
@@ -131,8 +132,7 @@ TEST_CASE("services::disk::d4::resolve_table_finds_unloaded_user_table") {
     std::vector<components::table::column_definition_t> cols;
     cols.emplace_back("id", components::types::complex_logical_type{components::types::logical_type::BIGINT});
     auto rt_oid = test_create_table(fx, ns_oid, "orders", std::move(cols));
-    auto resolved =
-        fx.invoke(&manager_disk_t::resolve_table, fx.ctx(), ns_oid, std::string("orders"), std::uint64_t{0});
+    auto resolved = test_probe::probe_table(fx, fx.ctx(), ns_oid, std::string("orders"));
     REQUIRE(resolved.found);
     REQUIRE(resolved.oid == rt_oid);
     // resolve_table did not need storage to be present in storages_ to answer the lookup.
@@ -149,8 +149,7 @@ TEST_CASE("services::disk::d4::drop_unloaded_table") {
     REQUIRE_FALSE(fx.manager->has_storage(rt_oid));
     test_drop_table(fx, rt_oid);
     // After drop the table is no longer resolvable.
-    auto resolved =
-        fx.invoke(&manager_disk_t::resolve_table, fx.ctx(), ns_oid, std::string("temp_t"), std::uint64_t{0});
+    auto resolved = test_probe::probe_table(fx, fx.ctx(), ns_oid, std::string("temp_t"));
     REQUIRE_FALSE(resolved.found);
 }
 
@@ -171,8 +170,7 @@ TEST_CASE("services::disk::d4::alter_unloaded_table_add_column") {
     // No user-storage materialisation as a side-effect of ALTER.
     REQUIRE_FALSE(fx.manager->has_storage(rt_oid));
     // The new column shows up via resolve_table.
-    auto resolved =
-        fx.invoke(&manager_disk_t::resolve_table, fx.ctx(), ns_oid, std::string("alter_me"), std::uint64_t{0});
+    auto resolved = test_probe::probe_table(fx, fx.ctx(), ns_oid, std::string("alter_me"));
     REQUIRE(resolved.found);
     REQUIRE(resolved.columns.size() == 2);
 }
@@ -187,7 +185,7 @@ TEST_CASE("services::disk::d4::repeated_resolve_does_not_create_storage") {
     cols.emplace_back("id", components::types::complex_logical_type{components::types::logical_type::BIGINT});
     auto rt_oid = test_create_table(fx, ns_oid, "readme", std::move(cols));
     for (int i = 0; i < 3; ++i) {
-        auto r = fx.invoke(&manager_disk_t::resolve_table, fx.ctx(), ns_oid, std::string("readme"), std::uint64_t{0});
+        auto r = test_probe::probe_table(fx, fx.ctx(), ns_oid, std::string("readme"));
         REQUIRE(r.found);
     }
     REQUIRE_FALSE(fx.manager->has_storage(rt_oid));
@@ -203,7 +201,7 @@ TEST_CASE("services::disk::d4::resolve_table_collects_columns_by_attrelid") {
     cols.emplace_back("b", components::types::complex_logical_type{components::types::logical_type::STRING_LITERAL});
     cols.emplace_back("c", components::types::complex_logical_type{components::types::logical_type::DOUBLE});
     auto rt_oid = test_create_table(fx, ns_oid, "multi", std::move(cols));
-    auto r = fx.invoke(&manager_disk_t::resolve_table, fx.ctx(), ns_oid, std::string("multi"), std::uint64_t{0});
+    auto r = test_probe::probe_table(fx, fx.ctx(), ns_oid, std::string("multi"));
     REQUIRE(r.found);
     REQUIRE(r.oid == rt_oid);
     REQUIRE(r.columns.size() == 3);

--- a/services/disk/tests/test_ddl_methods.cpp
+++ b/services/disk/tests/test_ddl_methods.cpp
@@ -12,6 +12,7 @@
 #include <core/non_thread_scheduler/scheduler_test.hpp>
 #include <services/disk/manager_disk.hpp>
 
+#include "catalog_probe.hpp"
 #include "disk_test_helpers.hpp"
 
 #include <algorithm>
@@ -97,7 +98,7 @@ TEST_CASE("services::disk::ddl::add_column_round_trip") {
     auto attoid = test_add_column(fx, table_oid, std::move(new_col), 2);
     REQUIRE(attoid >= FIRST_USER_OID);
     // After add, the column count visible via resolve_table grows.
-    auto rs = fx.invoke(&manager_disk_t::resolve_table, fx.ctx(), ns_oid, std::string("t"), std::uint64_t{0});
+    auto rs = test_probe::probe_table(fx, fx.ctx(), ns_oid, std::string("t"));
     REQUIRE(rs.found);
     REQUIRE(rs.columns.size() == 2);
 }
@@ -124,7 +125,7 @@ TEST_CASE("services::disk::ddl::computed_register_type_evolution") {
     REQUIRE(attoid_text != attoid_int);
 
     // resolve_table must report the latest version (TEXT) of column "a".
-    auto rs = fx.invoke(&manager_disk_t::resolve_table, fx.ctx(), ns_oid, std::string("agg"), std::uint64_t{0});
+    auto rs = test_probe::probe_table(fx, fx.ctx(), ns_oid, std::string("agg"));
     REQUIRE(rs.found);
     REQUIRE(rs.relkind == components::catalog::relkind::computed);
     REQUIRE(rs.columns.size() == 1);
@@ -175,14 +176,18 @@ TEST_CASE("services::disk::ddl::computed_register_same_type_idempotent") {
     std::pmr::vector<components::types::logical_value_t> v1{&fx.resource};
     v1.emplace_back(toid_lv);
     v1.emplace_back(name_lv);
-    auto batches = fx.invoke(&manager_disk_t::read_chunks_by_key, fx.ctx(), pg_cc, std::move(k1), std::move(v1));
+    auto batches = fx.invoke(&manager_disk_t::read_chunks_by_key,
+                             fx.ctx(),
+                             pg_cc,
+                             std::move(k1),
+                             test_probe::build_key_chunk(&fx.resource, std::move(v1)));
     std::uint64_t total = 0;
     for (const auto& c : batches)
         total += c.size();
     REQUIRE(total == 1);
     REQUIRE(batches[0].value(6, 0).value<std::int64_t>() == 1);
 
-    auto rs = fx.invoke(&manager_disk_t::resolve_table, fx.ctx(), ns_oid, std::string("agg"), std::uint64_t{0});
+    auto rs = test_probe::probe_table(fx, fx.ctx(), ns_oid, std::string("agg"));
     REQUIRE(rs.found);
     REQUIRE(rs.columns.size() == 1);
 }
@@ -204,7 +209,7 @@ TEST_CASE("services::disk::ddl::computed_unregister_then_resolve_hides_column") 
     REQUIRE(attoid >= FIRST_USER_OID);
 
     // Confirm column visible before unregister.
-    auto rs_before = fx.invoke(&manager_disk_t::resolve_table, fx.ctx(), ns_oid, std::string("agg"), std::uint64_t{0});
+    auto rs_before = test_probe::probe_table(fx, fx.ctx(), ns_oid, std::string("agg"));
     REQUIRE(rs_before.found);
     REQUIRE(rs_before.columns.size() == 1);
     REQUIRE(rs_before.columns[0].attname == "count");
@@ -213,7 +218,7 @@ TEST_CASE("services::disk::ddl::computed_unregister_then_resolve_hides_column") 
     REQUIRE(test_computed_unregister(fx, table_oid, "count"));
 
     // Column hidden from resolve_table.
-    auto rs_after = fx.invoke(&manager_disk_t::resolve_table, fx.ctx(), ns_oid, std::string("agg"), std::uint64_t{0});
+    auto rs_after = test_probe::probe_table(fx, fx.ctx(), ns_oid, std::string("agg"));
     REQUIRE(rs_after.found);
     REQUIRE(rs_after.relkind == components::catalog::relkind::computed);
     REQUIRE(rs_after.columns.empty());
@@ -246,7 +251,11 @@ TEST_CASE("services::disk::ddl::computed_unregister_marks_dead") {
     std::pmr::vector<components::types::logical_value_t> v2{&fx.resource};
     v2.emplace_back(toid_lv);
     v2.emplace_back(name_lv);
-    auto batches = fx.invoke(&manager_disk_t::read_chunks_by_key, fx.ctx(), pg_cc, std::move(k2), std::move(v2));
+    auto batches = fx.invoke(&manager_disk_t::read_chunks_by_key,
+                             fx.ctx(),
+                             pg_cc,
+                             std::move(k2),
+                             test_probe::build_key_chunk(&fx.resource, std::move(v2)));
     std::uint64_t total = 0;
     for (const auto& c : batches)
         total += c.size();
@@ -325,7 +334,11 @@ TEST_CASE("services::disk::ddl::computed_field_drop_then_readd") {
     k3.emplace_back("relid");
     std::pmr::vector<components::types::logical_value_t> v3{&fx.resource};
     v3.emplace_back(toid_lv);
-    auto batches = fx.invoke(&manager_disk_t::read_chunks_by_key, fx.ctx(), pg_cc, std::move(k3), std::move(v3));
+    auto batches = fx.invoke(&manager_disk_t::read_chunks_by_key,
+                             fx.ctx(),
+                             pg_cc,
+                             std::move(k3),
+                             test_probe::build_key_chunk(&fx.resource, std::move(v3)));
     std::uint64_t total_rows = 0;
     for (const auto& c : batches)
         total_rows += c.size();
@@ -386,7 +399,7 @@ TEST_CASE("services::disk::ddl::computed_field_drop_then_readd") {
     }
 
     // resolve_table reflects the resolver's refcount>0 + max-attversion gate.
-    auto rs = fx.invoke(&manager_disk_t::resolve_table, fx.ctx(), ns_oid, std::string("foo"), std::uint64_t{0});
+    auto rs = test_probe::probe_table(fx, fx.ctx(), ns_oid, std::string("foo"));
     REQUIRE(rs.found);
     REQUIRE(rs.relkind == components::catalog::relkind::computed);
 
@@ -458,7 +471,11 @@ TEST_CASE("services::disk::ddl::vacuum_gc_clears_dead_computed_columns") {
         kk.emplace_back("relid");
         std::pmr::vector<components::types::logical_value_t> vv{&fx.resource};
         vv.emplace_back(toid_lv);
-        auto batches = fx.invoke(&manager_disk_t::read_chunks_by_key, fx.ctx(), pg_cc, std::move(kk), std::move(vv));
+        auto batches = fx.invoke(&manager_disk_t::read_chunks_by_key,
+                                 fx.ctx(),
+                                 pg_cc,
+                                 std::move(kk),
+                                 test_probe::build_key_chunk(&fx.resource, std::move(vv)));
         std::uint64_t total = 0;
         for (const auto& c : batches)
             total += c.size();
@@ -475,7 +492,11 @@ TEST_CASE("services::disk::ddl::vacuum_gc_clears_dead_computed_columns") {
         kk.emplace_back("relid");
         std::pmr::vector<components::types::logical_value_t> vv{&fx.resource};
         vv.emplace_back(toid_lv);
-        auto batches = fx.invoke(&manager_disk_t::read_chunks_by_key, fx.ctx(), pg_cc, std::move(kk), std::move(vv));
+        auto batches = fx.invoke(&manager_disk_t::read_chunks_by_key,
+                                 fx.ctx(),
+                                 pg_cc,
+                                 std::move(kk),
+                                 test_probe::build_key_chunk(&fx.resource, std::move(vv)));
         std::vector<catalog::oid_t> dead_attoids;
         for (const auto& chunk : batches) {
             REQUIRE(chunk.column_count() >= 7);
@@ -504,7 +525,11 @@ TEST_CASE("services::disk::ddl::vacuum_gc_clears_dead_computed_columns") {
         kk.emplace_back("relid");
         std::pmr::vector<components::types::logical_value_t> vv{&fx.resource};
         vv.emplace_back(toid_lv);
-        auto batches = fx.invoke(&manager_disk_t::read_chunks_by_key, fx.ctx(), pg_cc, std::move(kk), std::move(vv));
+        auto batches = fx.invoke(&manager_disk_t::read_chunks_by_key,
+                                 fx.ctx(),
+                                 pg_cc,
+                                 std::move(kk),
+                                 test_probe::build_key_chunk(&fx.resource, std::move(vv)));
         std::uint64_t total = 0;
         for (const auto& c : batches)
             total += c.size();
@@ -520,7 +545,7 @@ TEST_CASE("services::disk::ddl::vacuum_gc_clears_dead_computed_columns") {
     }
 
     // resolve_table sees only {a, c}.
-    auto rs = fx.invoke(&manager_disk_t::resolve_table, fx.ctx(), ns_oid, std::string("agg"), std::uint64_t{0});
+    auto rs = test_probe::probe_table(fx, fx.ctx(), ns_oid, std::string("agg"));
     REQUIRE(rs.found);
     REQUIRE(rs.relkind == components::catalog::relkind::computed);
     REQUIRE(rs.columns.size() == 2);
@@ -597,7 +622,11 @@ TEST_CASE("services::disk::ddl::vacuum_physical_compaction_removes_dropped_colum
         kk.emplace_back("relid");
         std::pmr::vector<logical_value_t> vv{&fx.resource};
         vv.emplace_back(toid_lv);
-        auto batches = fx.invoke(&manager_disk_t::read_chunks_by_key, fx.ctx(), pg_cc, std::move(kk), std::move(vv));
+        auto batches = fx.invoke(&manager_disk_t::read_chunks_by_key,
+                                 fx.ctx(),
+                                 pg_cc,
+                                 std::move(kk),
+                                 test_probe::build_key_chunk(&fx.resource, std::move(vv)));
         std::vector<catalog::oid_t> dead_attoids;
         for (const auto& chunk : batches) {
             for (std::uint64_t i = 0; i < chunk.size(); ++i) {
@@ -798,10 +827,193 @@ TEST_CASE("services::disk::ddl::storage_expand_on_write_for_dynamic_schema") {
     // pg_computed_column, which DOES grow correctly across the three
     // test_computed_register calls. This is the path the runtime relies on
     // for dynamic-schema growth — independent of what storage_append does.
-    auto rs = fx.invoke(&manager_disk_t::resolve_table, fx.ctx(), ns_oid, std::string("docs"), std::uint64_t{0});
+    auto rs = test_probe::probe_table(fx, fx.ctx(), ns_oid, std::string("docs"));
     REQUIRE(rs.found);
     REQUIRE(rs.relkind == components::catalog::relkind::computed);
     REQUIRE(rs.columns.size() == 3);
+}
+
+// Batched DROP: drop_storage_many erases N user storages in ONE call. Create N
+// IN_MEMORY user storages (with one row each so they're observably non-empty),
+// confirm each is present, then send a single drop_storage_many with the N oids
+// and assert all N are gone (has_storage false / storage_total_rows 0 /
+// read_chunks_by_key empty) while a non-targeted storage survives untouched.
+TEST_CASE("services::disk::ddl::drop_storage_many_erases_n") {
+    using components::types::complex_logical_type;
+    using components::types::logical_type;
+    using components::types::logical_value_t;
+    using components::vector::data_chunk_t;
+
+    fixture fx;
+
+    // Allocate N+1 fresh user OIDs (N targeted for DROP + 1 survivor).
+    constexpr std::size_t N = 4;
+    auto oids = fx.invoke(&manager_disk_t::allocate_oids_batch, std::size_t{N + 1});
+    REQUIRE(oids.size() == N + 1);
+
+    std::vector<catalog::oid_t> targets(oids.begin(), oids.begin() + N);
+    const catalog::oid_t survivor = oids[N];
+
+    auto append_one = [&](catalog::oid_t oid, std::int64_t kval) {
+        std::pmr::vector<complex_logical_type> types(&fx.resource);
+        for (auto n : {"k", "payload"}) {
+            complex_logical_type t{logical_type::BIGINT};
+            t.set_alias(n);
+            types.push_back(std::move(t));
+        }
+        auto chunk = std::make_unique<data_chunk_t>(&fx.resource, types, 1);
+        chunk->set_cardinality(1);
+        chunk->set_value(0, 0, logical_value_t(&fx.resource, kval));
+        chunk->set_value(1, 0, logical_value_t(&fx.resource, std::int64_t{kval * 10}));
+        components::execution_context_t append_ctx{session_id_t{},
+                                                   components::table::transaction_data{0, 0},
+                                                   {},
+                                                   oid};
+        fx.invoke(&manager_disk_t::storage_append, append_ctx, oid, std::move(chunk));
+    };
+
+    // Create + populate the N targets and the survivor.
+    for (std::size_t i = 0; i < N; ++i) {
+        fx.invoke(&manager_disk_t::create_storage, session_id_t{}, targets[i], well_known_oid::main_database);
+        append_one(targets[i], static_cast<std::int64_t>(i + 1));
+    }
+    fx.invoke(&manager_disk_t::create_storage, session_id_t{}, survivor, well_known_oid::main_database);
+    append_one(survivor, std::int64_t{777});
+
+    // Pre-DROP: every target is present and non-empty.
+    for (std::size_t i = 0; i < N; ++i) {
+        REQUIRE(fx.manager->has_storage(targets[i]));
+        auto rows = fx.invoke(&manager_disk_t::storage_total_rows, session_id_t{}, targets[i]);
+        REQUIRE(rows == 1);
+    }
+    REQUIRE(fx.manager->has_storage(survivor));
+    REQUIRE(fx.invoke(&manager_disk_t::storage_total_rows, session_id_t{}, survivor) == 1);
+
+    // ONE batched drop for all N targets (survivor NOT in the oid list).
+    {
+        std::pmr::vector<catalog::oid_t> drop_oids{&fx.resource};
+        for (auto oid : targets)
+            drop_oids.push_back(oid);
+        fx.invoke(&manager_disk_t::drop_storage_many, session_id_t{}, std::move(drop_oids));
+    }
+
+    // Post-DROP: all N targets are gone on every observable surface.
+    for (std::size_t i = 0; i < N; ++i) {
+        REQUIRE_FALSE(fx.manager->has_storage(targets[i]));
+        REQUIRE(fx.invoke(&manager_disk_t::storage_total_rows, session_id_t{}, targets[i]) == 0);
+        std::pmr::vector<std::string> key_cols{&fx.resource};
+        key_cols.emplace_back("k");
+        std::pmr::vector<logical_value_t> vals{&fx.resource};
+        vals.emplace_back(&fx.resource, static_cast<std::int64_t>(i + 1));
+        auto chunks = fx.invoke(&manager_disk_t::read_chunks_by_key,
+                                fx.ctx(),
+                                targets[i],
+                                std::move(key_cols),
+                                test_probe::build_key_chunk(&fx.resource, std::move(vals)));
+        std::uint64_t total = 0;
+        for (const auto& c : chunks)
+            total += c.size();
+        REQUIRE(total == 0);
+    }
+
+    // Survivor untouched: still present, still 1 row, still readable.
+    REQUIRE(fx.manager->has_storage(survivor));
+    REQUIRE(fx.invoke(&manager_disk_t::storage_total_rows, session_id_t{}, survivor) == 1);
+    {
+        std::pmr::vector<std::string> key_cols{&fx.resource};
+        key_cols.emplace_back("k");
+        std::pmr::vector<logical_value_t> vals{&fx.resource};
+        vals.emplace_back(&fx.resource, std::int64_t{777});
+        auto chunks = fx.invoke(&manager_disk_t::read_chunks_by_key,
+                                fx.ctx(),
+                                survivor,
+                                std::move(key_cols),
+                                test_probe::build_key_chunk(&fx.resource, std::move(vals)));
+        std::uint64_t total = 0;
+        for (const auto& c : chunks)
+            total += c.size();
+        REQUIRE(total == 1);
+    }
+}
+
+// Batched DROP-GC marking: mark_storage_dropped_many records N GC entries in ONE
+// call, and a subsequent on_horizon_advanced past the dropped_at_commit_id
+// reclaims each storage's .otbx file. The per-agent dropped_storages_ slice has
+// no direct accessor, so observability is via the GC side effect: create N
+// DISK-backed storages (each gets a real <db>/<oid>/table.otbx), mark them all
+// dropped at commit D, advance the horizon past D, and assert the .otbx files
+// are gone. A non-marked DISK storage's .otbx survives.
+//
+// NOTE on the limitation: mark_storage_dropped_many does NOT remove the storage
+// entry from storages_ (that is drop_storage_many's job) and does NOT itself
+// delete files; it only records the GC entry. The .otbx removal is performed by
+// on_horizon_advanced_inner (agent_disk.cpp: dropped_at_commit_id < new_horizon).
+// So the file-reclamation assertion below is the strongest feasible observation
+// of the recorded GC entries without a dropped_storages_ accessor.
+TEST_CASE("services::disk::ddl::mark_storage_dropped_many_records_n_gc_entries") {
+    using components::table::column_definition_t;
+    using components::types::complex_logical_type;
+    using components::types::logical_type;
+
+    fixture fx;
+
+    constexpr std::size_t N = 3;
+    auto oids = fx.invoke(&manager_disk_t::allocate_oids_batch, std::size_t{N + 1});
+    REQUIRE(oids.size() == N + 1);
+    std::vector<catalog::oid_t> targets(oids.begin(), oids.begin() + N);
+    const catalog::oid_t survivor = oids[N];
+
+    // .otbx path layout mirrors manager_disk_t::create_storage_disk:
+    //   <config.path>/<db_oid>/<tbl_oid>/table.otbx
+    constexpr catalog::oid_t db_oid = well_known_oid::main_database;
+    auto otbx_path_for = [&](catalog::oid_t tbl) {
+        return std::filesystem::path(ddl_dir()) / std::to_string(static_cast<unsigned>(db_oid)) /
+               std::to_string(static_cast<unsigned>(tbl)) / "table.otbx";
+    };
+
+    auto make_disk_storage = [&](catalog::oid_t tbl) {
+        std::vector<column_definition_t> cols;
+        cols.emplace_back("k", complex_logical_type{logical_type::BIGINT});
+        fx.invoke(&manager_disk_t::create_storage_disk, session_id_t{}, tbl, db_oid, std::move(cols));
+    };
+
+    for (auto oid : targets)
+        make_disk_storage(oid);
+    make_disk_storage(survivor);
+
+    // Every DISK-backed storage materialised its .otbx on creation.
+    for (auto oid : targets)
+        REQUIRE(std::filesystem::exists(otbx_path_for(oid)));
+    REQUIRE(std::filesystem::exists(otbx_path_for(survivor)));
+
+    // ONE batched mark for all N targets at dropped_at_commit_id = D (survivor
+    // not in the list). mark does NOT remove storages_ entries or touch files.
+    constexpr std::uint64_t D = 5000;
+    {
+        std::pmr::vector<catalog::oid_t> mark_oids{&fx.resource};
+        for (auto oid : targets)
+            mark_oids.push_back(oid);
+        fx.invoke(&manager_disk_t::mark_storage_dropped_many, session_id_t{}, std::move(mark_oids), D);
+    }
+
+    // Marking alone leaves the .otbx files in place (GC is horizon-driven).
+    for (auto oid : targets)
+        REQUIRE(std::filesystem::exists(otbx_path_for(oid)));
+
+    // A horizon advance that does NOT pass D (dropped_at_commit_id < new_horizon
+    // is false for new_horizon <= D) reclaims nothing.
+    fx.invoke(&manager_disk_t::on_horizon_advanced, D);
+    for (auto oid : targets)
+        REQUIRE(std::filesystem::exists(otbx_path_for(oid)));
+
+    // Advancing the horizon PAST D fires the GC sweep: each recorded entry's
+    // .otbx (and sidecars) is reclaimed.
+    fx.invoke(&manager_disk_t::on_horizon_advanced, D + 1);
+    for (auto oid : targets)
+        REQUIRE_FALSE(std::filesystem::exists(otbx_path_for(oid)));
+
+    // The non-marked survivor's .otbx is untouched (no GC entry was recorded).
+    REQUIRE(std::filesystem::exists(otbx_path_for(survivor)));
 }
 
 // Computing tables (relkind='g') get no pg_attribute rows on creation —
@@ -816,7 +1028,7 @@ TEST_CASE("services::disk::ddl::computing_table_pg_attribute_empty") {
                                        std::vector<components::table::column_definition_t>{},
                                        catalog::relkind::computed);
     REQUIRE(table_oid >= FIRST_USER_OID);
-    auto rr = fx.invoke(&manager_disk_t::resolve_table, fx.ctx(), ns_oid, std::string("agg"), std::uint64_t{0});
+    auto rr = test_probe::probe_table(fx, fx.ctx(), ns_oid, std::string("agg"));
     REQUIRE(rr.found);
     REQUIRE(rr.relkind == components::catalog::relkind::computed);
     REQUIRE(rr.columns.empty());
@@ -825,7 +1037,7 @@ TEST_CASE("services::disk::ddl::computing_table_pg_attribute_empty") {
     // V4 resolve_table for relkind='g' tables fills `columns` from pg_computed_column
     // (latest non-zero refcount per attname).
     test_computed_append_simple(fx, table_oid, "count", components::catalog::well_known_oid::int64_type);
-    auto rr2 = fx.invoke(&manager_disk_t::resolve_table, fx.ctx(), ns_oid, std::string("agg"), std::uint64_t{0});
+    auto rr2 = test_probe::probe_table(fx, fx.ctx(), ns_oid, std::string("agg"));
     REQUIRE(rr2.found);
     REQUIRE(rr2.relkind == components::catalog::relkind::computed);
     REQUIRE(rr2.columns.size() == 1);

--- a/services/disk/tests/test_error_handling.cpp
+++ b/services/disk/tests/test_error_handling.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch.hpp>
 
+#include "catalog_probe.hpp"
 #include "disk_test_helpers.hpp"
 #include <actor-zeta/spawn.hpp>
 #include <components/catalog/catalog_codes.hpp>
@@ -94,14 +95,14 @@ TEST_CASE("services::disk::error::resolve_unknown_namespace") {
 TEST_CASE("services::disk::error::resolve_unknown_table") {
     fixture fx;
     auto ns_oid = test_create_namespace(fx, "ns");
-    auto rt = fx.invoke(&manager_disk_t::resolve_table, fx.ctx(), ns_oid, std::string("not_a_table"), std::uint64_t{0});
+    auto rt = test_probe::probe_table(fx, fx.ctx(), ns_oid, std::string("not_a_table"));
     REQUIRE_FALSE(rt.found);
 }
 
 // 3. resolve_table with INVALID_OID namespace returns found=false.
 TEST_CASE("services::disk::error::resolve_table_invalid_namespace") {
     fixture fx;
-    auto rt = fx.invoke(&manager_disk_t::resolve_table, fx.ctx(), INVALID_OID, std::string("any"), std::uint64_t{0});
+    auto rt = test_probe::probe_table(fx, fx.ctx(), INVALID_OID, std::string("any"));
     REQUIRE_FALSE(rt.found);
 }
 
@@ -153,7 +154,6 @@ TEST_CASE("services::disk::error::empty_name_accepted") {
 TEST_CASE("services::disk::error::resolve_unknown_function") {
     fixture fx;
     auto ns_oid = test_create_namespace(fx, "ns");
-    auto rf =
-        fx.invoke(&manager_disk_t::resolve_function, fx.ctx(), ns_oid, std::string("unknown_fn"), std::uint64_t{0});
+    auto rf = test_probe::probe_function(fx, fx.ctx(), ns_oid, std::string("unknown_fn"));
     REQUIRE_FALSE(rf.found);
 }

--- a/services/disk/tests/test_mvcc_ddl.cpp
+++ b/services/disk/tests/test_mvcc_ddl.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch.hpp>
 
+#include "catalog_probe.hpp"
 #include "disk_test_helpers.hpp"
 #include <actor-zeta/spawn.hpp>
 #include <limits>
@@ -135,7 +136,7 @@ TEST_CASE("services::disk::mvcc::auto_commit_drop_invisible") {
     const auto table_oid =
         disk_test_helpers::test_create_table(fx, ns_oid, std::string("t"), cols, catalog::relkind::regular);
     disk_test_helpers::test_drop_table(fx, table_oid);
-    auto rr = fx.invoke(&manager_disk_t::resolve_table, fx.auto_ctx(), ns_oid, std::string("t"), std::uint64_t{0});
+    auto rr = test_probe::probe_table(fx, fx.auto_ctx(), ns_oid, std::string("t"));
     REQUIRE_FALSE(rr.found);
 }
 
@@ -170,7 +171,7 @@ TEST_CASE("services::disk::mvcc::uncommitted_delete_invisible_to_other_readers")
         fx.invoke(&manager_disk_t::delete_pg_catalog_rows, fx.txn_ctx(uncommitted), pg_dep, std::int64_t{3}, table_oid);
         // Intentionally no MVCC swap (no storage_publish_commits call).
     }
-    auto rr = fx.invoke(&manager_disk_t::resolve_table, fx.auto_ctx(), ns_oid, std::string("doomed"), std::uint64_t{0});
+    auto rr = test_probe::probe_table(fx, fx.auto_ctx(), ns_oid, std::string("doomed"));
     REQUIRE(rr.found);
 }
 
@@ -239,8 +240,7 @@ TEST_CASE("services::disk::mvcc::uncommitted_drop_index_invisible") {
         fx.invoke(&manager_disk_t::delete_pg_catalog_rows, fx.txn_ctx(uncommitted), pg_dep, std::int64_t{3}, index_oid);
         // Intentionally no MVCC swap (no storage_publish_commits call).
     }
-    auto rr =
-        fx.invoke(&manager_disk_t::resolve_table, fx.auto_ctx(), ns_oid, std::string("idx_doomed"), std::uint64_t{0});
+    auto rr = test_probe::probe_table(fx, fx.auto_ctx(), ns_oid, std::string("idx_doomed"));
     REQUIRE(rr.found);
 }
 
@@ -259,7 +259,7 @@ TEST_CASE("services::disk::mvcc::uncommitted_drop_type_invisible") {
         fx.invoke(&manager_disk_t::delete_pg_catalog_rows, fx.txn_ctx(uncommitted), pg_dep, std::int64_t{3}, type_oid);
         // Intentionally no MVCC swap (no storage_publish_commits call).
     }
-    auto rr = fx.invoke(&manager_disk_t::resolve_type, fx.auto_ctx(), ns_oid, std::string("widget"), std::uint64_t{0});
+    auto rr = test_probe::probe_type(fx, fx.auto_ctx(), ns_oid, std::string("widget"));
     REQUIRE(rr.found);
 }
 
@@ -298,19 +298,16 @@ TEST_CASE("services::disk::mvcc::test_ddl_rollback_cleans_up") {
     }
     REQUIRE(table_oid >= FIRST_USER_OID);
     // Before rollback: invisible to other sessions (insert_id >= TRANSACTION_ID_START).
-    auto before_other =
-        fx.invoke(&manager_disk_t::resolve_table, fx.auto_ctx(), ns_oid, std::string("ephemeral"), std::uint64_t{0});
+    auto before_other = test_probe::probe_table(fx, fx.auto_ctx(), ns_oid, std::string("ephemeral"));
     REQUIRE_FALSE(before_other.found);
     // Revert via batched API. The test captured append ranges above
     // (from append_pg_catalog_row return values).
     fx.invoke(&manager_disk_t::storage_revert_appends, fx.txn_ctx(txn), std::move(appends_for_test));
     // After rollback: still not found — no orphan rows.
-    auto after =
-        fx.invoke(&manager_disk_t::resolve_table, fx.auto_ctx(), ns_oid, std::string("ephemeral"), std::uint64_t{0});
+    auto after = test_probe::probe_table(fx, fx.auto_ctx(), ns_oid, std::string("ephemeral"));
     REQUIRE_FALSE(after.found);
     // Same txn also cannot find the rolled-back table.
-    auto after_same =
-        fx.invoke(&manager_disk_t::resolve_table, fx.txn_ctx(txn), ns_oid, std::string("ephemeral"), std::uint64_t{0});
+    auto after_same = test_probe::probe_table(fx, fx.txn_ctx(txn), ns_oid, std::string("ephemeral"));
     REQUIRE_FALSE(after_same.found);
 }
 
@@ -340,10 +337,8 @@ TEST_CASE("services::disk::mvcc::drop_cascade_uncommitted_invisible_to_other_rea
         fx.invoke(&manager_disk_t::delete_pg_catalog_rows, fx.txn_ctx(uncommitted), pg_dep, std::int64_t{3}, ns_oid);
         // Intentionally no MVCC swap (no storage_publish_commits call).
     }
-    auto rt_after =
-        fx.invoke(&manager_disk_t::resolve_table, fx.auto_ctx(), ns_oid, std::string("t"), std::uint64_t{0});
-    auto idx_after =
-        fx.invoke(&manager_disk_t::resolve_table, fx.auto_ctx(), ns_oid, std::string("child_idx"), std::uint64_t{0});
+    auto rt_after = test_probe::probe_table(fx, fx.auto_ctx(), ns_oid, std::string("t"));
+    auto idx_after = test_probe::probe_table(fx, fx.auto_ctx(), ns_oid, std::string("child_idx"));
     REQUIRE(rt_after.found);
     REQUIRE(idx_after.found);
 }
@@ -378,8 +373,7 @@ TEST_CASE("services::disk::mvcc::dynamic_schema_register_invisible_until_commit"
     }
 
     // Other-session read (txn=0) must NOT see the uncommitted column.
-    auto resolved_other =
-        fx.invoke(&manager_disk_t::resolve_table, fx.auto_ctx(), ns_oid, std::string("docs"), std::uint64_t{0});
+    auto resolved_other = test_probe::probe_table(fx, fx.auto_ctx(), ns_oid, std::string("docs"));
     REQUIRE(resolved_other.found);
     REQUIRE(resolved_other.relkind == components::catalog::relkind::computed);
     REQUIRE(resolved_other.columns.size() == 0);
@@ -391,8 +385,7 @@ TEST_CASE("services::disk::mvcc::dynamic_schema_register_invisible_until_commit"
               std::move(pending_ranges));
 
     // Fresh reader (txn=0) now sees the committed column.
-    auto resolved_after =
-        fx.invoke(&manager_disk_t::resolve_table, fx.auto_ctx(), ns_oid, std::string("docs"), std::uint64_t{0});
+    auto resolved_after = test_probe::probe_table(fx, fx.auto_ctx(), ns_oid, std::string("docs"));
     REQUIRE(resolved_after.found);
     REQUIRE(resolved_after.columns.size() == 1);
     REQUIRE(resolved_after.columns[0].attname == "a");
@@ -425,8 +418,7 @@ TEST_CASE("services::disk::mvcc::dynamic_schema_register_rollback_undoes") {
     }
 
     // Before rollback: invisible to other readers (uncommitted).
-    auto before =
-        fx.invoke(&manager_disk_t::resolve_table, fx.auto_ctx(), ns_oid, std::string("docs"), std::uint64_t{0});
+    auto before = test_probe::probe_table(fx, fx.auto_ctx(), ns_oid, std::string("docs"));
     REQUIRE(before.found);
     REQUIRE(before.columns.size() == 0);
 
@@ -434,12 +426,10 @@ TEST_CASE("services::disk::mvcc::dynamic_schema_register_rollback_undoes") {
     fx.invoke(&manager_disk_t::storage_revert_appends, fx.txn_ctx(txn1), std::move(pending_ranges));
 
     // After rollback: still no column visible from any reader.
-    auto after_other =
-        fx.invoke(&manager_disk_t::resolve_table, fx.auto_ctx(), ns_oid, std::string("docs"), std::uint64_t{0});
+    auto after_other = test_probe::probe_table(fx, fx.auto_ctx(), ns_oid, std::string("docs"));
     REQUIRE(after_other.found);
     REQUIRE(after_other.columns.size() == 0);
-    auto after_same =
-        fx.invoke(&manager_disk_t::resolve_table, fx.txn_ctx(txn1), ns_oid, std::string("docs"), std::uint64_t{0});
+    auto after_same = test_probe::probe_table(fx, fx.txn_ctx(txn1), ns_oid, std::string("docs"));
     REQUIRE(after_same.found);
     REQUIRE(after_same.columns.size() == 0);
 }
@@ -479,13 +469,16 @@ TEST_CASE("services::disk::mvcc::dynamic_schema_register_visible_in_same_txn") {
         fx.invoke(&manager_disk_t::append_pg_catalog_row, fx.txn_ctx(txn1), pg_cc, std::move(row));
     }
 
-    // resolve_table from the SAME txn — inline_scan goes through committed_version_operator
-    // with (current_version_, current_version_), so own-uncommitted writes are NOT visible.
+    // Resolve from the SAME txn using PRODUCTION semantics: operator_resolve_table issues
+    // read_chunks_by_key with the caller's real ctx->txn (committed_scan=false), so the txn
+    // reads its own in-flight catalog write back (read-your-own-writes). This matches the
+    // production resolve path; the deleted disk resolve_table scanned committed-only and
+    // would have hidden it.
     auto resolved_self =
-        fx.invoke(&manager_disk_t::resolve_table, fx.txn_ctx(txn1), ns_oid, std::string("docs"), std::uint64_t{0});
+        test_probe::probe_table(fx, fx.txn_ctx(txn1), ns_oid, std::string("docs"), /*committed_scan=*/false);
     REQUIRE(resolved_self.found);
     REQUIRE(resolved_self.relkind == components::catalog::relkind::computed);
-    REQUIRE(resolved_self.columns.size() == 0);
+    REQUIRE(resolved_self.columns.size() == 1);
 }
 
 // Concurrent INSERTs into a relkind='g' table can register the

--- a/services/disk/tests/test_persistence.cpp
+++ b/services/disk/tests/test_persistence.cpp
@@ -13,6 +13,7 @@
 #include <core/non_thread_scheduler/scheduler_test.hpp>
 #include <services/disk/manager_disk.hpp>
 
+#include "catalog_probe.hpp"
 #include "disk_test_helpers.hpp"
 
 #include <filesystem>
@@ -110,9 +111,9 @@ TEST_CASE("services::disk::persistence::test_type_persistence_across_restart") {
     }
     {
         fresh_disk fd2(dir);
-        fd2.manager->load_system_tables_sync();
+        fd2.manager->bootstrap_system_tables_sync();
         fd2.manager->restore_oid_generator_sync();
-        auto rr = fd2.invoke(&manager_disk_t::resolve_type, fd2.ctx(), ns_oid, std::string("money"), std::uint64_t{0});
+        auto rr = test_probe::probe_type(fd2, fd2.ctx(), ns_oid, std::string("money"));
         REQUIRE(rr.found);
         REQUIRE(rr.oid == type_oid);
     }
@@ -137,10 +138,9 @@ TEST_CASE("services::disk::persistence::test_function_persistence") {
     }
     {
         fresh_disk fd2(dir);
-        fd2.manager->load_system_tables_sync();
+        fd2.manager->bootstrap_system_tables_sync();
         fd2.manager->restore_oid_generator_sync();
-        auto rr =
-            fd2.invoke(&manager_disk_t::resolve_function, fd2.ctx(), ns_oid, std::string("incr"), std::uint64_t{0});
+        auto rr = test_probe::probe_function(fd2, fd2.ctx(), ns_oid, std::string("incr"));
         REQUIRE(rr.found);
         REQUIRE(rr.oid == fn_oid);
     }
@@ -174,10 +174,10 @@ TEST_CASE("services::disk::persistence::test_constraint_persistence") {
 
         // Resolve column attoids — needed by test_create_constraint (conkey/confkey are
         // attoid CSVs).
-        auto rrc = fd.invoke(&manager_disk_t::resolve_table, fd.ctx(), ns_oid, std::string("child"), std::uint64_t{0});
+        auto rrc = test_probe::probe_table(fd, fd.ctx(), ns_oid, std::string("child"));
         REQUIRE(rrc.found);
         REQUIRE_FALSE(rrc.columns.empty());
-        auto rrp = fd.invoke(&manager_disk_t::resolve_table, fd.ctx(), ns_oid, std::string("parent"), std::uint64_t{0});
+        auto rrp = test_probe::probe_table(fd, fd.ctx(), ns_oid, std::string("parent"));
         REQUIRE(rrp.found);
         REQUIRE_FALSE(rrp.columns.empty());
 
@@ -198,7 +198,7 @@ TEST_CASE("services::disk::persistence::test_constraint_persistence") {
     }
     {
         fresh_disk fd2(dir);
-        fd2.manager->load_system_tables_sync();
+        fd2.manager->bootstrap_system_tables_sync();
         fd2.manager->restore_oid_generator_sync();
         // Verify FK constraint persisted: resolve child table should still succeed
         // (fk_constraints_for_table removed in Etap 5.1; field-level checks moved to
@@ -231,7 +231,7 @@ TEST_CASE("services::disk::persistence::test_oid_persistence") {
                           components::types::complex_logical_type{components::types::logical_type::STRING_LITERAL});
         table_oid = test_create_table(fd, ns_oid, "widgets", std::move(cols));
 
-        auto rr = fd.invoke(&manager_disk_t::resolve_table, fd.ctx(), ns_oid, std::string("widgets"), std::uint64_t{0});
+        auto rr = test_probe::probe_table(fd, fd.ctx(), ns_oid, std::string("widgets"));
         REQUIRE(rr.found);
         column_oids_before.clear();
         column_oids_before.reserve(rr.columns.size());
@@ -242,10 +242,9 @@ TEST_CASE("services::disk::persistence::test_oid_persistence") {
     }
     {
         fresh_disk fd2(dir);
-        fd2.manager->load_system_tables_sync();
+        fd2.manager->bootstrap_system_tables_sync();
         fd2.manager->restore_oid_generator_sync();
-        auto rr =
-            fd2.invoke(&manager_disk_t::resolve_table, fd2.ctx(), ns_oid, std::string("widgets"), std::uint64_t{0});
+        auto rr = test_probe::probe_table(fd2, fd2.ctx(), ns_oid, std::string("widgets"));
         REQUIRE(rr.found);
         REQUIRE(rr.oid == table_oid);
         REQUIRE(rr.columns.size() == column_oids_before.size());
@@ -292,7 +291,7 @@ TEST_CASE("services::disk::persistence::test_oid_no_reuse_after_drop") {
         // must not let a fresh CREATE land on dropped_oid. The remaining live OIDs
         // (namespace, t_new, columns) seed the high-water mark above dropped_oid.
         fresh_disk fd2(dir);
-        fd2.manager->load_system_tables_sync();
+        fd2.manager->bootstrap_system_tables_sync();
         fd2.manager->restore_oid_generator_sync();
 
         std::vector<components::table::column_definition_t> cols3;
@@ -340,7 +339,7 @@ TEST_CASE("services::disk::persistence::test_pg_class_lists_all_objects") {
     }
     {
         fresh_disk fd2(dir);
-        fd2.manager->load_system_tables_sync();
+        fd2.manager->bootstrap_system_tables_sync();
         fd2.manager->restore_oid_generator_sync();
         struct expected_t {
             std::string name;
@@ -356,7 +355,7 @@ TEST_CASE("services::disk::persistence::test_pg_class_lists_all_objects") {
             {"regular_t_idx", idx_oid, components::catalog::relkind::index},
         };
         for (const auto& exp : objects) {
-            auto r = fd2.invoke(&manager_disk_t::resolve_table, fd2.ctx(), ns_oid, exp.name, std::uint64_t{0});
+            auto r = test_probe::probe_table(fd2, fd2.ctx(), ns_oid, exp.name);
             INFO("relation: " << exp.name);
             REQUIRE(r.found);
             REQUIRE(r.oid == exp.oid);
@@ -389,9 +388,9 @@ TEST_CASE("services::disk::persistence::test_computing_table_persists_restart") 
     }
     {
         fresh_disk fd2(dir);
-        fd2.manager->load_system_tables_sync();
+        fd2.manager->bootstrap_system_tables_sync();
         fd2.manager->restore_oid_generator_sync();
-        auto rr = fd2.invoke(&manager_disk_t::resolve_table, fd2.ctx(), ns_oid, std::string("agg"), std::uint64_t{0});
+        auto rr = test_probe::probe_table(fd2, fd2.ctx(), ns_oid, std::string("agg"));
         REQUIRE(rr.found);
         REQUIRE(rr.oid == comp_oid);
         REQUIRE(rr.relkind == components::catalog::relkind::computed);
@@ -424,7 +423,11 @@ TEST_CASE("services::disk::persistence::test_sequence_persistence") {
         std::pmr::vector<components::types::logical_value_t> sv1{&fd.resource};
         sv1.emplace_back(components::types::logical_value_t(&fd.resource, seq_oid));
         auto seq_batches =
-            fd.invoke(&manager_disk_t::read_chunks_by_key, fd.ctx(), pg_seq, std::move(sk1), std::move(sv1));
+            fd.invoke(&manager_disk_t::read_chunks_by_key,
+                      fd.ctx(),
+                      pg_seq,
+                      std::move(sk1),
+                      test_probe::build_key_chunk(&fd.resource, std::move(sv1)));
         uint64_t seq_total = 0;
         for (auto& c : seq_batches)
             seq_total += c.size();
@@ -436,7 +439,11 @@ TEST_CASE("services::disk::persistence::test_sequence_persistence") {
         std::pmr::vector<components::types::logical_value_t> sv2{&fd.resource};
         sv2.emplace_back(components::types::logical_value_t(&fd.resource, seq_oid));
         auto seq_batches_after =
-            fd.invoke(&manager_disk_t::read_chunks_by_key, fd.ctx(), pg_seq, std::move(sk2), std::move(sv2));
+            fd.invoke(&manager_disk_t::read_chunks_by_key,
+                      fd.ctx(),
+                      pg_seq,
+                      std::move(sk2),
+                      test_probe::build_key_chunk(&fd.resource, std::move(sv2)));
         uint64_t seq_total_after = 0;
         for (auto& c : seq_batches_after)
             seq_total_after += c.size();
@@ -448,10 +455,9 @@ TEST_CASE("services::disk::persistence::test_sequence_persistence") {
     {
         // AC #3: pg_sequence row still readable after restart.
         fresh_disk fd2(dir);
-        fd2.manager->load_system_tables_sync();
+        fd2.manager->bootstrap_system_tables_sync();
         fd2.manager->restore_oid_generator_sync();
-        auto r =
-            fd2.invoke(&manager_disk_t::resolve_table, fd2.ctx(), ns_oid, std::string("counter2"), std::uint64_t{0});
+        auto r = test_probe::probe_table(fd2, fd2.ctx(), ns_oid, std::string("counter2"));
         REQUIRE(r.found);
         REQUIRE(r.oid == seq_oid);
         REQUIRE(r.relkind == components::catalog::relkind::sequence);
@@ -461,7 +467,11 @@ TEST_CASE("services::disk::persistence::test_sequence_persistence") {
         std::pmr::vector<components::types::logical_value_t> sv3{&fd2.resource};
         sv3.emplace_back(components::types::logical_value_t(&fd2.resource, seq_oid));
         auto seq_batches2 =
-            fd2.invoke(&manager_disk_t::read_chunks_by_key, fd2.ctx(), pg_seq2, std::move(sk3), std::move(sv3));
+            fd2.invoke(&manager_disk_t::read_chunks_by_key,
+                       fd2.ctx(),
+                       pg_seq2,
+                       std::move(sk3),
+                       test_probe::build_key_chunk(&fd2.resource, std::move(sv3)));
         uint64_t seq_total2 = 0;
         for (auto& c : seq_batches2)
             seq_total2 += c.size();
@@ -492,7 +502,11 @@ TEST_CASE("services::disk::persistence::test_view_persistence") {
         std::pmr::vector<components::types::logical_value_t> rv1{&fd.resource};
         rv1.emplace_back(components::types::logical_value_t(&fd.resource, view_oid));
         auto rewrite_batches =
-            fd.invoke(&manager_disk_t::read_chunks_by_key, fd.ctx(), pg_rewrite_tbl, std::move(rk1), std::move(rv1));
+            fd.invoke(&manager_disk_t::read_chunks_by_key,
+                      fd.ctx(),
+                      pg_rewrite_tbl,
+                      std::move(rk1),
+                      test_probe::build_key_chunk(&fd.resource, std::move(rv1)));
         uint64_t rewrite_total = 0;
         for (auto& c : rewrite_batches)
             rewrite_total += c.size();
@@ -504,7 +518,11 @@ TEST_CASE("services::disk::persistence::test_view_persistence") {
         std::pmr::vector<components::types::logical_value_t> rv2{&fd.resource};
         rv2.emplace_back(components::types::logical_value_t(&fd.resource, view_oid));
         auto rewrite_batches_after =
-            fd.invoke(&manager_disk_t::read_chunks_by_key, fd.ctx(), pg_rewrite_tbl, std::move(rk2), std::move(rv2));
+            fd.invoke(&manager_disk_t::read_chunks_by_key,
+                      fd.ctx(),
+                      pg_rewrite_tbl,
+                      std::move(rk2),
+                      test_probe::build_key_chunk(&fd.resource, std::move(rv2)));
         uint64_t rewrite_total_after = 0;
         for (auto& c : rewrite_batches_after)
             rewrite_total_after += c.size();
@@ -516,10 +534,9 @@ TEST_CASE("services::disk::persistence::test_view_persistence") {
     {
         // AC #4: ev_action survives restart.
         fresh_disk fd2(dir);
-        fd2.manager->load_system_tables_sync();
+        fd2.manager->bootstrap_system_tables_sync();
         fd2.manager->restore_oid_generator_sync();
-        auto r =
-            fd2.invoke(&manager_disk_t::resolve_table, fd2.ctx(), ns_oid, std::string("my_view2"), std::uint64_t{0});
+        auto r = test_probe::probe_table(fd2, fd2.ctx(), ns_oid, std::string("my_view2"));
         REQUIRE(r.found);
         REQUIRE(r.oid == view_oid);
         REQUIRE(r.relkind == components::catalog::relkind::view);
@@ -529,7 +546,11 @@ TEST_CASE("services::disk::persistence::test_view_persistence") {
         std::pmr::vector<components::types::logical_value_t> rv3{&fd2.resource};
         rv3.emplace_back(components::types::logical_value_t(&fd2.resource, view_oid));
         auto rewrite_batches2 =
-            fd2.invoke(&manager_disk_t::read_chunks_by_key, fd2.ctx(), pg_rewrite_tbl2, std::move(rk3), std::move(rv3));
+            fd2.invoke(&manager_disk_t::read_chunks_by_key,
+                       fd2.ctx(),
+                       pg_rewrite_tbl2,
+                       std::move(rk3),
+                       test_probe::build_key_chunk(&fd2.resource, std::move(rv3)));
         uint64_t rewrite_total2 = 0;
         for (auto& c : rewrite_batches2)
             rewrite_total2 += c.size();
@@ -559,7 +580,11 @@ TEST_CASE("services::disk::persistence::test_macro_persistence") {
         std::pmr::vector<components::types::logical_value_t> mv1{&fd.resource};
         mv1.emplace_back(components::types::logical_value_t(&fd.resource, macro_oid));
         auto rewrite_batches_m =
-            fd.invoke(&manager_disk_t::read_chunks_by_key, fd.ctx(), pg_rewrite_m, std::move(mk1), std::move(mv1));
+            fd.invoke(&manager_disk_t::read_chunks_by_key,
+                      fd.ctx(),
+                      pg_rewrite_m,
+                      std::move(mk1),
+                      test_probe::build_key_chunk(&fd.resource, std::move(mv1)));
         uint64_t rewrite_total_m = 0;
         for (auto& c : rewrite_batches_m)
             rewrite_total_m += c.size();
@@ -568,9 +593,9 @@ TEST_CASE("services::disk::persistence::test_macro_persistence") {
     }
     {
         fresh_disk fd2(dir);
-        fd2.manager->load_system_tables_sync();
+        fd2.manager->bootstrap_system_tables_sync();
         fd2.manager->restore_oid_generator_sync();
-        auto r = fd2.invoke(&manager_disk_t::resolve_table, fd2.ctx(), ns_oid, std::string("double"), std::uint64_t{0});
+        auto r = test_probe::probe_table(fd2, fd2.ctx(), ns_oid, std::string("double"));
         REQUIRE(r.found);
         REQUIRE(r.oid == macro_oid);
         REQUIRE(r.relkind == components::catalog::relkind::macro);
@@ -580,7 +605,11 @@ TEST_CASE("services::disk::persistence::test_macro_persistence") {
         std::pmr::vector<components::types::logical_value_t> mv2{&fd2.resource};
         mv2.emplace_back(components::types::logical_value_t(&fd2.resource, macro_oid));
         auto rewrite_batches_m2 =
-            fd2.invoke(&manager_disk_t::read_chunks_by_key, fd2.ctx(), pg_rewrite_m2, std::move(mk2), std::move(mv2));
+            fd2.invoke(&manager_disk_t::read_chunks_by_key,
+                       fd2.ctx(),
+                       pg_rewrite_m2,
+                       std::move(mk2),
+                       test_probe::build_key_chunk(&fd2.resource, std::move(mv2)));
         uint64_t rewrite_total_m2 = 0;
         for (auto& c : rewrite_batches_m2)
             rewrite_total_m2 += c.size();
@@ -609,8 +638,8 @@ TEST_CASE("services::disk::persistence::test_pg_constraint_orphan_after_drop_tab
         auto child_oid = test_create_table(fd, ns_oid, "child", std::move(ccols));
 
         // Resolve attoids to wire the FK.
-        auto pr = fd.invoke(&manager_disk_t::resolve_table, fd.ctx(), ns_oid, std::string("parent"), std::uint64_t{0});
-        auto cr = fd.invoke(&manager_disk_t::resolve_table, fd.ctx(), ns_oid, std::string("child"), std::uint64_t{0});
+        auto pr = test_probe::probe_table(fd, fd.ctx(), ns_oid, std::string("parent"));
+        auto cr = test_probe::probe_table(fd, fd.ctx(), ns_oid, std::string("child"));
         REQUIRE(pr.found);
         REQUIRE(cr.found);
         REQUIRE_FALSE(pr.columns.empty());
@@ -656,16 +685,21 @@ TEST_CASE("services::disk::persistence::test_oid_no_collision_after_restore") {
         // The rule_oid is the highest; restore must pick it up from pg_rewrite col-0 scan.
         test_create_view(fd, ns_oid, "v");
         // Capture the peak OID BEFORE checkpoint so we know what restore must beat.
-        pre_restart_peak = fd.manager->oid_gen().peek() - 1; // last issued OID
+        // allocate_oids_batch(1) returns the next free OID, so peak == that - 1.
+        auto probe = fd.invoke(&manager_disk_t::allocate_oids_batch, std::size_t{1});
+        REQUIRE(probe.size() == 1);
+        pre_restart_peak = probe[0] - 1; // last issued OID
         fd.checkpoint();
     }
     {
         fresh_disk fd2(dir);
-        fd2.manager->load_system_tables_sync();
+        fd2.manager->bootstrap_system_tables_sync();
         fd2.manager->restore_oid_generator_sync();
-        // After restore the generator must be seeded at or above the pre-restart peak.
-        auto new_oid = fd2.manager->oid_gen().allocate();
-        REQUIRE(new_oid > pre_restart_peak);
+        // After restore the generator must be seeded at or above the pre-restart peak,
+        // so the next allocation is strictly greater than the last issued OID.
+        auto next = fd2.invoke(&manager_disk_t::allocate_oids_batch, std::size_t{1});
+        REQUIRE(next.size() == 1);
+        REQUIRE(next[0] > pre_restart_peak);
     }
     std::filesystem::remove_all(dir);
 }
@@ -700,7 +734,7 @@ TEST_CASE("services::disk::persistence::test_check_constraint_persistence") {
     }
     {
         fresh_disk fd2(dir);
-        fd2.manager->load_system_tables_sync();
+        fd2.manager->bootstrap_system_tables_sync();
         fd2.manager->restore_oid_generator_sync();
         constexpr oid_t pg_constr = well_known_oid::pg_constraint_table;
         std::pmr::vector<std::string> ck{&fd2.resource};
@@ -708,7 +742,11 @@ TEST_CASE("services::disk::persistence::test_check_constraint_persistence") {
         std::pmr::vector<components::types::logical_value_t> cv{&fd2.resource};
         cv.emplace_back(components::types::logical_value_t(&fd2.resource, table_oid));
         auto check_batches =
-            fd2.invoke(&manager_disk_t::read_chunks_by_key, fd2.ctx(), pg_constr, std::move(ck), std::move(cv));
+            fd2.invoke(&manager_disk_t::read_chunks_by_key,
+                       fd2.ctx(),
+                       pg_constr,
+                       std::move(ck),
+                       test_probe::build_key_chunk(&fd2.resource, std::move(cv)));
         uint64_t check_total = 0;
         for (auto& c : check_batches)
             check_total += c.size();

--- a/services/disk/tests/test_pg_depend.cpp
+++ b/services/disk/tests/test_pg_depend.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch.hpp>
 
+#include "catalog_probe.hpp"
 #include "disk_test_helpers.hpp"
 #include <actor-zeta/spawn.hpp>
 #include <components/catalog/catalog_codes.hpp>
@@ -102,7 +103,7 @@ TEST_CASE("services::disk::pg_depend::table_to_namespace_cascade") {
     disk_test_helpers::test_drop_table(fx, t_oid);
     disk_test_helpers::test_drop_namespace(fx, ns_oid);
     // Resolving the table afterwards must miss.
-    auto rt = fx.invoke(&manager_disk_t::resolve_table, fx.ctx(), ns_oid, std::string("t1"), std::uint64_t{0});
+    auto rt = test_probe::probe_table(fx, fx.ctx(), ns_oid, std::string("t1"));
     REQUIRE_FALSE(rt.found);
 }
 
@@ -113,7 +114,7 @@ TEST_CASE("services::disk::pg_depend::drop_namespace_restrict_blocks") {
     fixture fx;
     auto [ns_oid, t_oid] = fx.make_ns_table("ns_b", "t1");
     // Table must be resolvable before any drop.
-    auto rt_before = fx.invoke(&manager_disk_t::resolve_table, fx.ctx(), ns_oid, std::string("t1"), std::uint64_t{0});
+    auto rt_before = test_probe::probe_table(fx, fx.ctx(), ns_oid, std::string("t1"));
     REQUIRE(rt_before.found);
     REQUIRE(rt_before.oid == t_oid);
 }
@@ -132,7 +133,7 @@ TEST_CASE("services::disk::pg_depend::index_cascades_with_table") {
     disk_test_helpers::test_drop_table(fx, t_oid);
     disk_test_helpers::test_drop_index(fx, idx_oid);
     // Index gone too — pg_class entry for the index removed.
-    auto rt_idx = fx.invoke(&manager_disk_t::resolve_table, fx.ctx(), ns_oid, std::string("idx_id"), std::uint64_t{0});
+    auto rt_idx = test_probe::probe_table(fx, fx.ctx(), ns_oid, std::string("idx_id"));
     REQUIRE_FALSE(rt_idx.found);
 }
 
@@ -144,7 +145,7 @@ TEST_CASE("services::disk::pg_depend::type_cascades_with_namespace") {
     REQUIRE(type_oid >= FIRST_USER_OID);
     disk_test_helpers::test_drop_type(fx, type_oid);
     disk_test_helpers::test_drop_namespace(fx, ns_oid);
-    auto rr = fx.invoke(&manager_disk_t::resolve_type, fx.ctx(), ns_oid, std::string("widget_type"), std::uint64_t{0});
+    auto rr = test_probe::probe_type(fx, fx.ctx(), ns_oid, std::string("widget_type"));
     REQUIRE_FALSE(rr.found);
 }
 
@@ -190,8 +191,7 @@ TEST_CASE("services::disk::pg_depend::drop_type_restrict_no_deps") {
                   std::uint64_t{1000},
                   std::move(deletes_local));
     }
-    auto rr =
-        fx.invoke(&manager_disk_t::resolve_type, fx.ctx(), ns_oid, std::string("standalone_type"), std::uint64_t{0});
+    auto rr = test_probe::probe_type(fx, fx.ctx(), ns_oid, std::string("standalone_type"));
     REQUIRE_FALSE(rr.found);
 }
 
@@ -210,8 +210,8 @@ TEST_CASE("services::disk::pg_depend::multi_level_cascade") {
     disk_test_helpers::test_drop_table(fx, t_oid);
     disk_test_helpers::test_drop_namespace(fx, ns_oid);
     // All gone: namespace, table, index.
-    auto rt_t = fx.invoke(&manager_disk_t::resolve_table, fx.ctx(), ns_oid, std::string("t1"), std::uint64_t{0});
-    auto rt_i = fx.invoke(&manager_disk_t::resolve_table, fx.ctx(), ns_oid, std::string("idx_id"), std::uint64_t{0});
+    auto rt_t = test_probe::probe_table(fx, fx.ctx(), ns_oid, std::string("t1"));
+    auto rt_i = test_probe::probe_table(fx, fx.ctx(), ns_oid, std::string("idx_id"));
     REQUIRE_FALSE(rt_t.found);
     REQUIRE_FALSE(rt_i.found);
 }
@@ -230,7 +230,7 @@ TEST_CASE("services::disk::pg_depend::drop_table_restrict_vs_cascade") {
                                                               std::vector<catalog::oid_t>{});
     (void) idx_oid;
     disk_test_helpers::test_drop_table(fx, t_oid);
-    auto rt_after_r = fx.invoke(&manager_disk_t::resolve_table, fx.ctx(), ns_oid, std::string("t1"), std::uint64_t{0});
+    auto rt_after_r = test_probe::probe_table(fx, fx.ctx(), ns_oid, std::string("t1"));
     REQUIRE_FALSE(rt_after_r.found);
 }
 
@@ -327,7 +327,7 @@ TEST_CASE("services::disk::pg_depend::test_column_level_pg_depend_written") {
 
     // Drop table (helper issues committed delete for pg_class/pg_attribute/pg_depend).
     disk_test_helpers::test_drop_table(fx, t_oid);
-    auto rt = fx.invoke(&manager_disk_t::resolve_table, fx.ctx(), ns_oid, std::string("t_col"), std::uint64_t{0});
+    auto rt = test_probe::probe_table(fx, fx.ctx(), ns_oid, std::string("t_col"));
     REQUIRE_FALSE(rt.found);
 }
 
@@ -362,10 +362,8 @@ TEST_CASE("services::disk::pg_depend::cross_namespace_fk_restricts_parent_drop")
     REQUIRE(child_oid >= FIRST_USER_OID);
 
     // Both tables must be resolvable.
-    auto parent_resolve =
-        fx.invoke(&manager_disk_t::resolve_table, fx.ctx(), ns_a_oid, std::string("parent_xfk"), std::uint64_t{0});
+    auto parent_resolve = test_probe::probe_table(fx, fx.ctx(), ns_a_oid, std::string("parent_xfk"));
     REQUIRE(parent_resolve.found);
-    auto child_resolve =
-        fx.invoke(&manager_disk_t::resolve_table, fx.ctx(), ns_b_oid, std::string("child_xfk"), std::uint64_t{0});
+    auto child_resolve = test_probe::probe_table(fx, fx.ctx(), ns_b_oid, std::string("child_xfk"));
     REQUIRE(child_resolve.found);
 }

--- a/services/disk/tests/test_recovery.cpp
+++ b/services/disk/tests/test_recovery.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch.hpp>
 
+#include "catalog_probe.hpp"
 #include "disk_test_helpers.hpp"
 #include <actor-zeta/spawn.hpp>
 #include <components/catalog/catalog_oids.hpp>
@@ -100,8 +101,9 @@ namespace {
 // 1. test_recovery_system_wal_before_user — system DDL replayed first on restart.
 //    Drive a CREATE NAMESPACE through the active fixture (writes a pg_namespace row +
 //    a WAL physical record), drop the fixture, spin a fresh one and call
-//    load_system_tables_sync. The system table must come back populated, which can only
-//    happen if the system replay path runs before any user-table loading.
+//    bootstrap_system_tables_sync (its load path picks up existing .otbx files). The
+//    system table must come back populated, which can only happen if the system replay
+//    path runs before any user-table loading.
 TEST_CASE("test_recovery_system_wal_before_user") {
     auto dir = recovery_test_dir() + "/sys_first";
     cleanup_dir(dir);
@@ -113,15 +115,16 @@ TEST_CASE("test_recovery_system_wal_before_user") {
         REQUIRE(created_namespace_oid != components::catalog::INVALID_OID);
     }
 
-    // Restart: skip bootstrap (already done), call load_system_tables_sync.
+    // Restart: re-run bootstrap_system_tables_sync, whose load path re-hydrates the
+    // already-created system tables from their .otbx files.
     {
         recovery_fixture fx(dir, /*bootstrap=*/false);
-        // load_system_tables_sync MUST run before any user storage is touched on restart;
+        // bootstrap_system_tables_sync MUST run before any user storage is touched on restart;
         // here we call it explicitly and require the previously-created namespace OID is
         // recovered from pg_namespace via restore_oid_generator_sync (its scan walks
         // pg_namespace as a "fresh OID source", which proves the system table's rows are
         // back in place before user paths run).
-        REQUIRE_NOTHROW(fx.disk->load_system_tables_sync());
+        REQUIRE_NOTHROW(fx.disk->bootstrap_system_tables_sync());
         REQUIRE_NOTHROW(fx.disk->restore_oid_generator_sync());
     }
     cleanup_dir(dir);
@@ -167,13 +170,13 @@ TEST_CASE("test_recovery_ddl_then_dml") {
         (void) cp_future;
     }
 
-    // Restart and verify the DDL state is durable: load_system_tables_sync must succeed,
+    // Restart and verify the DDL state is durable: bootstrap_system_tables_sync must succeed,
     // restore_oid_generator_sync must seed the counter past ns_oid (since pg_namespace
     // now contains its row), and a brand-new namespace allocation yields a strictly
     // higher OID.
     {
         recovery_fixture fx(dir, /*bootstrap=*/false);
-        REQUIRE_NOTHROW(fx.disk->load_system_tables_sync());
+        REQUIRE_NOTHROW(fx.disk->bootstrap_system_tables_sync());
         REQUIRE_NOTHROW(fx.disk->restore_oid_generator_sync());
 
         const auto post_ns_oid = disk_test_helpers::test_create_namespace(fx, std::string("post_recovery_ns"));
@@ -208,7 +211,7 @@ TEST_CASE("test_recovery_orphaned_uncommitted_ddl") {
 
     {
         recovery_fixture fx(dir, /*bootstrap=*/false);
-        REQUIRE_NOTHROW(fx.disk->load_system_tables_sync());
+        REQUIRE_NOTHROW(fx.disk->bootstrap_system_tables_sync());
         REQUIRE_NOTHROW(fx.disk->restore_oid_generator_sync());
 
         // ns_name_to_oid_ is rebuilt by rebuild_lookup_indexes via inline_scan →
@@ -226,7 +229,7 @@ TEST_CASE("test_recovery_orphaned_uncommitted_ddl") {
 //    on restart replays WAL via direct_append_sync (bypassing the operator pipeline).
 //    This test verifies the round trip: register two columns under a 'g' table, drop the
 //    fixture (flushes WAL + checkpoint persists storage), spin a fresh fixture pointing at
-//    the same path, run load_system_tables_sync, and require pg_computed_column reports
+//    the same path, run bootstrap_system_tables_sync, and require pg_computed_column reports
 //    both rows + resolve_table reconstructs both columns from them.
 TEST_CASE("services::disk::recovery::dynamic_schema_persists_across_restart") {
     auto dir = recovery_test_dir() + "/dynamic_schema";
@@ -266,12 +269,13 @@ TEST_CASE("services::disk::recovery::dynamic_schema_persists_across_restart") {
     }
 
     // Restart: bootstrap=false → don't re-create fresh empty system tables; instead
-    // call load_system_tables_sync, which replays WAL via direct_append_sync into
-    // pg_computed_column. After that, pg_computed_column must hold both rows and
-    // resolve_table must reconstruct the dynamic schema for "docs".
+    // bootstrap_system_tables_sync re-hydrates them from disk (its load path) and the
+    // recovery fixture replays WAL via direct_append_sync into pg_computed_column. After
+    // that, pg_computed_column must hold both rows and resolve_table must reconstruct the
+    // dynamic schema for "docs".
     {
         recovery_fixture fx_reopen(dir, /*bootstrap=*/false);
-        REQUIRE_NOTHROW(fx_reopen.disk->load_system_tables_sync());
+        REQUIRE_NOTHROW(fx_reopen.disk->bootstrap_system_tables_sync());
         REQUIRE_NOTHROW(fx_reopen.disk->restore_oid_generator_sync());
 
         // Direct read of pg_computed_column: relid=table_oid → 2 live rows.
@@ -285,7 +289,7 @@ TEST_CASE("services::disk::recovery::dynamic_schema_persists_across_restart") {
                                         fx_reopen.ctx(),
                                         pg_cc,
                                         std::move(rk),
-                                        std::move(rv));
+                                        test_probe::build_key_chunk(&fx_reopen.resource, std::move(rv)));
         std::uint64_t total = 0;
         for (const auto& c : batches)
             total += c.size();
@@ -320,11 +324,7 @@ TEST_CASE("services::disk::recovery::dynamic_schema_persists_across_restart") {
         // resolve_table on restart must report relkind='g' and reconstruct both columns
         // from the replayed pg_computed_column rows (computed-schema path skips
         // pg_attribute and reads pg_computed_column directly).
-        auto rs = fx_reopen.invoke(&manager_disk_t::resolve_table,
-                                   fx_reopen.ctx(),
-                                   ns_oid,
-                                   std::string("docs"),
-                                   std::uint64_t{0});
+        auto rs = test_probe::probe_table(fx_reopen, fx_reopen.ctx(), ns_oid, std::string("docs"));
         REQUIRE(rs.found);
         REQUIRE(rs.relkind == components::catalog::relkind::computed);
         REQUIRE(rs.columns.size() == 2);

--- a/services/disk/tests/test_resolve.cpp
+++ b/services/disk/tests/test_resolve.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch.hpp>
 
+#include "catalog_probe.hpp"
 #include "disk_test_helpers.hpp"
 #include <actor-zeta/spawn.hpp>
 #include <components/catalog/catalog_codes.hpp>
@@ -9,12 +10,16 @@
 #include <components/session/session.hpp>
 #include <components/table/column_definition.hpp>
 #include <components/types/types.hpp>
+#include <components/vector/data_chunk.hpp>
 #include <core/non_thread_scheduler/scheduler_test.hpp>
 #include <services/disk/manager_disk.hpp>
 
+#include <algorithm>
 #include <filesystem>
 #include <thread>
 #include <unistd.h>
+#include <utility>
+#include <vector>
 
 using namespace services::disk;
 namespace catalog = components::catalog;
@@ -111,11 +116,7 @@ TEST_CASE("services::disk::resolve::table_finds_after_create") {
                                                                 catalog::relkind::regular);
     REQUIRE(table_oid >= FIRST_USER_OID);
 
-    auto r = fx.invoke_async(&manager_disk_t::resolve_table,
-                             fx.ctx(),
-                             well_known_oid::public_namespace,
-                             std::string("users"),
-                             std::uint64_t{0});
+    auto r = test_probe::probe_table(fx, fx.ctx(), well_known_oid::public_namespace, std::string("users"));
     REQUIRE(r.found);
     REQUIRE(r.oid == table_oid);
     REQUIRE(r.namespace_oid == well_known_oid::public_namespace);
@@ -132,22 +133,14 @@ TEST_CASE("services::disk::resolve::table_misses_in_wrong_namespace") {
                                          std::vector<components::table::column_definition_t>{},
                                          catalog::relkind::regular);
 
-    auto r = fx.invoke_async(&manager_disk_t::resolve_table,
-                             fx.ctx(),
-                             well_known_oid::pg_catalog_namespace,
-                             std::string("users"),
-                             std::uint64_t{0});
+    auto r = test_probe::probe_table(fx, fx.ctx(), well_known_oid::pg_catalog_namespace, std::string("users"));
     REQUIRE_FALSE(r.found);
 }
 
 // 5. resolve_type finds the bootstrap "int64" type in pg_catalog.
 TEST_CASE("services::disk::resolve::type_finds_bootstrap") {
     fixture fx;
-    auto r = fx.invoke_async(&manager_disk_t::resolve_type,
-                             fx.ctx(),
-                             well_known_oid::pg_catalog_namespace,
-                             std::string("int64"),
-                             std::uint64_t{0});
+    auto r = test_probe::probe_type(fx, fx.ctx(), well_known_oid::pg_catalog_namespace, std::string("int64"));
     REQUIRE(r.found);
     REQUIRE(r.oid == well_known_oid::int64_type);
 }
@@ -155,11 +148,159 @@ TEST_CASE("services::disk::resolve::type_finds_bootstrap") {
 // 6. resolve_function finds the bootstrap "count" aggregate.
 TEST_CASE("services::disk::resolve::function_finds_bootstrap_count") {
     fixture fx;
-    auto r = fx.invoke_async(&manager_disk_t::resolve_function,
-                             fx.ctx(),
-                             well_known_oid::pg_catalog_namespace,
-                             std::string("count"),
-                             std::uint64_t{0});
+    auto r = test_probe::probe_function(fx, fx.ctx(), well_known_oid::pg_catalog_namespace, std::string("count"));
     REQUIRE(r.found);
     REQUIRE(r.oid == well_known_oid::fn_count);
+}
+
+// 7. read_chunks_by_keys (batched, N-row columnar keys) == N independent
+// read_chunks_by_key calls (parity). A single batched call carries an N-row
+// keys data_chunk (column j = key_col_names[j], row i = i-th key-tuple) and
+// returns vector<vector<data_chunk_t>> with result[k] == the singular
+// read_chunks_by_key result for key k. Covers a no-match key (empty entry)
+// and a multi-row-match key.
+TEST_CASE("services::disk::resolve::read_chunks_by_keys_multi_key_parity") {
+    using components::types::complex_logical_type;
+    using components::types::logical_type;
+    using components::types::logical_value_t;
+    using components::vector::data_chunk_t;
+
+    fixture fx;
+    auto ns_oid = disk_test_helpers::test_create_namespace(fx, "ns_rbk");
+    auto table_oid = disk_test_helpers::test_create_table(
+        fx,
+        ns_oid,
+        "rbk_tbl",
+        std::vector<components::table::column_definition_t>{},
+        catalog::relkind::regular);
+    REQUIRE(table_oid >= FIRST_USER_OID);
+
+    // Regular IN_MEMORY storage with an explicit {k, payload} schema. The rows
+    // appended below give:
+    //   k=10 -> one row (payload 100)
+    //   k=20 -> two rows (payload 200, 201)  [multi-row match]
+    //   k=30 -> one row (payload 300)
+    //   k=99 -> no row                        [no-match]
+    {
+        std::vector<components::table::column_definition_t> scols;
+        scols.emplace_back("k", complex_logical_type{logical_type::BIGINT});
+        scols.emplace_back("payload", complex_logical_type{logical_type::BIGINT});
+        fx.invoke(&manager_disk_t::create_storage_with_columns,
+                  session_id_t{},
+                  table_oid,
+                  well_known_oid::main_database,
+                  std::move(scols));
+    }
+    {
+        std::pmr::vector<complex_logical_type> types(&fx.resource);
+        for (auto n : {"k", "payload"}) {
+            complex_logical_type t{logical_type::BIGINT};
+            t.set_alias(n);
+            types.push_back(std::move(t));
+        }
+        constexpr std::uint64_t nrows = 4;
+        auto chunk = std::make_unique<data_chunk_t>(&fx.resource, types, nrows);
+        chunk->set_cardinality(nrows);
+        const std::int64_t kvals[nrows] = {10, 20, 20, 30};
+        const std::int64_t pvals[nrows] = {100, 200, 201, 300};
+        for (std::uint64_t r = 0; r < nrows; ++r) {
+            chunk->set_value(0, r, logical_value_t(&fx.resource, kvals[r]));
+            chunk->set_value(1, r, logical_value_t(&fx.resource, pvals[r]));
+        }
+        components::execution_context_t append_ctx{session_id_t{},
+                                                   components::table::transaction_data{0, 0},
+                                                   {},
+                                                   table_oid};
+        auto [start, count] =
+            fx.invoke(&manager_disk_t::storage_append, append_ctx, table_oid, std::move(chunk));
+        REQUIRE(count == nrows);
+        (void) start;
+    }
+
+    // The N distinct key values we probe (one no-match: 99).
+    const std::vector<std::int64_t> probe_keys = {10, 20, 30, 99};
+    const std::size_t N = probe_keys.size();
+
+    auto total_rows = [](const auto& chunks) {
+        std::uint64_t t = 0;
+        for (const auto& c : chunks)
+            t += c.size();
+        return t;
+    };
+
+    // --- batched: ONE read_chunks_by_keys with an N-row keys chunk ---
+    std::vector<std::vector<data_chunk_t>> batched;
+    {
+        std::pmr::vector<complex_logical_type> ktypes(&fx.resource);
+        complex_logical_type kt{logical_type::BIGINT};
+        ktypes.push_back(std::move(kt));
+        data_chunk_t keys(&fx.resource, ktypes, N);
+        for (std::size_t i = 0; i < N; ++i) {
+            keys.set_value(0, i, logical_value_t(&fx.resource, probe_keys[i]));
+        }
+        keys.set_cardinality(N);
+        std::pmr::vector<std::string> key_cols{&fx.resource};
+        key_cols.emplace_back("k");
+        auto res = fx.invoke(&manager_disk_t::read_chunks_by_keys,
+                             fx.ctx(),
+                             table_oid,
+                             std::move(key_cols),
+                             std::move(keys));
+        REQUIRE(res.size() == N);
+        // Copy into a std::vector for re-use in the parity loop (chunk-by-chunk
+        // size/value comparison below).
+        for (auto& entry : res) {
+            std::vector<data_chunk_t> e;
+            for (auto& c : entry)
+                e.push_back(std::move(c));
+            batched.push_back(std::move(e));
+        }
+    }
+
+    // Batched cardinalities: 10->1, 20->2 (multi-row), 30->1, 99->0 (no-match).
+    REQUIRE(total_rows(batched[0]) == 1);
+    REQUIRE(total_rows(batched[1]) == 2);
+    REQUIRE(total_rows(batched[2]) == 1);
+    REQUIRE(total_rows(batched[3]) == 0);
+
+    // --- parity: result[k] of the batched call == singular read_chunks_by_key(k) ---
+    for (std::size_t i = 0; i < N; ++i) {
+        std::pmr::vector<std::string> single_key_cols{&fx.resource};
+        single_key_cols.emplace_back("k");
+        std::pmr::vector<logical_value_t> single_vals{&fx.resource};
+        single_vals.emplace_back(&fx.resource, probe_keys[i]);
+        auto single = fx.invoke(&manager_disk_t::read_chunks_by_key,
+                                fx.ctx(),
+                                table_oid,
+                                std::move(single_key_cols),
+                                test_probe::build_key_chunk(&fx.resource, std::move(single_vals)));
+
+        // Same total row count per key (the no-match key yields 0 on both paths).
+        std::uint64_t single_total = total_rows(single);
+        std::uint64_t batched_total = 0;
+        for (auto& c : batched[i])
+            batched_total += c.size();
+        REQUIRE(batched_total == single_total);
+
+        // Same set of (k, payload) pairs per key on both paths.
+        auto collect_pairs = [](auto& chunks) {
+            std::vector<std::pair<std::int64_t, std::int64_t>> pairs;
+            for (auto& c : chunks) {
+                for (std::uint64_t r = 0; r < c.size(); ++r) {
+                    pairs.emplace_back(c.value(0, r).template value<std::int64_t>(),
+                                       c.value(1, r).template value<std::int64_t>());
+                }
+            }
+            std::sort(pairs.begin(), pairs.end());
+            return pairs;
+        };
+        auto batched_pairs = collect_pairs(batched[i]);
+        auto single_pairs = collect_pairs(single);
+        REQUIRE(batched_pairs == single_pairs);
+
+        // Every returned row actually carries the probed key value.
+        for (auto& pr : single_pairs) {
+            REQUIRE(pr.first == probe_keys[i]);
+        }
+    }
 }

--- a/services/disk/tests/test_system_table_bootstrap.cpp
+++ b/services/disk/tests/test_system_table_bootstrap.cpp
@@ -8,6 +8,7 @@
 #include <services/disk/manager_disk.hpp>
 
 #include <filesystem>
+#include <thread>
 #include <unistd.h>
 
 using namespace services::disk;
@@ -90,6 +91,18 @@ namespace {
             scheduler->stop();
             delete scheduler;
         }
+
+        // Drive a manager mailbox handler synchronously through the test scheduler.
+        template<typename Fn, typename... Args>
+        auto invoke(Fn fn, Args&&... args) {
+            auto [_, future] = actor_zeta::otterbrix::send(manager->address(), fn, std::forward<Args>(args)...);
+            for (int i = 0; i < 100000 && !future.is_ready(); ++i) {
+                scheduler->run(1000);
+                std::this_thread::yield();
+            }
+            REQUIRE(future.is_ready());
+            return std::move(future).take_ready();
+        }
     };
 } // namespace
 
@@ -146,7 +159,8 @@ TEST_CASE("services::disk::sysboot::bootstrap_is_idempotent") {
     cleanup_boot_dir();
 }
 
-// 3. Restart path: load_system_tables_sync picks up all 10 tables created by a prior bootstrap.
+// 3. Restart path: bootstrap_system_tables_sync's load path picks up all 10 tables
+//    created by a prior bootstrap.
 TEST_CASE("services::disk::sysboot::restart_loads_all_10") {
     cleanup_boot_dir();
     auto base = std::filesystem::path(boot_test_dir());
@@ -159,9 +173,9 @@ TEST_CASE("services::disk::sysboot::restart_loads_all_10") {
 
     {
         disk_only_fixture fx(base);
-        // Fresh manager — no in-memory state. Load picks up the persisted .otbx files.
-        // The call must not throw (each .otbx is a valid empty single-file block manager).
-        REQUIRE_NOTHROW(fx.manager->load_system_tables_sync());
+        // Fresh manager — no in-memory state. The load path picks up the persisted .otbx
+        // files. The call must not throw (each .otbx is a valid empty single-file block manager).
+        REQUIRE_NOTHROW(fx.manager->bootstrap_system_tables_sync());
     }
 
     cleanup_boot_dir();
@@ -177,7 +191,7 @@ TEST_CASE("services::disk::sysboot::no_path_is_safe_noop") {
     auto m = actor_zeta::spawn<manager_disk_t>(&resource, scheduler, scheduler, c, log);
 
     REQUIRE_NOTHROW(m->bootstrap_system_tables_sync());
-    REQUIRE_NOTHROW(m->load_system_tables_sync());
+    REQUIRE_NOTHROW(m->bootstrap_system_tables_sync()); // idempotent re-run
     REQUIRE_NOTHROW(m->restore_oid_generator_sync());
 
     // Destroy the manager first: its dtor joins the internal loop thread, which may
@@ -187,9 +201,9 @@ TEST_CASE("services::disk::sysboot::no_path_is_safe_noop") {
     delete scheduler;
 }
 
-// 5. oid_gen() accessor returns a generator that allocates from FIRST_USER_OID by default.
-//    (Stub restore_oid_generator_sync should leave the generator at its default seed; M3 will
-//    teach it to scan pg_class etc. and seed to max+1.)
+// 5. The OID generator allocates from FIRST_USER_OID by default and hands out
+//    monotonically increasing OIDs. Observed through allocate_oids_batch (restore on an
+//    empty catalog should leave the generator at its default seed).
 TEST_CASE("services::disk::sysboot::oid_generator_default_seed") {
     cleanup_boot_dir();
     auto base = std::filesystem::path(boot_test_dir());
@@ -199,10 +213,10 @@ TEST_CASE("services::disk::sysboot::oid_generator_default_seed") {
     fx.manager->bootstrap_system_tables_sync();
     fx.manager->restore_oid_generator_sync();
 
-    oid_t first = fx.manager->oid_gen().allocate();
-    REQUIRE(first >= FIRST_USER_OID);
-    oid_t second = fx.manager->oid_gen().allocate();
-    REQUIRE(second == first + 1);
+    auto oids = fx.invoke(&manager_disk_t::allocate_oids_batch, std::size_t{2});
+    REQUIRE(oids.size() == 2);
+    REQUIRE(oids[0] >= FIRST_USER_OID);
+    REQUIRE(oids[1] == oids[0] + 1);
 
     cleanup_boot_dir();
 }
@@ -232,7 +246,7 @@ TEST_CASE("services::disk::sysboot::dir_layout_per_table") {
     cleanup_boot_dir();
 }
 
-// 8. After bootstrap+load, requesting load again on the same in-memory state is idempotent
+// 8. Re-running bootstrap on the same in-memory state is idempotent
 //    (does not throw, does not crash on already-loaded entries).
 TEST_CASE("services::disk::sysboot::load_after_bootstrap_in_same_process") {
     cleanup_boot_dir();
@@ -241,8 +255,8 @@ TEST_CASE("services::disk::sysboot::load_after_bootstrap_in_same_process") {
 
     disk_only_fixture fx(base);
     fx.manager->bootstrap_system_tables_sync();
-    REQUIRE_NOTHROW(fx.manager->load_system_tables_sync());
-    REQUIRE_NOTHROW(fx.manager->load_system_tables_sync()); // double-call
+    REQUIRE_NOTHROW(fx.manager->bootstrap_system_tables_sync());
+    REQUIRE_NOTHROW(fx.manager->bootstrap_system_tables_sync()); // double-call
 
     cleanup_boot_dir();
 }

--- a/services/disk/tests/test_wal_catalog.cpp
+++ b/services/disk/tests/test_wal_catalog.cpp
@@ -48,7 +48,11 @@ namespace {
         std::unique_ptr<services::wal::manager_wal_replicate_t, actor_zeta::pmr::deleter_t> wal;
         std::unique_ptr<manager_disk_t, actor_zeta::pmr::deleter_t> disk;
 
-        explicit fixture(const std::string& dir)
+        // wire_wal=false leaves the WAL manager unwired (disk never learns the WAL
+        // address, so agent_disk_t::manager_wal_addr_ stays empty_address()): catalog
+        // mutations still hit storage via direct_append_sync but emit no WAL records.
+        // Mirrors the production "WAL off" path and the bootstrap_alone_no_wal scenario.
+        explicit fixture(const std::string& dir, bool wire_wal = true)
             : log(initialization_logger("python", "/tmp/docker_logs/"))
             , scheduler(new core::non_thread_scheduler::scheduler_test_t(1, 1))
             , wal_config([&]() {
@@ -65,10 +69,12 @@ namespace {
             , wal(actor_zeta::spawn<services::wal::manager_wal_replicate_t>(&resource, scheduler, wal_config, log))
             , disk(actor_zeta::spawn<manager_disk_t>(&resource, scheduler, scheduler, disk_config, log)) {
             std::filesystem::create_directories(dir);
-            wal->sync(services::wal::wal_sync_pack_t{actor_zeta::address_t(disk->address()),
-                                                     actor_zeta::address_t::empty_address(),
-                                                     actor_zeta::address_t::empty_address()});
-            disk->sync(services::disk::manager_disk_t::disk_sync_pack_t{wal->address()});
+            if (wire_wal) {
+                wal->sync(services::wal::wal_sync_pack_t{actor_zeta::address_t(disk->address()),
+                                                         actor_zeta::address_t::empty_address(),
+                                                         actor_zeta::address_t::empty_address()});
+                disk->sync(services::disk::manager_disk_t::disk_sync_pack_t{wal->address()});
+            }
             disk->bootstrap_system_tables_sync();
         }
         ~fixture() {
@@ -163,6 +169,29 @@ namespace {
                 ++n;
         }
         return n;
+    }
+
+    // Ordered list of (type, table_oid) for every pg_catalog physical record, in
+    // wal-id order (== the order agent-0 wrote them). read_committed_records sorts
+    // by wal_id ascending, so this is the durable cross-catalog WAL ordering.
+    struct phys_rec_t {
+        services::wal::wal_record_type type;
+        components::catalog::oid_t table_oid;
+    };
+    std::vector<phys_rec_t> pg_catalog_physical_sequence(const std::string& dir) {
+        auto log = initialization_logger("python", "/tmp/docker_logs/");
+        configuration::config_wal c;
+        c.path = dir;
+        c.on = true;
+        services::wal::wal_reader_t reader(c, log);
+        auto records = reader.read_committed_records(services::wal::id_t{0});
+        std::vector<phys_rec_t> seq;
+        for (auto& r : records) {
+            if (r.is_physical() && r.table_oid != components::catalog::INVALID_OID &&
+                r.table_oid < components::catalog::FIRST_USER_OID)
+                seq.push_back(phys_rec_t{r.record_type, r.table_oid});
+        }
+        return seq;
     }
 } // namespace
 
@@ -404,5 +433,117 @@ TEST_CASE("services::disk::wal_catalog::create_sequence_writes_pg_class") {
         test_create_sequence(fx, ns_oid, "widget_seq");
     }
     REQUIRE(pg_catalog_records_for(dir, "pg_class") >= cls_before + 1);
+    cleanup_dir(dir);
+}
+
+// 13. agent-0 catalog WAL ordering — a single txn sends append(pg_depend) →
+//     delete(pg_depend) → append(pg_index) and the durable WAL must replay those
+//     three physical records in the SAME order. The catalog-DDL→agent migration
+//     funnels every pg_* mutation through agent-0's single mailbox, so FIFO there
+//     is what preserves cross-catalog WAL record order. We compare exactly the
+//     tail of the physical record sequence (bootstrap emits none, see test 1).
+TEST_CASE("services::disk::wal_catalog::agent0_catalog_wal_ordering") {
+    auto dir = wal_cat_dir() + "/agent0_order";
+    cleanup_dir(dir);
+    constexpr catalog::oid_t pg_depend = catalog::well_known_oid::pg_depend_table;
+    constexpr catalog::oid_t pg_index = catalog::well_known_oid::pg_index_table;
+    {
+        fixture fx(dir);
+        // bootstrap seeds rows via direct_append_sync (txn=0), no WAL records yet.
+        REQUIRE(pg_catalog_physical_sequence(dir).empty());
+
+        // Allocate two oids: one objid for the pg_depend row, one for the pg_index row.
+        auto oids = fx.invoke(&manager_disk_t::allocate_oids_batch, std::size_t{2});
+        const catalog::oid_t dep_objid = oids[0];
+        const catalog::oid_t idx_oid = oids[1];
+
+        std::vector<components::pg_catalog_append_range_t> appends_local;
+
+        // (1) append a pg_depend row (objid is column index 1 in
+        //     [classid, objid, refclassid, refobjid, deptype]).
+        auto dep_row = catalog::build_pg_depend_row(&fx.resource,
+                                                    pg_index,   // classid
+                                                    dep_objid,  // objid
+                                                    pg_index,   // refclassid
+                                                    idx_oid,    // refobjid
+                                                    'n');
+        appends_local.push_back(
+            fx.invoke(&manager_disk_t::append_pg_catalog_row, auto_ctx(), pg_depend, std::move(dep_row)));
+
+        // (2) delete the pg_depend row we just appended (objid == col 1 == dep_objid).
+        //     delete_pg_catalog_rows_inner only emits a PHYSICAL_DELETE when it finds
+        //     a matching live row, so this targets the row from step (1). auto_ctx()
+        //     (txn=0) keeps the emitted record always-visible to read_committed_records
+        //     (no COMMIT marker is written in these disk-only tests), matching the
+        //     txn=0 the surrounding append calls use.
+        fx.invoke(&manager_disk_t::delete_pg_catalog_rows, auto_ctx(), pg_depend, std::int64_t{1}, dep_objid);
+
+        // (3) append a pg_index row — a DIFFERENT catalog, after the delete.
+        auto idx_row = catalog::build_pg_index_row(&fx.resource, idx_oid, idx_oid, std::string("0"), true);
+        appends_local.push_back(
+            fx.invoke(&manager_disk_t::append_pg_catalog_row, auto_ctx(), pg_index, std::move(idx_row)));
+
+        std::set<catalog::oid_t> deletes_local{pg_depend};
+        fx.invoke(&manager_disk_t::storage_publish_commits,
+                  rebuild_ctx(),
+                  std::uint64_t{1000},
+                  std::move(appends_local));
+        fx.invoke(&manager_disk_t::storage_publish_deletes, txn_ctx(), std::uint64_t{1000}, std::move(deletes_local));
+    }
+    // Durable WAL must hold exactly these three physical records in send order.
+    auto seq = pg_catalog_physical_sequence(dir);
+    REQUIRE(seq.size() == 3);
+    REQUIRE(seq[0].type == services::wal::wal_record_type::PHYSICAL_INSERT);
+    REQUIRE(seq[0].table_oid == pg_depend);
+    REQUIRE(seq[1].type == services::wal::wal_record_type::PHYSICAL_DELETE);
+    REQUIRE(seq[1].table_oid == pg_depend);
+    REQUIRE(seq[2].type == services::wal::wal_record_type::PHYSICAL_INSERT);
+    REQUIRE(seq[2].table_oid == pg_index);
+    cleanup_dir(dir);
+}
+
+// 14. WAL-disabled append still mutates storage, emits no WAL record. With the WAL
+//     manager left unwired (fixture(dir, /*wire_wal=*/false) → agent-0's
+//     manager_wal_addr_ stays empty), append_pg_catalog_row_inner skips
+//     write_physical_insert but still runs direct storage append. Mirrors
+//     bootstrap_alone_no_wal's "no WAL records" assertion and adds a read-back.
+TEST_CASE("services::disk::wal_catalog::wal_disabled_append_no_record") {
+    auto dir = wal_cat_dir() + "/wal_disabled";
+    cleanup_dir(dir);
+    constexpr catalog::oid_t pg_index = catalog::well_known_oid::pg_index_table;
+    {
+        fixture fx(dir, /*wire_wal=*/false);
+
+        auto oids = fx.invoke(&manager_disk_t::allocate_oids_batch, std::size_t{1});
+        const catalog::oid_t idx_oid = oids[0];
+
+        auto idx_row = catalog::build_pg_index_row(&fx.resource, idx_oid, idx_oid, std::string("0"), true);
+        auto rng = fx.invoke(&manager_disk_t::append_pg_catalog_row, auto_ctx(), pg_index, std::move(idx_row));
+        std::vector<components::pg_catalog_append_range_t> appends_local;
+        appends_local.push_back(std::move(rng));
+        fx.invoke(&manager_disk_t::storage_publish_commits,
+                  rebuild_ctx(),
+                  std::uint64_t{1000},
+                  std::move(appends_local));
+
+        // (a) the row is actually present: read pg_index back by indexrelid (col 0).
+        std::pmr::vector<std::string> keys{&fx.resource};
+        keys.emplace_back("indexrelid");
+        std::pmr::vector<components::types::logical_value_t> vals{&fx.resource};
+        vals.emplace_back(&fx.resource, idx_oid);
+        auto batches = services::disk::test_probe::probe_read(fx, auto_ctx(), pg_index, std::move(keys), std::move(vals));
+        std::size_t found = 0;
+        for (const auto& chunk : batches) {
+            for (std::uint64_t i = 0; i < chunk.size(); ++i) {
+                auto oid_v = chunk.value(0, i);
+                if (!oid_v.is_null() &&
+                    static_cast<catalog::oid_t>(oid_v.value<std::uint32_t>()) == idx_oid)
+                    ++found;
+            }
+        }
+        REQUIRE(found == 1);
+    }
+    // (b) no WAL record was emitted — WAL manager was never wired.
+    REQUIRE(pg_catalog_physical_count(dir) == 0);
     cleanup_dir(dir);
 }

--- a/services/dispatcher/tests/test_dispatcher_catalog.cpp
+++ b/services/dispatcher/tests/test_dispatcher_catalog.cpp
@@ -14,6 +14,7 @@
 #include <core/executor.hpp>
 #include <core/non_thread_scheduler/scheduler_test.hpp>
 #include <services/disk/manager_disk.hpp>
+#include <services/disk/tests/catalog_probe.hpp>
 #include <services/wal/manager_wal_replicate.hpp>
 
 using namespace services;
@@ -71,6 +72,30 @@ struct test_dispatcher : actor_zeta::actor::actor_mixin<test_dispatcher> {
 
     void step() { scheduler_->run(10000); }
 
+    // Generic disk-actor invoke used by the catalog_probe adapter below.
+    template<typename Fn, typename... Args>
+    auto disk_invoke(Fn fn, Args&&... args) {
+        auto [_, fut] = actor_zeta::otterbrix::send(manager_disk_->address(), fn, std::forward<Args>(args)...);
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+        while (!fut.is_ready() && std::chrono::steady_clock::now() < deadline) {
+            scheduler_->run(1000);
+            std::this_thread::yield();
+        }
+        REQUIRE(fut.is_ready());
+        return std::move(fut).take_ready();
+    }
+
+    // Adapter exposing the (resource, invoke) shape that test_probe helpers expect.
+    struct probe_fixture {
+        test_dispatcher* self;
+        std::pmr::memory_resource& resource;
+        template<typename Fn, typename... Args>
+        auto invoke(Fn fn, Args&&... args) {
+            return self->disk_invoke(fn, std::forward<Args>(args)...);
+        }
+    };
+    probe_fixture probe_fx() { return probe_fixture{this, *resource_}; }
+
     cursor_t_ptr take_result() {
         // execute_plan's future becomes ready asynchronously (the manager actors
         // self-drive on internal threads). Pump the child scheduler until ready,
@@ -110,24 +135,13 @@ struct test_dispatcher : actor_zeta::actor::actor_mixin<test_dispatcher> {
         return std::move(fut).take_ready();
     }
 
-    // Resolve a table via disk actor under a given namespace oid.
-    resolve_table_result_t resolve_table(components::catalog::oid_t ns_oid, const std::string& tname) {
+    // Resolve a table via the live read_chunks_by_key path (catalog-read oracle).
+    test_probe::probe_table_result_t resolve_table(components::catalog::oid_t ns_oid, const std::string& tname) {
         components::execution_context_t ctx{components::session::session_id_t{},
                                             components::table::transaction_data{0, 0},
                                             {}};
-        auto [_, fut] = actor_zeta::otterbrix::send(manager_disk_->address(),
-                                                    &manager_disk_t::resolve_table,
-                                                    ctx,
-                                                    ns_oid,
-                                                    tname,
-                                                    std::uint64_t{0});
-        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
-        while (!fut.is_ready() && std::chrono::steady_clock::now() < deadline) {
-            scheduler_->run(1000);
-            std::this_thread::yield();
-        }
-        REQUIRE(fut.is_ready());
-        return std::move(fut).take_ready();
+        auto adapter = probe_fx();
+        return test_probe::probe_table(adapter, ctx, ns_oid, tname);
     }
 
     void execute_sql(const std::string& query) {

--- a/services/dispatcher/tests/test_variant_e3_differential.cpp
+++ b/services/dispatcher/tests/test_variant_e3_differential.cpp
@@ -14,6 +14,7 @@
 #include <core/executor.hpp>
 #include <core/non_thread_scheduler/scheduler_test.hpp>
 #include <services/disk/manager_disk.hpp>
+#include <services/disk/tests/catalog_probe.hpp>
 #include <services/wal/manager_wal_replicate.hpp>
 
 // Differential test scaffold: same SQL fixture, drive dispatcher::execute_plan
@@ -78,6 +79,30 @@ namespace {
 
         void step() { scheduler_->run(10000); }
 
+        // Generic disk-actor invoke used by the catalog_probe adapter below.
+        template<typename Fn, typename... Args>
+        auto disk_invoke(Fn fn, Args&&... args) {
+            auto [_, fut] = actor_zeta::otterbrix::send(manager_disk_->address(), fn, std::forward<Args>(args)...);
+            const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+            while (!fut.is_ready() && std::chrono::steady_clock::now() < deadline) {
+                scheduler_->run(1000);
+                std::this_thread::yield();
+            }
+            REQUIRE(fut.is_ready());
+            return std::move(fut).take_ready();
+        }
+
+        // Adapter exposing the (resource, invoke) shape that test_probe helpers expect.
+        struct probe_fixture {
+            differential_fixture* self;
+            std::pmr::memory_resource& resource;
+            template<typename Fn, typename... Args>
+            auto invoke(Fn fn, Args&&... args) {
+                return self->disk_invoke(fn, std::forward<Args>(args)...);
+            }
+        };
+        probe_fixture probe_fx() { return probe_fixture{this, *resource_}; }
+
         cursor_t_ptr take_result() {
             // A plan can span a multi-actor co_await chain (e.g. SET TIMEZONE:
             // executor → dispatcher → disk → back). Each cross-actor co_await
@@ -115,23 +140,12 @@ namespace {
             return std::move(fut).take_ready();
         }
 
-        resolve_table_result_t resolve_table(components::catalog::oid_t ns_oid, const std::string& tname) {
+        test_probe::probe_table_result_t resolve_table(components::catalog::oid_t ns_oid, const std::string& tname) {
             components::execution_context_t ctx{components::session::session_id_t{},
                                                 components::table::transaction_data{0, 0},
                                                 {}};
-            auto [_, fut] = actor_zeta::otterbrix::send(manager_disk_->address(),
-                                                       &manager_disk_t::resolve_table,
-                                                       ctx,
-                                                       ns_oid,
-                                                       tname,
-                                                       std::uint64_t{0});
-            const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
-            while (!fut.is_ready() && std::chrono::steady_clock::now() < deadline) {
-                scheduler_->run(1000);
-                std::this_thread::yield();
-            }
-            REQUIRE(fut.is_ready());
-            return std::move(fut).take_ready();
+            auto adapter = probe_fx();
+            return test_probe::probe_table(adapter, ctx, ns_oid, tname);
         }
 
         // Post a parsed logical plan to manager_dispatcher's execute_plan handler.
@@ -406,8 +420,9 @@ TEST_CASE("variant-e3 differential: CREATE TYPE STRUCT") {
         auto cur = fx.take_result();
         REQUIRE(cur->is_success());
         // Verified indirectly via the table below that uses the type: the
-        // column-spec parser resolves it through resolve_type_sync, which only
-        // succeeds if the pg_type row + its nested pg_attribute rows were written.
+        // column-spec parser resolves it through the catalog type-resolution path,
+        // which only succeeds if the pg_type row + its nested pg_attribute rows
+        // were written.
     }
 
     fx.execute_sql("CREATE DATABASE ve3_ty_db;");
@@ -511,7 +526,7 @@ TEST_CASE("variant-e3 differential: DROP DATABASE") {
 
 // CREATE TABLE → CREATE VIEW. A view lands a pg_class relkind='v' row plus a
 // pg_rewrite ev_action row carrying the body SQL. Proxy: resolve_table(view).
-// relkind=='v'. The pg_rewrite row isn't exposed by resolve_table_result_t but
+// relkind=='v'. The pg_rewrite row isn't exposed by the probe_table result but
 // is required for SELECT-on-view expansion (covered e2e elsewhere).
 TEST_CASE("variant-e3 differential: CREATE VIEW") {
     auto mr = std::make_unique<std::pmr::synchronized_pool_resource>();

--- a/services/index/index_agent_disk.cpp
+++ b/services/index/index_agent_disk.cpp
@@ -68,14 +68,15 @@ namespace services::index {
             case actor_zeta::msg_id<index_agent_disk_t, &index_agent_disk_t::remove_many>:
                 co_await actor_zeta::dispatch(this, &index_agent_disk_t::remove_many, msg);
                 break;
+            case actor_zeta::msg_id<index_agent_disk_t, &index_agent_disk_t::force_flush>:
+                co_await actor_zeta::dispatch(this, &index_agent_disk_t::force_flush, msg);
+                break;
             default:
                 break;
         }
     }
 
     auto index_agent_disk_t::make_type() const noexcept -> const char* { return "index_agent_disk"; }
-
-    bool index_agent_disk_t::is_dropped() const { return is_dropped_; }
 
     index_agent_disk_t::unique_future<void> index_agent_disk_t::drop(session_id_t session) {
         trace(log_, "index_agent_disk_t::drop, session: {}", session.data());
@@ -146,12 +147,15 @@ namespace services::index {
         co_return core::error_t::no_error();
     }
 
-    // Synchronous owner-side entry — called by manager_index_t outside the
-    // actor mailbox.
-    void index_agent_disk_t::force_flush_sync() {
+    index_agent_disk_t::unique_future<void> index_agent_disk_t::force_flush(session_id_t session) {
+        // A dropped agent has no backing — flushing it would be a use-after-free,
+        // so skip. The is_dropped_ guard lives here now (was the owner-side check
+        // in manager_index_t::flush_all_indexes before this became a mailbox op).
+        trace(log_, "index_agent_disk_t::force_flush, session: {}", session.data());
         if (index_disk_ && !is_dropped_) {
             index_disk_->force_flush();
         }
+        co_return;
     }
 
 } //namespace services::index

--- a/services/index/index_agent_disk.hpp
+++ b/services/index/index_agent_disk.hpp
@@ -67,7 +67,6 @@ namespace services::index {
         ~index_agent_disk_t();
 
         components::catalog::oid_t table_oid() const { return table_oid_; }
-        bool is_dropped() const;
 
         unique_future<void> drop(session_id_t session);
         // Wipe the agent's stored index data while keeping the agent alive and
@@ -81,13 +80,17 @@ namespace services::index {
         unique_future<core::error_t>
         remove_many(session_id_t session, uint64_t txn_id, std::vector<std::pair<value_t, size_t>> values);
 
-        // Synchronous flush — bypasses actor mailbox, safe to call from owning manager
-        void force_flush_sync();
+        // Mailbox flush handler — fanned out by manager_index_t::flush_all_indexes.
+        // Guards on is_dropped_ internally (a dropped agent has no backing), then
+        // forces the backend to persist. Ordered behind any pending insert/remove
+        // ops in this agent's FIFO, so it never races an in-flight write.
+        unique_future<void> force_flush(session_id_t session);
 
         using dispatch_traits = actor_zeta::dispatch_traits<&index_agent_disk_t::drop,
                                                             &index_agent_disk_t::clear,
                                                             &index_agent_disk_t::insert_many,
-                                                            &index_agent_disk_t::remove_many>;
+                                                            &index_agent_disk_t::remove_many,
+                                                            &index_agent_disk_t::force_flush>;
 
         auto make_type() const noexcept -> const char*;
         actor_zeta::behavior_t behavior(actor_zeta::mailbox::message* msg);

--- a/services/index/manager_index.cpp
+++ b/services/index/manager_index.cpp
@@ -1317,16 +1317,35 @@ namespace services::index {
     manager_index_t::unique_future<void> manager_index_t::flush_all_indexes(session_id_t session) {
         trace(log_, "manager_index_t::flush_all_indexes, session: {}", session.data());
 
-        // Await all pending agent operations to ensure no in-flight writes
+        // Await all pending agent operations first: this is the cross-handler
+        // ordering barrier (e.g. the agent-drop futures parked by
+        // on_horizon_advanced) — a force_flush must never start before an
+        // in-flight drop finishes.
         for (auto& f : pending_void_) {
             co_await std::move(f);
         }
         pending_void_.clear();
-        // Now safe to call synchronously — no actor messaging, avoids TSan race
+
+        // Fan out force_flush as a mailbox op per owned disk agent (no direct
+        // cross-actor synchronous call). Two-phase: send every message with no
+        // intervening co_await so the agents flush in parallel, then await all
+        // futures. Each force_flush naturally orders behind any pending
+        // insert/remove already queued in that agent's FIFO, and the is_dropped
+        // guard now lives inside the agent handler.
+        std::pmr::vector<unique_future<void>> futures(resource_);
+        futures.reserve(disk_agents_owned_.size());
         for (auto& agent : disk_agents_owned_) {
-            if (agent && !agent->is_dropped()) {
-                agent->force_flush_sync();
+            if (!agent) {
+                continue;
             }
+            auto addr = agent->address();
+            auto [needs_sched, fut] =
+                actor_zeta::otterbrix::send(addr, &index_agent_disk_t::force_flush, session);
+            schedule_agent(addr, needs_sched);
+            futures.emplace_back(std::move(fut));
+        }
+        for (auto& f : futures) {
+            co_await std::move(f);
         }
         co_return;
     }
@@ -1364,8 +1383,8 @@ namespace services::index {
             // a new DROP TABLE re-marks the subscriber. The ack future is parked
             // in pending_void_ as a cross-handler ordering barrier: flush_all_indexes
             // co_awaits every pending_void_ future (including the agent-drop
-            // futures emitted above) BEFORE calling force_flush_sync(), so a
-            // force_flush can never race an in-flight agent drop (a btree-path
+            // futures emitted above) BEFORE fanning out its force_flush messages,
+            // so a force_flush can never race an in-flight agent drop (a btree-path
             // use-after-free).
             constexpr uint8_t INDEX_KIND = 2;
             pending_void_.emplace_back(std::move(


### PR DESCRIPTION
## Summary

`manager_disk_t` becomes a thin **router + fan-out orchestrator + disk-side transaction lifecycle**: it holds no `storages_`, performs no scans/WAL/mutations at runtime, and makes **zero runtime cross-actor synchronous calls**. All per-oid work runs on the `agent_disk_t` twins (keyed by `pool_idx_for_oid`); the remaining `*_sync` helpers are strictly bootstrap-only (pre-scheduler-start, `base_spaces`).

## Changes

**Track A — catalog DDL → agent-0**
- `append_pg_catalog_row` / `delete_pg_catalog_rows` / `update_pg_attribute_commit_id_field` / `compact_relkind_g_storage` / `mark_storage_dropped` moved to agent `_inner` handlers (scan + WAL + mutation on the agent thread); manager handlers are thin routers.
- WAL wiring: `agent_disk_t::set_manager_wal_sync` + `manager_wal_addr_`, fanned out in `manager_disk_t::sync`; catalog WAL is now written on agent-0.
- Removed all post-bootstrap `storage_entry_sync` borrows (fixes the shared-state rule).

**Track B — catalog reads**
- Offloaded `read_chunks_by_key` into agent `read_chunks_by_key_inner`; key carrier switched from row-major `logical_value_t` to columnar `data_chunk_t` (mirrors `scan_by_keys`); all prod + test callers updated.
- Added multi-key `read_chunks_by_keys` and converted the per-key read loops in `operator_resolve_constraint` and `operator_dynamic_cascade_delete`.
- Deleted prod-dead `resolve_table`/`resolve_type`/`resolve_function` (+ `resolve_type_sync`) and their dead result structs; disk tests use a `catalog_probe` helper over `read_chunks_by_key`.

**Track C — dead-code sweep (disk-service API)**
- Removed the singular MVCC trio, `total_rows_sync`/`checkpoint_wal_id_sync` chain, `role()`/`pool_idx()`/`make_type()`, `lv_i32/i64/bool`, `load_system_tables_sync`, `oid_gen()`, agent `direct_append_sync`, `storage_column_names_inner`, `drop_column_inner`, `table_storage_t::table() const`, and the redundant 4-arg `direct_append_sync`/`direct_delete_sync` overloads.

**Track D — batch conversions**
- `drop_storage_many` + `mark_storage_dropped_many` (per-agent partition); FK cascade SET NULL/DEFAULT collapsed to one fetch + one update; commit publish 4 round-trips → 2.
- `create_storage`/`_with_columns`/`_disk` converted to mailbox agent handlers (agent builds the SFBM on its own thread); `checkpoint_all` folds `has_in_memory` into `checkpoint_inner`'s return.

**Index**
- `flush_all_indexes` converted to a `force_flush` mailbox fan-out; removed the runtime `agent->force_flush_sync()`/`is_dropped()` cross-actor sync calls.

**Infra / tests**
- Extracted `services/disk/inline_scan.hpp`; added agent `scan_batched_local`.
- Added targeted tests (catalog WAL ordering, WAL-disabled append, `read_chunks_by_keys` parity, `drop_storage_many`, `mark_storage_dropped_many`, DROP INDEX delete fold).

