### PR TITLE
fix(operators, table): group operator error contracts; shared-build link gap

### DIFF
--- a/components/physical_plan/operators/operator_group.cpp
+++ b/components/physical_plan/operators/operator_group.cpp
@@ -309,6 +309,9 @@ namespace components::operators {
                 group_keys_.push_back({});
             } else {
                 create_list_rows(in_chunks);
+                if (has_error()) {
+                    return;
+                }
             }
 
             // Phase 3: Aggregate per group + build result chunk
@@ -364,6 +367,10 @@ namespace components::operators {
                 value.aggregator->clear();
                 value.aggregator->set_children(make_operator_batch(resource_, std::move(empty_chunks)));
                 value.aggregator->on_execute(pipeline_context);
+                if (value.aggregator->has_error()) {
+                    set_error(value.aggregator->get_error());
+                    return;
+                }
                 auto datum = value.aggregator->take_batch_values();
                 std::pmr::vector<types::logical_value_t> results(resource_);
                 if (std::holds_alternative<std::pmr::vector<types::logical_value_t>>(datum)) {
@@ -407,6 +414,20 @@ namespace components::operators {
     void operator_group_t::create_list_rows(const chunks_vector_t& in_chunks) {
         if (in_chunks.empty()) {
             return;
+        }
+
+        // Column keys must arrive with a resolved full_path: extract_key_value
+        // reads chunk.value(key.full_path, ...) and an empty path is UB there
+        // (its assert is compiled out in Release). Surface a clean operator
+        // error instead of relying on the assert.
+        for (const auto& key : keys_) {
+            if (key.type == group_key_t::kind::column && key.full_path.empty()) {
+                std::pmr::string msg{"group key '", resource_};
+                msg += key.name;
+                msg += "' has no resolved column path";
+                set_error(core::error_t(core::error_code_t::schema_error, std::move(msg)));
+                return;
+            }
         }
 
         // Try fast path: all keys are simple column type with resolved col_index
@@ -764,11 +785,38 @@ namespace components::operators {
             for (size_t k = 0; k < key_count; k++) {
                 const auto& key = keys_[k];
                 bool got = false;
-                if (key.type == group_key_t::kind::column && key.full_path.size() == 1 && !in_chunks.empty()) {
+                if (key.type == group_key_t::kind::column && !key.full_path.empty() && !in_chunks.empty()) {
                     const auto col_idx = key.full_path.front();
                     if (col_idx < in_chunks.front().column_count()) {
-                        out_types.push_back(in_chunks.front().data[col_idx].type());
-                        got = true;
+                        // Walk the remaining path components through the nested
+                        // type (STRUCT fields by index, ARRAY/LIST element type)
+                        // so multi-part paths get their source type too; fall
+                        // back to the value type when a component cannot be
+                        // resolved.
+                        const auto* walked = &in_chunks.front().data[col_idx].type();
+                        bool ok = true;
+                        for (auto it = std::next(key.full_path.begin()); ok && it != key.full_path.end(); ++it) {
+                            switch (walked->type()) {
+                                case types::logical_type::ARRAY:
+                                case types::logical_type::LIST:
+                                    walked = &walked->child_type();
+                                    break;
+                                case types::logical_type::STRUCT:
+                                    if (*it < walked->child_types().size()) {
+                                        walked = &walked->child_types()[*it];
+                                    } else {
+                                        ok = false;
+                                    }
+                                    break;
+                                default:
+                                    ok = false;
+                                    break;
+                            }
+                        }
+                        if (ok) {
+                            out_types.push_back(*walked);
+                            got = true;
+                        }
                     }
                 }
                 if (!got) {

--- a/components/table/CMakeLists.txt
+++ b/components/table/CMakeLists.txt
@@ -50,6 +50,7 @@ target_link_libraries(
         otterbrix_${PROJECT_NAME} PRIVATE
         otterbrix::expressions
         otterbrix::file
+        otterbrix::session
         otterbrix::types
         otterbrix::vector
 

--- a/integration/cpp/test/CMakeLists.txt
+++ b/integration/cpp/test/CMakeLists.txt
@@ -20,6 +20,7 @@ set( ${PROJECT_NAME}_SOURCES
         test_udfs.cpp
         test_batch_execution.cpp
         test_group_by_node_data.cpp
+        test_group_operator_contracts.cpp
         test_arithmetic.cpp
         test_clean_break_startup.cpp
         test_column_projection.cpp

--- a/integration/cpp/test/test_group_operator_contracts.cpp
+++ b/integration/cpp/test/test_group_operator_contracts.cpp
@@ -1,0 +1,147 @@
+#include <catch2/catch.hpp>
+
+#include <components/compute/function.hpp>
+#include <components/context/context.hpp>
+#include <components/physical_plan/operators/aggregate/operator_func.hpp>
+#include <components/physical_plan/operators/operator_data.hpp>
+#include <components/physical_plan/operators/operator_empty.hpp>
+#include <components/physical_plan/operators/operator_group.hpp>
+
+#include <memory_resource>
+
+using namespace components;
+
+// Error-contract tests for operator_group_t, built around direct operator
+// construction (no dispatcher): malformed key metadata and aggregator
+// failures must surface as clean operator errors (set_error / has_error),
+// never as asserts/UB inside the operator.
+
+namespace {
+
+    operators::operator_ptr make_child(std::pmr::memory_resource* resource, vector::data_chunk_t&& chunk) {
+        return operators::operator_ptr(
+            new operators::operator_empty_t(resource, operators::make_operator_data(resource, std::move(chunk))));
+    }
+
+} // namespace
+
+TEST_CASE("group operator contracts: unresolved column key surfaces operator error", "[group_contracts]") {
+    // Pre-fix this aborted in Debug via assert(!key.full_path.empty()) in
+    // extract_key_value (operator_group.cpp); in Release the assert is compiled
+    // out and chunk.value(empty_path, row) is UB.
+    auto resource = std::pmr::synchronized_pool_resource();
+
+    std::pmr::vector<types::complex_logical_type> cols(&resource);
+    cols.emplace_back(types::logical_type::BIGINT);
+    cols.back().set_alias("k");
+    vector::data_chunk_t chunk(&resource, cols, 2);
+    chunk.set_value(0, 0, types::logical_value_t(&resource, int64_t(1)));
+    chunk.set_value(0, 1, types::logical_value_t(&resource, int64_t(2)));
+    chunk.set_cardinality(2);
+
+    boost::intrusive_ptr<operators::operator_group_t> group(new operators::operator_group_t(&resource, log_t{}));
+    operators::group_key_t key(&resource);
+    key.name = std::pmr::string("k", &resource);
+    key.type = operators::group_key_t::kind::column;
+    // full_path deliberately left empty: an unresolved key must become an
+    // operator error, not an assert/UB.
+    group->add_key(std::move(key));
+    group->set_children(make_child(&resource, std::move(chunk)));
+
+    pipeline::context_t ctx(logical_plan::storage_parameters{&resource});
+    group->on_execute(&ctx);
+
+    REQUIRE(group->has_error());
+    REQUIRE(group->get_error().type == core::error_code_t::schema_error);
+    REQUIRE(group->get_error().what.find("k") != std::pmr::string::npos);
+}
+
+TEST_CASE("group operator contracts: struct-field key type comes from input schema, not first group value",
+          "[group_contracts]") {
+    // Key with a multi-part path ({struct column, field index}) where the FIRST
+    // group's key value is NULL (extracted as an NA-typed value). Pre-fix
+    // build_result_chunk fell back to group_keys_[0][k].type() == NA for any
+    // path with size != 1, so writing the later non-NULL keys aborted in Debug
+    // via assert("value has to be casted to vector's type before set_value")
+    // in vector_t::set_value.
+    auto resource = std::pmr::synchronized_pool_resource();
+
+    std::pmr::vector<types::complex_logical_type> fields(&resource);
+    fields.emplace_back(types::logical_type::BIGINT);
+    fields.back().set_alias("f");
+    auto struct_type = types::complex_logical_type::create_struct("s", fields, "s");
+
+    std::pmr::vector<types::complex_logical_type> cols(&resource);
+    cols.push_back(struct_type);
+    vector::data_chunk_t chunk(&resource, cols, 4);
+    auto field_null = types::logical_value_t(&resource, types::complex_logical_type{types::logical_type::NA});
+    auto make_row = [&](types::logical_value_t field_val) {
+        return types::logical_value_t::create_struct(&resource, struct_type, {std::move(field_val)});
+    };
+    // Groups form in row order: NULL first, then 10, then 20.
+    chunk.set_value(0, 0, make_row(field_null));
+    chunk.set_value(0, 1, make_row(types::logical_value_t(&resource, int64_t(10))));
+    chunk.set_value(0, 2, make_row(types::logical_value_t(&resource, int64_t(10))));
+    chunk.set_value(0, 3, make_row(types::logical_value_t(&resource, int64_t(20))));
+    chunk.set_cardinality(4);
+
+    boost::intrusive_ptr<operators::operator_group_t> group(new operators::operator_group_t(&resource, log_t{}));
+    operators::group_key_t key(&resource);
+    key.name = std::pmr::string("kf", &resource);
+    key.type = operators::group_key_t::kind::column;
+    key.full_path.push_back(0); // struct column
+    key.full_path.push_back(0); // field "f"
+    group->add_key(std::move(key));
+    group->set_children(make_child(&resource, std::move(chunk)));
+
+    pipeline::context_t ctx(logical_plan::storage_parameters{&resource});
+    group->on_execute(&ctx);
+
+    REQUIRE_FALSE(group->has_error());
+    REQUIRE(group->output());
+    auto& out = group->output()->data_chunk();
+    REQUIRE(out.size() == 3);
+    REQUIRE(out.column_count() == 1);
+    // The key column type must be the field's type walked through the input
+    // schema, not the NA type of the first (NULL) group key.
+    REQUIRE(out.data[0].type().type() == types::logical_type::BIGINT);
+    REQUIRE(out.data[0].is_null(0));
+    REQUIRE(out.value(0, 1).value<int64_t>() == 10);
+    REQUIRE(out.value(0, 2).value<int64_t>() == 20);
+}
+
+TEST_CASE("group operator contracts: aggregator error on empty-input global aggregate is propagated",
+          "[group_contracts]") {
+    // The empty-input global-aggregate branch (no left output, keys empty,
+    // values present) runs each aggregator and pre-fix never checked it for
+    // an error afterwards: AVG over a string argument fails kernel dispatch
+    // inside the aggregator, but the operator reported success and emitted a
+    // NULL row instead.
+    auto resource = std::pmr::synchronized_pool_resource();
+
+    auto* registry = compute::function_registry_t::get_default();
+    REQUIRE(registry != nullptr);
+    compute::function* avg_fn = nullptr;
+    for (const auto& [name, uid] : registry->get_functions()) {
+        if (name == "avg") {
+            avg_fn = registry->get_function(uid);
+            break;
+        }
+    }
+    REQUIRE(avg_fn != nullptr);
+
+    boost::intrusive_ptr<operators::operator_group_t> group(new operators::operator_group_t(&resource, log_t{}));
+    std::pmr::vector<expressions::param_storage> args(&resource);
+    args.emplace_back(core::parameter_id_t(1)); // AVG($1), $1 bound to a string below
+    group->add_value(std::pmr::string("a", &resource),
+                     operators::aggregate::operator_aggregate_ptr(
+                         new operators::aggregate::operator_func_t(&resource, log_t{}, avg_fn, std::move(args))));
+    // No children on purpose: left output is absent.
+
+    logical_plan::storage_parameters params{&resource};
+    logical_plan::add_parameter(params, core::parameter_id_t(1), std::string("not_a_number"));
+    pipeline::context_t ctx(std::move(params));
+    group->on_execute(&ctx);
+
+    REQUIRE(group->has_error());
+}


### PR DESCRIPTION
## Summary

Follow-up to #513 (now merged; same functions). Test-first hardening of the group operator's error contracts plus a shared-build link fix. History is ordered reproduction-first: commit 1 adds tests that crash/fail on the pre-fix code, commit 2 makes them pass, commit 3 is an independent build fix.

### 1. Unresolved group key path → clean error (was: assert / UB)
`extract_key_value` asserted `!key.full_path.empty()` — compiled out in Release, leaving `chunk.value(empty_path, ...)` UB. `create_list_rows` now validates column keys up front and reports `schema_error` ("group key '<name>' has no resolved column path") via `set_error`; `on_execute_impl` bails on error. Pre-fix evidence: SIGABRT `Assertion failed: (!key.full_path.empty() && "group key path must be resolved before execution")`.

### 2. Multi-part key path: result key column typed through the full path (was: NA-type trap)
`build_result_chunk` sourced key column types from the first group's key **value** for any non-single-index path; a NULL first group made the type NA and later non-NULL keys hit `set_value`'s cast-from-NA (the trap the function's own comment describes — previously guarded only for single-index paths). The type is now resolved by walking the full path through the input chunk's types (STRUCT `child_types()` / ARRAY/LIST element type), with the value type as last resort. Pre-fix evidence: SIGABRT `Assertion failed: (false && "value has to be casted to vector's type before set_value")`.

### 3. Global-aggregate branch: aggregator errors propagate (was: swallowed)
The empty-input global-aggregate `take_batch_values()` site ignored the aggregator's error state — a failed kernel (e.g. `AVG($1)` with a string parameter) silently produced a NULL row and a successful cursor. Now mirrors the batch path: `set_error` + bail. Pre-fix evidence: the new test's `REQUIRE(group->has_error())` failed cleanly.

### 4. Shared-build link gap (independent)
`components/table` uses `session_id_t::data()` but never declared `otterbrix::session`; static builds hide it, `BUILD_SHARED_LIBS=ON` (how the conan package is built) fails to link `libotterbrix_table.dylib`. One-line dependency addition.

## Testing

New `integration/cpp/test/test_group_operator_contracts.cpp` (3 cases, tagged `[group_contracts]`), each verified to fail/crash on pre-fix code and pass post-fix. Full suite: **194 cases / 51240 assertions green**; the rest of the suite was also run against pre-fix code with the new tests excluded to prove no collateral (191/51226 green). The shared-build fix verified by building `libotterbrix_services.dylib` with `BUILD_SHARED_LIBS=ON` (fails to link `libotterbrix_table.dylib` without it).