### PR TITLE
fix(dispatcher, operators): align join schema with runtime; harden group fallback

### DIFF
--- a/components/physical_plan/operators/operator_group.cpp
+++ b/components/physical_plan/operators/operator_group.cpp
@@ -313,6 +313,9 @@ namespace components::operators {
 
             // Phase 3: Aggregate per group + build result chunk
             auto result = calc_aggregate_values(pipeline_context, in_chunks);
+            if (has_error()) {
+                return;
+            }
 
             // Post-aggregate arithmetic (columnar)
             size_t size_before_post = result.data.size();
@@ -709,6 +712,10 @@ namespace components::operators {
             aggregator->clear();
             aggregator->set_children(make_operator_batch(resource_, std::move(group_chunks)));
             aggregator->on_execute(pipeline_context);
+            if (aggregator->has_error()) {
+                set_error(aggregator->get_error());
+                return vector::data_chunk_t(resource_, std::pmr::vector<types::complex_logical_type>{resource_}, 1);
+            }
 
             auto datum = aggregator->take_batch_values();
 
@@ -717,6 +724,9 @@ namespace components::operators {
                 for (auto& v : vals) {
                     v.set_alias(std::string(value.name));
                     results.push_back(std::move(v));
+                }
+                while (results.size() < num_groups) {
+                    results.emplace_back(resource_, types::logical_type::NA);
                 }
             } else {
                 // data_chunk_t — each row corresponds to a group
@@ -766,10 +776,14 @@ namespace components::operators {
                 }
             }
         }
+        // One column per aggregate, unconditionally: the fill loop below writes
+        // every aggregate at the fixed position key_count + agg_idx, so a
+        // skipped type here would shift all later columns and write past the
+        // chunk's column array. An aggregate with no results gets an NA-typed
+        // column filled with NULLs.
         for (size_t a = 0; a < values_.size(); a++) {
-            if (!agg_results[a].empty()) {
-                out_types.push_back(agg_results[a][0].type());
-            }
+            out_types.push_back(agg_results[a].empty() ? types::complex_logical_type(types::logical_type::NA)
+                                                       : agg_results[a][0].type());
         }
 
         // Create result chunk
@@ -787,7 +801,13 @@ namespace components::operators {
         // Fill aggregate columns
         for (size_t agg_idx = 0; agg_idx < values_.size(); agg_idx++) {
             for (size_t group_idx = 0; group_idx < num_groups; group_idx++) {
-                result.set_value(key_count + agg_idx, group_idx, std::move(agg_results[agg_idx][group_idx]));
+                if (group_idx < agg_results[agg_idx].size()) {
+                    result.set_value(key_count + agg_idx, group_idx, std::move(agg_results[agg_idx][group_idx]));
+                } else {
+                    result.set_value(key_count + agg_idx,
+                                     group_idx,
+                                     types::logical_value_t(resource_, types::logical_type::NA));
+                }
             }
         }
 

--- a/integration/cpp/test/CMakeLists.txt
+++ b/integration/cpp/test/CMakeLists.txt
@@ -19,6 +19,7 @@ set( ${PROJECT_NAME}_SOURCES
         test_connections.cpp
         test_udfs.cpp
         test_batch_execution.cpp
+        test_group_by_node_data.cpp
         test_arithmetic.cpp
         test_clean_break_startup.cpp
         test_column_projection.cpp

--- a/integration/cpp/test/test_group_by_node_data.cpp
+++ b/integration/cpp/test/test_group_by_node_data.cpp
@@ -1,0 +1,164 @@
+#include "test_config.hpp"
+#include <catch2/catch.hpp>
+
+#include <components/logical_plan/execution_plan.hpp>
+#include <components/logical_plan/node_aggregate.hpp>
+#include <components/logical_plan/node_data.hpp>
+#include <components/sql/parser/parser.h>
+#include <components/sql/transformer/transformer.hpp>
+#include <components/sql/transformer/utils.hpp>
+
+#include <deque>
+
+using namespace components;
+
+// Reproduction of a SIGSEGV in operator_group_t's fallback aggregation:
+// a GROUP BY over a table-qualified STRING key, where the table subtrees are
+// raw node_data chunks (the embedder/federation scenario — otterstax fetches
+// remote tables and splices the rows into the plan as node_data).
+//
+// Crash chain: operator_group_t::calc_aggregate_values_fallback
+//   -> build_result_chunk (key out_types fall back to group_keys_[0][k].type()
+//      because full_path.size() != 1; the extracted key value is NA)
+//   -> vector_t::set_value on the NA-typed vector
+//   -> validity_mask_t::set(nullptr)  [EXC_BAD_ACCESS, address=0x0]
+//
+// Notes from triage:
+//  - integer group keys + AVG(DOUBLE) over the same plan shape work;
+//  - the same query over real disk tables works (fast path, enrich resolves
+//    the key to a single column index);
+//  - the fallback path is unreachable from plain SQL — derived-table keys,
+//    joins of subqueries and expression keys are all rejected by the
+//    transformer/validator with clean errors before the group operator runs.
+
+namespace {
+
+    vector::data_chunk_t make_chunk(std::pmr::memory_resource* resource,
+                                    std::initializer_list<std::pair<const char*, types::logical_type>> names) {
+        std::pmr::vector<types::complex_logical_type> cols(resource);
+        for (auto& [n, t] : names) {
+            cols.emplace_back(t);
+            cols.back().set_alias(n);
+        }
+        vector::data_chunk_t chunk(resource, cols, 2);
+        for (size_t c = 0; c < cols.size(); ++c) {
+            for (size_t r = 0; r < 2; ++r) {
+                switch (cols[c].type()) {
+                    case types::logical_type::INTEGER:
+                        chunk.set_value(c, r, types::logical_value_t(resource, static_cast<int32_t>(r + 1)));
+                        break;
+                    case types::logical_type::DOUBLE:
+                        chunk.set_value(c, r, types::logical_value_t(resource, 100.5 * (r + 1)));
+                        break;
+                    default:
+                        chunk.set_value(c, r, types::logical_value_t(resource, std::string("n_") + std::to_string(r)));
+                        break;
+                }
+            }
+        }
+        chunk.set_cardinality(2);
+        return chunk;
+    }
+
+    // Parses + transforms the query, then swaps the two table aggregates for
+    // raw node_data chunks. string_key=false makes campaign_name an INTEGER
+    // column (the passing control case).
+    logical_plan::node_ptr build_plan(std::pmr::memory_resource* resource,
+                                      sql::transform::transformer& transformer,
+                                      logical_plan::parameter_node_ptr& out_params,
+                                      bool string_key) {
+        const char* sql = R"(
+            SELECT c.campaign_name, COUNT(p.product_id) as product_count, AVG(p.price) as avg_product_price
+            FROM db1.campaigns c
+            INNER JOIN pgdb.products p ON p.campaign_id = c.campaign_id
+            GROUP BY c.campaign_name ORDER BY product_count DESC;)";
+
+        auto* raw = raw_parser(resource, sql);
+        REQUIRE(raw != nullptr);
+        auto* res = reinterpret_cast<::Node*>(linitial(raw));
+        auto binder = transformer.transform(sql::transform::pg_cell_to_node_cast(res));
+        REQUIRE_FALSE(binder.has_error());
+        auto root = binder.node_ptr();
+        REQUIRE(root);
+        out_params = binder.params_ptr();
+
+        const auto name_type = string_key ? types::logical_type::STRING_LITERAL : types::logical_type::INTEGER;
+        std::deque<logical_plan::node_ptr> walk{root};
+        size_t swapped = 0;
+        while (!walk.empty()) {
+            auto n = walk.front();
+            walk.pop_front();
+            for (auto& child : n->children()) {
+                if (child && child->type() == logical_plan::node_type::aggregate_t) {
+                    const auto& rel = static_cast<const logical_plan::node_aggregate_t&>(*child).relname().t;
+                    if (rel == "campaigns") {
+                        child =
+                            logical_plan::make_node_raw_data(resource,
+                                                             make_chunk(resource,
+                                                                        {{"campaign_id", types::logical_type::INTEGER},
+                                                                         {"campaign_name", name_type},
+                                                                         {"budget", types::logical_type::DOUBLE}}));
+                        ++swapped;
+                        continue;
+                    }
+                    if (rel == "products") {
+                        child =
+                            logical_plan::make_node_raw_data(resource,
+                                                             make_chunk(resource,
+                                                                        {{"product_id", types::logical_type::INTEGER},
+                                                                         {"campaign_id", types::logical_type::INTEGER},
+                                                                         {"product_name", name_type},
+                                                                         {"price", types::logical_type::DOUBLE}}));
+                        ++swapped;
+                        continue;
+                    }
+                }
+                if (child) {
+                    walk.push_back(child);
+                }
+            }
+        }
+        REQUIRE(swapped == 2);
+        return root;
+    }
+
+} // namespace
+
+TEST_CASE("group by over node_data: integer key (control, passes)") {
+    auto config = test_create_config("/tmp/otterbrix_group_by_node_data_int");
+    test_clear_directory(config);
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+    auto* resource = dispatcher->resource();
+
+    sql::transform::transformer transformer(resource);
+    logical_plan::parameter_node_ptr params;
+    auto root = build_plan(resource, transformer, params, /*string_key=*/false);
+
+    auto cursor =
+        dispatcher->execute_plan(otterbrix::session_id_t(), logical_plan::execution_plan_t{resource, root, params});
+    REQUIRE(cursor);
+    REQUIRE_FALSE(cursor->is_error());
+    REQUIRE(cursor->size() == 2);
+}
+
+TEST_CASE("group by over node_data: string key (SIGSEGV before the fix)") {
+    auto config = test_create_config("/tmp/otterbrix_group_by_node_data_str");
+    test_clear_directory(config);
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+    auto* resource = dispatcher->resource();
+
+    sql::transform::transformer transformer(resource);
+    logical_plan::parameter_node_ptr params;
+    auto root = build_plan(resource, transformer, params, /*string_key=*/true);
+
+    auto cursor =
+        dispatcher->execute_plan(otterbrix::session_id_t(), logical_plan::execution_plan_t{resource, root, params});
+    REQUIRE(cursor);
+    REQUIRE_FALSE(cursor->is_error());
+    REQUIRE(cursor->size() == 2);
+    // Each campaign joins exactly one product: COUNT == 1 per group and
+    // AVG(price) is the row's own price.
+    REQUIRE(cursor->type_data().size() == 3);
+}

--- a/services/dispatcher/validate_logical_plan.cpp
+++ b/services/dispatcher/validate_logical_plan.cpp
@@ -138,31 +138,30 @@ namespace services::dispatcher {
             size_t key_order;
         };
 
-        // JOIN merge: keep both same-named columns when they come from different
-        // tables; only drop entries that are truly identical (same alias AND same result_alias).
+        // JOIN schema = pure concatenation of both sides. The runtime join
+        // operators (join_utils.hpp: res_types = left.types() + all right
+        // types) emit every column of both inputs, including same-named join
+        // keys. Dropping a duplicate here desynchronizes the validator's
+        // column indices from the runtime chunk layout: every key path
+        // resolved after the dropped column points one column to the left
+        // (wrong values for same-typed columns, kernel errors or worse for
+        // mismatched ones). Notably both sides carry an empty result_alias
+        // when they are raw node_data inputs, so a same-named join key used
+        // to be deduplicated exactly there.
         named_schema merge_schemas(std::pmr::memory_resource* resource, named_schema lhs, named_schema rhs) {
             named_schema merged(resource);
+            merged.reserve(lhs.size() + rhs.size());
             for (auto&& type : lhs) {
-                auto it = std::find_if(merged.begin(), merged.end(), [&type](const auto& t) {
-                    return t.type.alias() == type.type.alias() && t.result_alias == type.result_alias;
-                });
-                if (it == merged.end()) {
-                    if (type.side == side_t::undefined) {
-                        type.side = side_t::left;
-                    }
-                    merged.emplace_back(std::move(type));
+                if (type.side == side_t::undefined) {
+                    type.side = side_t::left;
                 }
+                merged.emplace_back(std::move(type));
             }
             for (auto&& type : rhs) {
-                auto it = std::find_if(merged.begin(), merged.end(), [&type](const auto& t) {
-                    return t.type.alias() == type.type.alias() && t.result_alias == type.result_alias;
-                });
-                if (it == merged.end()) {
-                    if (type.side == side_t::undefined) {
-                        type.side = side_t::right;
-                    }
-                    merged.emplace_back(std::move(type));
+                if (type.side == side_t::undefined) {
+                    type.side = side_t::right;
                 }
+                merged.emplace_back(std::move(type));
             }
             return merged;
         }
@@ -1539,17 +1538,21 @@ namespace services::dispatcher {
                         // them all (an EXPLICIT reference to such a name still errors
                         // as ambiguous in find_types and must use type selection).
                         // Duplicate names across JOIN'd tables are likewise legitimate
-                        // (PostgreSQL semantics). Reject only a truly-identical column:
-                        // same output alias AND same source name AND same physical type.
+                        // (PostgreSQL semantics) — including a self-join, where the
+                        // copies are distinguished by their join side. Reject only a
+                        // truly-identical column: same output alias AND same source
+                        // name AND same physical type AND same join side (multi-type
+                        // fields of one computing table all share one side).
                         struct column_key {
                             std::string result_alias;
                             std::string name;
                             logical_type type;
+                            side_t side;
                             auto operator<=>(const column_key&) const = default;
                         };
                         std::set<column_key> seen_cols;
                         for (const auto& col : incoming_schema) {
-                            column_key key{col.result_alias, std::string(col.type.alias()), col.type.type()};
+                            column_key key{col.result_alias, std::string(col.type.alias()), col.type.type(), col.side};
                             if (!seen_cols.insert(std::move(key)).second) {
                                 return core::error_t(
                                     core::error_code_t::schema_error,


### PR DESCRIPTION
## Summary

Fixes a SIGSEGV in `operator_group_t` and a silent wrong-results bug for GROUP BY over plans whose join inputs are raw `node_data` chunks (the embedder/federation scenario: a downstream consumer fetches remote tables and splices the rows into the plan).

### Root cause

The validator's join-schema merge (`validate_logical_plan.cpp::merge_schemas`) deduplicated same-named columns (same alias **and** result_alias), while the runtime join operators (`join_utils.hpp`) emit **every** column of both inputs. Raw `node_data` inputs carry an empty `result_alias`, so a duplicated join key was dropped from the inferred schema — and every key path resolved after it pointed one column to the left:

- aggregates silently computed over the **wrong column** when the shifted column's type matched (e.g. `AVG(price)` reading `product_name` typed INTEGER),
- errored on mismatched types (string) — and that error was **swallowed** in the group fallback,
- the swallowed error left one aggregate's results empty, desynchronizing the conditional types loop from the unconditional fill loop in `build_result_chunk` → out-of-bounds column write → SIGSEGV (`validity_mask_t::set` on garbage memory).

Diagnosed with lldb on a minimal reproduction: `AVG(p.price)` resolved to path `{5}` while `price` is column 6 of the 7-column runtime join output.

### Changes

- **`validate_logical_plan.cpp`**: join schema is now a pure concatenation of both sides, matching the runtime layout. The `SELECT *` truly-identical-column check now distinguishes join sides (`side_t`), so self-joins stay legal while multi-type fields of one computing table are still rejected.
- **`operator_group.cpp`**: aggregator errors propagate via `set_error` instead of being swallowed; per-aggregate results are padded to the group count; `build_result_chunk` emits one column per aggregate unconditionally and fills missing values with NULL — the types/fill loops can no longer disagree on column positions.
- **New test `integration/cpp/test/test_group_by_node_data.cpp`**: builds the plan via the engine's own `raw_parser` + transformer, swaps the table aggregates for `node_data`, and executes through `wrapper_dispatcher` — integer-key control case plus the previously crashing string-key case, with semantic assertions (2 groups, 3 output columns).

Note: this path is unreachable from plain SQL (derived-table keys, joins of subqueries and expression group keys are all rejected before the group operator runs) — it is only reachable through the public `execute_plan` embedder API, which is how the federation layer (otterstax) hit it.

## Testing

Full `test_otterbrix` suite: **191/191 cases, 51226 assertions** — including the previously failing self-join `SELECT *` case unchanged, and the two new reproduction cases.
