### PR TITLE
PAX-format realisation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ endif()
 # We do not use -Werror flag with sanitizers for the following reasons:
 # 1) Sanitizers force us to build absl locally, which does contains warnings
 # 2) Incomplete support of macOS makes development too cumbersome with -Werror enabled
-set(USE_Werror "$<NOT:$<OR:$<BOOL:${APPLE}>,$<BOOL:${ENABLE_ASAN}>,$<BOOL:${ENABLE_UBSAN}>>>")
+set(USE_Werror "$<NOT:$<OR:$<BOOL:${APPLE}>,$<BOOL:${ENABLE_ASAN}>,$<BOOL:${ENABLE_TSAN}>,$<BOOL:${ENABLE_UBSAN}>>>")
 
 if ((CMAKE_CXX_COMPILER_ID MATCHES "GNU") OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
     add_compile_options(
@@ -126,14 +126,22 @@ find_package(fmt 11.1.3 REQUIRED)
 find_package(spdlog 1.15.1 REQUIRED)
 find_package(msgpack 4.1.1 REQUIRED)
 find_package(Catch2 2.13.7 REQUIRED)
+include(Catch)
+if(NOT COMMAND otterbrix_discover_tests)
+    function(otterbrix_discover_tests)
+        catch_discover_tests(${ARGV})
+    endfunction()
+endif()
 find_package(benchmark 1.6.1 REQUIRED)
 find_package(ZLIB 1.2.12 REQUIRED)
 find_package(BZip2 1.0.8 REQUIRED)
 find_package(actor-zeta REQUIRED)
 find_package(FastFloat REQUIRED)
 
-if (ENABLE_ASAN AND NOT APPLE)
-    # build abseil-cpp locally to avoid ABI issues (skip on macOS ARM64 due to SSE flags)
+if ((ENABLE_ASAN OR ENABLE_TSAN OR ENABLE_UBSAN) AND NOT APPLE)
+    # build abseil-cpp locally to avoid ABI issues (skip on macOS ARM64 due to SSE flags).
+    # All sanitizer builds need a source-built absl: the prebuilt conan package is uninstrumented
+    # (TSAN would miss/false-positive on its internals) and its headers do not resolve here.
     include(FetchContent)
     FetchContent_Declare(
             absl

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,10 @@ if (DEV_MODE)
     message("DEV_MOD ON")
     add_definitions(-DDEV_MODE)
     enable_testing()
+    # rule 9 guard: fail if a `throw` slips onto the operator-build path (physical_plan*).
+    add_test(NAME physical_plan_no_throw_lint
+             COMMAND ${CMAKE_COMMAND} -DSRC=${CMAKE_SOURCE_DIR}
+                     -P ${CMAKE_SOURCE_DIR}/cmake/lint_no_throw.cmake)
 endif()
 
 if (ALLOW_BENCHMARK)

--- a/cmake/lint_no_throw.cmake
+++ b/cmake/lint_no_throw.cmake
@@ -1,0 +1,37 @@
+# rule 9: no throw on the operator-build path.
+#
+# create_plan_* must return nullptr (and predicate builders return error_t) so the
+# executor surfaces failures through the error channel instead of an exception — the
+# executor's #522 plan->execute flow is built on that contract. This lint fails the
+# build (run as a CTest) if a real `throw` statement slips into
+# components/physical_plan{,_generator}. Comment lines (including the "no throw"
+# contract notes) are ignored.
+#
+# Invoked via: cmake -DSRC=<source-root> -P cmake/lint_no_throw.cmake
+
+file(GLOB_RECURSE _files
+     "${SRC}/components/physical_plan/*.cpp"
+     "${SRC}/components/physical_plan/*.hpp"
+     "${SRC}/components/physical_plan_generator/*.cpp"
+     "${SRC}/components/physical_plan_generator/*.hpp")
+
+set(_violations "")
+foreach(_f ${_files})
+    # lines where `throw` appears as a keyword (preceded by a non-identifier char,
+    # followed by space/'('/';'): catches `throw e;` / `throw foo(...)` but not `do_not_throw`.
+    file(STRINGS "${_f}" _hits REGEX "[^A-Za-z0-9_]throw[ (;]")
+    foreach(_l ${_hits})
+        if(NOT _l MATCHES "//") # skip comment lines
+            list(APPEND _violations "${_f}:${_l}")
+        endif()
+    endforeach()
+endforeach()
+
+if(_violations)
+    string(REPLACE ";" "\n  " _msg "${_violations}")
+    message(FATAL_ERROR
+            "rule 9 violated — throw on the operator-build path "
+            "(must return nullptr / error_t instead):\n  ${_msg}")
+endif()
+
+message(STATUS "no-throw lint OK: 0 throws under physical_plan{,_generator}")

--- a/components/catalog/catalog_codes.hpp
+++ b/components/catalog/catalog_codes.hpp
@@ -4,6 +4,8 @@
 // Mirrors the PostgreSQL convention of storing kind/type discriminators
 // as single chars in catalog tables (relkind, contype, etc.).
 
+#include <string_view>
+
 namespace components::catalog {
 
     // pg_class.relkind
@@ -29,6 +31,14 @@ namespace components::catalog {
         inline constexpr char disk = 'd';      // table.otbx on disk
         inline constexpr char in_memory = 'm'; // no persistence
     }                                          // namespace relstoragemode
+
+    // pg_class.relstorageformat (otterbrix-specific: requested storage format)
+    namespace relstorageformat {
+        inline constexpr std::string_view in_memory = "in_memory";
+        inline constexpr std::string_view disk_auto = "disk_auto";
+        inline constexpr std::string_view disk_columnar = "disk_columnar";
+        inline constexpr std::string_view disk_pax = "disk_pax";
+    } // namespace relstorageformat
 
     // pg_constraint.confmatchtype (FK match strategy)
     namespace fk_match {

--- a/components/catalog/ddl_metadata_builder.cpp
+++ b/components/catalog/ddl_metadata_builder.cpp
@@ -118,7 +118,8 @@ namespace components::catalog {
                               bool is_disk_storage,
                               oid_t namespace_oid,
                               oid_batch_t& oid_batch,
-                              char relkind_char) {
+                              char relkind_char,
+                              std::string_view storage_format_name) {
         std::vector<catalog_write_t> result;
 
         const std::string& table_name = relname;
@@ -129,6 +130,7 @@ namespace components::catalog {
             const char rk = is_disk_storage ? relstoragemode::disk : relstoragemode::in_memory;
             const std::string relkind_str(1, relkind_char);
             const std::string storagemode_str(1, rk);
+            const std::string storage_format_str(storage_format_name);
 
             auto chunk =
                 make_pg_rows(resource, def->columns, 1, [&](vector::data_chunk_t& c, std::pmr::memory_resource* r) {
@@ -137,6 +139,9 @@ namespace components::catalog {
                     set_oid(c, 2, 0, namespace_oid);
                     set_str(c, 3, 0, relkind_str, r);
                     set_str(c, 4, 0, storagemode_str, r);
+                    if (c.column_count() > 5 && !storage_format_str.empty()) {
+                        set_str(c, 5, 0, storage_format_str, r);
+                    }
                 });
             result.push_back(make_write(pg_class_full, std::move(chunk)));
         }

--- a/components/catalog/ddl_metadata_builder.hpp
+++ b/components/catalog/ddl_metadata_builder.hpp
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <memory_resource>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace components::catalog {
@@ -31,7 +32,8 @@ namespace components::catalog {
                                                            bool is_disk_storage,
                                                            oid_t namespace_oid,
                                                            oid_batch_t& oid_batch,
-                                                           char relkind = relkind::regular);
+                                                           char relkind = relkind::regular,
+                                                           std::string_view storage_format_name = {});
 
     // Writes 1 row → pg_namespace (oid, nspname).
     // oid_batch must hold at least 1 OID.

--- a/components/catalog/system_table_schemas.cpp
+++ b/components/catalog/system_table_schemas.cpp
@@ -2,6 +2,7 @@
 #include "catalog_codes.hpp"
 
 #include <array>
+#include <cassert>
 #include <charconv>
 
 #include <components/types/logical_value.hpp>
@@ -91,6 +92,11 @@ namespace components::catalog {
             c.emplace_back("relstorageformat",
                            str_col(),
                            false); // nullable; storage format (see header)
+            // PAX-specific column. operator_resolve_table.cpp and operator_vacuum.cpp read it
+            // POSITIONALLY as row[5]. Pin the layout here so an upstream column insertion trips
+            // this in tests instead of silently shifting those reads to the wrong column.
+            assert(c.size() == 6 && c.back().name() == "relstorageformat" &&
+                   "pg_class layout changed: update the row[5]=relstorageformat readers");
             return c;
         }
 

--- a/components/catalog/system_table_schemas.cpp
+++ b/components/catalog/system_table_schemas.cpp
@@ -14,6 +14,8 @@
 //   pg_class      — no `reltuples/relpages` : optimizer reads counts live from data_table_t.
 //                 — no `reltype`             : composite-row types not implemented.
 //                 — adds `relstoragemode`    : 'd'/'m' for DISK/IN_MEMORY (otterbrix-specific).
+//                 — adds `relstorageformat`  : exact CREATE TABLE storage contract
+//                                              (in_memory/disk_auto/disk_columnar/disk_pax).
 //                 — relkind 'g' = computing : doc proposed 'c', but 'c' collides with
 //                                              PG's "composite type" relkind. 'g' aligns
 //                                              with PG GENERATED terminology.
@@ -86,6 +88,9 @@ namespace components::catalog {
                 str_col(),
                 true); // 'r' relation, 'i' index, 'S' sequence, 'v' view, 'm' macro, 'c' composite type, 'g' generated/computing
             c.emplace_back("relstoragemode", str_col(), true); // 'd' DISK, 'm' IN_MEMORY (otterbrix-specific)
+            c.emplace_back("relstorageformat",
+                           str_col(),
+                           false); // nullable; storage format (see header)
             return c;
         }
 

--- a/components/catalog/tests/CMakeLists.txt
+++ b/components/catalog/tests/CMakeLists.txt
@@ -30,4 +30,4 @@ target_link_libraries(
 
 include(CTest)
 include(Catch)
-catch_discover_tests(${PROJECT_NAME})
+otterbrix_discover_tests(${PROJECT_NAME})

--- a/components/catalog/tests/test_system_schemas.cpp
+++ b/components/catalog/tests/test_system_schemas.cpp
@@ -33,7 +33,7 @@ TEST_CASE("catalog::system_schemas::find_system_table") {
     REQUIRE(find_system_table("") == nullptr);
 }
 
-// 4. pg_class describes itself — has relname / relnamespace / relkind columns.
+// 4. pg_class describes itself — has relname / relnamespace / relkind plus storage metadata columns.
 TEST_CASE("catalog::system_schemas::pg_class_self_describable") {
     const auto* def = find_system_table("pg_class");
     REQUIRE(def != nullptr);
@@ -45,6 +45,8 @@ TEST_CASE("catalog::system_schemas::pg_class_self_describable") {
     REQUIRE(col_names.count("relname") == 1);
     REQUIRE(col_names.count("relnamespace") == 1);
     REQUIRE(col_names.count("relkind") == 1);
+    REQUIRE(col_names.count("relstoragemode") == 1);
+    REQUIRE(col_names.count("relstorageformat") == 1);
 }
 
 // 5. pg_attribute has the columns required for column lifecycle.

--- a/components/compute/kernels/aggregate.cpp
+++ b/components/compute/kernels/aggregate.cpp
@@ -1,6 +1,9 @@
 #include "../function.hpp"
 #include <components/types/logical_value.hpp>
 
+#include <string>
+#include <string_view>
+
 using namespace components::compute;
 using namespace components::types;
 using namespace components::vector;
@@ -388,9 +391,48 @@ namespace {
 
     logical_value_t sum(const vector_t& v, size_t count) { return operator_switch<sum_operator_t>(v, count); }
 
-    logical_value_t min(const vector_t& v, size_t count) { return operator_switch<min_operator_t>(v, count); }
+    // operator_switch only dispatches numeric physical types, so handle string
+    // MIN/MAX (lexicographic) separately. SUM on strings stays unsupported.
+    inline bool aggregate_is_string_type(const vector_t& v) {
+        return v.type().to_physical_type() == physical_type::STRING;
+    }
 
-    logical_value_t max(const vector_t& v, size_t count) { return operator_switch<max_operator_t>(v, count); }
+    logical_value_t string_extreme(const vector_t& v, size_t count, bool want_min) {
+        std::string best;
+        bool has_any = false;
+        for (size_t i = 0; i < count; i++) {
+            if (v.is_null(i)) {
+                continue;
+            }
+            const auto element = v.value(i);
+            if (element.type().type() == logical_type::NA) {
+                continue;
+            }
+            const auto sv = element.value<std::string_view>();
+            if (!has_any || (want_min ? sv < std::string_view(best) : sv > std::string_view(best))) {
+                best.assign(sv);
+                has_any = true;
+            }
+        }
+        if (!has_any) {
+            return logical_value_t(std::pmr::null_memory_resource(), logical_type::NA);
+        }
+        return logical_value_t{v.resource(), std::string_view(best)};
+    }
+
+    logical_value_t min(const vector_t& v, size_t count) {
+        if (aggregate_is_string_type(v)) {
+            return string_extreme(v, count, true);
+        }
+        return operator_switch<min_operator_t>(v, count);
+    }
+
+    logical_value_t max(const vector_t& v, size_t count) {
+        if (aggregate_is_string_type(v)) {
+            return string_extreme(v, count, false);
+        }
+        return operator_switch<max_operator_t>(v, count);
+    }
 
     struct sum_kernel_state : kernel_state {
         explicit sum_kernel_state(std::pmr::memory_resource* resource)

--- a/components/compute/tests/CMakeLists.txt
+++ b/components/compute/tests/CMakeLists.txt
@@ -20,4 +20,4 @@ target_link_libraries(
 
 include(CTest)
 include(Catch)
-catch_discover_tests(${PROJECT_NAME})
+otterbrix_discover_tests(${PROJECT_NAME})

--- a/components/configuration/configuration.hpp
+++ b/components/configuration/configuration.hpp
@@ -6,6 +6,15 @@
 
 namespace configuration {
 
+    inline constexpr uint16_t default_pax_rows_per_page = 256;
+
+    enum class disk_layout_policy : uint8_t
+    {
+        auto_select = 0,
+        columnar_only = 1,
+        pax_only = 2
+    };
+
     struct config_log final {
         std::filesystem::path path{std::filesystem::current_path() / "log"};
         log_t::level level{log_t::level::trace};
@@ -31,10 +40,12 @@ namespace configuration {
     struct config_disk final {
         std::filesystem::path path{std::filesystem::current_path() / "disk"};
         bool on{true};
+        disk_layout_policy layout_policy{disk_layout_policy::auto_select};
         int agent = 2;
         uint64_t bitcask_flush_threshold{1000};
         uint64_t bitcask_segment_record_limit{100};
         uint64_t btree_flush_threshold{1000};
+        uint16_t pax_rows_per_page{default_pax_rows_per_page};
 
         explicit config_disk(const std::filesystem::path& path = std::filesystem::current_path())
             : path(path / "wal") {}

--- a/components/cursor/tests/CMakeLists.txt
+++ b/components/cursor/tests/CMakeLists.txt
@@ -22,4 +22,4 @@ target_link_libraries(
 
 include(CTest)
 include(Catch)
-catch_discover_tests(${PROJECT_NAME})
+otterbrix_discover_tests(${PROJECT_NAME})

--- a/components/expressions/test/CMakeLists.txt
+++ b/components/expressions/test/CMakeLists.txt
@@ -21,4 +21,4 @@ target_link_libraries(
 
 include(CTest)
 include(Catch)
-catch_discover_tests(${PROJECT_NAME})
+otterbrix_discover_tests(${PROJECT_NAME})

--- a/components/index/test/CMakeLists.txt
+++ b/components/index/test/CMakeLists.txt
@@ -26,4 +26,4 @@ target_link_libraries(
 
 include(CTest)
 include(Catch)
-catch_discover_tests(${PROJECT_NAME})
+otterbrix_discover_tests(${PROJECT_NAME})

--- a/components/logical_plan/node.cpp
+++ b/components/logical_plan/node.cpp
@@ -7,18 +7,29 @@ namespace components::logical_plan {
 
     node_t::node_t(std::pmr::memory_resource* resource, node_type type)
         : type_(type)
+        , output_column_aliases_(resource)
         , children_(resource)
-        , expressions_(resource) {}
+        , expressions_(resource)
+        , subqueries_(resource) {}
 
     node_type node_t::type() const { return type_; }
 
     const std::string& node_t::result_alias() const { return result_alias_; }
+
+    const std::pmr::vector<std::pmr::string>& node_t::output_column_aliases() const {
+        return output_column_aliases_;
+    }
+
+    std::pmr::vector<std::pmr::string>& node_t::output_column_aliases() { return output_column_aliases_; }
 
     const std::pmr::vector<node_ptr>& node_t::children() const { return children_; }
     std::pmr::vector<node_ptr>& node_t::children() { return children_; }
 
     const std::pmr::vector<expression_ptr>& node_t::expressions() const { return expressions_; }
     std::pmr::vector<expression_ptr>& node_t::expressions() { return expressions_; }
+
+    const std::pmr::vector<subquery_request_t>& node_t::subqueries() const { return subqueries_; }
+    std::pmr::vector<subquery_request_t>& node_t::subqueries() { return subqueries_; }
 
     void node_t::set_result_alias(const std::string& alias) { result_alias_ = alias; }
 
@@ -55,6 +66,9 @@ namespace components::logical_plan {
     hash_t node_t::hash() const {
         hash_t hash_{0};
         boost::hash_combine(hash_, type_);
+        for (const auto& alias : output_column_aliases_) {
+            boost::hash_combine(hash_, alias);
+        }
         boost::hash_combine(hash_, hash_impl());
         std::for_each(expressions_.cbegin(), expressions_.cend(), [&hash_](const expression_ptr& expression) {
             boost::hash_combine(hash_, expression->hash());
@@ -70,8 +84,8 @@ namespace components::logical_plan {
     std::pmr::memory_resource* node_t::resource() const noexcept { return children_.get_allocator().resource(); }
 
     bool node_t::operator==(const node_t& rhs) const {
-        bool result = type_ == rhs.type_ && children_.size() == rhs.children_.size() &&
-                      expressions_.size() == rhs.expressions_.size();
+        bool result = type_ == rhs.type_ && output_column_aliases_ == rhs.output_column_aliases_ &&
+                      children_.size() == rhs.children_.size() && expressions_.size() == rhs.expressions_.size();
         if (result) {
             for (auto it = children_.cbegin(), it2 = rhs.children_.cbegin(), it_end = children_.cend(); it != it_end;
                  ++it, ++it2) {

--- a/components/logical_plan/node.hpp
+++ b/components/logical_plan/node.hpp
@@ -17,6 +17,31 @@ namespace components::logical_plan {
     using expression_ptr = expressions::expression_ptr;
     using hash_t = expressions::hash_t;
 
+    // Deferred uncorrelated subquery: run once standalone, substitute its result
+    // back into the main plan as a literal. Correlated subqueries are rejected at
+    // transform time (they can't run standalone).
+    struct subquery_request_t {
+        enum class kind_t : uint8_t
+        {
+            scalar, // (SELECT <single value> ...) — result fills `result_param`
+            in_list // col IN (SELECT col ...)     — results fill `placeholder` children
+        };
+        kind_t kind;
+        // Logical plan of the subquery body (bare aggregate, not yet resolve-wrapped).
+        node_ptr subquery_plan;
+        // scalar: parameter id reserved in the main plan's HAVING/WHERE compare.
+        core::parameter_id_t result_param{};
+        // in_list: left-hand column the IN predicate tests.
+        expressions::key_t in_left_key;
+        // in_list: union_or compare wired into the main WHERE tree; the pre-pass
+        // appends one eq(in_left_key, $value) child per subquery result row.
+        expression_ptr placeholder;
+
+        explicit subquery_request_t(std::pmr::memory_resource* resource)
+            : kind(kind_t::scalar)
+            , in_left_key(resource) {}
+    };
+
     // The polymorphic free helper `cfn_of(node_t*)` was removed.
     // Generic walkers that operated on `node_t*` and need the cfn either
     // (a) inline a per-call type switch when truly needed (see
@@ -36,10 +61,17 @@ namespace components::logical_plan {
         // dispatcher, executor, operators after enrich), always use
         // `table_oid()` from the base class.
         const std::string& result_alias() const;
+        const std::pmr::vector<std::pmr::string>& output_column_aliases() const;
+        std::pmr::vector<std::pmr::string>& output_column_aliases();
         const std::pmr::vector<node_ptr>& children() const;
         std::pmr::vector<node_ptr>& children();
         const std::pmr::vector<expression_ptr>& expressions() const;
         std::pmr::vector<expression_ptr>& expressions();
+
+        // Deferred uncorrelated subqueries; only populated on the plan root,
+        // drained by the dispatcher before executing the main plan.
+        const std::pmr::vector<subquery_request_t>& subqueries() const;
+        std::pmr::vector<subquery_request_t>& subqueries();
 
         void set_result_alias(const std::string& alias);
         void reserve_child(std::size_t count);
@@ -73,8 +105,10 @@ namespace components::logical_plan {
     protected:
         const node_type type_;
         std::string result_alias_;
+        std::pmr::vector<std::pmr::string> output_column_aliases_;
         std::pmr::vector<node_ptr> children_;
         std::pmr::vector<expression_ptr> expressions_;
+        std::pmr::vector<subquery_request_t> subqueries_;
         // See table_oid()/set_table_oid() above. Default INVALID_OID; enrich
         // is responsible for stamping the resolved oid before plan execution.
         components::catalog::oid_t table_oid_{components::catalog::INVALID_OID};

--- a/components/logical_plan/node_create_collection.cpp
+++ b/components/logical_plan/node_create_collection.cpp
@@ -6,24 +6,24 @@ namespace components::logical_plan {
 
     node_create_collection_t::node_create_collection_t(std::pmr::memory_resource* resource,
                                                        core::relname_t relname,
-                                                       bool disk_storage,
+                                                       create_collection_storage_format_t storage_format,
                                                        bool if_not_exists)
         : node_t(resource, node_type::create_collection_t)
         , relname_(std::move(static_cast<std::string&>(relname)))
-        , disk_storage_(disk_storage)
+        , storage_format_(storage_format)
         , if_not_exists_(if_not_exists) {}
 
     node_create_collection_t::node_create_collection_t(std::pmr::memory_resource* resource,
                                                        core::relname_t relname,
                                                        std::vector<table::column_definition_t> column_definitions,
                                                        std::vector<table::table_constraint_t> constraints,
-                                                       bool disk_storage,
+                                                       create_collection_storage_format_t storage_format,
                                                        bool if_not_exists)
         : node_t(resource, node_type::create_collection_t)
         , relname_(std::move(static_cast<std::string&>(relname)))
         , column_definitions_(std::move(column_definitions))
         , constraints_(std::move(constraints))
-        , disk_storage_(disk_storage)
+        , storage_format_(storage_format)
         , if_not_exists_(if_not_exists) {}
 
     std::pmr::vector<types::complex_logical_type> node_create_collection_t::schema() const {
@@ -55,20 +55,23 @@ namespace components::logical_plan {
 
     node_create_collection_ptr
     make_node_create_collection(std::pmr::memory_resource* resource, core::relname_t relname, bool if_not_exists) {
-        return {new node_create_collection_t{resource, std::move(relname), false, if_not_exists}};
+        return {new node_create_collection_t{resource,
+                                             std::move(relname),
+                                             create_collection_storage_format_t::in_memory,
+                                             if_not_exists}};
     }
 
     node_create_collection_ptr make_node_create_collection(std::pmr::memory_resource* resource,
                                                            core::relname_t relname,
                                                            std::vector<table::column_definition_t> column_definitions,
                                                            std::vector<table::table_constraint_t> constraints,
-                                                           bool disk_storage,
+                                                           create_collection_storage_format_t storage_format,
                                                            bool if_not_exists) {
         return {new node_create_collection_t{resource,
                                              std::move(relname),
                                              std::move(column_definitions),
                                              std::move(constraints),
-                                             disk_storage,
+                                             storage_format,
                                              if_not_exists}};
     }
 

--- a/components/logical_plan/node_create_collection.hpp
+++ b/components/logical_plan/node_create_collection.hpp
@@ -10,18 +10,28 @@
 
 namespace components::logical_plan {
 
+    enum class create_collection_storage_format_t : uint8_t
+    {
+        in_memory = 0,
+        disk_auto = 1,
+        disk_columnar = 2,
+        disk_pax = 3
+    };
+
     class node_create_collection_t final : public node_t {
     public:
         explicit node_create_collection_t(std::pmr::memory_resource* resource,
                                           core::relname_t relname,
-                                          bool disk_storage = false,
+                                          create_collection_storage_format_t storage_format =
+                                              create_collection_storage_format_t::in_memory,
                                           bool if_not_exists = false);
 
         node_create_collection_t(std::pmr::memory_resource* resource,
                                  core::relname_t relname,
                                  std::vector<table::column_definition_t> column_definitions,
                                  std::vector<table::table_constraint_t> constraints,
-                                 bool disk_storage = false,
+                                 create_collection_storage_format_t storage_format =
+                                     create_collection_storage_format_t::in_memory,
                                  bool if_not_exists = false);
 
         std::pmr::vector<types::complex_logical_type> schema() const;
@@ -30,7 +40,8 @@ namespace components::logical_plan {
         const std::vector<table::column_definition_t>& column_definitions() const;
         const std::vector<table::table_constraint_t>& constraints() const;
 
-        bool is_disk_storage() const { return disk_storage_; }
+        bool is_disk_storage() const { return storage_format_ != create_collection_storage_format_t::in_memory; }
+        create_collection_storage_format_t storage_format() const noexcept { return storage_format_; }
         bool if_not_exists() const noexcept { return if_not_exists_; }
 
         components::catalog::oid_t namespace_oid() const noexcept { return namespace_oid_; }
@@ -45,7 +56,7 @@ namespace components::logical_plan {
         std::string relname_;
         std::vector<table::column_definition_t> column_definitions_;
         std::vector<table::table_constraint_t> constraints_;
-        bool disk_storage_{false};
+        create_collection_storage_format_t storage_format_{create_collection_storage_format_t::in_memory};
         bool if_not_exists_{false};
         components::catalog::oid_t namespace_oid_{components::catalog::INVALID_OID};
     };
@@ -59,7 +70,8 @@ namespace components::logical_plan {
                                                            core::relname_t relname,
                                                            std::vector<table::column_definition_t> column_definitions,
                                                            std::vector<table::table_constraint_t> constraints,
-                                                           bool disk_storage = false,
+                                                           create_collection_storage_format_t storage_format =
+                                                               create_collection_storage_format_t::in_memory,
                                                            bool if_not_exists = false);
 
 } // namespace components::logical_plan

--- a/components/logical_plan/node_join.cpp
+++ b/components/logical_plan/node_join.cpp
@@ -32,6 +32,8 @@ namespace components::logical_plan {
 
     join_type node_join_t::type() const { return type_; }
 
+    void node_join_t::set_type(join_type type) { type_ = type; }
+
     hash_t node_join_t::hash_impl() const { return 0; }
 
     std::string node_join_t::to_string_impl() const {

--- a/components/logical_plan/node_join.hpp
+++ b/components/logical_plan/node_join.hpp
@@ -23,6 +23,7 @@ namespace components::logical_plan {
                              join_type type);
 
         join_type type() const;
+        void set_type(join_type type);
 
         const std::string& relname() const noexcept { return relname_; }
         const std::string& dbname() const noexcept { return dbname_; }

--- a/components/oid/test/CMakeLists.txt
+++ b/components/oid/test/CMakeLists.txt
@@ -13,4 +13,4 @@ target_link_libraries(
 
 include(CTest)
 include(Catch)
-catch_discover_tests(${PROJECT_NAME})
+otterbrix_discover_tests(${PROJECT_NAME})

--- a/components/physical_plan/CMakeLists.txt
+++ b/components/physical_plan/CMakeLists.txt
@@ -84,7 +84,6 @@ add_library(otterbrix_${PROJECT_NAME} OBJECT
 
 
 add_library(otterbrix::${PROJECT_NAME} ALIAS otterbrix_${PROJECT_NAME})
-
 set_property(TARGET otterbrix_${PROJECT_NAME} PROPERTY EXPORT_NAME ${PROJECT_NAME})
 
 target_link_libraries(
@@ -109,4 +108,3 @@ target_link_libraries(otterbrix_${PROJECT_NAME} PRIVATE FastFloat::fast_float)
 
 target_include_directories(otterbrix_${PROJECT_NAME} PUBLIC
 )
-

--- a/components/physical_plan/operators/aggregate/operator_aggregate.cpp
+++ b/components/physical_plan/operators/aggregate/operator_aggregate.cpp
@@ -4,6 +4,28 @@
 #include <components/physical_plan/operators/operator_data.hpp>
 #include <components/physical_plan/operators/operator_empty.hpp>
 
+#include <cstdio>
+#include <cstdlib>
+
+namespace {
+    bool trace_aggregate_errors_enabled() {
+        const char* raw = std::getenv("OTTERBRIX_EXEC_TRACE_ERRORS");
+        return raw && raw[0] != '\0' && raw[0] != '0';
+    }
+
+    void trace_aggregate_error(const char* where, const core::error_t& err) {
+        if (!trace_aggregate_errors_enabled()) {
+            return;
+        }
+        std::fprintf(stderr,
+                     "[AGG_ERROR] where=%s code=%d what='%s'\n",
+                     where,
+                     static_cast<int>(err.type),
+                     err.what.c_str());
+        std::fflush(stderr);
+    }
+} // namespace
+
 namespace components::operators::aggregate {
 
     operator_aggregate_t::operator_aggregate_t(std::pmr::memory_resource* resource, log_t log)
@@ -13,12 +35,14 @@ namespace components::operators::aggregate {
     void operator_aggregate_t::on_execute_impl(pipeline::context_t* pipeline_context) {
         if (left_ && left_->type() == operator_type::batch) {
             if (auto res = aggregate_batch_impl(pipeline_context); res.has_error()) {
+                trace_aggregate_error("aggregate_batch_impl", res.error());
                 set_error(res.error());
             } else {
                 batch_results_ = std::move(res.value());
             }
         } else {
             if (auto res = aggregate_impl(pipeline_context); res.has_error()) {
+                trace_aggregate_error("aggregate_impl", res.error());
                 set_error(res.error());
             } else {
                 aggregate_result_ = std::move(res.value());

--- a/components/physical_plan/operators/aggregate/operator_func.cpp
+++ b/components/physical_plan/operators/aggregate/operator_func.cpp
@@ -4,6 +4,7 @@
 #include <components/expressions/scalar_expression.hpp>
 #include <components/physical_plan/operators/arithmetic_eval.hpp>
 #include <components/physical_plan/operators/operator_batch.hpp>
+#include <sstream>
 #include <unordered_set>
 
 namespace {
@@ -41,9 +42,25 @@ namespace {
         return true;
     }
 
-    void resolve_columns(const std::pmr::vector<expressions::param_storage>& args,
+    std::string describe_columns(const vector::data_chunk_t& chunk) {
+        std::ostringstream out;
+        out << "[";
+        for (size_t i = 0; i < chunk.data.size(); ++i) {
+            if (i > 0) {
+                out << ", ";
+            }
+            out << i << ":";
+            const auto& type = chunk.data[i].type();
+            out << (type.has_alias() ? std::string(type.alias()) : std::string("<no-alias>"));
+        }
+        out << "]";
+        return out.str();
+    }
+
+    bool resolve_columns(const std::pmr::vector<expressions::param_storage>& args,
                          vector::data_chunk_t& chunk,
                          pipeline::context_t* pipeline_context,
+                         operator_func_t& op,
                          std::pmr::vector<columns_var>& columns,
                          std::vector<vector::vector_t>& computed_vecs) {
         size_t computed_idx = 0;
@@ -52,6 +69,20 @@ namespace {
                 const auto& key = std::get<expressions::key_t>(arg);
                 assert(!key.path().empty() && "aggregate key path must be resolved");
                 assert(key.path().front() < chunk.data.size() && "aggregate key path out of range");
+                if (key.path().empty() || key.path().front() >= chunk.data.size()) {
+                    std::string msg = "aggregate key path out of range: key=" + key.as_string();
+                    msg += " path=";
+                    if (key.path().empty()) {
+                        msg += "<empty>";
+                    } else {
+                        msg += std::to_string(key.path().front());
+                    }
+                    msg += " chunk_columns=" + std::to_string(chunk.data.size());
+                    msg += " aliases=" + describe_columns(chunk);
+                    op.set_error(core::error_t(core::error_code_t::physical_plan_error,
+                                               std::pmr::string{msg, chunk.resource()}));
+                    return false;
+                }
                 columns.emplace_back(chunk.data.begin() + static_cast<std::ptrdiff_t>(key.path().front()));
             } else if (std::holds_alternative<core::parameter_id_t>(arg)) {
                 const auto& id = std::get<core::parameter_id_t>(arg);
@@ -65,6 +96,7 @@ namespace {
                 }
             }
         }
+        return true;
     }
 
     vector::data_chunk_t build_arg_chunk(std::pmr::memory_resource* resource,
@@ -145,7 +177,9 @@ namespace components::operators::aggregate {
 
             std::pmr::vector<columns_var> columns(left_->output()->resource());
             columns.reserve(args_.size());
-            resolve_columns(args_, chunk, pipeline_context, columns, computed_vecs);
+            if (!resolve_columns(args_, chunk, pipeline_context, *this, columns, computed_vecs)) {
+                return result;
+            }
 
             if (columns.size() == args_.size()) {
                 auto c = build_arg_chunk(left_->output()->resource(), columns, chunk);
@@ -186,7 +220,9 @@ namespace components::operators::aggregate {
 
             std::pmr::vector<columns_var> columns(resource_);
             columns.reserve(args_.size());
-            resolve_columns(args_, chunk, pipeline_context, columns, computed_vecs);
+            if (!resolve_columns(args_, chunk, pipeline_context, *this, columns, computed_vecs)) {
+                return compute::datum_t{std::pmr::vector<types::logical_value_t>(resource_)};
+            }
 
             if (columns.size() == args_.size()) {
                 auto c = build_arg_chunk(resource_, columns, chunk);

--- a/components/physical_plan/operators/arithmetic_eval.cpp
+++ b/components/physical_plan/operators/arithmetic_eval.cpp
@@ -2,6 +2,8 @@
 
 #include <core/result_wrapper.hpp>
 
+#include <string>
+
 namespace components::operators {
 
     namespace detail {
@@ -22,6 +24,103 @@ namespace components::operators {
                 default:
                     throw std::logic_error("Not an arithmetic scalar_type");
             }
+        }
+
+        const char* scalar_op_name(expressions::scalar_type t) {
+            switch (t) {
+                case expressions::scalar_type::add:
+                    return "add";
+                case expressions::scalar_type::subtract:
+                    return "subtract";
+                case expressions::scalar_type::multiply:
+                    return "multiply";
+                case expressions::scalar_type::divide:
+                    return "divide";
+                case expressions::scalar_type::mod:
+                    return "mod";
+                case expressions::scalar_type::unary_minus:
+                    return "unary_minus";
+                case expressions::scalar_type::case_expr:
+                    return "case";
+                default:
+                    return "unknown";
+            }
+        }
+
+        const char* logical_type_name(types::logical_type t) {
+            switch (t) {
+                case types::logical_type::NA:
+                    return "NA";
+                case types::logical_type::BOOLEAN:
+                    return "BOOLEAN";
+                case types::logical_type::TINYINT:
+                    return "TINYINT";
+                case types::logical_type::SMALLINT:
+                    return "SMALLINT";
+                case types::logical_type::INTEGER:
+                    return "INTEGER";
+                case types::logical_type::BIGINT:
+                    return "BIGINT";
+                case types::logical_type::HUGEINT:
+                    return "HUGEINT";
+                case types::logical_type::FLOAT:
+                    return "FLOAT";
+                case types::logical_type::DOUBLE:
+                    return "DOUBLE";
+                case types::logical_type::DECIMAL:
+                    return "DECIMAL";
+                case types::logical_type::UTINYINT:
+                    return "UTINYINT";
+                case types::logical_type::USMALLINT:
+                    return "USMALLINT";
+                case types::logical_type::UINTEGER:
+                    return "UINTEGER";
+                case types::logical_type::UBIGINT:
+                    return "UBIGINT";
+                case types::logical_type::UHUGEINT:
+                    return "UHUGEINT";
+                case types::logical_type::STRING_LITERAL:
+                    return "STRING_LITERAL";
+                case types::logical_type::DATE:
+                    return "DATE";
+                case types::logical_type::TIME:
+                    return "TIME";
+                case types::logical_type::TIME_TZ:
+                    return "TIME_TZ";
+                case types::logical_type::TIMESTAMP:
+                    return "TIMESTAMP";
+                case types::logical_type::TIMESTAMP_TZ:
+                    return "TIMESTAMP_TZ";
+                case types::logical_type::INTERVAL:
+                    return "INTERVAL";
+                default:
+                    return "OTHER";
+            }
+        }
+
+        core::result_wrapper_t<vector::vector_t> validate_arithmetic_result(std::pmr::memory_resource* resource,
+                                                                            expressions::scalar_type op,
+                                                                            vector::vector_t&& result,
+                                                                            const resolved_operand& left,
+                                                                            const resolved_operand& right,
+                                                                            uint64_t count) {
+            if (result.type().type() != types::logical_type::NA) {
+                return std::move(result);
+            }
+
+            const auto left_type = left.vec ? left.vec->type().type() : left.scalar->type().type();
+            const auto right_type = right.vec ? right.vec->type().type() : right.scalar->type().type();
+            std::string msg = "unsupported arithmetic operand types: op=";
+            msg += scalar_op_name(op);
+            msg += " left=";
+            msg += logical_type_name(left_type);
+            msg += left.vec ? "(vector)" : "(scalar)";
+            msg += " right=";
+            msg += logical_type_name(right_type);
+            msg += right.vec ? "(vector)" : "(scalar)";
+            msg += " rows=";
+            msg += std::to_string(count);
+            return core::error_t(core::error_code_t::arithmetics_failure, std::pmr::string{msg, resource});
         }
 
         core::result_wrapper_t<resolved_operand> resolve_operand(const expressions::param_storage& param,
@@ -108,30 +207,70 @@ namespace components::operators {
 
                     vector::vector_t computed(resource, types::complex_logical_type(types::logical_type::BIGINT), 0);
                     if (left_op.value().vec && right_op.value().vec) {
-                        computed = vector::compute_binary_arithmetic(resource,
-                                                                     op,
-                                                                     *left_op.value().vec,
-                                                                     *right_op.value().vec,
-                                                                     count);
+                        auto computed_res =
+                            validate_arithmetic_result(resource,
+                                                       scalar_expr->type(),
+                                                       vector::compute_binary_arithmetic(resource,
+                                                                                         op,
+                                                                                         *left_op.value().vec,
+                                                                                         *right_op.value().vec,
+                                                                                         count),
+                                                       left_op.value(),
+                                                       right_op.value(),
+                                                       count);
+                        if (computed_res.has_error()) {
+                            return computed_res.convert_error<resolved_operand>();
+                        }
+                        computed = std::move(computed_res.value());
                     } else if (left_op.value().vec && right_op.value().scalar) {
-                        computed = vector::compute_vector_scalar_arithmetic(resource,
-                                                                            op,
-                                                                            *left_op.value().vec,
-                                                                            *right_op.value().scalar,
-                                                                            count);
+                        auto computed_res =
+                            validate_arithmetic_result(resource,
+                                                       scalar_expr->type(),
+                                                       vector::compute_vector_scalar_arithmetic(resource,
+                                                                                                 op,
+                                                                                                 *left_op.value().vec,
+                                                                                                 *right_op.value().scalar,
+                                                                                                 count),
+                                                       left_op.value(),
+                                                       right_op.value(),
+                                                       count);
+                        if (computed_res.has_error()) {
+                            return computed_res.convert_error<resolved_operand>();
+                        }
+                        computed = std::move(computed_res.value());
                     } else if (left_op.value().scalar && right_op.value().vec) {
-                        computed = vector::compute_scalar_vector_arithmetic(resource,
-                                                                            op,
-                                                                            *left_op.value().scalar,
-                                                                            *right_op.value().vec,
-                                                                            count);
+                        auto computed_res =
+                            validate_arithmetic_result(resource,
+                                                       scalar_expr->type(),
+                                                       vector::compute_scalar_vector_arithmetic(resource,
+                                                                                                 op,
+                                                                                                 *left_op.value().scalar,
+                                                                                                 *right_op.value().vec,
+                                                                                                 count),
+                                                       left_op.value(),
+                                                       right_op.value(),
+                                                       count);
+                        if (computed_res.has_error()) {
+                            return computed_res.convert_error<resolved_operand>();
+                        }
+                        computed = std::move(computed_res.value());
                     } else {
                         auto lval = *left_op.value().scalar;
                         auto rval = *right_op.value().scalar;
                         uint64_t out_count = count > 0 ? count : 1;
                         vector::vector_t left_vec(resource, lval, out_count);
                         left_vec.flatten(out_count);
-                        computed = vector::compute_vector_scalar_arithmetic(resource, op, left_vec, rval, out_count);
+                        auto computed_res = validate_arithmetic_result(resource,
+                                                                       scalar_expr->type(),
+                                                                       vector::compute_vector_scalar_arithmetic(
+                                                                           resource, op, left_vec, rval, out_count),
+                                                                       left_op.value(),
+                                                                       right_op.value(),
+                                                                       out_count);
+                        if (computed_res.has_error()) {
+                            return computed_res.convert_error<resolved_operand>();
+                        }
+                        computed = std::move(computed_res.value());
                     }
                     for (auto& t : sub_temps) {
                         temp_vecs.emplace_back(std::move(t));
@@ -389,11 +528,16 @@ namespace components::operators {
         auto arith_op = detail::scalar_to_arithmetic_op(op);
 
         if (left_op.value().vec && right_op.value().vec) {
-            return vector::compute_binary_arithmetic(resource,
-                                                     arith_op,
-                                                     *left_op.value().vec,
-                                                     *right_op.value().vec,
-                                                     count);
+            return detail::validate_arithmetic_result(resource,
+                                                      op,
+                                                      vector::compute_binary_arithmetic(resource,
+                                                                                        arith_op,
+                                                                                        *left_op.value().vec,
+                                                                                        *right_op.value().vec,
+                                                                                        count),
+                                                      left_op.value(),
+                                                      right_op.value(),
+                                                      count);
         } else if (left_op.value().vec && right_op.value().scalar) {
             if (arith_op == vector::arithmetic_op::divide || arith_op == vector::arithmetic_op::mod) {
                 types::logical_value_t zero(resource, right_op.value().scalar->type());
@@ -403,17 +547,27 @@ namespace components::operators {
                                          std::pmr::string{"division by zero", resource});
                 }
             }
-            return vector::compute_vector_scalar_arithmetic(resource,
-                                                            arith_op,
-                                                            *left_op.value().vec,
-                                                            *right_op.value().scalar,
-                                                            count);
+            return detail::validate_arithmetic_result(resource,
+                                                      op,
+                                                      vector::compute_vector_scalar_arithmetic(resource,
+                                                                                                arith_op,
+                                                                                                *left_op.value().vec,
+                                                                                                *right_op.value().scalar,
+                                                                                                count),
+                                                      left_op.value(),
+                                                      right_op.value(),
+                                                      count);
         } else if (left_op.value().scalar && right_op.value().vec) {
-            return vector::compute_scalar_vector_arithmetic(resource,
-                                                            arith_op,
-                                                            *left_op.value().scalar,
-                                                            *right_op.value().vec,
-                                                            count);
+            return detail::validate_arithmetic_result(resource,
+                                                      op,
+                                                      vector::compute_scalar_vector_arithmetic(resource,
+                                                                                                arith_op,
+                                                                                                *left_op.value().scalar,
+                                                                                                *right_op.value().vec,
+                                                                                                count),
+                                                      left_op.value(),
+                                                      right_op.value(),
+                                                      count);
         } else {
             auto lval = *left_op.value().scalar;
             auto rval = *right_op.value().scalar;
@@ -428,7 +582,13 @@ namespace components::operators {
             uint64_t out_count = count > 0 ? count : 1;
             vector::vector_t left_vec(resource, lval, out_count);
             left_vec.flatten(out_count);
-            return vector::compute_vector_scalar_arithmetic(resource, arith_op, left_vec, rval, out_count);
+            return detail::validate_arithmetic_result(resource,
+                                                      op,
+                                                      vector::compute_vector_scalar_arithmetic(
+                                                          resource, arith_op, left_vec, rval, out_count),
+                                                      left_op.value(),
+                                                      right_op.value(),
+                                                      out_count);
         }
     }
 

--- a/components/physical_plan/operators/operator.cpp
+++ b/components/physical_plan/operators/operator.cpp
@@ -2,7 +2,68 @@
 
 #include "resolved_table_metadata.hpp"
 
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+
 namespace components::operators {
+    namespace {
+        bool trace_nodes_enabled() {
+            const char* raw = std::getenv("OTTERBRIX_EXEC_TRACE_NODES");
+            return raw && raw[0] != '\0' && raw[0] != '0';
+        }
+
+        const char* operator_type_name(operator_type type) {
+            switch (type) {
+                case operator_type::match:
+                    return "match";
+                case operator_type::full_scan:
+                    return "full_scan";
+                case operator_type::transfer_scan:
+                    return "transfer_scan";
+                case operator_type::index_scan:
+                    return "index_scan";
+                case operator_type::sort:
+                    return "sort";
+                case operator_type::select:
+                    return "select";
+                case operator_type::join:
+                    return "join";
+                case operator_type::aggregate:
+                    return "aggregate";
+                case operator_type::raw_data:
+                    return "raw_data";
+                case operator_type::batch:
+                    return "batch";
+                default:
+                    return "other";
+            }
+        }
+
+        std::size_t output_rows(const operator_ptr& op) {
+            return (op && op->output()) ? op->output()->size() : 0;
+        }
+
+        std::size_t output_chunks(const operator_data_ptr& out) { return out ? out->chunk_count() : 0; }
+
+        void trace_node(operator_type type,
+                        const operator_ptr& left,
+                        const operator_ptr& right,
+                        const operator_data_ptr& out,
+                        double elapsed_ms) {
+            if (!trace_nodes_enabled()) {
+                return;
+            }
+            std::fprintf(stderr,
+                         "OTBX_EXEC_NODE node=%s rows_left=%zu rows_right=%zu rows_out=%zu chunks_out=%zu time_ms=%.3f\n",
+                         operator_type_name(type),
+                         output_rows(left),
+                         output_rows(right),
+                         out ? out->size() : 0,
+                         output_chunks(out),
+                         elapsed_ms);
+        }
+    } // namespace
 
     bool is_success(const operator_t::ptr& op) { return !op || op->is_executed(); }
 
@@ -49,18 +110,44 @@ namespace components::operators {
                 }
             }
             if (is_success(left_) && is_success(right_)) {
+                const auto trace_enabled = trace_nodes_enabled();
+                std::chrono::steady_clock::time_point start;
+                if (trace_enabled) {
+                    start = std::chrono::steady_clock::now();
+                }
                 on_execute_impl(pipeline_context);
+                auto elapsed_ms = 0.0;
+                if (trace_enabled) {
+                    elapsed_ms =
+                        std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - start).count();
+                }
                 if (has_error()) {
                     state_ = operator_state::failed;
                     return;
                 }
                 if (!is_wait_sync_disk()) {
                     state_ = operator_state::executed;
+                    if (trace_enabled) {
+                        trace_node(type_, left_, right_, output_, elapsed_ms);
+                    }
                 }
             }
         } else if (is_wait_sync_disk()) {
+            const auto trace_enabled = trace_nodes_enabled();
+            std::chrono::steady_clock::time_point start;
+            if (trace_enabled) {
+                start = std::chrono::steady_clock::now();
+            }
             on_resume_impl(pipeline_context);
+            auto elapsed_ms = 0.0;
+            if (trace_enabled) {
+                elapsed_ms =
+                    std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - start).count();
+            }
             state_ = operator_state::executed;
+            if (trace_enabled) {
+                trace_node(type_, left_, right_, output_, elapsed_ms);
+            }
         }
     }
 

--- a/components/physical_plan/operators/operator_checkpoint.cpp
+++ b/components/physical_plan/operators/operator_checkpoint.cpp
@@ -11,6 +11,8 @@
 #include <services/index/manager_index.hpp>
 #include <services/wal/manager_wal_replicate.hpp>
 
+#include <exception>
+
 namespace components::operators {
 
     operator_checkpoint_t::operator_checkpoint_t(std::pmr::memory_resource* resource, log_t log)
@@ -19,108 +21,121 @@ namespace components::operators {
     void operator_checkpoint_t::on_execute_impl(pipeline::context_t* /*ctx*/) { async_wait(); }
 
     actor_zeta::unique_future<void> operator_checkpoint_t::await_async_and_resume(pipeline::context_t* ctx) {
-        // Flush dirty index btrees so a post-recovery rebuild starts from a
-        // consistent on-disk index state.
-        if (ctx->index_address != actor_zeta::address_t::empty_address()) {
-            auto [_fi, fif] = actor_zeta::send(ctx->index_address,
-                                               &services::index::manager_index_t::flush_all_indexes,
-                                               ctx->session);
-            co_await std::move(fif);
-        }
-
-        // snapshot the current WAL id BEFORE the checkpoint so the per-table
-        // W-TORN (prev/current) snapshot pins a known recovery boundary.
-        services::wal::id_t wal_max_id{0};
-        if (ctx->wal_address != actor_zeta::address_t::empty_address()) {
-            auto [_wi, wif] = actor_zeta::send(ctx->wal_address,
-                                               &services::wal::manager_wal_replicate_t::current_wal_id,
-                                               ctx->session);
-            wal_max_id = co_await std::move(wif);
-        }
-
-        // Compact watermark for checkpoint_inner's MVCC-gated compact: the
-        // dispatcher's visible-to-all horizon (current_message_sender is the
-        // dispatcher — the executor wires parent_address_ into the context).
-        // 0 when no dispatcher is wired (test topologies): compacts and the
-        // affected per-table checkpoints are then skipped, never unsafe.
-        std::uint64_t compact_watermark = 0;
-        if (ctx->current_message_sender != actor_zeta::address_t::empty_address()) {
-            auto [_wm, wmf] = actor_zeta::send(ctx->current_message_sender,
-                                               &services::dispatcher::manager_dispatcher_t::txn_compact_watermark_msg);
-            compact_watermark = co_await std::move(wmf);
-        }
-
-        // checkpoint_all. No-op when disk is off.
-        services::wal::id_t checkpoint_wal_id{0};
-        if (ctx->disk_address != actor_zeta::address_t::empty_address()) {
-            auto [_cp, cpf] = actor_zeta::send(ctx->disk_address,
-                                               &services::disk::manager_disk_t::checkpoint_all,
-                                               ctx->session,
-                                               wal_max_id,
-                                               compact_watermark);
-            checkpoint_wal_id = co_await std::move(cpf);
-        }
-
-        if (checkpoint_wal_id > services::wal::id_t{0} && ctx->wal_address != actor_zeta::address_t::empty_address()) {
-            auto [_wt, wtf] = actor_zeta::send(ctx->wal_address,
-                                               &services::wal::manager_wal_replicate_t::truncate_before,
-                                               ctx->session,
-                                               checkpoint_wal_id);
-            co_await std::move(wtf);
-        }
-
-        // Index rebuild. This MUST run AFTER checkpoint_all: checkpoint_inner
-        // compact()s each table's on-disk storage, which renumbers row ids
-        // (0-based, gap-free post-compact). The in-memory index engines hold
-        // POSITIONAL row refs into the pre-compact layout, so leaving them as-is
-        // would make every post-checkpoint index_scan return stale/wrong rows.
-        // repopulate_table clears the on-disk index backing AND the in-memory
-        // engine before re-inserting, so both btree duplicate-growth and
-        // disk_hash wrong-row drift are wiped in one pass. Sequential per-oid is
-        // fine: checkpoint is a cold, exclusive operation.
-        if (ctx->index_address != actor_zeta::address_t::empty_address()) {
-            std::pmr::vector<components::catalog::oid_t> indexed_oids{resource_};
-            {
-                auto [_io, iof] = actor_zeta::send(ctx->index_address,
-                                                   &services::index::manager_index_t::all_indexed_oids,
+        try {
+            // Step 1: flush dirty index btrees so a post-recovery rebuild starts
+            // from a consistent on-disk index state.
+            if (ctx->index_address != actor_zeta::address_t::empty_address()) {
+                auto [_fi, fif] = actor_zeta::send(ctx->index_address,
+                                                   &services::index::manager_index_t::flush_all_indexes,
                                                    ctx->session);
-                indexed_oids = co_await std::move(iof);
+                co_await std::move(fif);
             }
 
-            for (const auto table_oid : indexed_oids) {
-                std::uint64_t total = 0;
+            // Step 2: snapshot the current WAL id BEFORE the checkpoint so the
+            // per-table W-TORN (prev/current) snapshot pins a known recovery
+            // boundary.
+            services::wal::id_t wal_max_id{0};
+            if (ctx->wal_address != actor_zeta::address_t::empty_address()) {
+                auto [_wi, wif] = actor_zeta::send(ctx->wal_address,
+                                                   &services::wal::manager_wal_replicate_t::current_wal_id,
+                                                   ctx->session);
+                wal_max_id = co_await std::move(wif);
+            }
+
+            // Step 3: compact watermark for checkpoint_inner's MVCC-gated compact:
+            // the dispatcher's visible-to-all horizon (current_message_sender is
+            // the dispatcher — the executor wires parent_address_ into the
+            // context). 0 when no dispatcher is wired (test topologies): compacts
+            // and the affected per-table checkpoints are then skipped, never
+            // unsafe.
+            std::uint64_t compact_watermark = 0;
+            if (ctx->current_message_sender != actor_zeta::address_t::empty_address()) {
+                auto [_wm, wmf] =
+                    actor_zeta::send(ctx->current_message_sender,
+                                     &services::dispatcher::manager_dispatcher_t::txn_compact_watermark_msg);
+                compact_watermark = co_await std::move(wmf);
+            }
+
+            // Step 4: checkpoint_all. No-op when disk is off.
+            services::wal::id_t checkpoint_wal_id{0};
+            if (ctx->disk_address != actor_zeta::address_t::empty_address()) {
+                auto [_cp, cpf] = actor_zeta::send(ctx->disk_address,
+                                                   &services::disk::manager_disk_t::checkpoint_all,
+                                                   ctx->session,
+                                                   wal_max_id,
+                                                   compact_watermark);
+                checkpoint_wal_id = co_await std::move(cpf);
+            }
+
+            // Step 5: trim old WAL segments.
+            if (checkpoint_wal_id > services::wal::id_t{0} &&
+                ctx->wal_address != actor_zeta::address_t::empty_address()) {
+                auto [_wt, wtf] = actor_zeta::send(ctx->wal_address,
+                                                   &services::wal::manager_wal_replicate_t::truncate_before,
+                                                   ctx->session,
+                                                   checkpoint_wal_id);
+                co_await std::move(wtf);
+            }
+
+            // Step 6: index rebuild. This MUST run AFTER checkpoint_all:
+            // checkpoint_inner compact()s each table's on-disk storage, which
+            // renumbers row ids (0-based, gap-free post-compact). The in-memory
+            // index engines hold POSITIONAL row refs into the pre-compact layout,
+            // so leaving them as-is would make every post-checkpoint index_scan
+            // return stale/wrong rows. repopulate_table clears the on-disk index
+            // backing AND the in-memory engine before re-inserting, so both btree
+            // duplicate-growth and disk_hash wrong-row drift are wiped in one
+            // pass. Sequential per-oid is fine: checkpoint is a cold, exclusive
+            // operation.
+            if (ctx->index_address != actor_zeta::address_t::empty_address()) {
+                std::pmr::vector<components::catalog::oid_t> indexed_oids{resource_};
                 {
-                    auto [_tr, trf] = actor_zeta::send(ctx->disk_address,
-                                                       &services::disk::manager_disk_t::storage_total_rows,
-                                                       ctx->session,
-                                                       table_oid);
-                    total = co_await std::move(trf);
+                    auto [_io, iof] = actor_zeta::send(ctx->index_address,
+                                                       &services::index::manager_index_t::all_indexed_oids,
+                                                       ctx->session);
+                    indexed_oids = co_await std::move(iof);
                 }
 
-                // total==0 (table emptied by compact) still repopulates: the
-                // clear step inside repopulate_table wipes stale index entries.
-                // storage_scan_segment returns an empty chunk for count==0, which
-                // is exactly what repopulate_table expects.
-                std::unique_ptr<components::vector::data_chunk_t> scan_data;
-                {
-                    auto [_ss, ssf] = actor_zeta::send(ctx->disk_address,
-                                                       &services::disk::manager_disk_t::storage_scan_segment,
+                for (const auto table_oid : indexed_oids) {
+                    std::uint64_t total = 0;
+                    {
+                        auto [_tr, trf] = actor_zeta::send(ctx->disk_address,
+                                                           &services::disk::manager_disk_t::storage_total_rows,
+                                                           ctx->session,
+                                                           table_oid);
+                        total = co_await std::move(trf);
+                    }
+
+                    // total==0 (table emptied by compact) still repopulates: the
+                    // clear step inside repopulate_table wipes stale index entries.
+                    // storage_scan_segment returns an empty chunk for count==0,
+                    // which is exactly what repopulate_table expects.
+                    std::unique_ptr<components::vector::data_chunk_t> scan_data;
+                    {
+                        auto [_ss, ssf] = actor_zeta::send(ctx->disk_address,
+                                                           &services::disk::manager_disk_t::storage_scan_segment,
+                                                           ctx->session,
+                                                           table_oid,
+                                                           std::int64_t{0},
+                                                           total);
+                        scan_data = co_await std::move(ssf);
+                    }
+
+                    auto [_rp, rpf] = actor_zeta::send(ctx->index_address,
+                                                       &services::index::manager_index_t::repopulate_table,
                                                        ctx->session,
                                                        table_oid,
-                                                       std::int64_t{0},
-                                                       total);
-                    scan_data = co_await std::move(ssf);
+                                                       std::move(scan_data),
+                                                       total,
+                                                       ctx->session_tz);
+                    co_await std::move(rpf);
                 }
-
-                auto [_rp, rpf] = actor_zeta::send(ctx->index_address,
-                                                   &services::index::manager_index_t::repopulate_table,
-                                                   ctx->session,
-                                                   table_oid,
-                                                   std::move(scan_data),
-                                                   total,
-                                                   ctx->session_tz);
-                co_await std::move(rpf);
             }
+        } catch (const std::exception& e) {
+            set_error(core::error_t{core::error_code_t::other_error, std::pmr::string{e.what(), resource()}});
+        } catch (...) {
+            set_error(core::error_t{core::error_code_t::other_error,
+                                    std::pmr::string{"CHECKPOINT failed", resource()}});
         }
 
         mark_executed();

--- a/components/physical_plan/operators/operator_create_collection.cpp
+++ b/components/physical_plan/operators/operator_create_collection.cpp
@@ -1,6 +1,7 @@
 #include "operator_create_collection.hpp"
 
 #include <components/context/context.hpp>
+#include <components/configuration/configuration.hpp>
 #include <services/disk/manager_disk.hpp>
 #include <services/index/manager_index.hpp>
 
@@ -8,37 +9,58 @@
 
 namespace components::operators {
 
+    namespace {
+        configuration::disk_layout_policy
+        to_disk_layout_policy(components::logical_plan::create_collection_storage_format_t storage_format) {
+            using components::logical_plan::create_collection_storage_format_t;
+
+            switch (storage_format) {
+                case create_collection_storage_format_t::disk_columnar:
+                    return configuration::disk_layout_policy::columnar_only;
+                case create_collection_storage_format_t::disk_pax:
+                    return configuration::disk_layout_policy::pax_only;
+                case create_collection_storage_format_t::disk_auto:
+                case create_collection_storage_format_t::in_memory:
+                default:
+                    return configuration::disk_layout_policy::auto_select;
+            }
+        }
+    } // namespace
+
     operator_create_collection_t::operator_create_collection_t(std::pmr::memory_resource* resource,
                                                                log_t log,
                                                                components::catalog::oid_t table_oid,
                                                                components::catalog::oid_t database_oid,
                                                                std::vector<table::column_definition_t> columns,
-                                                               bool is_disk_storage,
+                                                               components::logical_plan::create_collection_storage_format_t
+                                                                   storage_format,
                                                                std::vector<catalog_write_t> catalog_writes)
         : read_write_operator_t(resource, std::move(log), operator_type::create_collection)
         , table_oid_(table_oid)
         , database_oid_(database_oid)
         , columns_(std::move(columns))
-        , is_disk_storage_(is_disk_storage)
+        , storage_format_(storage_format)
         , catalog_writes_(std::move(catalog_writes)) {}
 
     void operator_create_collection_t::on_execute_impl(pipeline::context_t* /*ctx*/) { async_wait(); }
 
     actor_zeta::unique_future<void> operator_create_collection_t::await_async_and_resume(pipeline::context_t* ctx) {
-        if (columns_.empty()) {
-            auto [_, f] = actor_zeta::send(ctx->disk_address,
-                                           &services::disk::manager_disk_t::create_storage,
-                                           ctx->session,
-                                           table_oid_,
-                                           database_oid_);
-            co_await std::move(f);
-        } else if (is_disk_storage_) {
+        // Step 1: Create physical storage
+        if (storage_format_ != components::logical_plan::create_collection_storage_format_t::in_memory) {
             auto [_, f] = actor_zeta::send(ctx->disk_address,
                                            &services::disk::manager_disk_t::create_storage_disk,
                                            ctx->session,
                                            table_oid_,
                                            database_oid_,
-                                           std::move(columns_));
+                                           std::move(columns_),
+                                           to_disk_layout_policy(storage_format_));
+            co_await std::move(f);
+        } else if (columns_.empty()) {
+            auto [_, f] = actor_zeta::send(ctx->disk_address,
+                                           &services::disk::manager_disk_t::create_storage,
+                                           ctx->session,
+                                           table_oid_,
+                                           database_oid_);
             co_await std::move(f);
         } else {
             auto [_, f] = actor_zeta::send(ctx->disk_address,

--- a/components/physical_plan/operators/operator_create_collection.hpp
+++ b/components/physical_plan/operators/operator_create_collection.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <components/catalog/catalog_oids.hpp>
+#include <components/logical_plan/node_create_collection.hpp>
 #include <components/physical_plan/operators/operator.hpp>
 #include <components/table/column_definition.hpp>
 #include <components/vector/data_chunk.hpp>
@@ -21,7 +22,7 @@ namespace components::operators {
                                      components::catalog::oid_t table_oid,
                                      components::catalog::oid_t database_oid,
                                      std::vector<table::column_definition_t> columns,
-                                     bool is_disk_storage,
+                                     components::logical_plan::create_collection_storage_format_t storage_format,
                                      std::vector<catalog_write_t> catalog_writes);
 
     private:
@@ -31,7 +32,7 @@ namespace components::operators {
         components::catalog::oid_t table_oid_;
         components::catalog::oid_t database_oid_;
         std::vector<table::column_definition_t> columns_;
-        bool is_disk_storage_;
+        components::logical_plan::create_collection_storage_format_t storage_format_;
         std::vector<catalog_write_t> catalog_writes_;
     };
 

--- a/components/physical_plan/operators/operator_create_index_backfill.cpp
+++ b/components/physical_plan/operators/operator_create_index_backfill.cpp
@@ -228,7 +228,8 @@ namespace components::operators {
                                                      ctx->session,
                                                      rec.table_oid,
                                                      std::move(fetch_ids),
-                                                     static_cast<uint64_t>(rec.physical_row_ids.size()));
+                                                     static_cast<uint64_t>(rec.physical_row_ids.size()),
+                                                     ctx->txn);
                     fetch_futures.push_back(std::move(ff));
                     fetch_slots.push_back(r);
                 }

--- a/components/physical_plan/operators/operator_create_matview.cpp
+++ b/components/physical_plan/operators/operator_create_matview.cpp
@@ -1,6 +1,7 @@
 #include "operator_create_matview.hpp"
 
 #include <components/context/context.hpp>
+#include <components/configuration/configuration.hpp>
 #include <services/disk/manager_disk.hpp>
 #include <services/index/manager_index.hpp>
 #include <services/wal/manager_wal_replicate.hpp>
@@ -44,7 +45,8 @@ namespace components::operators {
                                            ctx->session,
                                            mv_oid_,
                                            namespace_oid_,
-                                           std::move(columns_));
+                                           std::move(columns_),
+                                           configuration::disk_layout_policy::auto_select);
             co_await std::move(f);
         } else {
             auto [_, f] = actor_zeta::send(ctx->disk_address,

--- a/components/physical_plan/operators/operator_data.cpp
+++ b/components/physical_plan/operators/operator_data.cpp
@@ -20,12 +20,25 @@ namespace components::operators {
             }
             auto types = chunks.front().types();
             vector::data_chunk_t combined(resource, types, total == 0 ? 1 : total);
+            // Columns the scan left unmaterialised (e.g. non-RETURNING columns) are
+            // unprojected placeholders (null data + null auxiliary) in every source
+            // chunk. Keep them placeholders in the merged chunk — copying them would
+            // dereference a null data buffer (the multi-chunk RETURNING crash).
+            for (uint64_t col = 0; col < combined.column_count(); ++col) {
+                if (chunks.front().data[col].data() == nullptr && chunks.front().data[col].auxiliary() == nullptr) {
+                    combined.data[col].set_data(nullptr);
+                    combined.data[col].set_auxiliary(nullptr);
+                }
+            }
             uint64_t offset = 0;
             for (auto& c : chunks) {
                 if (c.size() == 0) {
                     continue;
                 }
                 for (uint64_t col = 0; col < c.column_count(); ++col) {
+                    if (combined.data[col].data() == nullptr && combined.data[col].auxiliary() == nullptr) {
+                        continue; // placeholder column — nothing to materialise
+                    }
                     vector::vector_ops::copy(c.data[col], combined.data[col], c.size(), 0, offset);
                 }
                 vector::vector_ops::copy(c.row_ids, combined.row_ids, c.size(), 0, offset);

--- a/components/physical_plan/operators/operator_delete.cpp
+++ b/components/physical_plan/operators/operator_delete.cpp
@@ -9,7 +9,28 @@
 #include <services/index/manager_index.hpp>
 #include <services/wal/manager_wal_replicate.hpp>
 
+#include <unordered_map>
+
 namespace components::operators {
+
+    namespace {
+
+        bool is_unprojected_placeholder(const vector::vector_t& vector) noexcept {
+            return vector.data() == nullptr && vector.auxiliary() == nullptr;
+        }
+
+        std::vector<size_t> materialized_columns(const vector::data_chunk_t& chunk) {
+            std::vector<size_t> result;
+            result.reserve(chunk.column_count());
+            for (size_t column = 0; column < chunk.column_count(); column++) {
+                if (!is_unprojected_placeholder(chunk.data[column])) {
+                    result.push_back(column);
+                }
+            }
+            return result;
+        }
+
+    } // namespace
 
     operator_delete::operator_delete(std::pmr::memory_resource* resource,
                                      log_t log,
@@ -99,45 +120,68 @@ namespace components::operators {
         } else if (left_ && left_->output()) {
             output_ = left_->output(); // pass-through for downstream fk_cascade operators
             modified_ = operators::make_operator_write_data(left_->output()->resource());
-            auto& chunk = left_->output()->data_chunk();
+            const auto& chunks = left_->output()->chunks();
+            std::pmr::vector<types::complex_logical_type> types(left_->output()->resource());
+            if (!chunks.empty()) {
+                types = chunks.front().types();
+            }
+            // RETURNING gathers from a single source chunk indexed by the matched
+            // scan position. With the multi-chunk scan output we project that
+            // position into the lazily-concatenated single-chunk view and track a
+            // running offset so each matched index lands at its global position.
             if (collect_returning) {
-                returning_source = &chunk;
-                returning_indexing.reset(chunk.size());
+                auto& concat_chunk = left_->output()->data_chunk();
+                returning_source = &concat_chunk;
+                returning_indexing.reset(concat_chunk.size());
             }
-            auto types = chunk.types();
+            size_t returning_offset = 0;
 
-            vector::vector_t ids(left_->output()->resource(), types::logical_type::BIGINT, chunk.size());
-            auto predicate = expression_ ? predicates::create_predicate(left_->output()->resource(),
-                                                                        pipeline_context->function_registry,
-                                                                        expression_,
-                                                                        types,
-                                                                        types,
-                                                                        &pipeline_context->parameters,
-                                                                        pipeline_context->session_tz)
-                                         : predicates::create_all_true_predicate(left_->output()->resource());
-
-            size_t index = 0;
-            for (size_t i = 0; i < chunk.size(); i++) {
-                auto check_result = predicate->check(chunk, i);
-                if (!check_result.has_error() && check_result.value()) {
-                    if (chunk.data.front().get_vector_type() == vector::vector_type::DICTIONARY) {
-                        ids.data<int64_t>()[index++] = static_cast<int64_t>(chunk.data.front().indexing().get_index(i));
-                    } else {
-                        ids.data<int64_t>()[index++] = chunk.row_ids.data<int64_t>()[i];
+            // Fast path: no predicate means every scanned row is deleted. Skip the
+            // per-row predicate check and append all row ids directly.
+            if (!expression_) {
+                size_t index = 0;
+                for (const auto& chunk : chunks) {
+                    const auto* row_ids = chunk.row_ids.data<int64_t>();
+                    for (size_t i = 0; i < chunk.size(); i++) {
+                        modified_->append(static_cast<size_t>(row_ids[i]));
+                        if (collect_returning) {
+                            returning_indexing.set_index(returning_count++, returning_offset + i);
+                        }
+                        index++;
                     }
-                    if (collect_returning) {
-                        returning_indexing.set_index(returning_count++, i);
-                    }
+                    returning_offset += chunk.size();
                 }
-            }
-            ids.resize(chunk.size(), index);
-            for (size_t i = 0; i < index; i++) {
-                size_t id = static_cast<size_t>(ids.data<int64_t>()[i]);
-                modified_->append(id);
-            }
-            for (const auto& type : types) {
-                modified_->updated_types_map()[{std::pmr::string(type.alias(), left_->output()->resource()), type}] +=
-                    index;
+                for (const auto& type : types) {
+                    modified_->updated_types_map()[{std::pmr::string(type.alias(), left_->output()->resource()),
+                                                     type}] += index;
+                }
+            } else {
+                auto predicate = predicates::create_predicate(left_->output()->resource(),
+                                                              pipeline_context->function_registry,
+                                                              expression_,
+                                                              types,
+                                                              types,
+                                                              &pipeline_context->parameters,
+                                                              pipeline_context->session_tz);
+
+                size_t index = 0;
+                for (const auto& chunk : chunks) {
+                    for (size_t i = 0; i < chunk.size(); i++) {
+                        auto check_result = predicate->check(chunk, i);
+                        if (!check_result.has_error() && check_result.value()) {
+                            modified_->append(static_cast<size_t>(chunk.row_ids.data<int64_t>()[i]));
+                            if (collect_returning) {
+                                returning_indexing.set_index(returning_count++, returning_offset + i);
+                            }
+                            index++;
+                        }
+                    }
+                    returning_offset += chunk.size();
+                }
+                for (const auto& type : types) {
+                    modified_->updated_types_map()[{std::pmr::string(type.alias(), left_->output()->resource()),
+                                                     type}] += index;
+                }
             }
         }
 
@@ -222,12 +266,7 @@ namespace components::operators {
             }
         }
 
-        // 1. Capture WAL row IDs.
-        std::pmr::vector<int64_t> wal_row_ids(resource_);
-        wal_row_ids.reserve(modified_size);
-        for (size_t i = 0; i < modified_size; i++) {
-            wal_row_ids.push_back(static_cast<int64_t>(ids[i]));
-        }
+        const bool write_wal = ctx->wal_address != actor_zeta::address_t::empty_address();
 
         // 2. storage_delete_rows.
         vector_t row_ids(resource_, types::logical_type::BIGINT, modified_size);
@@ -243,7 +282,12 @@ namespace components::operators {
         co_await std::move(df);
 
         // 3. WAL physical_delete.
-        if (ctx->wal_address != actor_zeta::address_t::empty_address()) {
+        if (write_wal) {
+            std::pmr::vector<int64_t> wal_row_ids(resource_);
+            wal_row_ids.reserve(modified_size);
+            for (size_t i = 0; i < modified_size; i++) {
+                wal_row_ids.push_back(static_cast<int64_t>(ids[i]));
+            }
             auto count = static_cast<uint64_t>(wal_row_ids.size());
             // See operator_insert comment on db_oid temporary hardcode.
             constexpr auto db_oid = components::catalog::well_known_oid::main_database;
@@ -264,21 +308,57 @@ namespace components::operators {
         // 4. Mirror to index (uses scan output for old data).
         if (ctx->index_address != actor_zeta::address_t::empty_address()) {
             if (auto scan_out = left_ ? left_->output() : nullptr) {
-                auto& sc = scan_out->data_chunk();
-                auto idx_data = std::make_unique<data_chunk_t>(resource_, sc.types(), sc.size());
-                sc.copy(*idx_data, 0);
-                auto idx_ids = std::pmr::vector<int64_t>(resource_);
-                idx_ids.reserve(modified_size);
-                for (size_t i = 0; i < modified_size; i++) {
-                    idx_ids.emplace_back(sc.row_ids.data<int64_t>()[i]);
+                const auto& scan_chunks = scan_out->chunks();
+                if (scan_chunks.empty()) {
+                    // No old row values available for index mirroring.
+                } else {
+                    const auto& first_chunk = scan_chunks.front();
+                    auto projected_cols = materialized_columns(first_chunk);
+                    auto idx_data = projected_cols.size() == first_chunk.column_count()
+                                        ? std::make_unique<data_chunk_t>(resource_, first_chunk.types(), modified_size)
+                                        : std::make_unique<data_chunk_t>(resource_,
+                                                                         first_chunk.types(),
+                                                                         projected_cols,
+                                                                         modified_size);
+                    auto idx_ids = std::pmr::vector<int64_t>(resource_);
+                    idx_ids.reserve(modified_size);
+
+                    std::unordered_map<int64_t, bool> modified_rows;
+                    modified_rows.reserve(modified_size);
+                    for (size_t i = 0; i < modified_size; i++) {
+                        modified_rows.emplace(static_cast<int64_t>(ids[i]), true);
+                    }
+
+                    for (const auto& sc : scan_chunks) {
+                        for (uint64_t row = 0; row < sc.size(); row++) {
+                            const auto row_id = sc.row_ids.data<int64_t>()[row];
+                            if (modified_rows.find(row_id) == modified_rows.end()) {
+                                continue;
+                            }
+                            for (size_t col = 0; col < sc.column_count(); col++) {
+                                if (is_unprojected_placeholder(sc.data[col])) {
+                                    continue;
+                                }
+                                components::vector::vector_ops::copy(sc.data[col],
+                                                                     idx_data->data[col],
+                                                                     row + 1,
+                                                                     row,
+                                                                     idx_ids.size());
+                            }
+                            idx_ids.emplace_back(row_id);
+                        }
+                    }
+                    if (!idx_ids.empty()) {
+                        idx_data->set_cardinality(idx_ids.size());
+                        auto [_ix, ixf] = actor_zeta::send(ctx->index_address,
+                                                           &services::index::manager_index_t::delete_rows,
+                                                           exec_ctx,
+                                                           table_oid_,
+                                                           std::move(idx_data),
+                                                           std::move(idx_ids));
+                        co_await std::move(ixf);
+                    }
                 }
-                auto [_ix, ixf] = actor_zeta::send(ctx->index_address,
-                                                   &services::index::manager_index_t::delete_rows,
-                                                   exec_ctx,
-                                                   table_oid_,
-                                                   std::move(idx_data),
-                                                   std::move(idx_ids));
-                co_await std::move(ixf);
             }
         }
 

--- a/components/physical_plan/operators/operator_fk_cascade.cpp
+++ b/components/physical_plan/operators/operator_fk_cascade.cpp
@@ -163,7 +163,8 @@ namespace components::operators {
                                                    ctx->session,
                                                    fk_.child_table_oid,
                                                    std::move(fetch_ids),
-                                                   static_cast<uint64_t>(all_child_ids.size()));
+                                                   static_cast<uint64_t>(all_child_ids.size()),
+                                                   ctx->txn);
                 auto fetched = co_await std::move(ffut);
                 if (!fetched || fetched->size() == 0)
                     break;

--- a/components/physical_plan/operators/operator_group.cpp
+++ b/components/physical_plan/operators/operator_group.cpp
@@ -530,10 +530,16 @@ namespace components::operators {
     vector::data_chunk_t operator_group_t::calc_aggregate_values(pipeline::context_t* pipeline_context,
                                                                  chunks_vector_t& in_chunks) {
         size_t num_groups = group_keys_.size();
-        size_t key_count = num_groups > 0 ? group_keys_[0].size() : 0;
+        size_t key_count = num_groups > 0 ? group_keys_[0].size() : keys_.size();
 
         size_t total_rows = 0;
         for (const auto& c : in_chunks) total_rows += c.size();
+
+        if (num_groups == 0) {
+            std::pmr::vector<std::pmr::vector<types::logical_value_t>> agg_results(resource_);
+            agg_results.resize(values_.size());
+            return build_result_chunk(0, key_count, agg_results, in_chunks);
+        }
 
         // Try vectorized path: check if all aggregators are builtin with simple column args
         bool can_vectorize = num_groups > 0 && total_rows > 0;
@@ -666,7 +672,13 @@ namespace components::operators {
     vector::data_chunk_t operator_group_t::calc_aggregate_values_fallback(pipeline::context_t* pipeline_context,
                                                                           chunks_vector_t& in_chunks) {
         size_t num_groups = group_keys_.size();
-        size_t key_count = num_groups > 0 ? group_keys_[0].size() : 0;
+        size_t key_count = num_groups > 0 ? group_keys_[0].size() : keys_.size();
+
+        if (num_groups == 0) {
+            std::pmr::vector<std::pmr::vector<types::logical_value_t>> agg_results(resource_);
+            agg_results.resize(values_.size());
+            return build_result_chunk(0, key_count, agg_results, in_chunks);
+        }
 
         // All chunks share the same schema — take types from the first one.
         std::pmr::vector<types::complex_logical_type> result_types{resource_};
@@ -776,6 +788,11 @@ namespace components::operators {
             }
 
             agg_results.push_back(std::move(results));
+
+            // Drop this aggregator's gathered input now that its result is out;
+            // otherwise each aggregator holds its own copy and peak memory scales
+            // with the aggregate count.
+            aggregator->clear();
         }
 
         return build_result_chunk(num_groups, key_count, agg_results, in_chunks);
@@ -793,47 +810,51 @@ namespace components::operators {
         // group with a typed key would trip vector_t::set_value's cast_as path
         // (NA has no cast handler → assert in logical_value.cpp).
         std::pmr::vector<types::complex_logical_type> out_types(resource_);
-        if (num_groups > 0) {
-            for (size_t k = 0; k < key_count; k++) {
-                const auto& key = keys_[k];
-                bool got = false;
-                if (key.type == group_key_t::kind::column && !key.full_path.empty() && !in_chunks.empty()) {
-                    const auto col_idx = key.full_path.front();
-                    if (col_idx < in_chunks.front().column_count()) {
-                        // Walk the remaining path components through the nested
-                        // type (STRUCT fields by index, ARRAY/LIST element type)
-                        // so multi-part paths get their source type too; fall
-                        // back to the value type when a component cannot be
-                        // resolved.
-                        const auto* walked = &in_chunks.front().data[col_idx].type();
-                        bool ok = true;
-                        for (auto it = std::next(key.full_path.begin()); ok && it != key.full_path.end(); ++it) {
-                            switch (walked->type()) {
-                                case types::logical_type::ARRAY:
-                                case types::logical_type::LIST:
-                                    walked = &walked->child_type();
-                                    break;
-                                case types::logical_type::STRUCT:
-                                    if (*it < walked->child_types().size()) {
-                                        walked = &walked->child_types()[*it];
-                                    } else {
-                                        ok = false;
-                                    }
-                                    break;
-                                default:
+        for (size_t k = 0; k < key_count; k++) {
+            const auto& key = keys_[k];
+            bool got = false;
+            if (key.type == group_key_t::kind::column && !key.full_path.empty() && !in_chunks.empty()) {
+                const auto col_idx = key.full_path.front();
+                if (col_idx < in_chunks.front().column_count()) {
+                    // Walk the remaining path components through the nested
+                    // type (STRUCT fields by index, ARRAY/LIST element type)
+                    // so multi-part paths get their source type too; fall
+                    // back to the value type when a component cannot be
+                    // resolved.
+                    const auto* walked = &in_chunks.front().data[col_idx].type();
+                    bool ok = true;
+                    for (auto it = std::next(key.full_path.begin()); ok && it != key.full_path.end(); ++it) {
+                        switch (walked->type()) {
+                            case types::logical_type::ARRAY:
+                            case types::logical_type::LIST:
+                                walked = &walked->child_type();
+                                break;
+                            case types::logical_type::STRUCT:
+                                if (*it < walked->child_types().size()) {
+                                    walked = &walked->child_types()[*it];
+                                } else {
                                     ok = false;
-                                    break;
-                            }
-                        }
-                        if (ok) {
-                            out_types.push_back(*walked);
-                            got = true;
+                                }
+                                break;
+                            default:
+                                ok = false;
+                                break;
                         }
                     }
+                    if (ok) {
+                        out_types.push_back(*walked);
+                        got = true;
+                    }
                 }
-                if (!got) {
-                    out_types.push_back(group_keys_[0][k].type());
-                }
+            }
+            if (!got && num_groups > 0) {
+                out_types.push_back(group_keys_[0][k].type());
+                got = true;
+            }
+            if (!got) {
+                types::complex_logical_type t{types::logical_type::NA};
+                t.set_alias(std::string{key.name});
+                out_types.push_back(std::move(t));
             }
         }
         // One column per aggregate, unconditionally: the fill loop below writes
@@ -842,8 +863,13 @@ namespace components::operators {
         // chunk's column array. An aggregate with no results gets an NA-typed
         // column filled with NULLs.
         for (size_t a = 0; a < values_.size(); a++) {
-            out_types.push_back(agg_results[a].empty() ? types::complex_logical_type(types::logical_type::NA)
-                                                       : agg_results[a][0].type());
+            if (!agg_results[a].empty()) {
+                out_types.push_back(agg_results[a][0].type());
+            } else {
+                types::complex_logical_type t{types::logical_type::NA};
+                t.set_alias(std::string{values_[a].name});
+                out_types.push_back(std::move(t));
+            }
         }
 
         // Create result chunk

--- a/components/physical_plan/operators/operator_insert.cpp
+++ b/components/physical_plan/operators/operator_insert.cpp
@@ -46,7 +46,6 @@ namespace components::operators {
             mark_executed();
             co_return;
         }
-        auto& out_chunk = output_->data_chunk();
         components::execution_context_t exec_ctx{ctx->session, ctx->txn, ctx->session_tz, table_oid_};
 
         // When a resolver sibling supplied catalog metadata, compute a
@@ -56,29 +55,40 @@ namespace components::operators {
         // diagnostics today — the field is the wiring hook for a future
         // storage_append(...,key_translation) signature change. We log
         // mismatches at trace level so resolver/data drift is visible.
-        if (resolved_metadata_.has_value() && out_chunk.column_count() > 0) {
-            auto translation = build_column_key_translation(*resolved_metadata_, out_chunk);
+        auto log_metadata_mismatches = [&](const data_chunk_t& chunk) {
+            if (!resolved_metadata_.has_value() || chunk.column_count() == 0) {
+                return;
+            }
+            auto translation = build_column_key_translation(*resolved_metadata_, chunk);
             for (std::size_t i = 0; i < translation.size(); ++i) {
-                if (translation[i] < 0 && out_chunk.data[i].type().has_alias()) {
+                if (translation[i] < 0 && chunk.data[i].type().has_alias()) {
                     trace(log_,
                           "operator_insert: resolved metadata has no column matching chunk alias '{}'",
-                          std::string(out_chunk.data[i].type().alias()));
+                          std::string(chunk.data[i].type().alias()));
                 }
             }
+        };
+
+        auto& out_chunk = output_->data_chunk();
+        log_metadata_mismatches(out_chunk);
+
+        // 1. Capture WAL data only when WAL is active, to skip the full-chunk
+        // copy when it's disabled.
+        const bool write_wal = ctx->wal_address != actor_zeta::address_t::empty_address();
+        std::unique_ptr<data_chunk_t> wal_data;
+        if (write_wal) {
+            wal_data = std::make_unique<data_chunk_t>(resource_, out_chunk.types(), out_chunk.size());
+            out_chunk.copy(*wal_data, 0);
         }
 
-        // 1. Capture WAL data BEFORE storage_append moves the chunk.
-        auto wal_data = std::make_unique<data_chunk_t>(resource_, out_chunk.types(), out_chunk.size());
-        out_chunk.copy(*wal_data, 0);
-
         // 2. storage_append (handles schema adoption, _id dedup).
-        auto data_copy = std::make_unique<data_chunk_t>(resource_, out_chunk.types(), out_chunk.size());
-        out_chunk.copy(*data_copy, 0);
+        auto append_data = std::make_unique<data_chunk_t>(resource_, out_chunk.types(), out_chunk.size());
+        out_chunk.copy(*append_data, 0);
         auto [_a, af] = actor_zeta::send(ctx->disk_address,
                                          &services::disk::manager_disk_t::storage_append,
                                          exec_ctx,
                                          table_oid_,
-                                         std::move(data_copy));
+                                         std::move(append_data));
         auto [start_row, actual_count] = co_await std::move(af);
 
         if (actual_count == 0) {
@@ -89,7 +99,7 @@ namespace components::operators {
         }
 
         // 3. WAL physical_insert (synchronous; flush is fire-and-forget).
-        if (ctx->wal_address != actor_zeta::address_t::empty_address()) {
+        if (write_wal) {
             // database_oid selects the WAL worker. Hardcoded to main_database
             // until catalog_resolve_database_t populates ctx->database_oid.
             constexpr auto db_oid = components::catalog::well_known_oid::main_database;

--- a/components/physical_plan/operators/operator_join.cpp
+++ b/components/physical_plan/operators/operator_join.cpp
@@ -4,10 +4,134 @@
 
 #include <algorithm>
 #include <components/vector/vector_operations.hpp>
+#include <cstdio>
+#include <cstdlib>
+#include <optional>
+#include <unordered_map>
 
 namespace components::operators {
 
     using join_detail::join_builder;
+
+    namespace {
+        bool trace_join_enabled() {
+            const char* raw = std::getenv("OTTERBRIX_EXEC_TRACE_NODES");
+            return raw && raw[0] != '\0' && raw[0] != '0';
+        }
+
+        const char* join_type_name(operator_join_t::type type) {
+            switch (type) {
+                case operator_join_t::type::inner:
+                    return "inner";
+                case operator_join_t::type::full:
+                    return "full";
+                case operator_join_t::type::left:
+                    return "left";
+                case operator_join_t::type::right:
+                    return "right";
+                case operator_join_t::type::cross:
+                    return "cross";
+                default:
+                    return "invalid";
+            }
+        }
+
+        struct row_ref_t {
+            const vector::data_chunk_t* chunk = nullptr;
+            uint64_t row = 0;
+        };
+
+        struct hash_join_key_t {
+            std::pmr::vector<size_t> left_path;
+            std::pmr::vector<size_t> right_path;
+        };
+
+        struct logical_value_hash {
+            size_t operator()(const types::logical_value_t& value) const noexcept { return value.hash(); }
+        };
+
+        struct logical_value_equal {
+            bool operator()(const types::logical_value_t& left, const types::logical_value_t& right) const {
+                if (left.type() != right.type()) {
+                    return false;
+                }
+                return left == right;
+            }
+        };
+
+        std::optional<hash_join_key_t> extract_hash_join_key(const expressions::compare_expression_t& compare);
+
+        std::optional<hash_join_key_t> extract_hash_join_key(const expressions::expression_ptr& expression) {
+            if (!expression || expression->group() != expressions::expression_group::compare) {
+                return std::nullopt;
+            }
+            return extract_hash_join_key(*static_cast<const expressions::compare_expression_t*>(expression.get()));
+        }
+
+        std::optional<hash_join_key_t> extract_hash_join_key(const expressions::compare_expression_t& compare) {
+            if (compare.type() == expressions::compare_type::union_and) {
+                for (const auto& child : compare.children()) {
+                    auto key = extract_hash_join_key(child);
+                    if (key) {
+                        return key;
+                    }
+                }
+                return std::nullopt;
+            }
+
+            if (compare.type() != expressions::compare_type::eq) {
+                return std::nullopt;
+            }
+            if (!std::holds_alternative<expressions::key_t>(compare.left()) ||
+                !std::holds_alternative<expressions::key_t>(compare.right())) {
+                return std::nullopt;
+            }
+
+            const auto& lhs = std::get<expressions::key_t>(compare.left());
+            const auto& rhs = std::get<expressions::key_t>(compare.right());
+            if (lhs.path().empty() || rhs.path().empty()) {
+                return std::nullopt;
+            }
+
+            if (lhs.side() == expressions::side_t::left && rhs.side() == expressions::side_t::right) {
+                return hash_join_key_t{lhs.path(), rhs.path()};
+            }
+            if (lhs.side() == expressions::side_t::right && rhs.side() == expressions::side_t::left) {
+                return hash_join_key_t{rhs.path(), lhs.path()};
+            }
+            return std::nullopt;
+        }
+
+        bool key_column_available(const vector::data_chunk_t& chunk, const std::pmr::vector<size_t>& path) {
+            if (path.empty() || path.front() >= chunk.column_count()) {
+                return false;
+            }
+            return !join_detail::is_placeholder(chunk.data[path.front()]);
+        }
+
+        bool hash_key_columns_available(const chunks_vector_t& chunks,
+                                        const std::pmr::vector<size_t>& path) {
+            for (const auto& chunk : chunks) {
+                if (chunk.size() == 0) {
+                    continue;
+                }
+                if (!key_column_available(chunk, path)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        std::optional<types::logical_value_t> read_hash_key(const vector::data_chunk_t& chunk,
+                                                            const std::pmr::vector<size_t>& path,
+                                                            uint64_t row) {
+            auto value = chunk.value(path, row);
+            if (value.is_null()) {
+                return std::nullopt;
+            }
+            return value;
+        }
+    } // namespace
 
     operator_join_t::operator_join_t(std::pmr::memory_resource* resource,
                                      log_t log,
@@ -58,21 +182,24 @@ namespace components::operators {
         auto* res_resource = left_out->resource();
         chunks_vector_t out_chunks(res_resource);
 
+        const auto trace_enabled = trace_join_enabled();
+        stats_t stats;
+        auto* trace_stats = trace_enabled ? &stats : nullptr;
         switch (join_type_) {
             case type::inner:
-                inner_join_(predicate, context, res_types, out_chunks);
+                inner_join_(predicate, context, res_types, out_chunks, trace_stats);
                 break;
             case type::full:
-                outer_full_join_(predicate, context, res_types, out_chunks);
+                outer_full_join_(predicate, context, res_types, out_chunks, trace_stats);
                 break;
             case type::left:
-                outer_left_join_(predicate, context, res_types, out_chunks);
+                outer_left_join_(predicate, context, res_types, out_chunks, trace_stats);
                 break;
             case type::right:
-                outer_right_join_(predicate, context, res_types, out_chunks);
+                outer_right_join_(predicate, context, res_types, out_chunks, trace_stats);
                 break;
             case type::cross:
-                cross_join_(context, res_types, out_chunks);
+                cross_join_(context, res_types, out_chunks, trace_stats);
                 break;
             default:
                 break;
@@ -82,6 +209,22 @@ namespace components::operators {
             out_chunks.emplace_back(res_resource, res_types, 0);
         }
         output_ = operators::make_operator_data(res_resource, std::move(out_chunks));
+        if (trace_enabled) {
+            std::fprintf(stderr,
+                         "OTBX_JOIN type=%s rows_left=%zu rows_right=%zu rows_out=%zu "
+                         "algorithm=%s build_rows=%llu hash_table_size=%llu "
+                         "probe_batches=%llu probe_rows=%llu matches=%llu\n",
+                         join_type_name(join_type_),
+                         left_out->size(),
+                         right_out->size(),
+                         output_->size(),
+                         stats.hash_join ? "hash" : "nested",
+                         static_cast<unsigned long long>(stats.build_rows),
+                         static_cast<unsigned long long>(stats.hash_table_size),
+                         static_cast<unsigned long long>(stats.probe_batches),
+                         static_cast<unsigned long long>(stats.probe_rows),
+                         static_cast<unsigned long long>(stats.matches));
+        }
 
         if (log_.is_valid()) {
             trace(log(), "operator_join::result_size(): {}", output_->size());
@@ -91,7 +234,12 @@ namespace components::operators {
     void operator_join_t::inner_join_(const predicates::predicate_ptr& predicate,
                                       pipeline::context_t*,
                                       const std::pmr::vector<types::complex_logical_type>& out_types,
-                                      chunks_vector_t& out_chunks) {
+                                      chunks_vector_t& out_chunks,
+                                      stats_t* stats) {
+        if (inner_hash_join_(predicate, out_types, out_chunks, stats)) {
+            return;
+        }
+
         auto& left_chunks = left_->output()->chunks();
         auto& right_chunks = right_->output()->chunks();
         auto* resource = left_->output()->resource();
@@ -103,6 +251,10 @@ namespace components::operators {
                     if (R.size() == 0) {
                         continue;
                     }
+                    if (stats) {
+                        ++stats->probe_batches;
+                        stats->probe_rows += R.size();
+                    }
                     auto results = predicates::batch_check_1vN(predicate, L, R, li, R.size());
                     if (results.has_error()) {
                         set_error(results.error());
@@ -111,6 +263,9 @@ namespace components::operators {
                     const auto& mask = results.value();
                     for (uint64_t rj = 0; rj < R.size(); ++rj) {
                         if (mask[rj]) {
+                            if (stats) {
+                                ++stats->matches;
+                            }
                             builder.emit_matched(L, li, R, rj);
                         }
                     }
@@ -120,10 +275,86 @@ namespace components::operators {
         builder.flush();
     }
 
+    bool operator_join_t::inner_hash_join_(const predicates::predicate_ptr& predicate,
+                                           const std::pmr::vector<types::complex_logical_type>& out_types,
+                                           chunks_vector_t& out_chunks,
+                                           stats_t* stats) {
+        auto key = extract_hash_join_key(expression_);
+        if (!key) {
+            return false;
+        }
+
+        auto& left_chunks = left_->output()->chunks();
+        auto& right_chunks = right_->output()->chunks();
+        if (!hash_key_columns_available(left_chunks, key->left_path) ||
+            !hash_key_columns_available(right_chunks, key->right_path)) {
+            return false;
+        }
+
+        auto* resource = left_->output()->resource();
+        using hash_table_t =
+            std::unordered_map<types::logical_value_t, std::vector<row_ref_t>, logical_value_hash, logical_value_equal>;
+        hash_table_t hash_table;
+
+        for (const auto& R : right_chunks) {
+            for (uint64_t rj = 0; rj < R.size(); ++rj) {
+                auto build_key = read_hash_key(R, key->right_path, rj);
+                if (!build_key) {
+                    continue;
+                }
+                hash_table[std::move(*build_key)].push_back(row_ref_t{&R, rj});
+                if (stats) {
+                    ++stats->build_rows;
+                }
+            }
+        }
+
+        if (stats) {
+            stats->hash_join = true;
+            stats->hash_table_size = hash_table.size();
+        }
+
+        join_builder builder(resource, out_types, indices_left_, indices_right_, out_chunks);
+        for (const auto& L : left_chunks) {
+            if (stats && L.size() > 0) {
+                ++stats->probe_batches;
+            }
+            for (uint64_t li = 0; li < L.size(); ++li) {
+                if (stats) {
+                    ++stats->probe_rows;
+                }
+                auto probe_key = read_hash_key(L, key->left_path, li);
+                if (!probe_key) {
+                    continue;
+                }
+                auto range = hash_table.find(*probe_key);
+                if (range == hash_table.end()) {
+                    continue;
+                }
+                for (const auto& right_ref : range->second) {
+                    auto passed = predicate->check(L, *right_ref.chunk, li, right_ref.row);
+                    if (passed.has_error()) {
+                        set_error(passed.error());
+                        return true;
+                    }
+                    if (passed.value()) {
+                        if (stats) {
+                            ++stats->matches;
+                        }
+                        builder.emit_matched(L, li, *right_ref.chunk, right_ref.row);
+                    }
+                }
+            }
+        }
+        builder.flush();
+        return true;
+    }
+
     void operator_join_t::outer_full_join_(const predicates::predicate_ptr& predicate,
                                            pipeline::context_t*,
                                            const std::pmr::vector<types::complex_logical_type>& out_types,
-                                           chunks_vector_t& out_chunks) {
+                                           chunks_vector_t& out_chunks,
+                                           stats_t* stats) {
         auto& left_chunks = left_->output()->chunks();
         auto& right_chunks = right_->output()->chunks();
         auto* resource = left_->output()->resource();
@@ -143,6 +374,10 @@ namespace components::operators {
                     if (R.size() == 0) {
                         continue;
                     }
+                    if (stats) {
+                        ++stats->probe_batches;
+                        stats->probe_rows += R.size();
+                    }
                     auto results = predicates::batch_check_1vN(predicate, L, R, li, R.size());
                     if (results.has_error()) {
                         set_error(results.error());
@@ -151,6 +386,9 @@ namespace components::operators {
                     const auto& mask = results.value();
                     for (uint64_t rj = 0; rj < R.size(); ++rj) {
                         if (mask[rj]) {
+                            if (stats) {
+                                ++stats->matches;
+                            }
                             any_match = true;
                             visited_right[ci_r][rj] = true;
                             builder.emit_matched(L, li, R, rj);
@@ -178,7 +416,8 @@ namespace components::operators {
     void operator_join_t::outer_left_join_(const predicates::predicate_ptr& predicate,
                                            pipeline::context_t*,
                                            const std::pmr::vector<types::complex_logical_type>& out_types,
-                                           chunks_vector_t& out_chunks) {
+                                           chunks_vector_t& out_chunks,
+                                           stats_t* stats) {
         auto& left_chunks = left_->output()->chunks();
         auto& right_chunks = right_->output()->chunks();
         auto* resource = left_->output()->resource();
@@ -191,6 +430,10 @@ namespace components::operators {
                     if (R.size() == 0) {
                         continue;
                     }
+                    if (stats) {
+                        ++stats->probe_batches;
+                        stats->probe_rows += R.size();
+                    }
                     auto results = predicates::batch_check_1vN(predicate, L, R, li, R.size());
                     if (results.has_error()) {
                         set_error(results.error());
@@ -199,6 +442,9 @@ namespace components::operators {
                     const auto& mask = results.value();
                     for (uint64_t rj = 0; rj < R.size(); ++rj) {
                         if (mask[rj]) {
+                            if (stats) {
+                                ++stats->matches;
+                            }
                             any_match = true;
                             builder.emit_matched(L, li, R, rj);
                         }
@@ -215,7 +461,8 @@ namespace components::operators {
     void operator_join_t::outer_right_join_(const predicates::predicate_ptr& predicate,
                                             pipeline::context_t*,
                                             const std::pmr::vector<types::complex_logical_type>& out_types,
-                                            chunks_vector_t& out_chunks) {
+                                            chunks_vector_t& out_chunks,
+                                            stats_t* stats) {
         auto& left_chunks = left_->output()->chunks();
         auto& right_chunks = right_->output()->chunks();
         auto* resource = left_->output()->resource();
@@ -228,6 +475,10 @@ namespace components::operators {
                     if (L.size() == 0) {
                         continue;
                     }
+                    if (stats) {
+                        ++stats->probe_batches;
+                        stats->probe_rows += L.size();
+                    }
                     auto results = predicates::batch_check_Nv1(predicate, L, R, L.size(), rj);
                     if (results.has_error()) {
                         set_error(results.error());
@@ -236,6 +487,9 @@ namespace components::operators {
                     const auto& mask = results.value();
                     for (uint64_t li = 0; li < L.size(); ++li) {
                         if (mask[li]) {
+                            if (stats) {
+                                ++stats->matches;
+                            }
                             any_match = true;
                             builder.emit_matched(L, li, R, rj);
                         }
@@ -251,7 +505,8 @@ namespace components::operators {
 
     void operator_join_t::cross_join_(pipeline::context_t*,
                                       const std::pmr::vector<types::complex_logical_type>& out_types,
-                                      chunks_vector_t& out_chunks) {
+                                      chunks_vector_t& out_chunks,
+                                      stats_t* stats) {
         auto& left_chunks = left_->output()->chunks();
         auto& right_chunks = right_->output()->chunks();
         auto* resource = left_->output()->resource();
@@ -260,7 +515,14 @@ namespace components::operators {
         for (const auto& L : left_chunks) {
             for (uint64_t li = 0; li < L.size(); ++li) {
                 for (const auto& R : right_chunks) {
+                    if (stats) {
+                        ++stats->probe_batches;
+                        stats->probe_rows += R.size();
+                    }
                     for (uint64_t rj = 0; rj < R.size(); ++rj) {
+                        if (stats) {
+                            ++stats->matches;
+                        }
                         builder.emit_matched(L, li, R, rj);
                     }
                 }

--- a/components/physical_plan/operators/operator_join.hpp
+++ b/components/physical_plan/operators/operator_join.hpp
@@ -24,26 +24,44 @@ namespace components::operators {
         std::vector<size_t> indices_left_;
         std::vector<size_t> indices_right_;
 
+        struct stats_t {
+            bool hash_join = false;
+            uint64_t build_rows = 0;
+            uint64_t hash_table_size = 0;
+            uint64_t probe_batches = 0;
+            uint64_t probe_rows = 0;
+            uint64_t matches = 0;
+        };
+
         void on_execute_impl(pipeline::context_t* context) override;
         void inner_join_(const predicates::predicate_ptr&,
                          pipeline::context_t* context,
                          const std::pmr::vector<types::complex_logical_type>& out_types,
-                         chunks_vector_t& out_chunks);
+                         chunks_vector_t& out_chunks,
+                         stats_t* stats);
+        bool inner_hash_join_(const predicates::predicate_ptr&,
+                              const std::pmr::vector<types::complex_logical_type>& out_types,
+                              chunks_vector_t& out_chunks,
+                              stats_t* stats);
         void outer_full_join_(const predicates::predicate_ptr&,
                               pipeline::context_t* context,
                               const std::pmr::vector<types::complex_logical_type>& out_types,
-                              chunks_vector_t& out_chunks);
+                              chunks_vector_t& out_chunks,
+                              stats_t* stats);
         void outer_left_join_(const predicates::predicate_ptr&,
                               pipeline::context_t* context,
                               const std::pmr::vector<types::complex_logical_type>& out_types,
-                              chunks_vector_t& out_chunks);
+                              chunks_vector_t& out_chunks,
+                              stats_t* stats);
         void outer_right_join_(const predicates::predicate_ptr&,
                                pipeline::context_t* context,
                                const std::pmr::vector<types::complex_logical_type>& out_types,
-                               chunks_vector_t& out_chunks);
+                               chunks_vector_t& out_chunks,
+                               stats_t* stats);
         void cross_join_(pipeline::context_t* context,
                          const std::pmr::vector<types::complex_logical_type>& out_types,
-                         chunks_vector_t& out_chunks);
+                         chunks_vector_t& out_chunks,
+                         stats_t* stats);
     };
 
 } // namespace components::operators

--- a/components/physical_plan/operators/operator_register_udf.cpp
+++ b/components/physical_plan/operators/operator_register_udf.cpp
@@ -87,6 +87,17 @@ namespace components::operators {
         //    plan's function_uid() set from global matches no local entry and the
         //    predicate gets a null function pointer at runtime.
         if (auto* def_reg = components::compute::function_registry_t::get_default()) {
+            // The default registry is a process-wide singleton, so an earlier
+            // registration of this name may sit at a stale uid that no current
+            // per-executor registry knows. Drop any same-name entry whose uid we
+            // aren't about to (re)write so name lookups stay deterministic.
+            if (!uids.empty()) {
+                for (const auto& [existing_name, existing_uid] : def_reg->get_functions()) {
+                    if (existing_name == func_name && existing_uid != uids.front()) {
+                        def_reg->remove_function(existing_uid);
+                    }
+                }
+            }
             auto res = uids.empty() ? def_reg->add_function(function_->get_copy(resource_))
                                     : def_reg->add_function_with_uid(uids.front(), function_->get_copy(resource_));
             if (res.has_error()) {

--- a/components/physical_plan/operators/operator_resolve_table.cpp
+++ b/components/physical_plan/operators/operator_resolve_table.cpp
@@ -152,7 +152,7 @@ namespace components::operators {
 
         // read pg_class by oid to determine relkind and relnamespace.
         // pg_class layout: [0=oid, 1=relname, 2=relnamespace, 3=relkind,
-        // 4=relstoragemode]. We key by "oid" so we get a single row at most.
+        // 4=relstoragemode, 5=relstorageformat]. We key by "oid" so we get a single row at most.
         {
             types::logical_value_t toid_lv(resource_, table_oid_);
             std::pmr::vector<std::string> pc_keys(resource_);
@@ -468,14 +468,6 @@ namespace components::operators {
         // operator output chunk; decoded type derived from atttypspec or
         // atttypid via the existing catalog helpers.
         if (target_node_) {
-            std::fprintf(stderr,
-                         "[RT] populate md table_oid=%u ns_oid=%u relkind='%c' rows=%zu relname='%s'\n",
-                         static_cast<unsigned>(table_oid_),
-                         static_cast<unsigned>(namespace_oid_),
-                         relkind_ ? relkind_ : '?',
-                         rows.size(),
-                         relname_.c_str());
-            std::fflush(stderr);
             components::logical_plan::resolved_table_metadata_t md;
             md.table_oid = table_oid_;
             md.namespace_oid = namespace_oid_;

--- a/components/physical_plan/operators/operator_select.cpp
+++ b/components/physical_plan/operators/operator_select.cpp
@@ -2,6 +2,7 @@
 
 #include "arithmetic_eval.hpp"
 #include <components/expressions/compare_expression.hpp>
+#include <components/physical_plan/operators/predicates/utils.hpp>
 
 namespace components::operators {
 
@@ -161,6 +162,10 @@ namespace components::operators {
                                                                      vector::data_chunk_t* right_input) {
         const auto num_rows = input->size();
         const uint64_t cap = num_rows > 0 ? num_rows : 1;
+        // Function-kind projection columns evaluate against the process-global
+        // function registry (the RETURNING / select callers do not thread a
+        // per-pipeline registry through evaluate_projection's contract).
+        const auto* function_registry = compute::function_registry_t::get_default();
 
         // Assemble the output chunk directly: one column per projection entry
         // (star_expand fans out to one per input column). Columns are pushed
@@ -209,6 +214,43 @@ namespace components::operators {
                         vec.set_value(row, col.constant_value);
                     }
                     vec.set_type_alias(std::string{col.key.name});
+                    result.data.push_back(std::move(vec));
+                    break;
+                }
+                case select_column_t::kind::function: {
+                    if (!col.function_expr || !function_registry) {
+                        return core::error_t(core::error_code_t::unrecognized_function,
+                                             std::pmr::string{"function expression is not resolved", resource});
+                    }
+
+                    auto getter = predicates::impl::create_value_getter(resource,
+                                                                        function_registry,
+                                                                        col.function_expr,
+                                                                        &parameters);
+                    // A right-side key reads from right_input; the merged JOIN chunk
+                    // is passed as both, so a getter over either side resolves.
+                    const vector::data_chunk_t& right_src = right_input ? *right_input : *input;
+                    types::complex_logical_type col_type{types::logical_type::NA};
+                    std::pmr::vector<types::logical_value_t> values(resource);
+                    values.reserve(num_rows);
+                    for (uint64_t row = 0; row < num_rows; ++row) {
+                        auto value = getter(*input, right_src, row, row);
+                        if (value.has_error()) {
+                            return value.error();
+                        }
+                        auto val = std::move(value.value());
+                        if (col_type.type() == types::logical_type::NA) {
+                            col_type = val.type();
+                        }
+                        values.push_back(std::move(val));
+                    }
+
+                    vector::vector_t vec(resource, col_type, cap);
+                    for (uint64_t row = 0; row < num_rows; ++row) {
+                        vec.set_value(row, values[row]);
+                    }
+                    vec.set_type_alias(col.function_expr->result_alias().empty() ? col.function_expr->name()
+                                                                                  : col.function_expr->result_alias());
                     result.data.push_back(std::move(vec));
                     break;
                 }

--- a/components/physical_plan/operators/operator_select.hpp
+++ b/components/physical_plan/operators/operator_select.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <components/expressions/function_expression.hpp>
 #include <components/physical_plan/operators/operator.hpp>
 #include <components/physical_plan/operators/operator_group.hpp>
 
@@ -14,6 +15,7 @@ namespace components::operators {
             case_when,  // CASE WHEN ... END                   — uses group_key_t::kind::case_when
             arithmetic, // add/subtract/multiply/divide/...    — uses arith_op + operands
             constant,   // literal constant                    — uses constant_value
+            function,   // row/vector function call
             star_expand // SELECT * — copy all columns from input chunk as-is
         };
 
@@ -30,6 +32,9 @@ namespace components::operators {
 
         // Used for constant.
         types::logical_value_t constant_value;
+
+        // Used for function.
+        expressions::function_expression_ptr function_expr;
 
         explicit select_column_t(std::pmr::memory_resource* r)
             : key(r)

--- a/components/physical_plan/operators/operator_update.cpp
+++ b/components/physical_plan/operators/operator_update.cpp
@@ -8,6 +8,9 @@
 #include <services/index/manager_index.hpp>
 #include <services/wal/manager_wal_replicate.hpp>
 
+#include <algorithm>
+#include <unordered_map>
+
 namespace components::operators {
 
     operator_update::operator_update(std::pmr::memory_resource* resource,
@@ -34,6 +37,197 @@ namespace components::operators {
     }
 
     namespace {
+        bool is_unprojected_placeholder(const vector::vector_t& vector) noexcept {
+            return vector.data() == nullptr && vector.auxiliary() == nullptr;
+        }
+
+        std::vector<size_t> materialized_columns(const vector::data_chunk_t& chunk) {
+            std::vector<size_t> result;
+            result.reserve(chunk.column_count());
+            for (size_t column = 0; column < chunk.column_count(); column++) {
+                if (!is_unprojected_placeholder(chunk.data[column])) {
+                    result.push_back(column);
+                }
+            }
+            return result;
+        }
+
+        void append_unique_column(std::vector<size_t>& columns, size_t column_index) {
+            if (std::find(columns.begin(), columns.end(), column_index) == columns.end()) {
+                columns.push_back(column_index);
+            }
+        }
+
+        bool has_unprojected_placeholders(const vector::data_chunk_t& chunk) {
+            for (const auto& column : chunk.data) {
+                if (is_unprojected_placeholder(column)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        bool has_unprojected_placeholders(const chunks_vector_t& chunks) {
+            for (const auto& chunk : chunks) {
+                if (has_unprojected_placeholders(chunk)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        vector::data_chunk_t combine_update_chunks(std::pmr::memory_resource* resource,
+                                                   const chunks_vector_t& chunks,
+                                                   const std::vector<size_t>& projected_cols) {
+            if (chunks.empty()) {
+                std::pmr::vector<types::complex_logical_type> empty_types(resource);
+                return vector::data_chunk_t(resource, empty_types, 0);
+            }
+
+            uint64_t total_count = 0;
+            for (const auto& chunk : chunks) {
+                total_count += chunk.size();
+            }
+
+            auto types = chunks.front().types();
+            const bool sparse = projected_cols.size() < chunks.front().column_count();
+            vector::data_chunk_t result =
+                sparse ? vector::data_chunk_t(resource, types, projected_cols, total_count == 0 ? 1 : total_count)
+                       : vector::data_chunk_t(resource, types, total_count == 0 ? 1 : total_count);
+
+            uint64_t offset = 0;
+            for (const auto& chunk : chunks) {
+                if (chunk.size() == 0) {
+                    continue;
+                }
+                for (const auto column : projected_cols) {
+                    vector::vector_ops::copy(chunk.data[column], result.data[column], chunk.size(), 0, offset);
+                }
+                vector::vector_ops::copy(chunk.row_ids, result.row_ids, chunk.size(), 0, offset);
+                offset += chunk.size();
+            }
+            result.set_cardinality(total_count);
+            return result;
+        }
+
+        vector::data_chunk_t combine_update_chunks(std::pmr::memory_resource* resource, const chunks_vector_t& chunks) {
+            if (chunks.empty()) {
+                std::pmr::vector<types::complex_logical_type> empty_types(resource);
+                return vector::data_chunk_t(resource, empty_types, 0);
+            }
+            return combine_update_chunks(resource, chunks, materialized_columns(chunks.front()));
+        }
+
+        void copy_materialized_columns_by_row_id(const vector::data_chunk_t& source,
+                                                 vector::data_chunk_t& target,
+                                                 const std::vector<size_t>& projected_cols) {
+            std::unordered_map<int64_t, uint64_t> source_offsets;
+            source_offsets.reserve(source.size());
+            const auto* source_row_ids = source.row_ids.data<int64_t>();
+            for (uint64_t row = 0; row < source.size(); row++) {
+                source_offsets.emplace(source_row_ids[row], row);
+            }
+
+            const auto* target_row_ids = target.row_ids.data<int64_t>();
+            for (uint64_t row = 0; row < target.size(); row++) {
+                const auto found = source_offsets.find(target_row_ids[row]);
+                if (found == source_offsets.end()) {
+                    continue;
+                }
+                const auto source_row = found->second;
+                for (const auto column : projected_cols) {
+                    if (column >= source.column_count() || column >= target.column_count() ||
+                        is_unprojected_placeholder(source.data[column])) {
+                        continue;
+                    }
+                    vector::vector_ops::copy(source.data[column], target.data[column], source_row + 1, source_row, row);
+                }
+            }
+        }
+
+        void collect_update_target_paths(const expressions::update_expr_ptr& expression,
+                                         std::vector<std::vector<uint64_t>>& target_paths) {
+            if (!expression) {
+                return;
+            }
+            if (expression->type() == expressions::update_expr_type::set) {
+                const auto* set_expr = dynamic_cast<const expressions::update_expr_set_t*>(expression.get());
+                if (!set_expr || set_expr->key().path().empty()) {
+                    return;
+                }
+                std::vector<uint64_t> path{static_cast<uint64_t>(set_expr->key().path().front())};
+                if (std::find(target_paths.begin(), target_paths.end(), path) == target_paths.end()) {
+                    target_paths.emplace_back(std::move(path));
+                }
+                return;
+            }
+            collect_update_target_paths(expression->left(), target_paths);
+            collect_update_target_paths(expression->right(), target_paths);
+        }
+
+        std::vector<std::vector<uint64_t>>
+        collect_update_target_paths(const std::pmr::vector<expressions::update_expr_ptr>& updates) {
+            std::vector<std::vector<uint64_t>> target_paths;
+            for (const auto& update : updates) {
+                collect_update_target_paths(update, target_paths);
+            }
+            return target_paths;
+        }
+
+        void collect_update_source_columns(const expressions::update_expr_ptr& expression,
+                                           std::vector<size_t>& source_columns,
+                                           size_t column_count) {
+            if (!expression) {
+                return;
+            }
+
+            if (expression->type() == expressions::update_expr_type::set) {
+                const auto* set_expr = dynamic_cast<const expressions::update_expr_set_t*>(expression.get());
+                if (set_expr && set_expr->key().path().size() > 1) {
+                    const auto column = set_expr->key().path().front();
+                    if (column < column_count) {
+                        append_unique_column(source_columns, static_cast<size_t>(column));
+                    }
+                }
+            } else if (expression->type() == expressions::update_expr_type::get_value) {
+                const auto* get_expr = dynamic_cast<const expressions::update_expr_get_value_t*>(expression.get());
+                if (get_expr && !get_expr->key().path().empty()) {
+                    const auto column = get_expr->key().path().front();
+                    if (column < column_count) {
+                        append_unique_column(source_columns, static_cast<size_t>(column));
+                    }
+                }
+            }
+
+            collect_update_source_columns(expression->left(), source_columns, column_count);
+            collect_update_source_columns(expression->right(), source_columns, column_count);
+        }
+
+        std::vector<size_t> update_source_columns(const std::pmr::vector<expressions::update_expr_ptr>& updates,
+                                                  size_t column_count) {
+            std::vector<size_t> columns;
+            for (const auto& update : updates) {
+                collect_update_source_columns(update, columns, column_count);
+            }
+            std::sort(columns.begin(), columns.end());
+            columns.erase(std::unique(columns.begin(), columns.end()), columns.end());
+            return columns;
+        }
+
+        std::vector<size_t> writable_update_columns(const std::vector<size_t>& source_columns,
+                                                    const std::pmr::vector<expressions::update_expr_ptr>& updates,
+                                                    size_t column_count) {
+            auto columns = source_columns;
+            for (const auto& path : collect_update_target_paths(updates)) {
+                if (!path.empty() && path.front() < column_count) {
+                    append_unique_column(columns, static_cast<size_t>(path.front()));
+                }
+            }
+            std::sort(columns.begin(), columns.end());
+            columns.erase(std::unique(columns.begin(), columns.end()), columns.end());
+            return columns;
+        }
+
         // Applies all update expressions to out_chunk[0..match_count) and
         // populates modified_/no_modified_ lists.
         void apply_updates(std::pmr::memory_resource* resource,
@@ -216,7 +410,12 @@ namespace components::operators {
                     if (chunk.size() == 0) {
                         continue;
                     }
-                    vector::data_chunk_t out_chunk(resource, types, chunk.size());
+                    const auto source_cols = update_source_columns(updates_, chunk.column_count());
+                    const auto writable_cols = writable_update_columns(source_cols, updates_, chunk.column_count());
+                    const bool sparse = writable_cols.size() < chunk.column_count();
+                    vector::data_chunk_t out_chunk =
+                        sparse ? vector::data_chunk_t(resource, types, writable_cols, chunk.size())
+                               : vector::data_chunk_t(resource, types, chunk.size());
                     size_t index = 0;
                     for (size_t i = 0; i < chunk.size(); ++i) {
                         auto res = predicate->check(chunk, i);
@@ -227,13 +426,8 @@ namespace components::operators {
                         if (!res.value()) {
                             continue;
                         }
-                        if (chunk.data.front().get_vector_type() == vector::vector_type::DICTIONARY) {
-                            out_chunk.row_ids.data<int64_t>()[index] =
-                                static_cast<int64_t>(chunk.data.front().indexing().get_index(i));
-                        } else {
-                            out_chunk.row_ids.data<int64_t>()[index] = chunk.row_ids.data<int64_t>()[i];
-                        }
-                        for (size_t k = 0; k < chunk.column_count(); ++k) {
+                        out_chunk.row_ids.data<int64_t>()[index] = chunk.row_ids.data<int64_t>()[i];
+                        for (const auto k : source_cols) {
                             vector::vector_ops::copy(chunk.data[k], out_chunk.data[k], i + 1, i, index);
                         }
                         vector::validate_chunk_capacity(out_chunk, ++index);
@@ -273,8 +467,45 @@ namespace components::operators {
             mark_executed();
             co_return;
         }
-        auto& out_chunk = output_->data_chunk();
         components::execution_context_t exec_ctx{ctx->session, ctx->txn, ctx->session_tz, table_oid_};
+
+        const bool projected_update = has_unprojected_placeholders(output_->chunks());
+        std::unique_ptr<data_chunk_t> materialized_update_chunk;
+        std::unique_ptr<data_chunk_t> old_data_for_index;
+
+        if (projected_update) {
+            auto projected_chunk = combine_update_chunks(resource_, output_->chunks());
+            vector_t fetch_row_ids(resource_, types::logical_type::BIGINT, projected_chunk.size());
+            for (uint64_t i = 0; i < projected_chunk.size(); i++) {
+                fetch_row_ids.data<int64_t>()[i] = projected_chunk.row_ids.data<int64_t>()[i];
+            }
+
+            auto [_f, ff] = actor_zeta::send(ctx->disk_address,
+                                             &services::disk::manager_disk_t::storage_fetch,
+                                             ctx->session,
+                                             table_oid_,
+                                             std::move(fetch_row_ids),
+                                             projected_chunk.size(),
+                                             ctx->txn);
+            auto fetched = co_await std::move(ff);
+            if (!fetched) {
+                mark_executed();
+                co_return;
+            }
+
+            old_data_for_index = std::make_unique<data_chunk_t>(resource_, fetched->types(), fetched->size());
+            fetched->copy(*old_data_for_index, 0);
+
+            const auto projected_cols = materialized_columns(projected_chunk);
+            copy_materialized_columns_by_row_id(projected_chunk, *fetched, projected_cols);
+            materialized_update_chunk = std::move(fetched);
+        }
+
+        auto& out_chunk = projected_update ? *materialized_update_chunk : output_->data_chunk();
+        if (out_chunk.size() == 0) {
+            mark_executed();
+            co_return;
+        }
 
         // If a resolver sibling supplied catalog metadata, compute a
         // chunk_position -> table_position translation. See
@@ -337,10 +568,15 @@ namespace components::operators {
 
         // 4. Mirror to index (old + new data).
         if (ctx->index_address != actor_zeta::address_t::empty_address()) {
-            if (auto scan_out = left_ ? left_->output() : nullptr) {
-                auto& sc = scan_out->data_chunk();
-                auto old_data = std::make_unique<data_chunk_t>(resource_, sc.types(), sc.size());
-                sc.copy(*old_data, 0);
+            if (old_data_for_index || (left_ && left_->output())) {
+                std::unique_ptr<data_chunk_t> old_data;
+                if (old_data_for_index) {
+                    old_data = std::move(old_data_for_index);
+                } else {
+                    auto& sc = left_->output()->data_chunk();
+                    old_data = std::make_unique<data_chunk_t>(resource_, sc.types(), sc.size());
+                    sc.copy(*old_data, 0);
+                }
                 auto new_data = std::make_unique<data_chunk_t>(resource_, out_chunk.types(), out_chunk.size());
                 out_chunk.copy(*new_data, 0);
                 auto idx_ids = std::pmr::vector<int64_t>(resource_);

--- a/components/physical_plan/operators/operator_vacuum.cpp
+++ b/components/physical_plan/operators/operator_vacuum.cpp
@@ -99,7 +99,7 @@ namespace components::operators {
         std::vector<catalog::oid_t> computing_table_oids;
 
         for (std::uint64_t i = 0; i < pg_class_rows->size(); ++i) {
-            // pg_class columns: 0=oid, 1=relname, 2=relnamespace, 3=relkind, 4=relstoragemode
+            // pg_class columns: 0=oid, 1=relname, 2=relnamespace, 3=relkind, 4=relstoragemode, 5=relstorageformat
             auto rk_v = pg_class_rows->value(3, i);
             const auto rkv = rk_v.is_null() ? std::string_view{"r"} : rk_v.value<std::string_view>();
             const char relkind = rkv.empty() ? catalog::relkind::regular : rkv[0];

--- a/components/physical_plan/operators/scan/full_scan.cpp
+++ b/components/physical_plan/operators/scan/full_scan.cpp
@@ -10,6 +10,9 @@ namespace components::operators {
                         const std::pmr::vector<types::complex_logical_type>& types,
                         const logical_plan::storage_parameters* parameters,
                         core::date::timezone_offset_t session_tz) {
+        // The filter is destroyed on the disk thread, so allocate its storage from a
+        // thread-safe resource rather than the executor-local arena.
+        auto* filter_resource = std::pmr::new_delete_resource();
         if (!expression || expression->type() == expressions::compare_type::all_true) {
             return std::unique_ptr<table::table_filter_t>{};
         }
@@ -126,7 +129,7 @@ namespace components::operators {
             case expressions::compare_type::is_null:
             case expressions::compare_type::is_not_null: {
                 const auto& path = std::get<expressions::key_t>(expression->left()).path();
-                std::pmr::vector<uint64_t> indices(path.begin(), path.end(), path.get_allocator().resource());
+                std::pmr::vector<uint64_t> indices(path.begin(), path.end(), filter_resource);
                 return std::unique_ptr<table::table_filter_t>(
                     std::make_unique<table::is_null_filter_t>(expression->type(), std::move(indices)));
             }
@@ -134,7 +137,7 @@ namespace components::operators {
                 assert(std::holds_alternative<expressions::key_t>(expression->left()));
                 const auto& path = std::get<expressions::key_t>(expression->left()).path();
                 auto id = std::get<core::parameter_id_t>(expression->right());
-                std::pmr::vector<uint64_t> indices(path.begin(), path.end(), path.get_allocator().resource());
+                std::pmr::vector<uint64_t> indices(path.begin(), path.end(), filter_resource);
                 auto it = parameters->parameters.find(id);
                 if (it == parameters->parameters.end()) {
                     return core::error_t{
@@ -159,7 +162,7 @@ namespace components::operators {
                     // Storage holds the ordinal as int32 (ENUM physical_type=INT32).
                     // constant_filter_t's compare path doesn't auto-coerce ENUM<->INT32,
                     // so wrap the ordinal as a plain INT32 logical_value_t.
-                    types::logical_value_t ordinal_val{resource, coerced.value<int32_t>()};
+                    types::logical_value_t ordinal_val{filter_resource, coerced.value<int32_t>()};
                     return std::unique_ptr<table::table_filter_t>(
                         std::make_unique<table::constant_filter_t>(expression->type(),
                                                                    std::move(ordinal_val),
@@ -168,14 +171,18 @@ namespace components::operators {
                 if (!param_value.is_null() && param_value.type() != col_type) {
                     auto coerced = param_value.cast_as(col_type, session_tz);
                     if (!coerced.is_null()) {
+                        types::logical_value_t filter_value{filter_resource, coerced};
                         return std::unique_ptr<table::table_filter_t>(
                             std::make_unique<table::constant_filter_t>(expression->type(),
-                                                                       std::move(coerced),
+                                                                       std::move(filter_value),
                                                                        std::move(indices)));
                     }
                 }
+                types::logical_value_t filter_value{filter_resource, it->second};
                 return std::unique_ptr<table::table_filter_t>(
-                    std::make_unique<table::constant_filter_t>(expression->type(), it->second, std::move(indices)));
+                    std::make_unique<table::constant_filter_t>(expression->type(),
+                                                               std::move(filter_value),
+                                                               std::move(indices)));
             }
         }
     }
@@ -185,12 +192,14 @@ namespace components::operators {
                          components::catalog::oid_t table_oid,
                          const expressions::compare_expression_ptr& expression,
                          logical_plan::limit_t limit,
-                         std::vector<size_t> projected_cols)
+                         std::vector<size_t> projected_cols,
+                         bool row_ids_only)
         : read_only_operator_t(resource, log, operator_type::full_scan)
         , table_oid_(table_oid)
         , expression_(expression)
         , limit_(limit)
-        , projected_cols_(std::move(projected_cols)) {}
+        , projected_cols_(std::move(projected_cols))
+        , row_ids_only_(row_ids_only) {}
 
     void full_scan::on_execute_impl(pipeline::context_t* /*pipeline_context*/) {
         if (table_oid_ == components::catalog::INVALID_OID)
@@ -199,10 +208,6 @@ namespace components::operators {
     }
 
     actor_zeta::unique_future<void> full_scan::await_async_and_resume(pipeline::context_t* ctx) {
-        if (log_.is_valid()) {
-            trace(log(), "full_scan::await_async_and_resume on oid={}", static_cast<unsigned>(table_oid_));
-        }
-
         // Short-circuit: if expression is all_false, return empty result immediately
         if (expression_ && expression_->type() == expressions::compare_type::all_false) {
             output_ = make_operator_data(resource_, std::pmr::vector<types::complex_logical_type>{resource_});
@@ -253,6 +258,10 @@ namespace components::operators {
         int64_t offset_val = limit_.offset();
         int64_t limit_val = limit_.limit();
         int64_t scan_limit = (limit_val < 0) ? limit_val : limit_val + offset_val;
+        // The MVCC delete path needs full column payloads, so the row-ids-only scan
+        // stays off here. row_ids_only_ is kept on the wiring but ignored at scan time.
+        const bool row_ids_only = false;
+        (void) row_ids_only_;
         auto [_s, sf] = actor_zeta::send(ctx->disk_address,
                                          &services::disk::manager_disk_t::storage_scan_batched,
                                          ctx->session,
@@ -260,8 +269,13 @@ namespace components::operators {
                                          std::move(filter),
                                          scan_limit,
                                          projected_cols_,
+                                         row_ids_only,
                                          ctx->txn);
-        auto batches = co_await std::move(sf);
+        auto batches_ptr = co_await std::move(sf);
+        std::pmr::vector<vector::data_chunk_t> batches(resource_);
+        if (batches_ptr) {
+            batches = std::move(*batches_ptr);
+        }
 
         // Skip offset rows across batches.
         if (offset_val > 0) {
@@ -286,21 +300,14 @@ namespace components::operators {
         // chunk. storage_scan_batched can return an empty vector at SSB-scale when
         // the disk service get_storage(table_oid) hits an oid-resolution race with
         // CSV ingest commit. Without this guard, operator_join.cpp:125 asserts.
-        // Schema is taken from the projected scan signature so OUTER joins can
-        // still emit NULL-padded rows from the non-empty side.
+        // Keep the sparse projected shape: downstream expressions index by storage
+        // column, and cursor_t compacts the placeholders.
         if (batches.empty()) {
-            std::pmr::vector<types::complex_logical_type> projected_types(resource_);
             if (projected_cols_.empty()) {
-                projected_types = types;
+                batches.emplace_back(resource_, types, 0);
             } else {
-                projected_types.reserve(projected_cols_.size());
-                for (auto idx : projected_cols_) {
-                    if (idx < types.size()) {
-                        projected_types.push_back(types[idx]);
-                    }
-                }
+                batches.emplace_back(resource_, types, projected_cols_, 0);
             }
-            batches.emplace_back(resource_, projected_types, 0);
         }
 
         output_ = make_operator_data(resource_, std::move(batches));

--- a/components/physical_plan/operators/scan/full_scan.hpp
+++ b/components/physical_plan/operators/scan/full_scan.hpp
@@ -22,7 +22,8 @@ namespace components::operators {
                   components::catalog::oid_t table_oid,
                   const expressions::compare_expression_ptr& expression,
                   logical_plan::limit_t limit,
-                  std::vector<size_t> projected_cols = {});
+                  std::vector<size_t> projected_cols = {},
+                  bool row_ids_only = false);
 
         components::catalog::oid_t table_oid() const noexcept { return table_oid_; }
         const expressions::compare_expression_ptr& expression() const { return expression_; }
@@ -37,6 +38,7 @@ namespace components::operators {
         expressions::compare_expression_ptr expression_;
         const logical_plan::limit_t limit_;
         std::vector<size_t> projected_cols_;
+        bool row_ids_only_;
     };
 
 } // namespace components::operators

--- a/components/physical_plan/operators/scan/index_scan.cpp
+++ b/components/physical_plan/operators/scan/index_scan.cpp
@@ -1,9 +1,37 @@
 #include "index_scan.hpp"
 
+#include <components/vector/indexing_vector.hpp>
 #include <services/disk/manager_disk.hpp>
 #include <services/index/manager_index.hpp>
 
 namespace components::operators {
+
+    namespace {
+        bool compare_values(expressions::compare_type compare_type,
+                            const types::logical_value_t& left,
+                            const types::logical_value_t& right) {
+            if (left.is_null() || right.is_null()) {
+                return false;
+            }
+
+            switch (compare_type) {
+                case expressions::compare_type::eq:
+                    return left == right;
+                case expressions::compare_type::ne:
+                    return left != right;
+                case expressions::compare_type::lt:
+                    return left < right;
+                case expressions::compare_type::lte:
+                    return left <= right;
+                case expressions::compare_type::gt:
+                    return left > right;
+                case expressions::compare_type::gte:
+                    return left >= right;
+                default:
+                    return false;
+            }
+        }
+    } // namespace
 
     index_scan::index_scan(std::pmr::memory_resource* resource,
                            log_t log,
@@ -92,10 +120,27 @@ namespace components::operators {
                                              ctx->session,
                                              table_oid_,
                                              std::move(row_ids),
-                                             count);
+                                             count,
+                                             ctx->txn);
             auto data = co_await std::move(ff);
 
             if (data) {
+                auto column_index = data->column_index(key_.as_string());
+                // logical_value_t comparison asserts matching types, so cast the probe
+                // value to the column type before re-filtering.
+                const auto casted_value = value_.cast_as(data->data[column_index].type(), ctx->session_tz);
+                vector::indexing_vector_t matched(resource_, data->size());
+                uint64_t matched_count = 0;
+
+                for (uint64_t i = 0; i < data->size(); i++) {
+                    if (compare_values(compare_type_, data->value(column_index, i), casted_value)) {
+                        matched.set_index(matched_count++, i);
+                    }
+                }
+
+                if (matched_count < data->size()) {
+                    data->slice(matched, matched_count);
+                }
                 output_ = make_operator_data(resource_, split_chunk_into_batches(resource_, std::move(*data)));
             } else {
                 auto [_t2, tf2] = actor_zeta::send(ctx->disk_address,

--- a/components/physical_plan/operators/scan/primary_key_scan.cpp
+++ b/components/physical_plan/operators/scan/primary_key_scan.cpp
@@ -32,7 +32,8 @@ namespace components::operators {
                                              ctx->session,
                                              table_oid_,
                                              std::move(row_ids_copy),
-                                             size_);
+                                             size_,
+                                             ctx->txn);
             auto data = co_await std::move(ff);
 
             if (data) {

--- a/components/physical_plan/operators/scan/transfer_scan.cpp
+++ b/components/physical_plan/operators/scan/transfer_scan.cpp
@@ -35,8 +35,13 @@ namespace components::operators {
                                          std::unique_ptr<table::table_filter_t>(nullptr),
                                          scan_limit,
                                          projected_cols_,
+                                         false,
                                          ctx->txn);
-        auto batches = co_await std::move(sf);
+        auto batches_ptr = co_await std::move(sf);
+        std::pmr::vector<vector::data_chunk_t> batches(resource_);
+        if (batches_ptr) {
+            batches = std::move(*batches_ptr);
+        }
 
         // Skip offset rows across batches. Partial-copy the boundary batch.
         if (offset_val > 0) {
@@ -62,25 +67,19 @@ namespace components::operators {
         // service get_storage(table_oid) hits an oid-resolution race (observed
         // at SSB-scale on comma-join cross-products). Without this guard,
         // operator_join.cpp:125 asserts. Fetch types only on the empty path so
-        // the steady-state scan keeps a single async round-trip.
+        // the steady-state scan keeps a single async round-trip. Keep the
+        // projected shape here so downstream column indices still match storage.
         if (batches.empty()) {
             auto [_t, tf] = actor_zeta::send(ctx->disk_address,
                                              &services::disk::manager_disk_t::storage_types,
                                              ctx->session,
                                              table_oid_);
             auto tbl_types = co_await std::move(tf);
-            std::pmr::vector<types::complex_logical_type> projected_types(resource_);
             if (projected_cols_.empty()) {
-                projected_types = tbl_types;
+                batches.emplace_back(resource_, tbl_types, 0);
             } else {
-                projected_types.reserve(projected_cols_.size());
-                for (auto idx : projected_cols_) {
-                    if (idx < tbl_types.size()) {
-                        projected_types.push_back(tbl_types[idx]);
-                    }
-                }
+                batches.emplace_back(resource_, tbl_types, projected_cols_, 0);
             }
-            batches.emplace_back(resource_, projected_types, 0);
         }
 
         output_ = make_operator_data(resource_, std::move(batches));

--- a/components/physical_plan_generator/impl/create_plan_delete.cpp
+++ b/components/physical_plan_generator/impl/create_plan_delete.cpp
@@ -7,9 +7,82 @@
 #include <components/physical_plan/operators/operator_delete.hpp>
 #include <components/physical_plan/operators/scan/full_scan.hpp>
 
+#include <algorithm>
+#include <limits>
+
 #include "create_plan_data.hpp"
 
 namespace services::planner::impl {
+
+    namespace {
+
+        void append_unique_projected_col(std::vector<size_t>& projected_cols, size_t column_index) {
+            if (column_index == std::numeric_limits<size_t>::max()) {
+                return;
+            }
+            if (std::find(projected_cols.begin(), projected_cols.end(), column_index) == projected_cols.end()) {
+                projected_cols.push_back(column_index);
+            }
+        }
+
+        void collect_delete_scan_projection_from_expression(const components::expressions::expression_ptr& expression,
+                                                            std::vector<size_t>& projected_cols);
+
+        void collect_delete_scan_projection_from_param(const components::expressions::param_storage& param,
+                                                       std::vector<size_t>& projected_cols) {
+            using components::expressions::expression_ptr;
+            using components::expressions::key_t;
+
+            if (std::holds_alternative<key_t>(param)) {
+                const auto& key = std::get<key_t>(param);
+                if (!key.path().empty()) {
+                    append_unique_projected_col(projected_cols, key.path().front());
+                }
+                return;
+            }
+            if (std::holds_alternative<expression_ptr>(param)) {
+                collect_delete_scan_projection_from_expression(std::get<expression_ptr>(param), projected_cols);
+            }
+        }
+
+        void collect_delete_scan_projection_from_expression(const components::expressions::expression_ptr& expression,
+                                                            std::vector<size_t>& projected_cols) {
+            if (!expression || expression->group() != components::expressions::expression_group::compare) {
+                return;
+            }
+
+            const auto* compare = static_cast<const components::expressions::compare_expression_t*>(expression.get());
+            collect_delete_scan_projection_from_param(compare->left(), projected_cols);
+            collect_delete_scan_projection_from_param(compare->right(), projected_cols);
+            for (const auto& child : compare->children()) {
+                collect_delete_scan_projection_from_expression(child, projected_cols);
+            }
+        }
+
+        std::vector<size_t>
+        delete_scan_projection(const context_storage_t& context,
+                               const components::logical_plan::node_delete_t& node_delete,
+                               const components::logical_plan::node_ptr& node_match) {
+            if (!context.indexed_keys.empty() || !node_delete.referencing_fks().empty() || !node_match ||
+                node_match->expressions().empty()) {
+                return {};
+            }
+            // RETURNING needs every returned column materialised; a predicate-only
+            // projected scan leaves non-predicate columns as unprojected placeholders
+            // (null data), which RETURNING then reads as empty / cannot gather across
+            // chunks. Fall back to a full scan (no projection) when RETURNING is present.
+            if (!node_delete.returning().empty()) {
+                return {};
+            }
+
+            std::vector<size_t> projected_cols;
+            collect_delete_scan_projection_from_expression(node_match->expressions().front(), projected_cols);
+            std::sort(projected_cols.begin(), projected_cols.end());
+            projected_cols.erase(std::unique(projected_cols.begin(), projected_cols.end()), projected_cols.end());
+            return projected_cols;
+        }
+
+    } // namespace
 
     components::operators::operator_ptr create_plan_delete(const context_storage_t& context,
                                                            const components::logical_plan::node_ptr& node,
@@ -38,7 +111,10 @@ namespace services::planner::impl {
                                                                                         context.log.clone(),
                                                                                         table_oid,
                                                                                         std::move(returning)));
-            plan->set_children(create_plan_match(context, node_match, limit));
+            auto projected_cols = delete_scan_projection(context, *node_delete, node_match);
+            const bool row_ids_only =
+                context.indexed_keys.empty() && node_delete->referencing_fks().empty() && !projected_cols.empty();
+            plan->set_children(create_plan_match(context, node_match, limit, projected_cols, row_ids_only));
 
             return plan;
         } else {

--- a/components/physical_plan_generator/impl/create_plan_match.cpp
+++ b/components/physical_plan_generator/impl/create_plan_match.cpp
@@ -81,7 +81,10 @@ namespace services::planner::impl {
                 return false;
             }
             auto comp_expr = reinterpret_cast<const compare_expression_ptr&>(expr);
-            if (comp_expr->type() == compare_type::regex) {
+            // regex can't lower to a constant_filter; do_not_fold() marks comparisons whose
+            // RHS comes from a subquery (EXISTS/IN/ANY/ALL, see transform_sublink_expr) — those
+            // are not (column op constant) leaves and must not be pushed into the scan filter.
+            if (comp_expr->type() == compare_type::regex || comp_expr->do_not_fold()) {
                 return false;
             }
             for (const auto& child : comp_expr->children()) {

--- a/components/physical_plan_generator/impl/create_plan_match.cpp
+++ b/components/physical_plan_generator/impl/create_plan_match.cpp
@@ -50,6 +50,8 @@ namespace services::planner::impl {
             if (std::holds_alternative<expr::key_t>(comp.left()) &&
                 std::holds_alternative<core::parameter_id_t>(comp.right())) {
                 const auto& key = std::get<expr::key_t>(comp.left());
+                // A hashed index cannot answer a range predicate; require a non-hashed
+                // index on the key for gt/gte/lt/lte, else fall back to a full scan.
                 const bool range = is_range_compare(comp.type());
                 if (context.has_index_on(key) &&
                     (!range ||
@@ -79,7 +81,7 @@ namespace services::planner::impl {
                 return false;
             }
             auto comp_expr = reinterpret_cast<const compare_expression_ptr&>(expr);
-            if (comp_expr->type() == compare_type::regex || comp_expr->do_not_fold()) {
+            if (comp_expr->type() == compare_type::regex) {
                 return false;
             }
             for (const auto& child : comp_expr->children()) {
@@ -88,10 +90,22 @@ namespace services::planner::impl {
                 }
             }
 
-            // union compare expressions have nullptr in left and right slots
-            if (!is_union_compare_condition(comp_expr->type()) &&
-                (std::holds_alternative<expression_ptr>(comp_expr->left()) ||
-                 std::holds_alternative<expression_ptr>(comp_expr->right()))) {
+            // Union nodes keep their operands in children_, with left_/right_ left null, so the
+            // holds_alternative<expression_ptr> check below would reject them. Only union_and is
+            // pushable (lowers to conjunction_and_filter_t); or/not are not handled yet.
+            if (comp_expr->is_union()) {
+                return comp_expr->type() == compare_type::union_and;
+            }
+
+            if (std::holds_alternative<expression_ptr>(comp_expr->left()) ||
+                std::holds_alternative<expression_ptr>(comp_expr->right())) {
+                return false;
+            }
+            // A pushable leaf must be exactly (column key) op (constant): that's what
+            // transform_predicate lowers to a constant_filter. Reject both-key (a = b) and
+            // no-key (5 = 5) comparisons — neither can be lowered.
+            if (std::holds_alternative<expr::key_t>(comp_expr->left()) ==
+                std::holds_alternative<expr::key_t>(comp_expr->right())) {
                 return false;
             }
             return true;
@@ -101,7 +115,8 @@ namespace services::planner::impl {
                                                                components::catalog::oid_t table_oid,
                                                                const components::expressions::expression_ptr& expr,
                                                                components::logical_plan::limit_t limit,
-                                                               const std::vector<size_t>& projected_cols) {
+                                                               const std::vector<size_t>& projected_cols,
+                                                               bool row_ids_only) {
             if (context.has_table_oid(table_oid)) {
                 // TODO: function_expr in scans
                 if (is_pure_compare(expr)) {
@@ -133,7 +148,8 @@ namespace services::planner::impl {
                                                                                      table_oid,
                                                                                      comp_expr,
                                                                                      limit,
-                                                                                     projected_cols));
+                                                                                     projected_cols,
+                                                                                     row_ids_only));
                 } else {
                     // For now we do a full scan and apply function after
                     auto match_operator =
@@ -166,7 +182,8 @@ namespace services::planner::impl {
     components::operators::operator_ptr create_plan_match(const context_storage_t& context,
                                                           const components::logical_plan::node_ptr& node,
                                                           components::logical_plan::limit_t limit,
-                                                          const std::vector<size_t>& projected_cols) {
+                                                          const std::vector<size_t>& projected_cols,
+                                                          bool row_ids_only) {
         if (node->expressions().empty()) {
             // Build projected_cols (storage chunk indices). For relkind='g' read
             // live columns by their chunk_position (resolved at resolve-table time).
@@ -201,7 +218,8 @@ namespace services::planner::impl {
                                       match_node->table_oid(),
                                       match_node->expressions()[0],
                                       limit,
-                                      projected_cols);
+                                      projected_cols,
+                                      row_ids_only);
         }
     }
 

--- a/components/physical_plan_generator/impl/create_plan_match.hpp
+++ b/components/physical_plan_generator/impl/create_plan_match.hpp
@@ -14,7 +14,8 @@ namespace services::planner::impl {
     components::operators::operator_ptr create_plan_match(const context_storage_t& context,
                                                           const components::logical_plan::node_ptr& node,
                                                           components::logical_plan::limit_t limit,
-                                                          const std::vector<size_t>& projected_cols);
+                                                          const std::vector<size_t>& projected_cols,
+                                                          bool row_ids_only = false);
 
     components::operators::operator_ptr create_plan_having(const context_storage_t& context,
                                                            const components::logical_plan::node_ptr& node,

--- a/components/physical_plan_generator/impl/create_plan_select.cpp
+++ b/components/physical_plan_generator/impl/create_plan_select.cpp
@@ -1,6 +1,7 @@
 #include "create_plan_select.hpp"
 
 #include <components/expressions/aggregate_expression.hpp>
+#include <components/expressions/function_expression.hpp>
 #include <components/expressions/scalar_expression.hpp>
 #include <components/logical_plan/node_select.hpp>
 
@@ -209,11 +210,17 @@ namespace services::planner::impl {
         auto op = boost::intrusive_ptr(new components::operators::operator_select_t(plan_resource, plan_log));
 
         // Aggregates are always handled by operator_group_t upstream; node_select_t only contains
-        // scalar expressions (get_field, arithmetic, constant, star_expand, coalesce, case_when).
+        // scalar expressions (get_field, arithmetic, constant, star_expand, coalesce, case_when)
+        // and scalar row/vector functions.
         for (const auto& expr : node->expressions()) {
             if (expr->group() == expression_group::scalar) {
                 auto* scalar_expr = static_cast<const components::expressions::scalar_expression_t*>(expr.get());
                 op->add_column(make_select_column_scalar(plan_resource, scalar_expr, params));
+            } else if (expr->group() == expression_group::function) {
+                components::operators::select_column_t col(plan_resource);
+                col.type = components::operators::select_column_t::kind::function;
+                col.function_expr = reinterpret_cast<const components::expressions::function_expression_ptr&>(expr);
+                op->add_column(std::move(col));
             }
         }
 

--- a/components/physical_plan_generator/impl/create_plan_sequence.cpp
+++ b/components/physical_plan_generator/impl/create_plan_sequence.cpp
@@ -39,7 +39,7 @@ namespace services::planner::impl {
                                                                         cc->table_oid(),
                                                                         cc->namespace_oid(),
                                                                         cc->column_definitions(),
-                                                                        cc->is_disk_storage(),
+                                                                        cc->storage_format(),
                                                                         std::move(writes)));
         }
 

--- a/components/physical_plan_generator/impl/create_plan_update.cpp
+++ b/components/physical_plan_generator/impl/create_plan_update.cpp
@@ -1,14 +1,137 @@
 #include "create_plan_update.hpp"
 #include "create_plan_match.hpp"
-#include "create_plan_select.hpp"
+#include <components/expressions/compare_expression.hpp>
 #include <components/logical_plan/node_limit.hpp>
 #include <components/logical_plan/node_update.hpp>
 #include <components/physical_plan/operators/operator_update.hpp>
 #include <components/physical_plan/operators/scan/full_scan.hpp>
 
 #include "create_plan_data.hpp"
+#include "create_plan_select.hpp"
+
+#include <algorithm>
+#include <limits>
 
 namespace services::planner::impl {
+
+    namespace {
+
+        void append_unique_projected_col(std::vector<size_t>& projected_cols, size_t column_index) {
+            if (column_index == std::numeric_limits<size_t>::max()) {
+                return;
+            }
+            if (std::find(projected_cols.begin(), projected_cols.end(), column_index) == projected_cols.end()) {
+                projected_cols.push_back(column_index);
+            }
+        }
+
+        void collect_update_scan_projection_from_expression(const components::expressions::expression_ptr& expression,
+                                                            std::vector<size_t>& projected_cols);
+
+        void collect_update_scan_projection_from_param(const components::expressions::param_storage& param,
+                                                       std::vector<size_t>& projected_cols) {
+            using components::expressions::expression_ptr;
+            using components::expressions::key_t;
+
+            if (std::holds_alternative<key_t>(param)) {
+                const auto& key = std::get<key_t>(param);
+                if (!key.path().empty()) {
+                    append_unique_projected_col(projected_cols, key.path().front());
+                }
+                return;
+            }
+            if (std::holds_alternative<expression_ptr>(param)) {
+                collect_update_scan_projection_from_expression(std::get<expression_ptr>(param), projected_cols);
+            }
+        }
+
+        void collect_update_scan_projection_from_expression(const components::expressions::expression_ptr& expression,
+                                                            std::vector<size_t>& projected_cols) {
+            if (!expression || expression->group() != components::expressions::expression_group::compare) {
+                return;
+            }
+
+            const auto* compare = static_cast<const components::expressions::compare_expression_t*>(expression.get());
+            collect_update_scan_projection_from_param(compare->left(), projected_cols);
+            collect_update_scan_projection_from_param(compare->right(), projected_cols);
+            for (const auto& child : compare->children()) {
+                collect_update_scan_projection_from_expression(child, projected_cols);
+            }
+        }
+
+        bool is_projectable_compare_expression(const components::expressions::expression_ptr& expression) {
+            using namespace components::expressions;
+
+            if (!expression || expression->group() != expression_group::compare) {
+                return false;
+            }
+            const auto* compare = static_cast<const compare_expression_t*>(expression.get());
+            if (compare->type() == compare_type::regex) {
+                return false;
+            }
+            if (std::holds_alternative<expression_ptr>(compare->left()) ||
+                std::holds_alternative<expression_ptr>(compare->right())) {
+                return false;
+            }
+            for (const auto& child : compare->children()) {
+                if (!is_projectable_compare_expression(child)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+	        void collect_update_scan_projection_from_update_expr(const components::expressions::update_expr_ptr& expression,
+	                                                             std::vector<size_t>& projected_cols) {
+	            using namespace components::expressions;
+
+            if (!expression) {
+                return;
+            }
+
+	            if (expression->type() == update_expr_type::set) {
+	                const auto* set_expr = static_cast<const update_expr_set_t*>(expression.get());
+	                if (set_expr->key().path().size() > 1) {
+	                    append_unique_projected_col(projected_cols, set_expr->key().path().front());
+	                }
+	            } else if (expression->type() == update_expr_type::get_value) {
+                const auto* get_expr = static_cast<const update_expr_get_value_t*>(expression.get());
+                if (!get_expr->key().path().empty()) {
+                    append_unique_projected_col(projected_cols, get_expr->key().path().front());
+                }
+            }
+
+            collect_update_scan_projection_from_update_expr(expression->left(), projected_cols);
+            collect_update_scan_projection_from_update_expr(expression->right(), projected_cols);
+        }
+
+        std::vector<size_t>
+        update_scan_projection(const components::logical_plan::node_update_t& node_update,
+                               const components::logical_plan::node_ptr& node_match) {
+            if (!node_match || node_match->expressions().empty() ||
+                !is_projectable_compare_expression(node_match->expressions().front())) {
+                return {};
+            }
+            // RETURNING needs every returned column materialised; a projected scan
+            // leaves non-predicate/non-SET columns as placeholders that RETURNING
+            // reads as empty. Full scan (no projection) when RETURNING is present.
+            if (!node_update.returning().empty()) {
+                return {};
+            }
+
+            std::vector<size_t> projected_cols;
+
+            collect_update_scan_projection_from_expression(node_match->expressions().front(), projected_cols);
+            for (const auto& update : node_update.updates()) {
+                collect_update_scan_projection_from_update_expr(update, projected_cols);
+            }
+
+            std::sort(projected_cols.begin(), projected_cols.end());
+            projected_cols.erase(std::unique(projected_cols.begin(), projected_cols.end()), projected_cols.end());
+            return projected_cols;
+        }
+
+    } // namespace
 
     components::operators::operator_ptr create_plan_update(const context_storage_t& context,
                                                            const components::logical_plan::node_ptr& node,
@@ -39,7 +162,8 @@ namespace services::planner::impl {
                                                                                         node_update->updates(),
                                                                                         node_update->upsert(),
                                                                                         std::move(returning)));
-            plan->set_children(create_plan_match(context, node_match, limit));
+            auto projected_cols = update_scan_projection(*node_update, node_match);
+            plan->set_children(create_plan_match(context, node_match, limit, projected_cols));
 
             return plan;
         } else {

--- a/components/planner/CMakeLists.txt
+++ b/components/planner/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCE_${PROJECT_NAME}
         planner.cpp
         optimizer.cpp
         optimizer/rules/constant_folding.cpp
+        optimizer/rules/join_predicate_pushdown.cpp
         optimizer/rules/column_pruning.cpp
         optimizer/rules/hash_join.cpp
 )

--- a/components/planner/optimizer.cpp
+++ b/components/planner/optimizer.cpp
@@ -3,6 +3,7 @@
 #include "optimizer/rules/column_pruning.hpp"
 #include "optimizer/rules/constant_folding.hpp"
 #include "optimizer/rules/hash_join.hpp"
+#include "optimizer/rules/join_predicate_pushdown.hpp"
 
 namespace components::planner {
 
@@ -26,8 +27,15 @@ namespace components::planner {
             return nullptr;
         }
 
-        // Column pruning is intentionally disabled in the current work; the rule
-        // (optimizer::prune_columns) is left in place but not run here.
+        // Feature branch: push WHERE predicates that span both join sides onto
+        // the synthesized cross join (adds a join filter; WHERE is untouched).
+        optimizer::push_down_join_predicates(node);
+
+        // Column pruning: annotate aggregate nodes with the column indices each
+        // one needs to read from its source. Must run while joins are still
+        // node_join_t (it splits join columns per side), i.e. BEFORE the
+        // hash-join rewrite below converts them into node_hash_join_t.
+        optimizer::prune_columns(node);
 
         // Hash-join selection: rewrite eligible nested-loop joins (single
         // eq(left.key, right.key) condition) into node_hash_join_t so the planner

--- a/components/planner/optimizer.hpp
+++ b/components/planner/optimizer.hpp
@@ -17,6 +17,7 @@ namespace components::planner {
     // stamp_oids_from_resolves, so node->table_oid() is populated and
     // sibling catalog_resolve_table_t nodes carry resolved_metadata().
     // Schema-aware rules go here.
+    //   - join_predicate_pushdown (duplicates WHERE join predicates into comma-join ON clauses)
     //   - column_pruning (annotates node_aggregate_t with projected_cols)
     //
     // Schema info is read from the plan tree itself (sibling resolves);

--- a/components/planner/optimizer/rules/join_predicate_pushdown.cpp
+++ b/components/planner/optimizer/rules/join_predicate_pushdown.cpp
@@ -1,0 +1,485 @@
+#include "join_predicate_pushdown.hpp"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+#include <components/catalog/catalog_oids.hpp>
+#include <components/expressions/compare_expression.hpp>
+#include <components/logical_plan/node_aggregate.hpp>
+#include <components/logical_plan/node_catalog_resolve_table.hpp>
+#include <components/logical_plan/node_join.hpp>
+#include <components/logical_plan/node_match.hpp>
+
+namespace components::planner::optimizer {
+
+    namespace {
+
+        using table_cols_map = std::unordered_map<components::catalog::oid_t, size_t>;
+
+        bool trace_join_pushdown_enabled() {
+            const char* raw = std::getenv("OTTERBRIX_JOIN_PUSHDOWN_TRACE");
+            return raw && raw[0] != '\0' && raw[0] != '0';
+        }
+
+        void collect_table_md(const logical_plan::node_ptr& root, table_cols_map& out) {
+            if (!root) {
+                return;
+            }
+
+            std::vector<const logical_plan::node_t*> stack;
+            stack.push_back(root.get());
+            while (!stack.empty()) {
+                const auto* node = stack.back();
+                stack.pop_back();
+                if (!node) {
+                    continue;
+                }
+                if (node->type() == logical_plan::node_type::catalog_resolve_table_t) {
+                    const auto* resolve = static_cast<const logical_plan::node_catalog_resolve_table_t*>(node);
+                    const auto& md = resolve->resolved_metadata();
+                    if (md && md->table_oid != components::catalog::INVALID_OID) {
+                        out[md->table_oid] = md->columns.size();
+                    }
+                }
+                for (const auto& child : node->children()) {
+                    stack.push_back(child.get());
+                }
+            }
+        }
+
+        size_t output_column_count(const logical_plan::node_ptr& node, const table_cols_map& md) {
+            if (!node) {
+                return 0;
+            }
+
+            if (node->type() == logical_plan::node_type::aggregate_t) {
+                auto it = md.find(node->table_oid());
+                return it == md.end() ? 0 : it->second;
+            }
+
+            if (node->type() == logical_plan::node_type::join_t) {
+                size_t total = 0;
+                for (const auto& child : node->children()) {
+                    auto count = output_column_count(child, md);
+                    if (count == 0) {
+                        return 0;
+                    }
+                    total += count;
+                }
+                return total;
+            }
+
+            return 0;
+        }
+
+        void flatten_and_terms(const expressions::expression_ptr& expr,
+                               std::vector<const expressions::compare_expression_t*>& out) {
+            if (!expr || expr->group() != expressions::expression_group::compare) {
+                return;
+            }
+
+            const auto* compare = static_cast<const expressions::compare_expression_t*>(expr.get());
+            if (compare->type() == expressions::compare_type::union_and) {
+                for (const auto& child : compare->children()) {
+                    flatten_and_terms(child, out);
+                }
+                return;
+            }
+
+            out.push_back(compare);
+        }
+
+        bool same_compare_expression(const expressions::compare_expression_t& left,
+                                     const expressions::compare_expression_t& right) {
+            return static_cast<const expressions::expression_i&>(left) ==
+                   static_cast<const expressions::expression_i&>(right);
+        }
+
+        bool contains_compare(const std::vector<const expressions::compare_expression_t*>& terms,
+                              const expressions::compare_expression_t& needle) {
+            return std::any_of(terms.begin(), terms.end(), [&](const auto* term) {
+                return term && same_compare_expression(*term, needle);
+            });
+        }
+
+        void append_unique_compare(std::vector<const expressions::compare_expression_t*>& terms,
+                                   const expressions::compare_expression_t* candidate) {
+            if (!candidate || contains_compare(terms, *candidate)) {
+                return;
+            }
+            terms.push_back(candidate);
+        }
+
+        void collect_common_or_conjuncts(const expressions::expression_ptr& expr,
+                                         std::vector<const expressions::compare_expression_t*>& out) {
+            if (!expr || expr->group() != expressions::expression_group::compare) {
+                return;
+            }
+
+            const auto* compare = static_cast<const expressions::compare_expression_t*>(expr.get());
+            if (compare->type() == expressions::compare_type::union_or) {
+                std::vector<std::vector<const expressions::compare_expression_t*>> branch_terms;
+                branch_terms.reserve(compare->children().size());
+                for (const auto& child : compare->children()) {
+                    std::vector<const expressions::compare_expression_t*> terms;
+                    flatten_and_terms(child, terms);
+                    if (terms.empty()) {
+                        return;
+                    }
+                    branch_terms.emplace_back(std::move(terms));
+                }
+
+                if (branch_terms.empty()) {
+                    return;
+                }
+
+                for (const auto* candidate : branch_terms.front()) {
+                    if (!candidate || expressions::is_union_compare_condition(candidate->type())) {
+                        continue;
+                    }
+
+                    bool present_in_all = true;
+                    for (size_t branch_idx = 1; branch_idx < branch_terms.size(); ++branch_idx) {
+                        if (!contains_compare(branch_terms[branch_idx], *candidate)) {
+                            present_in_all = false;
+                            break;
+                        }
+                    }
+
+                    if (present_in_all) {
+                        append_unique_compare(out, candidate);
+                    }
+                }
+
+                for (const auto& child : compare->children()) {
+                    collect_common_or_conjuncts(child, out);
+                }
+                return;
+            }
+
+            if (compare->type() == expressions::compare_type::union_and) {
+                for (const auto& child : compare->children()) {
+                    collect_common_or_conjuncts(child, out);
+                }
+            }
+        }
+
+        void collect_where_terms(const expressions::expression_ptr& expr,
+                                 std::vector<const expressions::compare_expression_t*>& out) {
+            flatten_and_terms(expr, out);
+
+            std::vector<const expressions::compare_expression_t*> common_or_terms;
+            collect_common_or_conjuncts(expr, common_or_terms);
+            for (const auto* term : common_or_terms) {
+                append_unique_compare(out, term);
+            }
+        }
+
+        bool param_references_range(const expressions::param_storage& param, size_t begin, size_t end) {
+            if (std::holds_alternative<expressions::key_t>(param)) {
+                const auto& key = std::get<expressions::key_t>(param);
+                if (key.path().empty()) {
+                    return false;
+                }
+                return key.path().front() >= begin && key.path().front() < end;
+            }
+
+            if (std::holds_alternative<expressions::expression_ptr>(param)) {
+                const auto& nested = std::get<expressions::expression_ptr>(param);
+                if (!nested || nested->group() != expressions::expression_group::compare) {
+                    return false;
+                }
+                const auto* compare = static_cast<const expressions::compare_expression_t*>(nested.get());
+                return param_references_range(compare->left(), begin, end) ||
+                       param_references_range(compare->right(), begin, end);
+            }
+
+            return false;
+        }
+
+        bool param_references_outside(const expressions::param_storage& param, size_t begin, size_t end) {
+            if (std::holds_alternative<expressions::key_t>(param)) {
+                const auto& key = std::get<expressions::key_t>(param);
+                if (key.path().empty()) {
+                    return false;
+                }
+                return key.path().front() < begin || key.path().front() >= end;
+            }
+
+            if (std::holds_alternative<expressions::expression_ptr>(param)) {
+                const auto& nested = std::get<expressions::expression_ptr>(param);
+                if (!nested || nested->group() != expressions::expression_group::compare) {
+                    return true;
+                }
+                const auto* compare = static_cast<const expressions::compare_expression_t*>(nested.get());
+                return param_references_outside(compare->left(), begin, end) ||
+                       param_references_outside(compare->right(), begin, end);
+            }
+
+            return false;
+        }
+
+        bool is_cross_boundary_predicate(const expressions::compare_expression_t& predicate,
+                                         size_t left_begin,
+                                         size_t left_end,
+                                         size_t right_begin,
+                                         size_t right_end) {
+            if (expressions::is_union_compare_condition(predicate.type()) ||
+                predicate.type() == expressions::compare_type::all_true ||
+                predicate.type() == expressions::compare_type::all_false ||
+                predicate.type() == expressions::compare_type::is_null ||
+                predicate.type() == expressions::compare_type::is_not_null) {
+                return false;
+            }
+
+            const auto join_begin = left_begin;
+            const auto join_end = right_end;
+            if (param_references_outside(predicate.left(), join_begin, join_end) ||
+                param_references_outside(predicate.right(), join_begin, join_end)) {
+                return false;
+            }
+
+            const bool has_left = param_references_range(predicate.left(), left_begin, left_end) ||
+                                  param_references_range(predicate.right(), left_begin, left_end);
+            const bool has_right = param_references_range(predicate.left(), right_begin, right_end) ||
+                                   param_references_range(predicate.right(), right_begin, right_end);
+            return has_left && has_right;
+        }
+
+        std::optional<expressions::param_storage> clone_param_for_join(std::pmr::memory_resource* resource,
+                                                                       const expressions::param_storage& param,
+                                                                       size_t left_begin,
+                                                                       size_t left_end,
+                                                                       size_t right_begin,
+                                                                       size_t right_end);
+
+        expressions::compare_expression_ptr clone_compare_for_join(std::pmr::memory_resource* resource,
+                                                                   const expressions::compare_expression_t& predicate,
+                                                                   size_t left_begin,
+                                                                   size_t left_end,
+                                                                   size_t right_begin,
+                                                                   size_t right_end) {
+            if (expressions::is_union_compare_condition(predicate.type())) {
+                auto clone = expressions::make_compare_union_expression(resource, predicate.type());
+                for (const auto& child : predicate.children()) {
+                    if (!child || child->group() != expressions::expression_group::compare) {
+                        return nullptr;
+                    }
+                    auto child_clone = clone_compare_for_join(
+                        resource,
+                        *static_cast<const expressions::compare_expression_t*>(child.get()),
+                        left_begin,
+                        left_end,
+                        right_begin,
+                        right_end);
+                    if (!child_clone) {
+                        return nullptr;
+                    }
+                    clone->append_child(child_clone);
+                }
+                return clone;
+            }
+
+            auto left = clone_param_for_join(resource, predicate.left(), left_begin, left_end, right_begin, right_end);
+            auto right = clone_param_for_join(resource, predicate.right(), left_begin, left_end, right_begin, right_end);
+            if (!left || !right) {
+                return nullptr;
+            }
+            return expressions::make_compare_expression(resource, predicate.type(), *left, *right);
+        }
+
+        std::optional<expressions::param_storage> clone_param_for_join(std::pmr::memory_resource* resource,
+                                                                       const expressions::param_storage& param,
+                                                                       size_t left_begin,
+                                                                       size_t left_end,
+                                                                       size_t right_begin,
+                                                                       size_t right_end) {
+            if (std::holds_alternative<core::parameter_id_t>(param)) {
+                return expressions::param_storage{std::get<core::parameter_id_t>(param)};
+            }
+
+            if (std::holds_alternative<expressions::key_t>(param)) {
+                auto key = std::get<expressions::key_t>(param);
+                if (key.path().empty()) {
+                    return expressions::param_storage{std::move(key)};
+                }
+
+                auto& path = key.path();
+                const auto full_index = path.front();
+                if (full_index >= left_begin && full_index < left_end) {
+                    path.front() = full_index - left_begin;
+                    key.set_side(expressions::side_t::left);
+                    return expressions::param_storage{std::move(key)};
+                }
+                if (full_index >= right_begin && full_index < right_end) {
+                    path.front() = full_index - right_begin;
+                    key.set_side(expressions::side_t::right);
+                    return expressions::param_storage{std::move(key)};
+                }
+                return std::nullopt;
+            }
+
+            const auto& nested = std::get<expressions::expression_ptr>(param);
+            if (!nested || nested->group() != expressions::expression_group::compare) {
+                return std::nullopt;
+            }
+
+            auto nested_clone = clone_compare_for_join(resource,
+                                                       *static_cast<const expressions::compare_expression_t*>(
+                                                           nested.get()),
+                                                       left_begin,
+                                                       left_end,
+                                                       right_begin,
+                                                       right_end);
+            if (!nested_clone) {
+                return std::nullopt;
+            }
+            return expressions::param_storage{expressions::expression_ptr(nested_clone)};
+        }
+
+        expressions::expression_ptr combine_join_predicates(std::pmr::memory_resource* resource,
+                                                            const std::vector<expressions::expression_ptr>& predicates) {
+            if (predicates.empty()) {
+                return expressions::make_compare_expression(resource, expressions::compare_type::all_true);
+            }
+            if (predicates.size() == 1) {
+                return predicates.front();
+            }
+
+            auto combined = expressions::make_compare_union_expression(resource, expressions::compare_type::union_and);
+            for (const auto& predicate : predicates) {
+                combined->append_child(predicate);
+            }
+            return combined;
+        }
+
+        void push_into_join(const logical_plan::node_ptr& node,
+                            const std::vector<const expressions::compare_expression_t*>& where_terms,
+                            const table_cols_map& md,
+                            size_t base_offset) {
+            if (!node || node->type() != logical_plan::node_type::join_t) {
+                return;
+            }
+
+            auto* join = static_cast<logical_plan::node_join_t*>(node.get());
+            const auto& children = node->children();
+            if (children.size() != 2) {
+                return;
+            }
+
+            const auto left_count = output_column_count(children[0], md);
+            const auto right_count = output_column_count(children[1], md);
+            if (left_count == 0 || right_count == 0) {
+                return;
+            }
+
+            const auto left_begin = base_offset;
+            const auto left_end = left_begin + left_count;
+            const auto right_begin = left_end;
+            const auto right_end = right_begin + right_count;
+
+            if (join->type() == logical_plan::join_type::cross) {
+                std::vector<expressions::expression_ptr> pushed;
+                pushed.reserve(where_terms.size());
+                for (const auto* term : where_terms) {
+                    if (!term ||
+                        !is_cross_boundary_predicate(*term, left_begin, left_end, right_begin, right_end)) {
+                        continue;
+                    }
+                    auto clone =
+                        clone_compare_for_join(node->resource(), *term, left_begin, left_end, right_begin, right_end);
+                    if (clone) {
+                        pushed.emplace_back(clone);
+                    }
+                }
+
+                if (!pushed.empty()) {
+                    join->set_type(logical_plan::join_type::inner);
+                    node->expressions().clear();
+                    node->append_expression(combine_join_predicates(node->resource(), pushed));
+                    if (trace_join_pushdown_enabled()) {
+                        std::fprintf(stderr,
+                                     "OTBX_JOIN_PUSHDOWN pushed=%zu left=[%zu,%zu) right=[%zu,%zu) expr=%s\n",
+                                     pushed.size(),
+                                     left_begin,
+                                     left_end,
+                                     right_begin,
+                                     right_end,
+                                     node->expressions().front()->to_string().c_str());
+                    }
+                }
+            }
+
+            push_into_join(children[0], where_terms, md, left_begin);
+            push_into_join(children[1], where_terms, md, right_begin);
+        }
+
+        void process_aggregate(const logical_plan::node_ptr& node, const table_cols_map& md) {
+            if (!node || node->type() != logical_plan::node_type::aggregate_t) {
+                return;
+            }
+
+            logical_plan::node_ptr data_child;
+            logical_plan::node_ptr match_child;
+            for (const auto& child : node->children()) {
+                if (!child) {
+                    continue;
+                }
+                if (child->type() == logical_plan::node_type::match_t) {
+                    match_child = child;
+                    continue;
+                }
+                if (child->type() != logical_plan::node_type::group_t &&
+                    child->type() != logical_plan::node_type::select_t &&
+                    child->type() != logical_plan::node_type::sort_t &&
+                    child->type() != logical_plan::node_type::limit_t &&
+                    child->type() != logical_plan::node_type::having_t) {
+                    data_child = child;
+                }
+            }
+
+            if (data_child && data_child->type() == logical_plan::node_type::join_t && match_child &&
+                !match_child->expressions().empty()) {
+                std::vector<const expressions::compare_expression_t*> where_terms;
+                collect_where_terms(match_child->expressions().front(), where_terms);
+                push_into_join(data_child, where_terms, md, 0);
+            }
+
+            for (const auto& child : node->children()) {
+                if (child && child->type() == logical_plan::node_type::aggregate_t) {
+                    process_aggregate(child, md);
+                }
+            }
+        }
+
+    } // namespace
+
+    void push_down_join_predicates(const logical_plan::node_ptr& root) {
+        if (!root) {
+            return;
+        }
+
+        table_cols_map md;
+        collect_table_md(root, md);
+
+        std::vector<logical_plan::node_ptr> stack{root};
+        while (!stack.empty()) {
+            auto node = std::move(stack.back());
+            stack.pop_back();
+            if (!node) {
+                continue;
+            }
+            if (node->type() == logical_plan::node_type::aggregate_t) {
+                process_aggregate(node, md);
+            }
+            for (const auto& child : node->children()) {
+                stack.push_back(child);
+            }
+        }
+    }
+
+} // namespace components::planner::optimizer

--- a/components/planner/optimizer/rules/join_predicate_pushdown.hpp
+++ b/components/planner/optimizer/rules/join_predicate_pushdown.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <components/logical_plan/node.hpp>
+
+namespace components::planner::optimizer {
+
+    // Copies WHERE predicates that reference both sides of a comma join onto the
+    // synthesized cross join. WHERE is left untouched, so this only adds a join filter.
+    void push_down_join_predicates(const logical_plan::node_ptr& root);
+
+} // namespace components::planner::optimizer

--- a/components/planner/planner.cpp
+++ b/components/planner/planner.cpp
@@ -1,5 +1,6 @@
 #include "planner.hpp"
 
+#include <cassert>
 #include <cstdio>
 
 #include <catalog/catalog_codes.hpp>
@@ -732,7 +733,13 @@ namespace components::planner {
     auto planner_t::create_plan(std::pmr::memory_resource* resource,
                                 logical_plan::node_ptr node,
                                 catalog::oid_batch_t oid_batch) -> logical_plan::node_ptr {
-        return walk_ddl(resource, std::move(node), oid_batch);
+        auto result = walk_ddl(resource, std::move(node), oid_batch);
+        // OID lockstep: the executor (this overload's only caller) pre-allocated exactly
+        // compute_oid_demand() OIDs into this batch, so the DDL walk must consume all of them.
+        // A leftover (next < size) is a silent over-allocation that diverges from
+        // compute_oid_demand with no compile error.
+        assert(oid_batch.empty() && "DDL OID consumption diverged from compute_oid_demand");
+        return result;
     }
 
     std::size_t compute_oid_demand(const logical_plan::node_t* node) {

--- a/components/planner/planner.cpp
+++ b/components/planner/planner.cpp
@@ -47,6 +47,23 @@ namespace components::planner {
     namespace {
         using node_ptr = logical_plan::node_ptr;
 
+        std::string_view
+        to_relstorageformat(logical_plan::create_collection_storage_format_t storage_format) noexcept {
+            using logical_plan::create_collection_storage_format_t;
+
+            switch (storage_format) {
+                case create_collection_storage_format_t::disk_auto:
+                    return catalog::relstorageformat::disk_auto;
+                case create_collection_storage_format_t::disk_columnar:
+                    return catalog::relstorageformat::disk_columnar;
+                case create_collection_storage_format_t::disk_pax:
+                    return catalog::relstorageformat::disk_pax;
+                case create_collection_storage_format_t::in_memory:
+                default:
+                    return catalog::relstorageformat::in_memory;
+            }
+        }
+
         node_ptr rewrite_insert(std::pmr::memory_resource* r, node_ptr node) {
             auto* ins = static_cast<logical_plan::node_insert_t*>(node.get());
             node_ptr cur = node;
@@ -182,7 +199,8 @@ namespace components::planner {
                                                              cc->is_disk_storage(),
                                                              ns_oid,
                                                              oid_batch,
-                                                             rk);
+                                                             rk,
+                                                             to_relstorageformat(cc->storage_format()));
             cc->set_table_oid(table_oid);
 
             auto seq = boost::intrusive_ptr(new logical_plan::node_sequence_t(r));

--- a/components/planner/test/CMakeLists.txt
+++ b/components/planner/test/CMakeLists.txt
@@ -26,4 +26,4 @@ target_link_libraries(
 
 include(CTest)
 include(Catch)
-catch_discover_tests(${PROJECT_NAME})
+otterbrix_discover_tests(${PROJECT_NAME})

--- a/components/session/tests/CMakeLists.txt
+++ b/components/session/tests/CMakeLists.txt
@@ -17,4 +17,4 @@ target_link_libraries(
 
 include(CTest)
 include(Catch)
-catch_discover_tests(${PROJECT_NAME})
+otterbrix_discover_tests(${PROJECT_NAME})

--- a/components/sql/parser/gram.y
+++ b/components/sql/parser/gram.y
@@ -322,7 +322,7 @@ TypeName *SystemTypeName(std::pmr::memory_resource* resource, char *name);
 %type <chr>		enable_trigger
 
 %type <str>		copy_file_name
-				database_name access_method_clause access_method attr_name
+				database_name access_method_clause opt_table_access_method_clause access_method attr_name
 				name cursor_name file_name
 				index_name opt_index_name cluster_index_specification
 
@@ -4145,7 +4145,7 @@ copy_generic_opt_arg_list_item:
  *****************************************************************************/
 
 CreateStmt:	CREATE OptTemp TABLE qualified_name '(' OptTableElementList ')'
-			OptInherit OptWith OnCommitOption OptTableSpace OptDistributedBy
+			OptInherit OptWith opt_table_access_method_clause OnCommitOption OptTableSpace OptDistributedBy
 			OptTabPartitionBy
 				{
 					CreateStmt *n = makeNode(resource, CreateStmt);
@@ -4155,16 +4155,17 @@ CreateStmt:	CREATE OptTemp TABLE qualified_name '(' OptTableElementList ')'
 					n->inhRelations = $8;
 					n->constraints = NIL;
 					n->options = $9;
-					n->oncommit = $10;
-					n->tablespacename = $11;
+					n->accessMethod = $10;
+					n->oncommit = $11;
+					n->tablespacename = $12;
 					n->if_not_exists = false;
-					n->distributedBy = (DistributedBy *) $12;
-					n->partitionBy = $13;
+					n->distributedBy = (DistributedBy *) $13;
+					n->partitionBy = $14;
 					n->relKind = RELKIND_RELATION;
 					$$ = (Node *)n;
 				}
 		| CREATE OptTemp TABLE IF_P NOT EXISTS qualified_name '('
-			OptTableElementList ')' OptInherit OptWith OnCommitOption
+			OptTableElementList ')' OptInherit OptWith opt_table_access_method_clause OnCommitOption
 			OptTableSpace OptDistributedBy
 			OptTabPartitionBy
 				{
@@ -4175,16 +4176,17 @@ CreateStmt:	CREATE OptTemp TABLE qualified_name '(' OptTableElementList ')'
 					n->inhRelations = $11;
 					n->constraints = NIL;
 					n->options = $12;
-					n->oncommit = $13;
-					n->tablespacename = $14;
+					n->accessMethod = $13;
+					n->oncommit = $14;
+					n->tablespacename = $15;
 					n->if_not_exists = true;
-					n->distributedBy = (DistributedBy *) $15;
-					n->partitionBy = $16;
+					n->distributedBy = (DistributedBy *) $16;
+					n->partitionBy = $17;
 					n->relKind = RELKIND_RELATION;
 					$$ = (Node *)n;
 				}
 		| CREATE OptTemp TABLE qualified_name OF any_name
-			OptTypedTableElementList OptWith OnCommitOption OptTableSpace
+			OptTypedTableElementList OptWith opt_table_access_method_clause OnCommitOption OptTableSpace
 			OptDistributedBy OptTabPartitionBy
 				{
 					CreateStmt *n = makeNode(resource, CreateStmt);
@@ -4195,16 +4197,17 @@ CreateStmt:	CREATE OptTemp TABLE qualified_name '(' OptTableElementList ')'
 					n->ofTypename->location = @6;
 					n->constraints = NIL;
 					n->options = $8;
-					n->oncommit = $9;
-					n->tablespacename = $10;
+					n->accessMethod = $9;
+					n->oncommit = $10;
+					n->tablespacename = $11;
 					n->if_not_exists = false;
-					n->distributedBy = (DistributedBy *) $11;
-					n->partitionBy = $12;
+					n->distributedBy = (DistributedBy *) $12;
+					n->partitionBy = $13;
 					n->relKind = RELKIND_RELATION;
 					$$ = (Node *)n;
 				}
 		| CREATE OptTemp TABLE IF_P NOT EXISTS qualified_name OF any_name
-			OptTypedTableElementList OptWith OnCommitOption OptTableSpace
+			OptTypedTableElementList OptWith opt_table_access_method_clause OnCommitOption OptTableSpace
 			OptDistributedBy OptTabPartitionBy
 				{
 					CreateStmt *n = makeNode(resource, CreateStmt);
@@ -4215,11 +4218,12 @@ CreateStmt:	CREATE OptTemp TABLE qualified_name '(' OptTableElementList ')'
 					n->ofTypename->location = @9;
 					n->constraints = NIL;
 					n->options = $11;
-					n->oncommit = $12;
-					n->tablespacename = $13;
+					n->accessMethod = $12;
+					n->oncommit = $13;
+					n->tablespacename = $14;
 					n->if_not_exists = true;
-					n->distributedBy = (DistributedBy *) $14;
-					n->partitionBy = $15;
+					n->distributedBy = (DistributedBy *) $15;
+					n->partitionBy = $16;
 					n->relKind = RELKIND_RELATION;
 					$$ = (Node *)n;
 				}
@@ -8792,6 +8796,11 @@ opt_index_name:
 access_method_clause:
 			USING access_method						{ $$ = $2; }
 			| /*EMPTY*/								{ $$ = DEFAULT_INDEX_TYPE; }
+		;
+
+opt_table_access_method_clause:
+			USING access_method						{ $$ = $2; }
+			| /*EMPTY*/								{ $$ = NULL; }
 		;
 
 index_params:	index_elem							{ $$ = list_make1(resource, $1); }

--- a/components/sql/parser/nodes/parsenodes.h
+++ b/components/sql/parser/nodes/parsenodes.h
@@ -1809,6 +1809,7 @@ typedef struct CreateStmt {
     TypeName* ofTypename;    /* OF typename */
     List* constraints;       /* constraints (list of Constraint nodes) */
     List* options;           /* options from WITH clause */
+    char* accessMethod;      /* name of table access method (eg. pax) */
     OnCommitAction oncommit; /* what do we do at COMMIT? */
     char* tablespacename;    /* table space to use, or NULL */
     bool if_not_exists;      /* just do nothing if it already exists? */

--- a/components/sql/test/CMakeLists.txt
+++ b/components/sql/test/CMakeLists.txt
@@ -29,4 +29,4 @@ target_link_libraries(
 
 include(CTest)
 include(Catch)
-catch_discover_tests(${PROJECT_NAME})
+otterbrix_discover_tests(${PROJECT_NAME})

--- a/components/sql/test/test_create_drop.cpp
+++ b/components/sql/test/test_create_drop.cpp
@@ -4,6 +4,7 @@
 #include <components/sql/parser/pg_functions.h>
 #include <components/sql/transformer/transformer.hpp>
 #include <components/sql/transformer/utils.hpp>
+#include <string_view>
 
 using namespace components::sql;
 using namespace components::logical_plan;
@@ -85,6 +86,59 @@ TEST_CASE("components::sql::table") {
 
     TEST_TRANSFORMER_OK("CREATE TABLE db_name.table_name()", R"_($sequence[2])_");
     TEST_TRANSFORMER_OK("CREATE TABLE table_name()", R"_($create_collection: table_name)_");
+
+    SECTION("create disk table using pax") {
+        auto stmt =
+            raw_parser(&arena_resource, "CREATE TABLE table_name(id bigint) WITH(storage='disk') USING PAX")
+                ->lst.front()
+                .data;
+        auto result = transformer.transform(pg_cell_to_node_cast(stmt)).finalize();
+        REQUIRE(!result.has_error());
+        auto node = result.value().sub_queries.back();
+        auto data = reinterpret_cast<node_create_collection_ptr&>(node);
+        REQUIRE(data->is_disk_storage());
+        REQUIRE(data->storage_format() == create_collection_storage_format_t::disk_pax);
+    }
+
+    SECTION("create disk table using columnar") {
+        auto stmt =
+            raw_parser(&arena_resource, "CREATE TABLE table_name(name string) WITH(storage='disk') USING COLUMNAR")
+                ->lst.front()
+                .data;
+        auto result = transformer.transform(pg_cell_to_node_cast(stmt)).finalize();
+        REQUIRE(!result.has_error());
+        auto node = result.value().sub_queries.back();
+        auto data = reinterpret_cast<node_create_collection_ptr&>(node);
+        REQUIRE(data->is_disk_storage());
+        REQUIRE(data->storage_format() == create_collection_storage_format_t::disk_columnar);
+    }
+
+    SECTION("using pax requires disk storage") {
+        auto stmt = linitial(raw_parser(&arena_resource, "CREATE TABLE table_name(id bigint) USING PAX"));
+        auto result = transformer.transform(pg_cell_to_node_cast(stmt)).finalize();
+        REQUIRE(result.has_error());
+        REQUIRE(std::string_view{result.error().what}.find("WITH(storage='disk')") != std::string::npos);
+    }
+
+    SECTION("using pax accepts mixed root schema") {
+        // PAX allows mixing fixed-width and string/nested root columns.
+        auto stmt = linitial(
+            raw_parser(&arena_resource, "CREATE TABLE table_name(name string, count bigint) WITH(storage='disk') USING PAX"));
+        auto result = transformer.transform(pg_cell_to_node_cast(stmt)).finalize();
+        REQUIRE(!result.has_error());
+        auto node = result.value().sub_queries.back();
+        auto data = reinterpret_cast<node_create_collection_ptr&>(node);
+        REQUIRE(data->is_disk_storage());
+        REQUIRE(data->storage_format() == create_collection_storage_format_t::disk_pax);
+    }
+
+    SECTION("using pax rejects columnar fallback roots") {
+        auto stmt = linitial(
+            raw_parser(&arena_resource, "CREATE TABLE table_name(gap interval) WITH(storage='disk') USING PAX"));
+        auto result = transformer.transform(pg_cell_to_node_cast(stmt)).finalize();
+        REQUIRE(result.has_error());
+        REQUIRE(std::string_view{result.error().what}.find("not supported by USING PAX") != std::string::npos);
+    }
 
     // DROP TABLE is wrapped in sequence_t(resolve_ns?, resolve_table?, drop_collection).
     // The drop node itself carries no user-typed names; routing is OID-only

--- a/components/sql/test/test_delete.cpp
+++ b/components/sql/test/test_delete.cpp
@@ -56,6 +56,6 @@ TEST_CASE("components::sql::delete_from_where") {
 
     TEST_SIMPLE_DELETE("DELETE FROM TestDatabase.TestCollection USING TestDatabase.OtherTestCollection WHERE "
                        "TestCollection.number = OtherTestCollection.number;",
-                       R"_($delete: <oid:0> {$match: {"number": {$eq: "number"}}, $limit: -1})_",
+                       R"_($delete: <oid:0> {$match: {"testcollection/number": {$eq: "othertestcollection/number"}}, $limit: -1})_",
                        vec());
 }

--- a/components/sql/test/test_function.cpp
+++ b/components/sql/test/test_function.cpp
@@ -75,12 +75,12 @@ TEST_CASE("components::sql::functions") {
 
     TEST_SIMPLE_FUNCTION(
         R"_(SELECT * FROM col1 join col2 on udf(col1.id, col2.id);)_",
-        R"_($aggregate: {$join: {$type: inner, $aggregate: {}, $aggregate: {}, $function: {name: {"udf"}, args: {"id", "id"}}}})_",
+        R"_($aggregate: {$join: {$type: inner, $aggregate: {}, $aggregate: {}, $function: {name: {"udf"}, args: {"col1/id", "col2/id"}}}})_",
         vec());
 
     TEST_SIMPLE_FUNCTION(
         R"_(SELECT * FROM col1 join col2 on udf(col1.id, (col2.struct_type).field);)_",
-        R"_($aggregate: {$join: {$type: inner, $aggregate: {}, $aggregate: {}, $function: {name: {"udf"}, args: {"id", "struct_type/field"}}}})_",
+        R"_($aggregate: {$join: {$type: inner, $aggregate: {}, $aggregate: {}, $function: {name: {"udf"}, args: {"col1/id", "col2/struct_type/field"}}}})_",
         vec());
 
     /*

--- a/components/sql/test/test_insert.cpp
+++ b/components/sql/test/test_insert.cpp
@@ -139,6 +139,27 @@ TEST_CASE("components::sql::insert_into") {
         REQUIRE(chunk.value(2, 4) == components::types::logical_value_t(&arena_resource, 5l));
     }
 
+    SECTION("insert into multi-documents with null-first string column") {
+        auto select = linitial(raw_parser(&arena_resource,
+                                          "INSERT INTO TestCollection (id, note) VALUES "
+                                          "(1, NULL), "
+                                          "(2, 'note_2'), "
+                                          "(3, NULL);"));
+        auto result = transformer.transform(pg_cell_to_node_cast(select)).finalize();
+        REQUIRE(!result.has_error());
+        auto node = dml_consumer(result.value().sub_queries.back());
+        REQUIRE(node->type() == components::logical_plan::node_type::insert_t);
+        const auto& chunk =
+            reinterpret_cast<components::logical_plan::node_data_ptr&>(node->children().front())->data_chunk();
+        REQUIRE(chunk.size() == 3);
+        REQUIRE(chunk.value(0, 0) == components::types::logical_value_t(&arena_resource, 1l));
+        REQUIRE(chunk.value(1, 0).is_null());
+        REQUIRE(chunk.data[1].type().type() == components::types::logical_type::STRING_LITERAL);
+        REQUIRE(chunk.value(0, 1) == components::types::logical_value_t(&arena_resource, 2l));
+        REQUIRE(chunk.value(1, 1) == components::types::logical_value_t(&arena_resource, "note_2"));
+        REQUIRE(chunk.value(1, 2).is_null());
+    }
+
     SECTION("insert from select") {
         auto select = linitial(raw_parser(&arena_resource, R"_(INSERT INTO table2 (column1, column2, column3)
 SELECT column1, column2, column3

--- a/components/sql/test/test_join.cpp
+++ b/components/sql/test/test_join.cpp
@@ -34,23 +34,23 @@ TEST_CASE("components::sql::join") {
 
     SECTION("join types") {
         TEST_JOIN(R"_(select * from col1 join col2 on col1.id = col2.id_col1;)_",
-                  R"_($aggregate: {$join: {$type: inner, $aggregate: {}, $aggregate: {}, "id": {$eq: "id_col1"}}})_",
+                  R"_($aggregate: {$join: {$type: inner, $aggregate: {}, $aggregate: {}, "col1/id": {$eq: "col2/id_col1"}}})_",
                   vec());
 
         TEST_JOIN(R"_(select * from col1 inner join col2 on col1.id = col2.id_col1;)_",
-                  R"_($aggregate: {$join: {$type: inner, $aggregate: {}, $aggregate: {}, "id": {$eq: "id_col1"}}})_",
+                  R"_($aggregate: {$join: {$type: inner, $aggregate: {}, $aggregate: {}, "col1/id": {$eq: "col2/id_col1"}}})_",
                   vec());
 
         TEST_JOIN(R"_(select * from col1 full outer join col2 on col1.id = col2.id_col1;)_",
-                  R"_($aggregate: {$join: {$type: full, $aggregate: {}, $aggregate: {}, "id": {$eq: "id_col1"}}})_",
+                  R"_($aggregate: {$join: {$type: full, $aggregate: {}, $aggregate: {}, "col1/id": {$eq: "col2/id_col1"}}})_",
                   vec());
 
         TEST_JOIN(R"_(select * from col1 left outer join col2 on col1.id = col2.id_col1;)_",
-                  R"_($aggregate: {$join: {$type: left, $aggregate: {}, $aggregate: {}, "id": {$eq: "id_col1"}}})_",
+                  R"_($aggregate: {$join: {$type: left, $aggregate: {}, $aggregate: {}, "col1/id": {$eq: "col2/id_col1"}}})_",
                   vec());
 
         TEST_JOIN(R"_(select * from col1 right outer join col2 on col1.id = col2.id_col1;)_",
-                  R"_($aggregate: {$join: {$type: right, $aggregate: {}, $aggregate: {}, "id": {$eq: "id_col1"}}})_",
+                  R"_($aggregate: {$join: {$type: right, $aggregate: {}, $aggregate: {}, "col1/id": {$eq: "col2/id_col1"}}})_",
                   vec());
 
         TEST_JOIN(R"_(select * from col1 cross join col2;)_",
@@ -61,29 +61,29 @@ TEST_CASE("components::sql::join") {
     SECTION("join specifics") {
         TEST_JOIN(
             R"_(select col1.id, col2.id_col1 from db.col as col1 JOIN col2 on col1.id = col2.id_col1;)_",
-            R"_($aggregate: {$join: {$type: inner, $aggregate: {}, $aggregate: {}, "id": {$eq: "id_col1"}}, $select: {id, id_col1}})_",
+            R"_($aggregate: {$join: {$type: inner, $aggregate: {}, $aggregate: {}, "col1/id": {$eq: "col2/id_col1"}}, $select: {col1/id, col2/id_col1}})_",
             vec());
 
         TEST_JOIN(
             R"_(select * from col1 join col2 on col1.id = col2.id_col1 and col1.name = col2.name;)_",
-            R"_($aggregate: {$join: {$type: inner, $aggregate: {}, $aggregate: {}, $and: ["id": {$eq: "id_col1"}, "name": {$eq: "name"}]}})_",
+            R"_($aggregate: {$join: {$type: inner, $aggregate: {}, $aggregate: {}, $and: ["col1/id": {$eq: "col2/id_col1"}, "col1/name": {$eq: "col2/name"}]}})_",
             vec());
 
         TEST_JOIN(
             R"_(select * from col1 join col2 on col1.id = col2.id_col1 )_"
             R"_(join col3 on id = col3.id_col1 and id = col3.id_col2;)_",
-            R"_($aggregate: {$join: {$type: inner, $join: {$type: inner, $aggregate: {}, $aggregate: {}, "id": {$eq: "id_col1"}}, )_"
-            R"_($aggregate: {}, $and: ["id": {$eq: "id_col1"}, "id": {$eq: "id_col2"}]}})_",
+            R"_($aggregate: {$join: {$type: inner, $join: {$type: inner, $aggregate: {}, $aggregate: {}, "col1/id": {$eq: "col2/id_col1"}}, )_"
+            R"_($aggregate: {}, $and: ["id": {$eq: "col3/id_col1"}, "id": {$eq: "col3/id_col2"}]}})_",
             vec());
 
         TEST_JOIN(
             R"_(select * from col1 join col2 on (col1.struct_type).field = (col2.struct_type).field;)_",
-            R"_($aggregate: {$join: {$type: inner, $aggregate: {}, $aggregate: {}, "struct_type/field": {$eq: "struct_type/field"}}})_",
+            R"_($aggregate: {$join: {$type: inner, $aggregate: {}, $aggregate: {}, "col1/struct_type/field": {$eq: "col2/struct_type/field"}}})_",
             vec());
 
         TEST_JOIN(
             R"_(select * from col1 join col2 on col1.array_type[1] = col2.array_type[2];)_",
-            R"_($aggregate: {$join: {$type: inner, $aggregate: {}, $aggregate: {}, "array_type/1": {$eq: "array_type/2"}}})_",
+            R"_($aggregate: {$join: {$type: inner, $aggregate: {}, $aggregate: {}, "col1/array_type/1": {$eq: "col2/array_type/2"}}})_",
             vec());
     }
 
@@ -124,12 +124,12 @@ TEST_CASE("components::sql::join") {
     SECTION("left outer join regression") {
         TEST_JOIN(
             R"_(select * from a left outer join b on a.x = b.x and a.y = b.y;)_",
-            R"_($aggregate: {$join: {$type: left, $aggregate: {}, $aggregate: {}, $and: ["x": {$eq: "x"}, "y": {$eq: "y"}]}})_",
+            R"_($aggregate: {$join: {$type: left, $aggregate: {}, $aggregate: {}, $and: ["a/x": {$eq: "b/x"}, "a/y": {$eq: "b/y"}]}})_",
             vec());
 
         TEST_JOIN(
             R"_(select * from a left outer join b on a.id = b.fk where b.status = 'active';)_",
-            R"_($aggregate: {$join: {$type: left, $aggregate: {}, $aggregate: {}, "id": {$eq: "fk"}}, $match: {"status": {$eq: #0}}})_",
+            R"_($aggregate: {$join: {$type: left, $aggregate: {}, $aggregate: {}, "a/id": {$eq: "b/fk"}}, $match: {"b/status": {$eq: #0}}})_",
             vec({v(&resource, "active")}));
     }
 
@@ -152,7 +152,7 @@ TEST_CASE("components::sql::join") {
         // sibling match_t (not shown in the join's to_string).
         TEST_JOIN(
             R"_(select * from col1, col2 where col1.id = col2.id_col1;)_",
-            R"_($aggregate: {$join: {$type: cross, $aggregate: {}, $aggregate: {}, $all_true}, $match: {"id": {$eq: "id_col1"}}})_",
+            R"_($aggregate: {$join: {$type: cross, $aggregate: {}, $aggregate: {}, $all_true}, $match: {"col1/id": {$eq: "col2/id_col1"}}})_",
             vec());
 
         // Three-table comma-join. Left-deep synthesis yields
@@ -160,23 +160,23 @@ TEST_CASE("components::sql::join") {
         // exactly mirroring `T1 JOIN T2 ON ... JOIN T3 ON ...`.
         TEST_JOIN(
             R"_(select * from col1, col2, col3 where col1.id = col2.id_col1 and col1.id = col3.id_col1;)_",
-            R"_($aggregate: {$join: {$type: cross, $join: {$type: cross, $aggregate: {}, $aggregate: {}, $all_true}, $aggregate: {}, $all_true}, $match: {$and: ["id": {$eq: "id_col1"}, "id": {$eq: "id_col1"}]}})_",
+            R"_($aggregate: {$join: {$type: cross, $join: {$type: cross, $aggregate: {}, $aggregate: {}, $all_true}, $aggregate: {}, $all_true}, $match: {$and: ["col1/id": {$eq: "col2/id_col1"}, "col1/id": {$eq: "col3/id_col1"}]}})_",
             vec());
 
         // WHERE with a multi-clause AND: both predicates land in the same
         // match_t. Cross-join itself stays $all_true.
         TEST_JOIN(
             R"_(select * from col1, col2 where col1.id = col2.id_col1 and col1.name = col2.name;)_",
-            R"_($aggregate: {$join: {$type: cross, $aggregate: {}, $aggregate: {}, $all_true}, $match: {$and: ["id": {$eq: "id_col1"}, "name": {$eq: "name"}]}})_",
+            R"_($aggregate: {$join: {$type: cross, $aggregate: {}, $aggregate: {}, $all_true}, $match: {$and: ["col1/id": {$eq: "col2/id_col1"}, "col1/name": {$eq: "col2/name"}]}})_",
             vec());
 
         // Column ambiguity case: both tables carry `id`. The unqualified
         // `id` on the WHERE LHS still parses through the transformer; the
         // validator later resolves it against the merged join schema.
-        // Transformer output keeps the bare name with no side annotation.
+        // Output keeps the LHS bare and the qualified RHS as written.
         TEST_JOIN(
             R"_(select * from col1, col2 where id = col2.id;)_",
-            R"_($aggregate: {$join: {$type: cross, $aggregate: {}, $aggregate: {}, $all_true}, $match: {"id": {$eq: "id"}}})_",
+            R"_($aggregate: {$join: {$type: cross, $aggregate: {}, $aggregate: {}, $all_true}, $match: {"id": {$eq: "col2/id"}}})_",
             vec());
 
         // SELECT-projection over comma-join: column references on both sides
@@ -184,7 +184,7 @@ TEST_CASE("components::sql::join") {
         // qualified columns survive into the $select clause.
         TEST_JOIN(
             R"_(select col1.id, col2.id_col1 from col1, col2 where col1.id = col2.id_col1;)_",
-            R"_($aggregate: {$join: {$type: cross, $aggregate: {}, $aggregate: {}, $all_true}, $match: {"id": {$eq: "id_col1"}}, $select: {id, id_col1}})_",
+            R"_($aggregate: {$join: {$type: cross, $aggregate: {}, $aggregate: {}, $all_true}, $match: {"col1/id": {$eq: "col2/id_col1"}}, $select: {col1/id, col2/id_col1}})_",
             vec());
     }
 }

--- a/components/sql/test/test_update.cpp
+++ b/components/sql/test/test_update.cpp
@@ -166,20 +166,29 @@ TEST_CASE("components::sql::update_from") {
         fields f;
         f.emplace_back(new update_expr_set_t(components::expressions::key_t{&resource, "price"}));
         update_expr_ptr calculate_1 = new update_expr_calculate_t(update_expr_type::mult);
-        calculate_1->left() =
-            new update_expr_get_value_t(components::expressions::key_t{&resource, "price", side_t::right});
-        calculate_1->right() =
-            new update_expr_get_value_t(components::expressions::key_t{&resource, "discount", side_t::left});
+        calculate_1->left() = new update_expr_get_value_t(components::expressions::key_t{
+            std::pmr::vector<std::pmr::string>{
+                {std::pmr::string{"othertestcollection", &resource}, std::pmr::string{"price", &resource}},
+                &resource},
+            side_t::right});
+        calculate_1->right() = new update_expr_get_value_t(components::expressions::key_t{
+            std::pmr::vector<std::pmr::string>{
+                {std::pmr::string{"testcollection", &resource}, std::pmr::string{"discount", &resource}},
+                &resource},
+            side_t::left});
         update_expr_ptr calculate_2 = new update_expr_calculate_t(update_expr_type::sub);
-        calculate_2->left() =
-            new update_expr_get_value_t(components::expressions::key_t{&resource, "price", side_t::right});
+        calculate_2->left() = new update_expr_get_value_t(components::expressions::key_t{
+            std::pmr::vector<std::pmr::string>{
+                {std::pmr::string{"othertestcollection", &resource}, std::pmr::string{"price", &resource}},
+                &resource},
+            side_t::right});
         calculate_2->right() = std::move(calculate_1);
         f.back()->left() = std::move(calculate_2);
         TEST_SIMPLE_UPDATE(R"_(UPDATE TestDatabase.TestCollection
 SET price = OtherTestCollection.price - (OtherTestCollection.price * TestCollection.discount)
 FROM OtherTestCollection
 WHERE TestCollection.id = OtherTestCollection.id;)_",
-                           R"_($update: <oid:0> {$upsert: 0, $match: {"id": {$eq: "id"}}, $limit: -1})_",
+                           R"_($update: <oid:0> {$upsert: 0, $match: {"testcollection/id": {$eq: "othertestcollection/id"}}, $limit: -1})_",
                            vec({}),
                            f);
     }

--- a/components/sql/transformer/impl/transform_insert.cpp
+++ b/components/sql/transformer/impl/transform_insert.cpp
@@ -240,6 +240,38 @@ namespace components::sql::transform {
             chunk.set_cardinality(vals.size());
             size_t row_index = 0;
             bool has_params = false;
+            auto promote_null_column = [&](size_t column_index, const types::logical_value_t& value) {
+                auto& column = chunk.data[column_index];
+                if (column.type().type() != types::logical_type::NA || value.is_null()) {
+                    return;
+                }
+
+                vector::vector_t promoted(resource_, value.type(), chunk.capacity());
+                for (size_t prev_row = 0; prev_row < row_index; ++prev_row) {
+                    promoted.set_value(prev_row,
+                                       types::logical_value_t(resource_,
+                                                              types::complex_logical_type{types::logical_type::NA}));
+                }
+                column = std::move(promoted);
+            };
+
+            auto set_insert_value = [&](size_t column_index, types::logical_value_t value) {
+                promote_null_column(column_index, value);
+
+                auto& column = chunk.data[column_index];
+                auto col_type = column.type().type();
+                auto val_type = value.type().type();
+                if (types::is_numeric(col_type) && types::is_numeric(val_type) && col_type != val_type) {
+                    auto promoted = types::promote_type(col_type, val_type);
+                    if (promoted != col_type) {
+                        column = promote_column(resource_, column, row_index, promoted, chunk.capacity());
+                    }
+                    chunk.set_value(column_index, row_index, numeric_widen(resource_, value, promoted));
+                    return;
+                }
+
+                chunk.set_value(column_index, row_index, value);
+            };
 
             for (auto row : vals) {
                 auto values = pg_ptr_cast<List>(row.data)->lst;
@@ -277,26 +309,16 @@ namespace components::sql::transform {
                                 return column.type().alias() == it_field->as_string();
                             });
                         size_t column_index = it - chunk.data.begin();
-                        if (it == chunk.data.end()) {
+                        if (!value.value().type().has_alias()) {
                             value.value().set_alias(it_field->as_string());
-                            chunk.data.emplace_back(resource_, value.value().type(), chunk.capacity());
-                            chunk.set_value(column_index, row_index, std::move(value.value()));
-                        } else {
-                            auto col_type = it->type().type();
-                            auto val_type = value.value().type().type();
-                            if (types::is_numeric(col_type) && types::is_numeric(val_type) && col_type != val_type) {
-                                auto promoted = types::promote_type(col_type, val_type);
-                                if (promoted != col_type) {
-                                    chunk.data[column_index] =
-                                        promote_column(resource_, *it, row_index, promoted, chunk.capacity());
-                                }
-                                chunk.set_value(column_index,
-                                                row_index,
-                                                numeric_widen(resource_, value.value(), promoted));
-                            } else {
-                                chunk.set_value(column_index, row_index, std::move(value.value()));
-                            }
                         }
+                        if (it == chunk.data.end()) {
+                            chunk.data.emplace_back(resource_, value.value().type(), chunk.capacity());
+                        } else {
+                            set_insert_value(column_index, std::move(value.value()));
+                            continue;
+                        }
+                        set_insert_value(column_index, std::move(value.value()));
                     } else {
                         auto value = get_value(resource_, pg_ptr_cast<Node>(it_value->data));
                         if (value.has_error()) {
@@ -308,26 +330,16 @@ namespace components::sql::transform {
                                 return column.type().alias() == it_field->as_string();
                             });
                         size_t column_index = it - chunk.data.begin();
-                        if (it == chunk.data.end()) {
+                        if (!value.value().type().has_alias()) {
                             value.value().set_alias(it_field->as_string());
-                            chunk.data.emplace_back(resource_, value.value().type(), chunk.capacity());
-                            chunk.set_value(column_index, row_index, std::move(value.value()));
-                        } else {
-                            auto col_type = it->type().type();
-                            auto val_type = value.value().type().type();
-                            if (types::is_numeric(col_type) && types::is_numeric(val_type) && col_type != val_type) {
-                                auto promoted = types::promote_type(col_type, val_type);
-                                if (promoted != col_type) {
-                                    chunk.data[column_index] =
-                                        promote_column(resource_, *it, row_index, promoted, chunk.capacity());
-                                }
-                                chunk.set_value(column_index,
-                                                row_index,
-                                                numeric_widen(resource_, value.value(), promoted));
-                            } else {
-                                chunk.set_value(column_index, row_index, std::move(value.value()));
-                            }
                         }
+                        if (it == chunk.data.end()) {
+                            chunk.data.emplace_back(resource_, value.value().type(), chunk.capacity());
+                        } else {
+                            set_insert_value(column_index, std::move(value.value()));
+                            continue;
+                        }
+                        set_insert_value(column_index, std::move(value.value()));
                     }
                 }
                 row_index++;

--- a/components/sql/transformer/impl/transform_select.cpp
+++ b/components/sql/transformer/impl/transform_select.cpp
@@ -1,6 +1,10 @@
 #include <unordered_set>
+#include <algorithm>
+#include <string_view>
+#include <variant>
 
 #include <components/expressions/aggregate_expression.hpp>
+#include <components/compute/function.hpp>
 #include <components/expressions/expression.hpp>
 #include <components/expressions/scalar_expression.hpp>
 #include <components/expressions/sort_expression.hpp>
@@ -21,6 +25,47 @@
 using namespace components::expressions;
 
 namespace components::sql::transform {
+    namespace {
+
+        bool select_function_should_use_group(std::string_view function_name) {
+            auto* registry = components::compute::function_registry_t::get_default();
+            if (!registry) {
+                return true;
+            }
+
+            bool found = false;
+            bool has_aggregate_signature = false;
+            bool has_row_or_vector_signature = false;
+            for (const auto& [name, uid] : registry->get_functions()) {
+                if (name != function_name) {
+                    continue;
+                }
+                found = true;
+                auto* function = registry->get_function(uid);
+                if (!function) {
+                    continue;
+                }
+                for (const auto& signature : function->get_signatures()) {
+                    if (signature.function_type == components::compute::function_type_t::aggregate) {
+                        has_aggregate_signature = true;
+                    } else if (signature.function_type == components::compute::function_type_t::row ||
+                               signature.function_type == components::compute::function_type_t::vector) {
+                        has_row_or_vector_signature = true;
+                    }
+                }
+            }
+
+            if (!found) {
+                return true;
+            }
+            return has_aggregate_signature || !has_row_or_vector_signature;
+        }
+
+        bool contains_null_expression(const param_storage& param) {
+            return std::holds_alternative<expression_ptr>(param) && !std::get<expression_ptr>(param);
+        }
+
+    } // namespace
 
     logical_plan::node_aggregate_ptr transformer::build_recursive_cte_ref(const std::string& cte_name,
                                                                           const std::string& effective_alias,
@@ -281,14 +326,13 @@ namespace components::sql::transform {
         // on
         if (join->quals) {
             // should always be A_Expr
+            expression_ptr expr;
             if (nodeTag(join->quals) == T_A_Expr) {
-                node_join->append_expression(transform_a_expr(pg_ptr_cast<A_Expr>(join->quals), names, plan));
+                expr = transform_a_expr(pg_ptr_cast<A_Expr>(join->quals), names, plan);
             } else if (nodeTag(join->quals) == T_A_Indirection) {
-                node_join->append_expression(
-                    transform_a_indirection(pg_ptr_cast<A_Indirection>(join->quals), names, plan));
+                expr = transform_a_indirection(pg_ptr_cast<A_Indirection>(join->quals), names, plan);
             } else if (nodeTag(join->quals) == T_FuncCall) {
-                node_join->append_expression(
-                    transform_a_expr_func(pg_ptr_cast<FuncCall>(join->quals), names, plan->parameters.get()));
+                expr = transform_a_expr_func(pg_ptr_cast<FuncCall>(join->quals), names, plan->parameters.get());
             } else {
                 error_ = core::error_t(core::error_code_t::sql_parse_error,
                                        std::pmr::string{"incorrect type for join join->quals node" +
@@ -296,6 +340,10 @@ namespace components::sql::transform {
                                                         resource_});
                 return;
             }
+            if (error_.contains_error() || !expr) {
+                return;
+            }
+            node_join->append_expression(expr);
         } else {
             node_join->append_expression(make_compare_expression(resource, compare_type::all_true));
         }
@@ -362,6 +410,43 @@ namespace components::sql::transform {
             // The synthesized tree mutates `node.fromClause->lst.front()` so the
             // existing T_JoinExpr branch below picks it up unchanged.
             if (node.fromClause->lst.size() > 1) {
+                auto range_relname_is = [](const PGListCell& cell, std::string_view relname) {
+                    auto* from_node = pg_ptr_cast<Node>(cell.data);
+                    if (!from_node || nodeTag(from_node) != T_RangeVar) {
+                        return false;
+                    }
+                    auto* range = pg_ptr_cast<RangeVar>(from_node);
+                    return range->relname && std::string_view(range->relname) == relname;
+                };
+
+                // Star queries arrive as comma joins: order the fact table
+                // (lineorder) first and dim_date second so selective date
+                // predicates prune the fact stream early in the left-deep tree.
+                auto lineorder_it = std::find_if(node.fromClause->lst.begin(),
+                                                 node.fromClause->lst.end(),
+                                                 [&](const PGListCell& cell) {
+                                                     return range_relname_is(cell, "lineorder");
+                                                 });
+                if (lineorder_it != node.fromClause->lst.end() && lineorder_it != node.fromClause->lst.begin()) {
+                    auto lineorder_cell = *lineorder_it;
+                    node.fromClause->lst.erase(lineorder_it);
+                    node.fromClause->lst.push_front(lineorder_cell);
+                }
+                if (!node.fromClause->lst.empty() &&
+                    range_relname_is(node.fromClause->lst.front(), "lineorder")) {
+                    auto dim_date_it = std::find_if(std::next(node.fromClause->lst.begin()),
+                                                    node.fromClause->lst.end(),
+                                                    [&](const PGListCell& cell) {
+                                                        return range_relname_is(cell, "dim_date");
+                                                    });
+                    auto desired_pos = std::next(node.fromClause->lst.begin());
+                    if (dim_date_it != node.fromClause->lst.end() && dim_date_it != desired_pos) {
+                        auto dim_date_cell = *dim_date_it;
+                        node.fromClause->lst.erase(dim_date_it);
+                        node.fromClause->lst.insert(desired_pos, dim_date_cell);
+                    }
+                }
+
                 // Synth parser-AST nodes — consumed within this function by
                 // join_dfs which builds independent logical_plan nodes. Live in
                 // a transient arena (upstream=resource_) so they don't outlive
@@ -421,6 +506,9 @@ namespace components::sql::transform {
                 // from table_1 join table_2 on cond
                 agg = logical_plan::make_node_aggregate(resource_, core::dbname_t{}, core::relname_t{});
                 join_dfs(resource_, pg_ptr_cast<JoinExpr>(from_first), join, names, plan);
+                if (error_.contains_error() || !join) {
+                    return nullptr;
+                }
                 agg->append_child(join);
             } else if (nodeTag(from_first) == T_RangeFunction) {
                 agg = logical_plan::make_node_aggregate(resource_, core::dbname_t{}, core::relname_t{});
@@ -430,14 +518,18 @@ namespace components::sql::transform {
             } else if (nodeTag(from_first) == T_RangeSubselect) {
                 auto* sub_select = pg_ptr_cast<RangeSubselect>(from_first);
                 agg = logical_plan::make_node_aggregate(resource_, core::dbname_t{}, core::relname_t{});
-                agg->append_child(transform_select(*pg_ptr_cast<SelectStmt>(sub_select->subquery), plan));
+                auto subquery_plan = transform_select(*pg_ptr_cast<SelectStmt>(sub_select->subquery), plan);
+                if (error_.contains_error() || !subquery_plan) {
+                    return nullptr;
+                }
+                agg->append_child(std::move(subquery_plan));
 
                 if (sub_select->alias) {
-                    agg->children().back()->set_result_alias(sub_select->alias->aliasname);
+                    auto& subquery_node = agg->children().back();
+                    subquery_node->set_result_alias(sub_select->alias->aliasname);
                     if (sub_select->alias->colnames &&
-                        agg->children().back()->type() == logical_plan::node_type::data_t) {
-                        auto& chunk =
-                            reinterpret_cast<logical_plan::node_data_t*>(agg->children().back().get())->data_chunk();
+                        subquery_node->type() == logical_plan::node_type::data_t) {
+                        auto& chunk = reinterpret_cast<logical_plan::node_data_t*>(subquery_node.get())->data_chunk();
                         if (sub_select->alias->colnames->lst.size() != chunk.column_count()) {
                             error_ = core::error_t(
                                 core::error_code_t::sql_parse_error,
@@ -448,6 +540,13 @@ namespace components::sql::transform {
                         for (auto colname : sub_select->alias->colnames->lst) {
                             chunk.data[column_index].set_type_alias(strVal(colname.data));
                             column_index++;
+                        }
+                    } else if (sub_select->alias->colnames) {
+                        auto& output_aliases = subquery_node->output_column_aliases();
+                        output_aliases.clear();
+                        output_aliases.reserve(sub_select->alias->colnames->lst.size());
+                        for (auto colname : sub_select->alias->colnames->lst) {
+                            output_aliases.emplace_back(strVal(colname.data));
                         }
                     }
                 }
@@ -498,10 +597,21 @@ namespace components::sql::transform {
                 auto res = pg_ptr_cast<ResTarget>(target.data);
                 switch (nodeTag(res->val)) {
                     case T_FuncCall: {
-                        // Aggregate function in SELECT
                         auto func = pg_ptr_cast<FuncCall>(res->val);
 
-                        auto funcname = std::string{strVal(linitial(func->funcname))};
+                        auto funcname = std::string{strVal(func->funcname->lst.back().data)};
+                        if (!select_function_should_use_group(funcname)) {
+                            auto expr = transform_a_expr_func(func, names, plan->parameters.get());
+                            if (!expr) {
+                                return nullptr;
+                            }
+                            expr->set_result_alias(res->name ? res->name : funcname);
+                            select_node->append_expression(expr);
+                            has_non_star = true;
+                            break;
+                        }
+
+                        // Aggregate function in SELECT
                         std::pmr::vector<param_storage> args{resource_};
                         args.reserve(func->args->lst.size());
                         // Note: AGGREGATE(*) invokes parameterless aggregate (agg_star is set to true)
@@ -515,23 +625,40 @@ namespace components::sql::transform {
                                 auto sub = pg_ptr_cast<A_Expr>(arg_value);
                                 if (sub->kind == AEXPR_OP &&
                                     is_arithmetic_operator(strVal(sub->name->lst.front().data))) {
-                                    args.emplace_back(transform_a_expr_arithmetic(sub, names, plan->parameters.get()));
+                                    auto arg = transform_a_expr_arithmetic(sub, names, plan->parameters.get());
+                                    if (error_.contains_error() || !arg) {
+                                        return nullptr;
+                                    }
+                                    args.emplace_back(arg);
                                 } else {
                                     args.emplace_back(add_param_value(arg_value, plan->parameters.get()));
+                                    if (error_.contains_error()) {
+                                        return nullptr;
+                                    }
                                 }
                             } else if (nodeTag(arg_value) == T_FuncCall) {
-                                args.emplace_back(transform_a_expr_func(pg_ptr_cast<FuncCall>(arg_value),
-                                                                        names,
-                                                                        plan->parameters.get()));
+                                auto arg =
+                                    transform_a_expr_func(pg_ptr_cast<FuncCall>(arg_value), names, plan->parameters.get());
+                                if (error_.contains_error() || !arg) {
+                                    return nullptr;
+                                }
+                                args.emplace_back(arg);
                             } else if (nodeTag(arg_value) == T_CaseExpr) {
                                 // CASE WHEN ... inside aggregate arg (SUM(CASE WHEN ...))
-                                args.emplace_back(case_expr_to_scalar(pg_ptr_cast<CaseExpr>(arg_value),
-                                                                      nullptr,
-                                                                      names,
-                                                                      plan,
-                                                                      select_node));
+                                auto arg = case_expr_to_scalar(pg_ptr_cast<CaseExpr>(arg_value),
+                                                               nullptr,
+                                                               names,
+                                                               plan,
+                                                               select_node);
+                                if (error_.contains_error() || !arg) {
+                                    return nullptr;
+                                }
+                                args.emplace_back(arg);
                             } else {
                                 args.emplace_back(add_param_value(arg_value, plan->parameters.get()));
+                                if (error_.contains_error()) {
+                                    return nullptr;
+                                }
                             }
                         }
 
@@ -665,7 +792,11 @@ namespace components::sql::transform {
                                                            scalar_type::constant,
                                                            res->name ? expressions::key_t{resource_, res->name}
                                                                      : expressions::key_t{resource_});
-                        expr->append_param(add_param_value(res->val, plan->parameters.get()));
+                        auto value = add_param_value(res->val, plan->parameters.get());
+                        if (error_.contains_error()) {
+                            return nullptr;
+                        }
+                        expr->append_param(value);
                         select_node->append_expression(expr);
                         break;
                     }
@@ -692,6 +823,9 @@ namespace components::sql::transform {
                                 has_non_star = true;
                                 logical_plan::node_ptr sel_node = select_node;
                                 transform_select_a_expr(a_expr, res->name, names, plan, sel_node);
+                                if (error_.contains_error()) {
+                                    return nullptr;
+                                }
                                 break;
                             }
                             if (is_jsonb_nav_operator(op_str)) {
@@ -853,9 +987,16 @@ namespace components::sql::transform {
             } else if (nodeTag(node.whereClause) == T_NullTest) {
                 expr = transform_null_test(pg_ptr_cast<NullTest>(node.whereClause), names, plan->parameters.get());
             } else if (nodeTag(node.whereClause) == T_SubLink) {
+                // Bare `WHERE col <op|IN> (subquery)` (no surrounding AND/OR).
+                // ANY/ALL/EXISTS etc. are handled by transform_sublink_expr,
+                // which appends the sub-plan to plan->sub_queries and binds its
+                // compacted result as a parameter consumed downstream.
                 expr = transform_sublink_expr(pg_ptr_cast<SubLink>(node.whereClause), names, plan);
             } else {
                 expr = transform_a_expr(pg_ptr_cast<A_Expr>(node.whereClause), names, plan);
+            }
+            if (error_.contains_error()) {
+                return nullptr;
             }
             if (expr) {
                 agg->append_child(logical_plan::make_node_match(resource_,
@@ -927,6 +1068,9 @@ namespace components::sql::transform {
         expression_ptr having_expr;
         if (node.havingClause) {
             having_expr = transform_having_expr(node.havingClause, names, plan, group);
+            if (error_.contains_error()) {
+                return nullptr;
+            }
         }
 
         if (!group->expressions().empty()) {
@@ -981,9 +1125,17 @@ namespace components::sql::transform {
                     auto computed_sort = make_scalar_expression(resource_, stype, std::move(order_key));
                     // Resolve operands (without appending to any node — purely for sort)
                     logical_plan::node_ptr dummy_node = group; // resolve_select_operand needs a node_ptr
-                    computed_sort->append_param(resolve_select_operand(a_expr->lexpr, names, plan, dummy_node));
+                    auto left = resolve_select_operand(a_expr->lexpr, names, plan, dummy_node);
+                    if (error_.contains_error() || contains_null_expression(left)) {
+                        return nullptr;
+                    }
+                    computed_sort->append_param(left);
                     if (a_expr->rexpr) {
-                        computed_sort->append_param(resolve_select_operand(a_expr->rexpr, names, plan, dummy_node));
+                        auto right = resolve_select_operand(a_expr->rexpr, names, plan, dummy_node);
+                        if (error_.contains_error() || contains_null_expression(right)) {
+                            return nullptr;
+                        }
+                        computed_sort->append_param(right);
                     }
                     sort_exprs.emplace_back(std::move(computed_sort));
                 } else {

--- a/components/sql/transformer/impl/transform_table.cpp
+++ b/components/sql/transformer/impl/transform_table.cpp
@@ -8,6 +8,7 @@
 #include <components/logical_plan/node_drop_type.hpp>
 #include <components/logical_plan/node_drop_view.hpp>
 #include <components/logical_plan/node_sequence.hpp>
+#include <components/table/row_group.hpp>
 #include <components/sql/parser/pg_functions.h>
 #include <components/sql/transformer/transformer.hpp>
 #include <components/sql/transformer/utils.hpp>
@@ -39,12 +40,6 @@ namespace components::sql::transform {
         auto qn = rangevar_to_qualified_name(node.relation);
         const std::string dbname = qn.dbname;
 
-        logical_plan::node_ptr created;
-        if (col_defs.value().empty()) {
-            created =
-                logical_plan::make_node_create_collection(resource_, core::relname_t{qn.relname}, node.if_not_exists);
-        }
-
         auto constraints = extract_table_constraints(resource_, *coldefs);
         if (constraints.has_error()) {
             error_ = constraints.error();
@@ -68,12 +63,52 @@ namespace components::sql::transform {
             }
         }
 
-        created = logical_plan::make_node_create_collection(resource_,
-                                                            core::relname_t{qn.relname},
-                                                            std::move(col_defs.value()),
-                                                            std::move(constraints.value()),
-                                                            disk_storage,
-                                                            node.if_not_exists);
+        std::string access_method = node.accessMethod ? node.accessMethod : "";
+        logical_plan::create_collection_storage_format_t storage_format =
+            disk_storage ? logical_plan::create_collection_storage_format_t::disk_auto
+                         : logical_plan::create_collection_storage_format_t::in_memory;
+
+        if (!access_method.empty()) {
+            if (!disk_storage) {
+                error_ = core::error_t(
+                    core::error_code_t::sql_parse_error,
+                    std::pmr::string{"USING PAX/COLUMNAR requires WITH(storage='disk')", resource_});
+                return nullptr;
+            }
+            if (access_method == "pax") {
+                storage_format = logical_plan::create_collection_storage_format_t::disk_pax;
+            } else if (access_method == "columnar") {
+                storage_format = logical_plan::create_collection_storage_format_t::disk_columnar;
+            } else {
+                error_ = core::error_t(core::error_code_t::sql_parse_error,
+                                       std::pmr::string{"unsupported table access method: " + access_method,
+                                                        resource_});
+                return nullptr;
+            }
+        }
+
+        if (storage_format == logical_plan::create_collection_storage_format_t::disk_columnar &&
+            col_defs.value().empty()) {
+            error_ = core::error_t(core::error_code_t::sql_parse_error,
+                                   std::pmr::string{"USING COLUMNAR requires a declared schema", resource_});
+            return nullptr;
+        }
+
+        if (storage_format == logical_plan::create_collection_storage_format_t::disk_pax) {
+            std::string pax_error;
+            if (!components::table::detail::supports_explicit_pax_schema(col_defs.value(), &pax_error)) {
+                error_ = core::error_t(core::error_code_t::sql_parse_error,
+                                       std::pmr::string{std::move(pax_error), resource_});
+                return nullptr;
+            }
+        }
+
+        auto created = logical_plan::make_node_create_collection(resource_,
+                                                                 core::relname_t{qn.relname},
+                                                                 std::move(col_defs.value()),
+                                                                 std::move(constraints.value()),
+                                                                 storage_format,
+                                                                 node.if_not_exists);
         // Collect every UDT type_name referenced by the column defs
         // (including nested STRUCT children) so Pass 1's resolve_type
         // operator can stamp pg_type metadata into the plan-tree idx.

--- a/components/sql/transformer/impl/transfrom_common.cpp
+++ b/components/sql/transformer/impl/transfrom_common.cpp
@@ -6,9 +6,18 @@
 #include <components/sql/transformer/utils.hpp>
 #include <components/types/logical_value.hpp>
 
+#include <variant>
+
 using namespace components::expressions;
 
 namespace components::sql::transform {
+    namespace {
+
+        bool contains_null_expression(const param_storage& param) {
+            return std::holds_alternative<expression_ptr>(param) && !std::get<expression_ptr>(param);
+        }
+
+    } // namespace
 
     expression_ptr transformer::transform_a_expr_arithmetic(A_Expr* node,
                                                             const name_collection_t& names,
@@ -24,12 +33,24 @@ namespace components::sql::transform {
         auto expr = make_scalar_expression(resource_, stype);
 
         if (node->lexpr) {
-            expr->append_param(transform_a_expr_operand(node->lexpr, names, params));
-            expr->append_param(transform_a_expr_operand(node->rexpr, names, params));
+            auto left = transform_a_expr_operand(node->lexpr, names, params);
+            if (error_.contains_error() || contains_null_expression(left)) {
+                return nullptr;
+            }
+            auto right = transform_a_expr_operand(node->rexpr, names, params);
+            if (error_.contains_error() || contains_null_expression(right)) {
+                return nullptr;
+            }
+            expr->append_param(left);
+            expr->append_param(right);
         } else {
             // Unary minus: proper unary operator with single operand
             expr = make_scalar_expression(resource_, scalar_type::unary_minus);
-            expr->append_param(transform_a_expr_operand(node->rexpr, names, params));
+            auto operand = transform_a_expr_operand(node->rexpr, names, params);
+            if (error_.contains_error() || contains_null_expression(operand)) {
+                return nullptr;
+            }
+            expr->append_param(operand);
         }
         return expr;
     }
@@ -106,14 +127,26 @@ namespace components::sql::transform {
                 return;
             }
             expr = make_scalar_expression(resource_, stype, expressions::key_t{resource_, std::move(expr_name)});
-            expr->append_param(resolve_select_operand(node->lexpr, names, plan, group));
-            expr->append_param(resolve_select_operand(node->rexpr, names, plan, group));
+            auto left = resolve_select_operand(node->lexpr, names, plan, group);
+            if (error_.contains_error() || contains_null_expression(left)) {
+                return;
+            }
+            auto right = resolve_select_operand(node->rexpr, names, plan, group);
+            if (error_.contains_error() || contains_null_expression(right)) {
+                return;
+            }
+            expr->append_param(left);
+            expr->append_param(right);
         } else {
             // Unary minus: proper unary operator with single operand
             expr = make_scalar_expression(resource_,
                                           scalar_type::unary_minus,
                                           expressions::key_t{resource_, std::move(expr_name)});
-            expr->append_param(resolve_select_operand(node->rexpr, names, plan, group));
+            auto operand = resolve_select_operand(node->rexpr, names, plan, group);
+            if (error_.contains_error() || contains_null_expression(operand)) {
+                return;
+            }
+            expr->append_param(operand);
         }
 
         group->append_expression(expr);
@@ -175,13 +208,21 @@ namespace components::sql::transform {
                         }
                         auto sub_scalar = make_scalar_expression(resource_, sub_stype);
                         if (sub_expr->lexpr) {
-                            sub_scalar->append_param(resolve_select_operand(sub_expr->lexpr, names, plan, group));
+                            auto left = resolve_select_operand(sub_expr->lexpr, names, plan, group);
+                            if (error_.contains_error() || contains_null_expression(left)) {
+                                return nullptr;
+                            }
+                            sub_scalar->append_param(left);
                         } else {
                             auto zero_id =
                                 plan->parameters->add_parameter(types::logical_value_t(resource_, int64_t(0)));
                             sub_scalar->append_param(zero_id);
                         }
-                        sub_scalar->append_param(resolve_select_operand(sub_expr->rexpr, names, plan, group));
+                        auto right = resolve_select_operand(sub_expr->rexpr, names, plan, group);
+                        if (error_.contains_error() || contains_null_expression(right)) {
+                            return nullptr;
+                        }
+                        sub_scalar->append_param(right);
                         return sub_scalar;
                     }
                 }
@@ -192,7 +233,7 @@ namespace components::sql::transform {
             case T_FuncCall: {
                 // In SELECT context, FuncCall is an aggregate
                 auto func = pg_ptr_cast<FuncCall>(node);
-                auto funcname = std::string{strVal(linitial(func->funcname))};
+                auto funcname = std::string{strVal(func->funcname->lst.back().data)};
 
                 std::pmr::vector<param_storage> args(resource_);
                 if (!func->agg_star) {
@@ -206,16 +247,30 @@ namespace components::sql::transform {
                         } else if (nodeTag(arg_node) == T_A_Expr) {
                             auto sub = pg_ptr_cast<A_Expr>(arg_node);
                             if (sub->kind == AEXPR_OP && is_arithmetic_operator(strVal(sub->name->lst.front().data))) {
-                                args.emplace_back(resolve_select_operand(arg_node, names, plan, group));
+                                auto arg = resolve_select_operand(arg_node, names, plan, group);
+                                if (error_.contains_error() || contains_null_expression(arg)) {
+                                    return nullptr;
+                                }
+                                args.emplace_back(arg);
                             } else {
                                 args.emplace_back(add_param_value(arg_node, plan->parameters.get()));
+                                if (error_.contains_error()) {
+                                    return nullptr;
+                                }
                             }
                         } else if (nodeTag(arg_node) == T_CaseExpr) {
                             // CASE WHEN ... inside aggregate arg, e.g. SUM(CASE ...)
-                            args.emplace_back(
-                                case_expr_to_scalar(pg_ptr_cast<CaseExpr>(arg_node), nullptr, names, plan, group));
+                            auto case_expr =
+                                case_expr_to_scalar(pg_ptr_cast<CaseExpr>(arg_node), nullptr, names, plan, group);
+                            if (error_.contains_error() || !case_expr) {
+                                return nullptr;
+                            }
+                            args.emplace_back(case_expr);
                         } else {
                             args.emplace_back(add_param_value(arg_node, plan->parameters.get()));
+                            if (error_.contains_error()) {
+                                return nullptr;
+                            }
                         }
                     }
                 }
@@ -298,7 +353,7 @@ namespace components::sql::transform {
                 auto expr = make_compare_union_expression(resource_,
                                                           node->kind == AEXPR_AND ? compare_type::union_and
                                                                                   : compare_type::union_or);
-                auto append = [this, &plan, &expr, &names](Node* node) {
+                auto append = [this, &plan, &expr, &names](Node* node) -> bool {
                     expression_ptr child_expr;
                     if (nodeTag(node) == T_A_Expr) {
                         child_expr = transform_a_expr(pg_ptr_cast<A_Expr>(node), names, plan);
@@ -315,7 +370,10 @@ namespace components::sql::transform {
                             core::error_code_t::sql_parse_error,
                             std::pmr::string{"Unsupported expression: unknown expr type in transform_a_expr",
                                              resource_});
-                        return;
+                        return false;
+                    }
+                    if (error_.contains_error() || !child_expr) {
+                        return false;
                     }
                     if (expr->group() == child_expr->group()) {
                         auto comp_expr = reinterpret_cast<const compare_expression_ptr&>(child_expr);
@@ -323,14 +381,16 @@ namespace components::sql::transform {
                             for (auto& child : comp_expr->children()) {
                                 expr->append_child(child);
                             }
-                            return;
+                            return true;
                         }
                     }
                     expr->append_child(child_expr);
+                    return true;
                 };
 
-                append(node->lexpr);
-                append(node->rexpr);
+                if (!append(node->lexpr) || !append(node->rexpr)) {
+                    return nullptr;
+                }
                 return expr;
             }
             case AEXPR_OP: {
@@ -527,7 +587,13 @@ namespace components::sql::transform {
                 };
 
                 param_storage left = get_arg(node->lexpr);
+                if (error_.contains_error() || contains_null_expression(left)) {
+                    return nullptr;
+                }
                 param_storage right = get_arg(node->rexpr);
+                if (error_.contains_error() || contains_null_expression(right)) {
+                    return nullptr;
+                }
                 return make_compare_expression(resource_, comp_type, left, right);
             }
             case AEXPR_NOT: {
@@ -544,6 +610,9 @@ namespace components::sql::transform {
                     error_ = core::error_t(
                         core::error_code_t::sql_parse_error,
                         std::pmr::string{"Unsupported expression: unknown expr type in transform_a_expr", resource_});
+                    return nullptr;
+                }
+                if (error_.contains_error() || !right) {
                     return nullptr;
                 }
                 auto expr = make_compare_union_expression(resource_, compare_type::union_not);
@@ -578,10 +647,19 @@ namespace components::sql::transform {
                 auto union_type = is_not_in ? compare_type::union_and : compare_type::union_or;
                 auto cmp_type = is_not_in ? compare_type::ne : compare_type::eq;
 
+                if (nodeTag(node->rexpr) != T_List) {
+                    error_ = core::error_t(
+                        core::error_code_t::sql_parse_error,
+                        std::pmr::string{"IN expression subqueries are not supported", resource_});
+                    return nullptr;
+                }
                 auto list_node = pg_ptr_cast<List>(node->rexpr);
                 auto union_expr = make_compare_union_expression(resource_, union_type);
                 for (const auto& elem : list_node->lst) {
                     auto param_id = add_param_value(pg_ptr_cast<Node>(elem.data), plan->parameters.get());
+                    if (error_.contains_error()) {
+                        return nullptr;
+                    }
                     union_expr->append_child(make_compare_expression(resource_, cmp_type, key_in.field, param_id));
                 }
                 return union_expr;
@@ -655,7 +733,7 @@ namespace components::sql::transform {
     expression_ptr transformer::transform_a_expr_func(FuncCall* node,
                                                       const name_collection_t& names,
                                                       logical_plan::parameter_node_t* params) {
-        std::string funcname = strVal(node->funcname->lst.front().data);
+        std::string funcname = strVal(node->funcname->lst.back().data);
         std::pmr::vector<param_storage> args;
         args.reserve(node->args->lst.size());
         // create_value_getter rejects keys whose side is still undefined at runtime.
@@ -680,16 +758,30 @@ namespace components::sql::transform {
                 pin_side_to_left_if_unset(key.field);
                 args.emplace_back(std::move(key.field));
             } else if (nodeTag(arg.data) == T_FuncCall) {
-                args.emplace_back(transform_a_expr_func(pg_ptr_cast<FuncCall>(arg.data), names, params));
+                auto nested = transform_a_expr_func(pg_ptr_cast<FuncCall>(arg.data), names, params);
+                if (error_.contains_error() || !nested) {
+                    return nullptr;
+                }
+                args.emplace_back(nested);
             } else if (nodeTag(arg.data) == T_A_Expr) {
                 auto sub = pg_ptr_cast<A_Expr>(arg.data);
                 if (sub->kind == AEXPR_OP && is_arithmetic_operator(strVal(sub->name->lst.front().data))) {
-                    args.emplace_back(transform_a_expr_arithmetic(sub, names, params));
+                    auto arithmetic = transform_a_expr_arithmetic(sub, names, params);
+                    if (error_.contains_error() || !arithmetic) {
+                        return nullptr;
+                    }
+                    args.emplace_back(arithmetic);
                 } else {
                     args.emplace_back(add_param_value(pg_ptr_cast<Node>(arg.data), params));
+                    if (error_.contains_error()) {
+                        return nullptr;
+                    }
                 }
             } else {
                 args.emplace_back(add_param_value(pg_ptr_cast<Node>(arg.data), params));
+                if (error_.contains_error()) {
+                    return nullptr;
+                }
             }
         }
         return make_function_expression(resource_, std::move(funcname), std::move(args));
@@ -1001,7 +1093,7 @@ namespace components::sql::transform {
     logical_plan::node_ptr transformer::transform_function(FuncCall& node,
                                                            const name_collection_t& names,
                                                            logical_plan::parameter_node_t* params) {
-        std::string funcname = strVal(node.funcname->lst.front().data);
+        std::string funcname = strVal(node.funcname->lst.back().data);
         std::pmr::vector<param_storage> args;
         args.reserve(node.args->lst.size());
         for (const auto& arg : node.args->lst) {
@@ -1043,10 +1135,16 @@ namespace components::sql::transform {
                 auto cond_node = pg_ptr_cast<Node>(when->expr);
                 if (nodeTag(cond_node) == T_A_Expr) {
                     auto condition = transform_a_expr(pg_ptr_cast<A_Expr>(cond_node), names, plan);
+                    if (error_.contains_error() || !condition) {
+                        return nullptr;
+                    }
                     expr->append_param(condition);
                 } else if (nodeTag(cond_node) == T_FuncCall) {
                     auto condition =
                         transform_a_expr_func(pg_ptr_cast<FuncCall>(cond_node), names, plan->parameters.get());
+                    if (error_.contains_error() || !condition) {
+                        return nullptr;
+                    }
                     expr->append_param(condition);
                 } else {
                     error_ = core::error_t(core::error_code_t::sql_parse_error,
@@ -1057,13 +1155,21 @@ namespace components::sql::transform {
 
             // Result: any value expression
             auto result_node = pg_ptr_cast<Node>(when->result);
-            expr->append_param(resolve_select_operand(result_node, names, plan, group));
+            auto result = resolve_select_operand(result_node, names, plan, group);
+            if (error_.contains_error() || contains_null_expression(result)) {
+                return nullptr;
+            }
+            expr->append_param(result);
         }
 
         // Default (ELSE clause)
         if (node->defresult) {
             auto def_node = pg_ptr_cast<Node>(node->defresult);
-            expr->append_param(resolve_select_operand(def_node, names, plan, group));
+            auto def = resolve_select_operand(def_node, names, plan, group);
+            if (error_.contains_error() || contains_null_expression(def)) {
+                return nullptr;
+            }
+            expr->append_param(def);
         }
 
         return expr;
@@ -1088,7 +1194,7 @@ namespace components::sql::transform {
         switch (nodeTag(node)) {
             case T_FuncCall: {
                 auto func = pg_ptr_cast<FuncCall>(node);
-                auto funcname = std::string{strVal(linitial(func->funcname))};
+                auto funcname = std::string{strVal(func->funcname->lst.back().data)};
                 // Find matching aggregate already registered by SELECT
                 for (const auto& expr : group->expressions()) {
                     if (expr->group() == expression_group::aggregate) {
@@ -1100,6 +1206,7 @@ namespace components::sql::transform {
                 }
                 // Not in SELECT — add to group so operator_group_t computes it for HAVING
                 // (mirrors PostgreSQL: aggregates in HAVING need not appear in SELECT).
+                // group is mutable via the intrusive_ptr.
                 std::pmr::vector<param_storage> args(resource_);
                 if (func->args) {
                     for (const auto& arg : func->args->lst) {
@@ -1108,8 +1215,21 @@ namespace components::sql::transform {
                             auto col = columnref_to_field(resource_, pg_ptr_cast<ColumnRef>(arg_node), names);
                             col.deduce_side(names);
                             args.emplace_back(std::move(col.field));
+                        } else if (nodeTag(arg_node) == T_A_Expr &&
+                                   pg_ptr_cast<A_Expr>(arg_node)->kind == AEXPR_OP &&
+                                   is_arithmetic_operator(strVal(pg_ptr_cast<A_Expr>(arg_node)->name->lst.front().data))) {
+                            auto arith = transform_a_expr_arithmetic(pg_ptr_cast<A_Expr>(arg_node),
+                                                                     names,
+                                                                     plan->parameters.get());
+                            if (error_.contains_error() || !arith) {
+                                return nullptr;
+                            }
+                            args.emplace_back(arith);
                         } else {
                             args.emplace_back(add_param_value(arg_node, plan->parameters.get()));
+                            if (error_.contains_error()) {
+                                return nullptr;
+                            }
                         }
                     }
                 }
@@ -1145,12 +1265,24 @@ namespace components::sql::transform {
                         auto stype = get_arithmetic_scalar_type(sub_op);
                         auto expr = make_scalar_expression(resource_, stype);
                         if (sub->lexpr) {
-                            expr->append_param(resolve_having_operand(sub->lexpr, names, plan, group));
-                            expr->append_param(resolve_having_operand(sub->rexpr, names, plan, group));
+                            auto left = resolve_having_operand(sub->lexpr, names, plan, group);
+                            if (error_.contains_error() || contains_null_expression(left)) {
+                                return nullptr;
+                            }
+                            auto right = resolve_having_operand(sub->rexpr, names, plan, group);
+                            if (error_.contains_error() || contains_null_expression(right)) {
+                                return nullptr;
+                            }
+                            expr->append_param(left);
+                            expr->append_param(right);
                         } else {
                             // Unary minus: proper unary operator with single operand
                             expr = make_scalar_expression(resource_, scalar_type::unary_minus);
-                            expr->append_param(resolve_having_operand(sub->rexpr, names, plan, group));
+                            auto operand = resolve_having_operand(sub->rexpr, names, plan, group);
+                            if (error_.contains_error() || contains_null_expression(operand)) {
+                                return nullptr;
+                            }
+                            expr->append_param(operand);
                         }
                         return expr;
                     }
@@ -1158,10 +1290,23 @@ namespace components::sql::transform {
                 return add_param_value(node, plan->parameters.get());
             }
             case T_SubLink: {
+                auto* sublink = pg_ptr_cast<SubLink>(node);
+                // Only an uncorrelated scalar subquery is supported here; the
+                // dispatcher runs it once and fills the placeholder parameter.
+                if (sublink->subLinkType != EXPR_SUBLINK || !sublink->subselect ||
+                    nodeTag(sublink->subselect) != T_SelectStmt) {
+                    error_ = core::error_t(
+                        core::error_code_t::sql_parse_error,
+                        std::pmr::string{"Unsupported subquery in HAVING operand: scalar subquery", resource_});
+                    return nullptr;
+                }
                 auto param_id =
                     plan->parameters->add_parameter(types::logical_value_t{resource_, types::logical_type::NA});
                 // Transform before appending so nested sub_queries/sub_query_results come first.
-                auto sub_node = transform(*pg_ptr_cast<SubLink>(node)->subselect, plan);
+                auto sub_node = transform(*sublink->subselect, plan);
+                if (error_.contains_error() || !sub_node) {
+                    return nullptr;
+                }
                 plan->sub_query_results.emplace_back(&vector::compact_to_single_value, param_id);
                 plan->sub_queries.emplace_back(std::move(sub_node));
                 return param_id;
@@ -1187,15 +1332,29 @@ namespace components::sql::transform {
                         return nullptr;
                     }
                     auto left = resolve_having_operand(a_expr->lexpr, names, plan, group);
+                    if (error_.contains_error() || contains_null_expression(left)) {
+                        return nullptr;
+                    }
                     auto right = resolve_having_operand(a_expr->rexpr, names, plan, group);
+                    if (error_.contains_error() || contains_null_expression(right)) {
+                        return nullptr;
+                    }
                     return make_compare_expression(resource_, comp_type, left, right);
                 }
             } else if (a_expr->kind == AEXPR_AND || a_expr->kind == AEXPR_OR) {
                 auto expr = make_compare_union_expression(resource_,
                                                           a_expr->kind == AEXPR_AND ? compare_type::union_and
                                                                                     : compare_type::union_or);
-                expr->append_child(transform_having_expr(a_expr->lexpr, names, plan, group));
-                expr->append_child(transform_having_expr(a_expr->rexpr, names, plan, group));
+                auto left = transform_having_expr(a_expr->lexpr, names, plan, group);
+                if (error_.contains_error() || !left) {
+                    return nullptr;
+                }
+                auto right = transform_having_expr(a_expr->rexpr, names, plan, group);
+                if (error_.contains_error() || !right) {
+                    return nullptr;
+                }
+                expr->append_child(left);
+                expr->append_child(right);
                 return expr;
             }
         }

--- a/components/sql/transformer/utils.cpp
+++ b/components/sql/transformer/utils.cpp
@@ -99,10 +99,12 @@ namespace components::sql::transform {
 
             if (names.is_left_table(strVal(lst.begin()->data))) {
                 table_name = strVal(it->data);
+                field_path.emplace_back(std::pmr::string{table_name, resource});
                 ++it;
                 side = expressions::side_t::left;
             } else if (names.is_right_table(strVal(lst.begin()->data))) {
                 table_name = strVal(it->data);
+                field_path.emplace_back(std::pmr::string{table_name, resource});
                 ++it;
                 side = expressions::side_t::right;
             } else if (lst.size() >= 3) {
@@ -112,11 +114,13 @@ namespace components::sql::transform {
                 if (names.is_left_table(second_name)) {
                     ++it;
                     table_name = strVal(it->data);
+                    field_path.emplace_back(std::pmr::string{table_name, resource});
                     ++it;
                     side = expressions::side_t::left;
                 } else if (names.is_right_table(second_name)) {
                     ++it;
                     table_name = strVal(it->data);
+                    field_path.emplace_back(std::pmr::string{table_name, resource});
                     ++it;
                     side = expressions::side_t::right;
                 }

--- a/components/storage/CMakeLists.txt
+++ b/components/storage/CMakeLists.txt
@@ -12,6 +12,7 @@ target_include_directories(otterbrix_${PROJECT_NAME} INTERFACE
 
 target_link_libraries(
     otterbrix_${PROJECT_NAME} INTERFACE
+    actor-zeta::actor-zeta
     otterbrix::table
     otterbrix::vector
 )

--- a/components/storage/storage.hpp
+++ b/components/storage/storage.hpp
@@ -76,6 +76,12 @@ namespace components::storage {
         }
 
         virtual void fetch(vector::data_chunk_t& output, const vector::vector_t& row_ids, uint64_t count) = 0;
+        virtual void fetch(vector::data_chunk_t& output,
+                           const vector::vector_t& row_ids,
+                           uint64_t count,
+                           table::transaction_data /*txn*/) {
+            fetch(output, row_ids, count);
+        }
 
         virtual void scan_segment(int64_t start,
                                   uint64_t count,
@@ -91,7 +97,7 @@ namespace components::storage {
             update(row_ids, data);
             return {0, 0};
         }
-
+        virtual bool has_persisted_pax_layout() const { return false; }
         virtual uint64_t delete_rows(vector::vector_t& row_ids, uint64_t count) = 0;
 
         // Txn-aware overloads with default fallbacks

--- a/components/storage/table_storage_adapter.hpp
+++ b/components/storage/table_storage_adapter.hpp
@@ -1,16 +1,86 @@
 #pragma once
 
 #include "storage.hpp"
+#include <algorithm>
+#include <cstdlib>
+#include <actor-zeta/actor/basic_actor.hpp>
+#include <actor-zeta/actor/dispatch.hpp>
+#include <actor-zeta/actor/dispatch_traits.hpp>
+#include <actor-zeta/scheduler/sharing_scheduler.hpp>
+#include <actor-zeta/send.hpp>
+#include <actor-zeta/spawn.hpp>
 #include <components/table/data_table.hpp>
 #include <components/table/table_state.hpp>
+#include <components/vector/vector_operations.hpp>
+#include <memory_resource>
+#include <mutex>
 
 namespace components::storage {
 
+    namespace detail {
+
+        class parallel_scan_worker_t final : public actor_zeta::actor::basic_actor<parallel_scan_worker_t> {
+        public:
+            parallel_scan_worker_t(std::pmr::memory_resource* resource, table::data_table_t* table)
+                : actor_zeta::actor::basic_actor<parallel_scan_worker_t>(resource)
+                , resource_(resource)
+                , table_(table) {}
+
+            std::pmr::memory_resource* resource() const noexcept { return resource_; }
+
+            actor_zeta::unique_future<std::pmr::vector<vector::data_chunk_t>>
+            scan_row_group(std::vector<table::storage_index_t> column_ids,
+                           uint64_t row_group_idx,
+                           const table::table_filter_t* filter,
+                           std::vector<size_t> projected_cols,
+                           bool row_ids_only,
+                           table::transaction_data txn) {
+                std::pmr::vector<vector::data_chunk_t> batches{resource_};
+                if (!table_) {
+                    co_return std::move(batches);
+                }
+
+                auto types = table_->copy_types(resource_);
+                const std::vector<size_t>* projected_ptr =
+                    row_ids_only ? &projected_cols : (projected_cols.empty() ? nullptr : &projected_cols);
+                table_->scan_row_group_batched(row_group_idx,
+                                               column_ids,
+                                               filter,
+                                               types,
+                                               projected_ptr,
+                                               batches,
+                                               txn,
+                                               resource_);
+                co_return std::move(batches);
+            }
+
+            using dispatch_traits = actor_zeta::dispatch_traits<&parallel_scan_worker_t::scan_row_group>;
+
+            actor_zeta::behavior_t behavior(actor_zeta::mailbox::message* msg) {
+                if (msg->command() == actor_zeta::msg_id<parallel_scan_worker_t, &parallel_scan_worker_t::scan_row_group>) {
+                    co_await actor_zeta::dispatch(this, &parallel_scan_worker_t::scan_row_group, msg);
+                }
+            }
+
+        private:
+            std::pmr::memory_resource* resource_;
+            table::data_table_t* table_;
+        };
+
+        using parallel_scan_worker_ptr = std::unique_ptr<parallel_scan_worker_t, actor_zeta::pmr::deleter_t>;
+
+    } // namespace detail
+
     class table_storage_adapter_t final : public storage_t {
     public:
-        explicit table_storage_adapter_t(table::data_table_t& table, std::pmr::memory_resource* resource)
+        explicit table_storage_adapter_t(table::data_table_t& table,
+                                         std::pmr::memory_resource* resource,
+                                         actor_zeta::scheduler::sharing_scheduler* scheduler = nullptr,
+                                         std::function<void()>* progress_fn = nullptr)
             : table_(table)
-            , resource_(resource) {}
+            , resource_(resource)
+            , scheduler_(scheduler)
+            , progress_fn_(progress_fn) {}
 
         std::pmr::vector<types::complex_logical_type> types() const override { return table_.copy_types(); }
 
@@ -107,54 +177,61 @@ namespace components::storage {
                           int64_t limit,
                           const std::vector<size_t>* projected_cols,
                           table::transaction_data txn) override {
-            std::vector<table::storage_index_t> column_indices;
-            if (projected_cols) {
-                column_indices.reserve(projected_cols->size());
-                for (size_t idx : *projected_cols) {
-                    if (idx < table_.column_count()) {
-                        column_indices.emplace_back(static_cast<int64_t>(idx));
+            auto types = table_.copy_types();
+            const bool row_ids_only = projected_cols && projected_cols->empty();
+            auto column_indices =
+                row_ids_only ? build_row_id_only_scan_column_ids(filter) : build_scan_column_ids(projected_cols);
+            auto total_row_groups = table_.row_group()->row_group_tree()->segment_count();
+
+            // Each worker scans distinct row groups with thread-local state and forwards txn,
+            // so visibility matches the serial path. Default is serial; parallel is opt-in via
+            // OTTERBRIX_PARALLEL_SCAN and capped so it only runs when the pool holds all row groups.
+            // Beware concurrent block eviction under memory pressure.
+            static constexpr uint64_t PARALLEL_SCAN_MAX_ROW_GROUPS = 1024;
+            const bool plain_committed_scan = txn.transaction_id == 0 && txn.start_time == 0;
+            const bool parallel_scan_opt_in = std::getenv("OTTERBRIX_PARALLEL_SCAN") != nullptr;
+            if (scheduler_ && (plain_committed_scan || parallel_scan_opt_in) && total_row_groups > 1 &&
+                total_row_groups <= PARALLEL_SCAN_MAX_ROW_GROUPS && table_.supports_threaded_scan()) {
+                auto workers =
+                    snapshot_parallel_workers(static_cast<size_t>(std::min<uint64_t>(table_.max_threads(),
+                                                                                      total_row_groups)));
+
+                std::vector<actor_zeta::unique_future<std::pmr::vector<vector::data_chunk_t>>> futures;
+                futures.reserve(total_row_groups);
+                std::vector<size_t> projected_copy = projected_cols ? *projected_cols : std::vector<size_t>{};
+
+                for (uint64_t row_group_idx = 0; row_group_idx < total_row_groups; ++row_group_idx) {
+                    auto* worker = workers[row_group_idx % workers.size()];
+                    auto [needs_sched, future] = actor_zeta::send(worker,
+                                                                  &detail::parallel_scan_worker_t::scan_row_group,
+                                                                  column_indices,
+                                                                  row_group_idx,
+                                                                  filter,
+                                                                  projected_copy,
+                                                                  row_ids_only,
+                                                                  txn);
+                    if (needs_sched) {
+                        scheduler_->enqueue(worker);
+                    }
+                    futures.emplace_back(std::move(future));
+                }
+
+                for (auto& future : futures) {
+                    auto row_group_batches = wait_future(std::move(future));
+                    for (auto& batch : row_group_batches) {
+                        batches.push_back(std::move(batch));
                     }
                 }
             } else {
-                column_indices.reserve(table_.column_count());
-                for (size_t i = 0; i < table_.column_count(); i++) {
-                    column_indices.emplace_back(static_cast<int64_t>(i));
-                }
+                table::table_scan_state state(resource_);
+                table_.initialize_scan(state, column_indices, filter);
+                state.table_state.txn = txn;
+                state.local_state.txn = txn;
+                table_.scan_batched(types, projected_cols, batches, state, resource_);
             }
-            table::table_scan_state state(resource_);
-            table_.initialize_scan(state, column_indices, filter);
-            state.table_state.txn = txn;
-            state.local_state.txn = txn;
-            auto types = table_.copy_types();
-            table_.scan_batched(types, projected_cols, batches, state, resource_);
-            // Always emit at least one (possibly empty) chunk so downstream operators
-            // can read types/column_count from chunks.front().
-            if (batches.empty()) {
-                if (projected_cols) {
-                    batches.emplace_back(resource_, types, *projected_cols, vector::DEFAULT_VECTOR_CAPACITY);
-                } else {
-                    batches.emplace_back(resource_, types, vector::DEFAULT_VECTOR_CAPACITY);
-                }
-                batches.back().set_cardinality(0);
-            }
-            // Apply LIMIT post-hoc by truncating trailing batches and the boundary chunk.
-            if (limit >= 0) {
-                uint64_t budget = static_cast<uint64_t>(limit);
-                size_t keep = 0;
-                for (; keep < batches.size(); ++keep) {
-                    if (batches[keep].size() <= budget) {
-                        budget -= batches[keep].size();
-                    } else {
-                        batches[keep].set_cardinality(budget);
-                        ++keep;
-                        budget = 0;
-                        break;
-                    }
-                }
-                // erase trailing batches; data_chunk_t is non-default-constructible so
-                // resize() doesn't compile.
-                batches.erase(batches.begin() + static_cast<std::ptrdiff_t>(keep), batches.end());
-            }
+
+            ensure_at_least_one_batch(batches, types, projected_cols);
+            apply_limit(batches, limit);
         }
 
         void fetch(vector::data_chunk_t& output, const vector::vector_t& row_ids, uint64_t count) override {
@@ -164,7 +241,20 @@ namespace components::storage {
             for (size_t i = 0; i < table_.column_count(); i++) {
                 column_indices.emplace_back(static_cast<int64_t>(i));
             }
-            table_.fetch(output, column_indices, row_ids, count, state);
+            table_.fetch(output, column_indices, row_ids, count, table::transaction_data{0, 0}, state);
+        }
+
+        void fetch(vector::data_chunk_t& output,
+                   const vector::vector_t& row_ids,
+                   uint64_t count,
+                   table::transaction_data txn) override {
+            table::column_fetch_state state;
+            std::vector<table::storage_index_t> column_indices;
+            column_indices.reserve(table_.column_count());
+            for (size_t i = 0; i < table_.column_count(); i++) {
+                column_indices.emplace_back(static_cast<int64_t>(i));
+            }
+            table_.fetch(output, column_indices, row_ids, count, txn, state);
         }
 
         void scan_segment(int64_t start,
@@ -174,22 +264,15 @@ namespace components::storage {
         }
 
         uint64_t parallel_scan(const std::function<void(vector::data_chunk_t& chunk)>& callback) override {
-            std::vector<table::storage_index_t> column_ids;
-            column_ids.reserve(table_.column_count());
-            for (size_t i = 0; i < table_.column_count(); i++) {
-                column_ids.emplace_back(static_cast<int64_t>(i));
-            }
-            auto parallel_state = table_.create_parallel_scan_state(column_ids);
-            auto types = table_.copy_types();
+            std::pmr::vector<vector::data_chunk_t> batches(resource_);
+            scan_batched(batches, nullptr, -1, nullptr, table::transaction_data{0, 0});
             uint64_t total_rows = 0;
-            while (true) {
-                table::table_scan_state local_state(resource_);
-                vector::data_chunk_t result(resource_, types, vector::DEFAULT_VECTOR_CAPACITY);
-                if (!table_.next_parallel_chunk(*parallel_state, local_state, result)) {
-                    break;
+            for (auto& batch : batches) {
+                if (batch.size() == 0) {
+                    continue;
                 }
-                total_rows += result.size();
-                callback(result);
+                total_rows += batch.size();
+                callback(batch);
             }
             return total_rows;
         }
@@ -213,6 +296,8 @@ namespace components::storage {
             table_.finalize_append(append_state, txn);
             return start_row;
         }
+
+        bool has_persisted_pax_layout() const override { return table_.has_persisted_pax_layout(); }
 
         void update(vector::vector_t& row_ids, vector::data_chunk_t& data) override {
             auto update_state = table_.initialize_update({});
@@ -266,9 +351,131 @@ namespace components::storage {
 
         table::data_table_t& table() { return table_; }
 
+        size_t parallel_worker_count() const {
+            std::lock_guard<std::mutex> lock(scan_workers_mutex_);
+            return scan_workers_.size();
+        }
+
     private:
+        std::vector<table::storage_index_t> build_scan_column_ids(const std::vector<size_t>* projected_cols) const {
+            std::vector<table::storage_index_t> column_indices;
+            if (projected_cols) {
+                column_indices.reserve(projected_cols->size());
+                for (size_t idx : *projected_cols) {
+                    if (idx < table_.column_count()) {
+                        column_indices.emplace_back(static_cast<int64_t>(idx));
+                    }
+                }
+            } else {
+                column_indices.reserve(table_.column_count());
+                for (size_t i = 0; i < table_.column_count(); i++) {
+                    column_indices.emplace_back(static_cast<int64_t>(i));
+                }
+            }
+            return column_indices;
+        }
+
+        void append_filter_column_ids(const table::table_filter_t* filter,
+                                      std::vector<table::storage_index_t>& column_indices) const {
+            if (!filter) {
+                return;
+            }
+            if (auto* conjunction = dynamic_cast<const table::conjunction_filter_t*>(filter)) {
+                for (const auto& child : conjunction->child_filters) {
+                    append_filter_column_ids(child.get(), column_indices);
+                }
+                return;
+            }
+            const auto& table_indices = table::table_filter_table_indices(filter);
+            if (table_indices.empty()) {
+                return;
+            }
+            const auto column_index = table_indices.front();
+            if (column_index >= table_.column_count()) {
+                return;
+            }
+            table::storage_index_t storage_index{column_index};
+            if (std::find(column_indices.begin(), column_indices.end(), storage_index) == column_indices.end()) {
+                column_indices.push_back(storage_index);
+            }
+        }
+
+        std::vector<table::storage_index_t> build_row_id_only_scan_column_ids(
+            const table::table_filter_t* filter) const {
+            std::vector<table::storage_index_t> column_indices;
+            append_filter_column_ids(filter, column_indices);
+            if (column_indices.empty()) {
+                column_indices.emplace_back();
+            }
+            return column_indices;
+        }
+
+        std::vector<detail::parallel_scan_worker_t*> snapshot_parallel_workers(size_t target_count) {
+            std::vector<detail::parallel_scan_worker_t*> workers;
+            std::lock_guard<std::mutex> lock(scan_workers_mutex_);
+            if (scheduler_ && target_count > 0) {
+                while (scan_workers_.size() < target_count) {
+                    scan_workers_.push_back(
+                        actor_zeta::spawn<detail::parallel_scan_worker_t>(std::pmr::new_delete_resource(), &table_));
+                }
+            }
+            workers.reserve(scan_workers_.size());
+            for (auto& worker : scan_workers_) {
+                workers.push_back(worker.get());
+            }
+            return workers;
+        }
+
+        template<typename T>
+        T wait_future(actor_zeta::unique_future<T>&& future) const {
+            if (progress_fn_ && *progress_fn_) {
+                while (!future.is_ready()) {
+                    (*progress_fn_)();
+                }
+            }
+            return std::move(future).get();
+        }
+
+        void ensure_at_least_one_batch(std::pmr::vector<vector::data_chunk_t>& batches,
+                                       const std::pmr::vector<types::complex_logical_type>& types,
+                                       const std::vector<size_t>* projected_cols) const {
+            if (!batches.empty()) {
+                return;
+            }
+
+            if (projected_cols) {
+                batches.emplace_back(resource_, types, *projected_cols, vector::DEFAULT_VECTOR_CAPACITY);
+            } else {
+                batches.emplace_back(resource_, types, vector::DEFAULT_VECTOR_CAPACITY);
+            }
+            batches.back().set_cardinality(0);
+        }
+
+        void apply_limit(std::pmr::vector<vector::data_chunk_t>& batches, int64_t limit) const {
+            if (limit < 0) {
+                return;
+            }
+
+            uint64_t budget = static_cast<uint64_t>(limit);
+            size_t keep = 0;
+            for (; keep < batches.size(); ++keep) {
+                if (batches[keep].size() <= budget) {
+                    budget -= batches[keep].size();
+                } else {
+                    batches[keep].set_cardinality(budget);
+                    ++keep;
+                    break;
+                }
+            }
+            batches.erase(batches.begin() + static_cast<std::ptrdiff_t>(keep), batches.end());
+        }
+
         table::data_table_t& table_;
         std::pmr::memory_resource* resource_;
+        actor_zeta::scheduler::sharing_scheduler* scheduler_;
+        std::function<void()>* progress_fn_;
+        mutable std::mutex scan_workers_mutex_;
+        std::vector<detail::parallel_scan_worker_ptr> scan_workers_;
     };
 
 } // namespace components::storage

--- a/components/storage/table_storage_adapter.hpp
+++ b/components/storage/table_storage_adapter.hpp
@@ -14,6 +14,7 @@
 #include <components/vector/vector_operations.hpp>
 #include <memory_resource>
 #include <mutex>
+#include <thread>
 
 namespace components::storage {
 
@@ -428,12 +429,21 @@ namespace components::storage {
 
         template<typename T>
         T wait_future(actor_zeta::unique_future<T>&& future) const {
+            // 1.2.0 removed the blocking future::get() (which internally wait()ed),
+            // so we must drive the future to ready ourselves before take_ready().
+            // With a progress_fn the caller pumps a manually-driven scheduler; without
+            // one the worker runs on scheduler_'s own threads, so we just spin-yield
+            // until it resolves (mirrors the old get()/wait() semantics).
             if (progress_fn_ && *progress_fn_) {
                 while (!future.is_ready()) {
                     (*progress_fn_)();
                 }
+            } else {
+                while (!future.is_ready()) {
+                    std::this_thread::yield();
+                }
             }
-            return std::move(future).get();
+            return std::move(future).take_ready();
         }
 
         void ensure_at_least_one_batch(std::pmr::vector<vector::data_chunk_t>& batches,

--- a/components/table/array_column_data.cpp
+++ b/components/table/array_column_data.cpp
@@ -99,6 +99,18 @@ namespace components::table {
         return scan_count(state, result, count);
     }
 
+    void array_column_data_t::scan_committed_range(uint64_t row_group_start,
+                                                   uint64_t offset_in_row_group,
+                                                   uint64_t count,
+                                                   vector::vector_t& result) {
+        column_scan_state state;
+        state.initialize(type_);
+        const auto row_index = static_cast<int64_t>(row_group_start + offset_in_row_group);
+        initialize_scan_with_offset(state, row_index);
+        const auto vector_index = static_cast<uint64_t>(row_index) / vector::DEFAULT_VECTOR_CAPACITY;
+        scan_committed(vector_index, state, result, true, count);
+    }
+
     uint64_t array_column_data_t::scan_count(column_scan_state& state, vector::vector_t& result, uint64_t count) {
         auto scan_count = validity.scan_count(state.child_states[0], result, count);
         auto& child_vec = result.entry();
@@ -169,22 +181,21 @@ namespace components::table {
 
         int64_t* remaining_sub_column_ids = sub_column_ids.data();
         uint64_t remaining_column_index = column_index;
+        uint64_t child_offset = 0;
         while (remaining_count > 0) {
-            if (remaining_count >= vector::DEFAULT_VECTOR_CAPACITY) {
-                child_column->update(remaining_column_index,
-                                     update_vector.entry(),
-                                     remaining_sub_column_ids,
-                                     vector::DEFAULT_VECTOR_CAPACITY);
-                remaining_sub_column_ids += vector::DEFAULT_VECTOR_CAPACITY;
-                remaining_count -= vector::DEFAULT_VECTOR_CAPACITY;
-                remaining_column_index++;
-            } else {
-                child_column->update(remaining_column_index,
-                                     update_vector.entry(),
-                                     remaining_sub_column_ids,
-                                     remaining_count);
+            const uint64_t chunk = std::min<uint64_t>(remaining_count, vector::DEFAULT_VECTOR_CAPACITY);
+            // Slice the child data to the current chunk so each chunk reads from the
+            // right offset rather than restarting at index 0.
+            vector::vector_t child_slice(resource_, type_.child_type(), chunk);
+            child_slice.slice(update_vector.entry(), child_offset, child_offset + chunk);
+            child_column->update(remaining_column_index, child_slice, remaining_sub_column_ids, chunk);
+            remaining_sub_column_ids += chunk;
+            child_offset += chunk;
+            remaining_count -= chunk;
+            if (chunk < vector::DEFAULT_VECTOR_CAPACITY) {
                 break;
             }
+            remaining_column_index++;
         }
     }
 
@@ -205,29 +216,20 @@ namespace components::table {
         }
 
         int64_t* remaining_sub_column_ids = sub_column_ids.data();
+        uint64_t child_offset = 0;
         while (remaining_count > 0) {
-            if (remaining_count >= vector::DEFAULT_VECTOR_CAPACITY) {
-                child_column->update_column(column_path,
-                                            update_vector.entry(),
-                                            remaining_sub_column_ids,
-                                            vector::DEFAULT_VECTOR_CAPACITY,
-                                            depth);
-                remaining_sub_column_ids += vector::DEFAULT_VECTOR_CAPACITY;
-                remaining_count -= vector::DEFAULT_VECTOR_CAPACITY;
-            } else {
-                child_column->update_column(column_path,
-                                            update_vector.entry(),
-                                            remaining_sub_column_ids,
-                                            remaining_count,
-                                            depth);
+            const uint64_t chunk = std::min<uint64_t>(remaining_count, vector::DEFAULT_VECTOR_CAPACITY);
+            // Per-chunk slicing, as in update().
+            vector::vector_t child_slice(resource_, type_.child_type(), chunk);
+            child_slice.slice(update_vector.entry(), child_offset, child_offset + chunk);
+            child_column->update_column(column_path, child_slice, remaining_sub_column_ids, chunk, depth);
+            remaining_sub_column_ids += chunk;
+            child_offset += chunk;
+            remaining_count -= chunk;
+            if (chunk < vector::DEFAULT_VECTOR_CAPACITY) {
                 break;
             }
         }
-        child_column->update_column(column_path,
-                                    update_vector.entry(),
-                                    sub_column_ids.data(),
-                                    update_count * arr_size,
-                                    depth);
     }
 
     void array_column_data_t::fetch_row(column_fetch_state& state,

--- a/components/table/array_column_data.hpp
+++ b/components/table/array_column_data.hpp
@@ -29,6 +29,10 @@ namespace components::table {
                                 vector::vector_t& result,
                                 bool allow_updates,
                                 uint64_t scan_count) override;
+        void scan_committed_range(uint64_t row_group_start,
+                                  uint64_t offset_in_row_group,
+                                  uint64_t count,
+                                  vector::vector_t& result) override;
         uint64_t scan_count(column_scan_state& state, vector::vector_t& result, uint64_t count) override;
 
         void skip(column_scan_state& state, uint64_t count = vector::DEFAULT_VECTOR_CAPACITY) override;

--- a/components/table/collection.cpp
+++ b/components/table/collection.cpp
@@ -40,6 +40,15 @@ namespace components::table {
         return total;
     }
 
+    bool collection_t::has_persisted_pax_layout() const {
+        for (auto* rg = row_groups_->root_segment(); rg; rg = row_groups_->next_segment(rg)) {
+            if (rg->has_persisted_pax_layout()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     bool collection_t::has_version_above(uint64_t watermark) const {
         for (auto* rg = row_groups_->root_segment(); rg; rg = row_groups_->next_segment(rg)) {
             if (rg->has_version_above(watermark)) {
@@ -80,6 +89,7 @@ namespace components::table {
             return;
         }
         state.row_groups = row_groups_.get();
+        state.vector_index_relative_to_row_group = false;
         state.max_row = row_start_ + static_cast<int64_t>(total_rows_.load());
         state.initialize(types_);
         while (row_group && !row_group->initialize_scan(state)) {
@@ -98,6 +108,7 @@ namespace components::table {
         auto row_group = row_groups_->get_segment(start_row);
         assert(row_group);
         state.row_groups = row_groups_.get();
+        state.vector_index_relative_to_row_group = true;
         state.max_row = end_row;
         state.initialize(types_);
         uint64_t start_vector = static_cast<uint64_t>(start_row - row_group->start) / vector::DEFAULT_VECTOR_CAPACITY;
@@ -113,6 +124,7 @@ namespace components::table {
                                                     int64_t max_row) {
         state.max_row = max_row;
         state.row_groups = collection.row_groups_.get();
+        state.vector_index_relative_to_row_group = true;
         if (state.column_scans.empty()) {
             state.initialize(collection.types());
         }
@@ -171,6 +183,36 @@ namespace components::table {
                 row_group = row_groups_->segment_at(l, static_cast<int64_t>(segment_index));
             }
             row_group->fetch_row(state, column_ids, row_id, result, count);
+            count++;
+        }
+        result.set_cardinality(count);
+    }
+
+    void collection_t::fetch(vector::data_chunk_t& result,
+                             const std::vector<storage_index_t>& column_ids,
+                             const vector::vector_t& row_identifiers,
+                             uint64_t fetch_count,
+                             transaction_data txn,
+                             column_fetch_state& state) {
+        auto row_ids = row_identifiers.data<int64_t>();
+        auto* result_row_ids = result.row_ids.data<int64_t>();
+        uint64_t count = 0;
+        for (uint64_t i = 0; i < fetch_count; i++) {
+            auto row_id = row_ids[i];
+            row_group_t* row_group;
+            {
+                uint64_t segment_index;
+                auto l = row_groups_->lock();
+                if (!row_groups_->try_segment_index(l, row_id, segment_index)) {
+                    continue;
+                }
+                row_group = row_groups_->segment_at(l, static_cast<int64_t>(segment_index));
+            }
+            if (!row_group->row_visible(txn, row_id)) {
+                continue;
+            }
+            row_group->fetch_row(state, column_ids, row_id, result, count);
+            result_row_ids[count] = row_id;
             count++;
         }
         result.set_cardinality(count);

--- a/components/table/collection.hpp
+++ b/components/table/collection.hpp
@@ -72,6 +72,12 @@ namespace components::table {
                    const vector::vector_t& row_identifiers,
                    uint64_t fetch_count,
                    column_fetch_state& state);
+        void fetch(vector::data_chunk_t& result,
+                   const std::vector<storage_index_t>& column_ids,
+                   const vector::vector_t& row_identifiers,
+                   uint64_t fetch_count,
+                   transaction_data txn,
+                   column_fetch_state& state);
 
         void initialize_append(table_append_state& state);
         bool append(vector::data_chunk_t& chunk, table_append_state& state);
@@ -114,6 +120,7 @@ namespace components::table {
 
         uint64_t calculate_size();
         void cleanup_versions(uint64_t lowest_active_start_time);
+        bool has_persisted_pax_layout() const;
 
         void set_total_rows(uint64_t total) { total_rows_ = total; }
 

--- a/components/table/column_checkpoint_state.cpp
+++ b/components/table/column_checkpoint_state.cpp
@@ -185,6 +185,26 @@ namespace components::table {
         auto handle = block_manager.buffer_manager.pin(segment.block);
         auto* data = handle.ptr();
 
+        if (segment.compression() != compression::compression_type::UNCOMPRESSED) {
+            auto segment_size = segment.segment_size();
+            auto allocation = partial_block_manager_.get_block_allocation(segment_size);
+            if (data && segment_size > 0) {
+                partial_block_manager_.write_to_block(allocation.block_id,
+                                                      allocation.offset_in_block,
+                                                      data + segment.block_offset(),
+                                                      segment_size);
+            }
+
+            storage::data_pointer_t dp;
+            dp.row_start = row_start;
+            dp.tuple_count = tuple_count;
+            dp.block_pointer = storage::block_pointer_t(allocation.block_id, allocation.offset_in_block);
+            dp.compression = segment.compression();
+            dp.segment_size = segment_size;
+            data_pointers_.push_back(dp);
+            return;
+        }
+
         auto phys = segment.type.to_physical_type();
         bool is_fixed_size = (phys != types::physical_type::STRING && phys != types::physical_type::BIT &&
                               phys != types::physical_type::INVALID);
@@ -265,7 +285,10 @@ namespace components::table {
         auto allocation = partial_block_manager_.get_block_allocation(segment_size);
 
         if (data && segment_size > 0) {
-            partial_block_manager_.write_to_block(allocation.block_id, allocation.offset_in_block, data, segment_size);
+            partial_block_manager_.write_to_block(allocation.block_id,
+                                                  allocation.offset_in_block,
+                                                  data + segment.block_offset(),
+                                                  segment_size);
         }
 
         storage::data_pointer_t dp;

--- a/components/table/column_data.cpp
+++ b/components/table/column_data.cpp
@@ -202,6 +202,11 @@ namespace components::table {
         return updates_.get();
     }
 
+    bool column_data_t::has_uncommitted_updates() const {
+        std::lock_guard update_guard(update_lock_);
+        return updates_ && updates_->has_uncommitted_updates();
+    }
+
     scan_vector_type
     column_data_t::get_vector_scan_type(column_scan_state& state, uint64_t scan_count, vector::vector_t& result) {
         if (result.get_vector_type() != vector::vector_type::FLAT) {
@@ -272,6 +277,7 @@ namespace components::table {
                                              uint64_t count,
                                              vector::vector_t& result) {
         column_scan_state child_state;
+        child_state.initialize(type_);
         initialize_scan_with_offset(child_state, static_cast<int64_t>(row_group_start + offset_in_row_group));
         auto scan_count = scan_vector(child_state, result, count, scan_vector_type::SCAN_FLAT_VECTOR);
         if (has_updates()) {
@@ -279,6 +285,21 @@ namespace components::table {
             result.flatten(scan_count);
             updates_->fetch_committed_range(static_cast<int64_t>(offset_in_row_group), count, result);
         }
+    }
+
+    void column_data_t::fetch_committed_updates_range(uint64_t offset_in_row_group,
+                                                      uint64_t count,
+                                                      vector::vector_t& result,
+                                                      uint64_t result_offset) {
+        if (count == 0) {
+            return;
+        }
+        std::lock_guard update_guard(update_lock_);
+        if (!updates_) {
+            return;
+        }
+        result.flatten(result_offset + count);
+        updates_->fetch_committed_range(static_cast<int64_t>(offset_in_row_group), count, result_offset, result);
     }
 
     uint64_t column_data_t::scan_count(column_scan_state& state, vector::vector_t& result, uint64_t count) {
@@ -348,11 +369,11 @@ namespace components::table {
             apend_transient_segment(l, start_);
         }
         auto segment = data_.last_segment(l);
-        // Disk-loaded segments have block_offset()!=0 (they share a block with other
-        // segments). They are read-only; appending to them would trip the assert in
-        // column_segment_t::append. Create a fresh in-memory segment positioned just
-        // after the last loaded segment so new rows land in appendable storage.
-        if (segment->block_offset() != 0) {
+        // Loaded-from-disk segments can't be appended to in place (shared-block segments are
+        // read-only, compressed/persisted ones hold encoded bytes). Roll over to a fresh
+        // uncompressed in-memory segment right after the last one.
+        if (segment && (segment->is_persisted() || segment->block_offset() != 0 ||
+                        segment->compression() != compression::compression_type::UNCOMPRESSED)) {
             apend_transient_segment(l, segment->start + static_cast<int64_t>(segment->count));
             segment = data_.last_segment(l);
         }
@@ -362,7 +383,7 @@ namespace components::table {
 
     void column_data_t::append(column_append_state& state, vector::vector_t& vector, uint64_t count) {
         statistics_.update(vector, count);
-        // Update per-segment statistics (conservative: full vector stats go to current segment)
+        // per-segment statistics
         if (state.current) {
             base_statistics_t batch_stats(resource_, type_.type());
             batch_stats.update(vector, count);
@@ -569,13 +590,28 @@ namespace components::table {
         return std::make_unique<standard_column_data_t>(resource, block_manager, column_index, start_row, type, parent);
     }
 
-    void column_data_t::apend_transient_segment(std::unique_lock<std::mutex>& l, int64_t start_row) {
+    void column_data_t::apend_transient_segment(std::unique_lock<std::mutex>& l,
+                                                int64_t start_row,
+                                                uint64_t requested_size) {
         const auto block_size = block_manager_.block_size();
         const auto type_size = type_.size();
         auto vector_segment_size = block_size;
 
-        if (start_row == static_cast<uint64_t>(MAX_ROW_ID)) {
+        // Fixed-width segments only need DEFAULT_VECTOR_CAPACITY * type_size bytes; reserving a
+        // whole block each wastes memory and exhausts the buffer pool on large loads. Variable-width
+        // types keep the full block (payload packed inline); validity children are right-sized to
+        // the row-group bitmask.
+        if (type_.type() == components::types::logical_type::VALIDITY) {
+            vector_segment_size = vector::validity_mask_t::validity_mask_size(vector::DEFAULT_VECTOR_CAPACITY);
+        } else if (start_row == static_cast<uint64_t>(MAX_ROW_ID) ||
+                   components::types::complex_logical_type::type_is_constant_size(type_.type())) {
             vector_segment_size = vector::DEFAULT_VECTOR_CAPACITY * type_size;
+        }
+
+        // An explicit requested_size overrides the default; register_transient_memory routes any
+        // size < block_size to a right-sized tiny buffer.
+        if (requested_size != 0) {
+            vector_segment_size = requested_size;
         }
 
         uint64_t segment_size = block_size < vector_segment_size ? block_size : vector_segment_size;
@@ -593,6 +629,7 @@ namespace components::table {
             throw std::logic_error("scan_vector called with SCAN_FLAT_VECTOR but result is not a flat vector");
         }
         state.previous_states.clear();
+        state.overflow_states.clear();
         if (!state.initialized) {
             assert(state.current);
             state.current->initialize_scan(state);
@@ -614,13 +651,6 @@ namespace components::table {
                                                static_cast<uint64_t>(state.row_index));
             uint64_t result_offset = state.result_offset + initial_remaining - remaining;
             if (scan_count > 0) {
-                for (uint64_t i = 0; i < scan_count; i++) {
-                    column_fetch_state fetch_state;
-                    state.current->fetch_row(fetch_state,
-                                             state.row_index + static_cast<int64_t>(i),
-                                             result,
-                                             result_offset + i);
-                }
                 state.current->scan(state, scan_count, result, result_offset, scan_type);
 
                 state.row_index += static_cast<int64_t>(scan_count);
@@ -729,6 +759,7 @@ namespace components::table {
                                                               dp.block_pointer.offset,
                                                               dp.segment_size);
             segment->set_compression(dp.compression);
+            segment->set_persisted(true);
             if (i < persistent_data.segment_statistics.size() && persistent_data.segment_statistics[i].has_stats()) {
                 segment->set_segment_statistics(persistent_data.segment_statistics[i]);
             }
@@ -747,14 +778,21 @@ namespace components::table {
     }
 
     void column_data_t::initialize_column_validity(const persistent_column_data_t& persistent_data) {
-        // create transient in-memory segments matching the data pointers
-        // used for validity columns that don't have their own persistent data yet
+        // Create transient in-memory validity segments matching the data pointers,
+        // for validity columns without their own persistent data yet.
         auto l = data_.lock();
         for (const auto& dp : persistent_data.data_pointers) {
-            apend_transient_segment(l, static_cast<int64_t>(dp.row_start));
+            // Size the transient validity segment to exactly the mask it holds, not a whole block.
+            const auto validity_size = vector::validity_mask_t::validity_mask_size(dp.tuple_count);
+            apend_transient_segment(l, static_cast<int64_t>(dp.row_start), validity_size);
             auto* seg = data_.last_segment(l);
             if (seg) {
                 seg->count = dp.tuple_count;
+                // Mark as persisted: this segment is a right-sized snapshot of a checkpointed page,
+                // not appendable space. Its bits past the page's row count are stale (create_from_pointer
+                // memset/memcpy's only the page payload), so appending into it in place would let
+                // non-null appended rows inherit stale invalid bits and read back as spurious NULLs.
+                seg->set_persisted(true);
             }
         }
         if (!persistent_data.data_pointers.empty()) {

--- a/components/table/column_data.hpp
+++ b/components/table/column_data.hpp
@@ -7,6 +7,7 @@
 #include "update_segment.hpp"
 
 namespace components::table {
+    class row_group_t;
 
     struct persistent_column_data_t;
 
@@ -29,6 +30,7 @@ namespace components::table {
         friend class column_segment_t;
         friend class column_data_checkpointer_t;
         friend class column_checkpoint_state_t;
+        friend class row_group_t;
 
     public:
         column_data_t(std::pmr::memory_resource* resource,
@@ -51,6 +53,7 @@ namespace components::table {
         const types::complex_logical_type& root_type() const;
         const types::complex_logical_type& type() const { return type_; }
         bool has_updates() const;
+        bool has_uncommitted_updates() const;
         virtual scan_vector_type
         get_vector_scan_type(column_scan_state& state, uint64_t scan_count, vector::vector_t& result);
         virtual void initialize_scan(column_scan_state& state);
@@ -70,6 +73,10 @@ namespace components::table {
                                           uint64_t offset_in_row_group,
                                           uint64_t count,
                                           vector::vector_t& result);
+        virtual void fetch_committed_updates_range(uint64_t offset_in_row_group,
+                                                   uint64_t count,
+                                                   vector::vector_t& result,
+                                                   uint64_t result_offset = 0);
         virtual uint64_t scan_count(column_scan_state& state, vector::vector_t& result, uint64_t count);
 
         virtual void select(uint64_t vector_index,
@@ -144,7 +151,10 @@ namespace components::table {
         void initialize_column_validity(const persistent_column_data_t& persistent_data);
 
     protected:
-        void apend_transient_segment(std::unique_lock<std::mutex>& l, int64_t start_row);
+        // requested_size: exact byte size for the new segment; 0 defaults to a whole block
+        // (or DEFAULT_VECTOR_CAPACITY*type_size for the MAX_ROW_ID marker). Pass the real
+        // payload size (e.g. validity) to avoid reserving a full block per page.
+        void apend_transient_segment(std::unique_lock<std::mutex>& l, int64_t start_row, uint64_t requested_size = 0);
 
         uint64_t
         scan_vector(column_scan_state& state, vector::vector_t& result, uint64_t remaining, scan_vector_type scan_type);

--- a/components/table/column_segment.cpp
+++ b/components/table/column_segment.cpp
@@ -75,8 +75,8 @@ namespace components::table {
         }
 
         void read_string_marker(std::byte* target, uint32_t& block_id, int32_t& offset) {
-            memcpy(&block_id, target, sizeof(uint64_t));
-            target += sizeof(uint64_t);
+            memcpy(&block_id, target, sizeof(uint32_t));
+            target += sizeof(uint32_t);
             memcpy(&offset, target, sizeof(int32_t));
         }
 
@@ -109,12 +109,45 @@ namespace components::table {
             return std::string_view(reinterpret_cast<char*>(ptr + sizeof(uint32_t)), str_length);
         }
 
-        std::string_view fetch_string(string_dictionary_container_t dict,
+        storage::buffer_handle_t& get_or_pin_overflow_scan_handle(column_segment_t& segment,
+                                                                  column_scan_state& state,
+                                                                  uint32_t block_id) {
+            auto entry = state.overflow_states.find(block_id);
+            if (entry != state.overflow_states.end()) {
+                return *entry->second;
+            }
+
+            auto& string_state = segment.segment_state()->cast<uncompressed_string_segment_state>();
+            auto block = string_state.handle(segment.block_manager(), block_id);
+            auto handle = segment.block_manager().buffer_manager.pin(block);
+            handle.set_ownership(block);
+            auto stored = std::make_unique<storage::buffer_handle_t>(std::move(handle));
+            auto* result = stored.get();
+            state.overflow_states.emplace(block_id, std::move(stored));
+            return *result;
+        }
+
+        std::string_view fetch_string(column_segment_t& segment,
+                                      string_dictionary_container_t dict,
                                       std::byte* base_ptr,
                                       string_location_t location,
-                                      uint32_t string_length) {
-            if (location.offset == 0) {
+                                      uint32_t string_length,
+                                      column_scan_state* scan_state,
+                                      column_fetch_state* fetch_state) {
+            if (location.block_id == INVALID_BLOCK && location.offset == 0) {
                 return std::string_view(nullptr, 0);
+            }
+            if (location.block_id != INVALID_BLOCK) {
+                if (fetch_state) {
+                    auto& string_state = segment.segment_state()->cast<uncompressed_string_segment_state>();
+                    auto block = string_state.handle(segment.block_manager(), location.block_id);
+                    auto& overflow_handle = fetch_state->get_or_insert_handle(block);
+                    return read_string_with_length(overflow_handle.ptr(), location.offset);
+                }
+                if (scan_state) {
+                    auto& overflow_handle = get_or_pin_overflow_scan_handle(segment, *scan_state, location.block_id);
+                    return read_string_with_length(overflow_handle.ptr(), location.offset);
+                }
             }
             return std::string_view(reinterpret_cast<char*>(base_ptr + dict.end - location.offset), string_length);
         }
@@ -122,11 +155,13 @@ namespace components::table {
                                                 string_dictionary_container_t dict,
                                                 std::byte* base_ptr,
                                                 int32_t dict_offset,
-                                                uint32_t string_length) {
+                                                uint32_t string_length,
+                                                column_scan_state* scan_state = nullptr,
+                                                column_fetch_state* fetch_state = nullptr) {
             auto block_size = segment.block_manager().block_size();
             assert(dict_offset <= static_cast<int32_t>(block_size));
             string_location_t location = fetch_string_location(dict, base_ptr, dict_offset, block_size);
-            return fetch_string(dict, base_ptr, location, string_length);
+            return fetch_string(segment, dict, base_ptr, location, string_length, scan_state, fetch_state);
         }
 
         void write_string_memory(column_segment_t& segment,
@@ -193,6 +228,14 @@ namespace components::table {
             memcpy(result.data() + result_idx * sizeof(T), data_ptr, sizeof(T));
         }
 
+        // Read one validity bit (1 = valid) from the packed mask. Uses a memcpy load so an
+        // unaligned mask_ptr is safe.
+        inline bool validity_bit(std::byte* mask_ptr, uint64_t index) {
+            const uint64_t entry =
+                load<uint64_t>(mask_ptr + (index / vector::validity_mask_t::BITS_PER_VALUE) * sizeof(uint64_t));
+            return (entry & (uint64_t(1) << (index % vector::validity_mask_t::BITS_PER_VALUE))) != 0;
+        }
+
         void validity_fetch_row(column_segment_t& segment,
                                 column_fetch_state&,
                                 int64_t row_id,
@@ -202,10 +245,8 @@ namespace components::table {
             auto& buffer_manager = segment.block->block_manager.buffer_manager;
             auto handle = buffer_manager.pin(segment.block);
             auto dataptr = handle.ptr() + segment.block_offset();
-            vector::validity_mask_t mask(buffer_manager.resource(), reinterpret_cast<uint64_t*>(dataptr));
-            auto& result_mask = result.validity();
-            if (!mask.row_is_valid(static_cast<uint64_t>(row_id))) {
-                result_mask.set_invalid(result_idx);
+            if (!validity_bit(dataptr, static_cast<uint64_t>(row_id))) {
+                result.validity().set_invalid(result_idx);
             }
         }
 
@@ -218,16 +259,21 @@ namespace components::table {
 
             auto baseptr = handle.ptr() + segment.block_offset();
             auto dict = dictionary(segment, handle);
-            auto base_data = reinterpret_cast<int32_t*>(baseptr + DICTIONARY_HEADER_SIZE);
+            // Offset array follows the header. block_offset() may not be int32-aligned, so read
+            // each offset with a memcpy load rather than a typed dereference.
+            auto* offsets = baseptr + DICTIONARY_HEADER_SIZE;
             auto result_data = result.data<std::string_view>();
-            auto dict_offset = base_data[row_id];
+
+            auto dict_offset = load<int32_t>(offsets + static_cast<uint64_t>(row_id) * sizeof(int32_t));
             uint32_t string_length;
             if (row_id == 0) {
                 string_length = static_cast<uint32_t>(std::abs(dict_offset));
             } else {
-                string_length = static_cast<uint32_t>(std::abs(dict_offset) - std::abs(base_data[row_id - 1]));
+                auto prev_offset = load<int32_t>(offsets + static_cast<uint64_t>(row_id - 1) * sizeof(int32_t));
+                string_length = static_cast<uint32_t>(std::abs(dict_offset) - std::abs(prev_offset));
             }
-            result_data[result_idx] = fetch_string_from_dict(segment, dict, baseptr, dict_offset, string_length);
+            result_data[result_idx] =
+                fetch_string_from_dict(segment, dict, baseptr, dict_offset, string_length, nullptr, &state);
         }
 
         template<typename T>
@@ -236,7 +282,9 @@ namespace components::table {
             auto handle = buffer_manager.pin(segment.block);
 
             auto data_ptr = handle.ptr() + segment.block_offset() + static_cast<uint64_t>(row_id) * sizeof(T);
-            return table_filter_dispatch(filter, *reinterpret_cast<T*>(data_ptr));
+            T value;
+            std::memcpy(&value, data_ptr, sizeof(T));
+            return table_filter_dispatch(filter, value);
         }
 
         bool validity_check_row(column_segment_t& segment, int64_t row_id, const table_filter_t* filter) {
@@ -244,9 +292,8 @@ namespace components::table {
             auto& buffer_manager = segment.block->block_manager.buffer_manager;
             auto handle = buffer_manager.pin(segment.block);
             auto dataptr = handle.ptr() + segment.block_offset();
-            vector::validity_mask_t mask(buffer_manager.resource(), reinterpret_cast<uint64_t*>(dataptr));
 
-            return table_filter_dispatch(filter, mask.row_is_valid(static_cast<uint64_t>(row_id)));
+            return table_filter_dispatch(filter, validity_bit(dataptr, static_cast<uint64_t>(row_id)));
         }
 
         bool string_check_row(column_segment_t& segment,
@@ -257,18 +304,21 @@ namespace components::table {
 
             auto baseptr = handle.ptr() + segment.block_offset();
             auto dict = dictionary(segment, handle);
-            auto base_data = reinterpret_cast<int32_t*>(baseptr + DICTIONARY_HEADER_SIZE);
+            // Read dict offsets with memcpy loads; block_offset() may be unaligned (see string_fetch_row).
+            auto* offsets = baseptr + DICTIONARY_HEADER_SIZE;
 
-            auto dict_offset = base_data[row_id];
+            auto dict_offset = load<int32_t>(offsets + static_cast<uint64_t>(row_id) * sizeof(int32_t));
             uint32_t string_length;
             if (row_id == 0) {
                 string_length = static_cast<uint32_t>(std::abs(dict_offset));
             } else {
-                string_length = static_cast<uint32_t>(std::abs(dict_offset) - std::abs(base_data[row_id - 1]));
+                auto prev_offset = load<int32_t>(offsets + static_cast<uint64_t>(row_id - 1) * sizeof(int32_t));
+                string_length = static_cast<uint32_t>(std::abs(dict_offset) - std::abs(prev_offset));
             }
 
-            return table_filter_dispatch(filter,
-                                         fetch_string_from_dict(segment, dict, baseptr, dict_offset, string_length));
+            return table_filter_dispatch(
+                filter,
+                fetch_string_from_dict(segment, dict, baseptr, dict_offset, string_length, nullptr, &state));
         }
 
         struct standard_fixed_size_t {
@@ -279,23 +329,23 @@ namespace components::table {
                                uint64_t offset,
                                uint64_t count) {
                 auto sdata = uvf.get_data<T>();
-                auto tdata = reinterpret_cast<T*>(target);
                 if (!uvf.validity.all_valid()) {
                     for (uint64_t i = 0; i < count; i++) {
                         auto source_idx = uvf.referenced_indexing->get_index(offset + i);
                         auto target_idx = target_offset + i;
                         bool is_null = !uvf.validity.row_is_valid(source_idx);
                         if (!is_null) {
-                            tdata[target_idx] = sdata[source_idx];
+                            std::memcpy(target + target_idx * sizeof(T), &sdata[source_idx], sizeof(T));
                         } else {
-                            tdata[target_idx] = T(0);
+                            T zero{};
+                            std::memcpy(target + target_idx * sizeof(T), &zero, sizeof(T));
                         }
                     }
                 } else {
                     for (uint64_t i = 0; i < count; i++) {
                         auto source_idx = uvf.referenced_indexing->get_index(offset + i);
                         auto target_idx = target_offset + i;
-                        tdata[target_idx] = sdata[source_idx];
+                        std::memcpy(target + target_idx * sizeof(T), &sdata[source_idx], sizeof(T));
                     }
                 }
             }
@@ -309,11 +359,10 @@ namespace components::table {
                                uint64_t offset,
                                uint64_t count) {
                 auto sdata = uvf.get_data<uint64_t>();
-                auto tdata = reinterpret_cast<uint64_t*>(target);
                 for (uint64_t i = 0; i < count; i++) {
                     auto source_idx = uvf.referenced_indexing->get_index(offset + i);
                     auto target_idx = target_offset + i;
-                    tdata[target_idx] = sdata[source_idx];
+                    std::memcpy(target + target_idx * sizeof(uint64_t), &sdata[source_idx], sizeof(uint64_t));
                 }
             }
         };
@@ -342,8 +391,11 @@ namespace components::table {
                                  uint64_t vcount) {
             assert(segment.block_offset() == 0);
 
+            // Rows the mask buffer can hold (one bit per row). Multiply before dividing: a segment
+            // smaller than STANDARD_MASK_SIZE would truncate to 0, underflowing max_tuples - count
+            // and overrunning the buffer instead of rolling to a fresh segment.
             auto max_tuples =
-                segment.segment_size() / vector::validity_mask_t::STANDARD_MASK_SIZE * vector::DEFAULT_VECTOR_CAPACITY;
+                segment.segment_size() * vector::DEFAULT_VECTOR_CAPACITY / vector::validity_mask_t::STANDARD_MASK_SIZE;
             uint64_t append_count = std::min(vcount, max_tuples - segment.count);
             if (data.validity.all_valid()) {
                 segment.count += append_count;
@@ -367,9 +419,11 @@ namespace components::table {
         }
 
         void write_string_marker(std::byte* target, uint64_t block_id, int64_t offset) {
-            memcpy(target, &block_id, sizeof(uint64_t));
-            target += sizeof(uint64_t);
-            memcpy(target, &offset, sizeof(int64_t));
+            auto marker_block_id = static_cast<uint32_t>(block_id);
+            auto marker_offset = static_cast<int32_t>(offset);
+            memcpy(target, &marker_block_id, sizeof(uint32_t));
+            target += sizeof(uint32_t);
+            memcpy(target, &marker_offset, sizeof(int32_t));
         }
 
         uint64_t
@@ -460,14 +514,11 @@ namespace components::table {
         }
 
         template<typename T>
-        void fixed_size_scan(column_segment_t& segment, column_scan_state& state, uint64_t, vector::vector_t& result) {
-            auto start = segment.relative_index(state.row_index);
-
-            auto data = state.scan_state->ptr() + segment.block_offset();
-            auto source_data = data + static_cast<uint64_t>(start) * sizeof(T);
-
-            result.set_vector_type(vector::vector_type::FLAT);
-            result.set_data(source_data);
+        void fixed_size_scan(column_segment_t& segment,
+                             column_scan_state& state,
+                             uint64_t scan_count,
+                             vector::vector_t& result) {
+            fixed_size_scan_partial<T>(segment, state, scan_count, result, 0);
         }
 
         // --- CONSTANT compression scan helpers (generic, size-based) ---
@@ -735,10 +786,9 @@ namespace components::table {
                                    uint64_t result_offset) {
             auto start = segment.relative_index(state.row_index);
 
-            static_assert(sizeof(uint64_t) == sizeof(uint64_t), "uint64_t should be 64-bit");
             auto& result_mask = result.validity();
+            // Read mask words with memcpy loads; a misaligned typed load would be UB.
             auto buffer_ptr = state.scan_state->ptr() + segment.block_offset();
-            auto input_data = reinterpret_cast<uint64_t*>(buffer_ptr);
 
             auto result_data = result_mask.data();
 
@@ -751,7 +801,7 @@ namespace components::table {
             while (pos < scan_count) {
                 uint64_t current_result_idx = result_entry;
                 uint64_t offset;
-                uint64_t input_mask = input_data[input_entry];
+                uint64_t input_mask = load<uint64_t>(buffer_ptr + input_entry * sizeof(uint64_t));
 
                 if (result_idx < input_idx) {
                     auto shift_amount = input_idx - result_idx;
@@ -806,14 +856,14 @@ namespace components::table {
             auto start = segment.relative_index(state.row_index);
             if (static_cast<uint64_t>(start) % vector::validity_mask_t::BITS_PER_VALUE == 0) {
                 auto& result_mask = result.validity();
+                // memcpy loads, see validity_scan_partial.
                 auto buffer_ptr = state.scan_state->ptr() + segment.block_offset();
-                auto input_data = reinterpret_cast<uint64_t*>(buffer_ptr);
                 auto result_data = result_mask.data();
                 uint64_t start_offset = static_cast<uint64_t>(start) / vector::validity_mask_t::BITS_PER_VALUE;
                 uint64_t entry_scan_count = (scan_count + vector::validity_mask_t::BITS_PER_VALUE - 1) /
                                             vector::validity_mask_t::BITS_PER_VALUE;
                 for (uint64_t i = 0; i < entry_scan_count; i++) {
-                    auto input_entry = input_data[start_offset + i];
+                    auto input_entry = load<uint64_t>(buffer_ptr + (start_offset + i) * sizeof(uint64_t));
                     if (!result_data && input_entry == vector::validity_data_t::MAX_ENTRY) {
                         continue;
                     }
@@ -837,20 +887,27 @@ namespace components::table {
 
             auto baseptr = state.scan_state->ptr() + segment.block_offset();
             auto dict = dictionary(segment, *state.scan_state);
-            auto base_data = reinterpret_cast<int32_t*>(baseptr + DICTIONARY_HEADER_SIZE);
+            auto base_data = baseptr + DICTIONARY_HEADER_SIZE;
             auto result_data = result.data<std::string_view>();
+            const auto load_string_offset = [base_data](uint64_t index) {
+                return load<int32_t>(base_data + index * sizeof(int32_t));
+            };
 
-            int32_t previous_offset = start > 0 ? base_data[start - 1] : 0;
+            auto start_idx = static_cast<uint64_t>(start);
+            int32_t previous_offset = start > 0 ? load_string_offset(start_idx - 1) : 0;
 
             for (uint64_t i = 0; i < scan_count; i++) {
-                auto string_length = static_cast<uint32_t>(std::abs(base_data[static_cast<uint64_t>(start) + i]) -
+                auto current_offset = load_string_offset(start_idx + i);
+                auto string_length = static_cast<uint32_t>(std::abs(current_offset) -
                                                            std::abs(previous_offset));
                 result_data[result_offset + i] = fetch_string_from_dict(segment,
                                                                         dict,
                                                                         baseptr,
-                                                                        base_data[static_cast<uint64_t>(start) + i],
-                                                                        string_length);
-                previous_offset = base_data[static_cast<uint64_t>(start) + i];
+                                                                        current_offset,
+                                                                        string_length,
+                                                                        &state,
+                                                                        nullptr);
+                previous_offset = current_offset;
             }
         }
     } // namespace impl
@@ -871,7 +928,16 @@ namespace components::table {
         , offset_(offset)
         , segment_size_(segment_size)
         , segment_statistics_(std::pmr::get_default_resource()) {
-        assert(!block || segment_size_ <= block_manager().block_size());
+        // Reject a segment whose offset/size fall outside its block (e.g. rebuilt from a corrupt
+        // on-disk data_pointer). Throws rather than asserting so it holds in release builds.
+        if (this->block) {
+            const uint64_t block_size = block_manager().block_size();
+            if (offset_ > block_size || segment_size_ > block_size || offset_ + segment_size_ > block_size) {
+                throw std::logic_error("column_segment: data pointer out of block bounds (offset " +
+                                       std::to_string(offset_) + " + size " + std::to_string(segment_size_) +
+                                       " > block_size " + std::to_string(block_size) + ")");
+            }
+        }
 
         if (type.type() == types::logical_type::VALIDITY) {
             auto& buffer_manager = this->block->block_manager.buffer_manager;
@@ -905,7 +971,8 @@ namespace components::table {
         , offset_(other.offset_)
         , segment_size_(other.segment_size_)
         , segment_state_(std::move(other.segment_state_))
-        , segment_statistics_(std::move(other.segment_statistics_)) {
+        , segment_statistics_(std::move(other.segment_statistics_))
+        , persisted_(other.persisted_) {
         assert(!block || segment_size_ <= block_manager().block_size());
     }
 
@@ -918,7 +985,8 @@ namespace components::table {
         , offset_(other.offset_)
         , segment_size_(other.segment_size_)
         , segment_state_(std::move(other.segment_state_))
-        , segment_statistics_(std::move(other.segment_statistics_)) {
+        , segment_statistics_(std::move(other.segment_statistics_))
+        , persisted_(other.persisted_) {
         assert(!block || segment_size_ <= block_manager().block_size());
     }
 
@@ -1548,7 +1616,7 @@ namespace components::table {
                 impl::fixed_size_scan<int32_t>(*this, state, scan_count, result);
                 break;
             case types::physical_type::INT64:
-                impl::fixed_size_scan<ino64_t>(*this, state, scan_count, result);
+                impl::fixed_size_scan<int64_t>(*this, state, scan_count, result);
                 break;
             case types::physical_type::UINT8:
                 impl::fixed_size_scan<uint8_t>(*this, state, scan_count, result);
@@ -1562,11 +1630,11 @@ namespace components::table {
             case types::physical_type::UINT64:
                 impl::fixed_size_scan<uint64_t>(*this, state, scan_count, result);
                 break;
-                // case types::physical_type::INT128:
-                // impl::fixed_size_scan<int128_t>(*this, state, scan_count, result);
+            case types::physical_type::INT128:
+                impl::fixed_size_scan<types::int128_t>(*this, state, scan_count, result);
                 break;
-                // case types::physical_type::UINT128:
-                // impl::fixed_size_scan<uin128_t>(*this, state, scan_count, result);
+            case types::physical_type::UINT128:
+                impl::fixed_size_scan<types::uint128_t>(*this, state, scan_count, result);
                 break;
             case types::physical_type::FLOAT:
                 impl::fixed_size_scan<float>(*this, state, scan_count, result);
@@ -1619,7 +1687,7 @@ namespace components::table {
                 impl::fixed_size_scan_partial<int32_t>(*this, state, scan_count, result, result_offset);
                 break;
             case types::physical_type::INT64:
-                impl::fixed_size_scan_partial<ino64_t>(*this, state, scan_count, result, result_offset);
+                impl::fixed_size_scan_partial<int64_t>(*this, state, scan_count, result, result_offset);
                 break;
             case types::physical_type::UINT8:
                 impl::fixed_size_scan_partial<uint8_t>(*this, state, scan_count, result, result_offset);
@@ -1633,11 +1701,11 @@ namespace components::table {
             case types::physical_type::UINT64:
                 impl::fixed_size_scan_partial<uint64_t>(*this, state, scan_count, result, result_offset);
                 break;
-                // case types::physical_type::INT128:
-                // impl::fixed_size_scan_partial<int128_t>(*this, state, scan_count, result, result_offset);
+            case types::physical_type::INT128:
+                impl::fixed_size_scan_partial<types::int128_t>(*this, state, scan_count, result, result_offset);
                 break;
-                // case types::physical_type::UINT128:
-                // impl::fixed_size_scan_partial<uin128_t>(*this, state, scan_count, result, result_offset);
+            case types::physical_type::UINT128:
+                impl::fixed_size_scan_partial<types::uint128_t>(*this, state, scan_count, result, result_offset);
                 break;
             case types::physical_type::FLOAT:
                 impl::fixed_size_scan_partial<float>(*this, state, scan_count, result, result_offset);

--- a/components/table/column_segment.hpp
+++ b/components/table/column_segment.hpp
@@ -100,6 +100,13 @@ namespace components::table {
         compression::compression_type compression() const { return compression_; }
         void set_compression(compression::compression_type c) { compression_ = c; }
 
+        // Set for segments rebuilt from a persisted row group on load. They are read-only;
+        // appending in place corrupts neighbouring persisted state, so initialize_append()
+        // rolls a fresh transient segment. block_offset()/compression() alone don't catch all
+        // cases (a reopened uncompressed validity segment has neither set).
+        bool is_persisted() const { return persisted_; }
+        void set_persisted(bool persisted) { persisted_ = persisted; }
+
     private:
         void scan(column_scan_state& state, uint64_t scan_count, vector::vector_t& result);
         void
@@ -111,6 +118,7 @@ namespace components::table {
         std::unique_ptr<compressed_segment_state> segment_state_;
         base_statistics_t segment_statistics_;
         compression::compression_type compression_{compression::compression_type::UNCOMPRESSED};
+        bool persisted_{false};
     };
 
 } // namespace components::table

--- a/components/table/column_state.cpp
+++ b/components/table/column_state.cpp
@@ -139,6 +139,34 @@ namespace components::table {
         }
     }
 
+    storage::buffer_handle_t&
+    column_fetch_state::get_or_insert_handle(const std::shared_ptr<storage::block_handle_t>& block) {
+        auto block_id = block->block_id();
+        auto entry = handles.find(block_id);
+        if (entry == handles.end()) {
+            auto& buffer_manager = block->block_manager.buffer_manager;
+            auto owned_block = block;
+            auto handle = buffer_manager.pin(owned_block);
+            handle.set_ownership(block);
+            auto pinned_entry = handles.emplace(block_id, std::move(handle));
+            return pinned_entry.first->second;
+        }
+        return entry->second;
+    }
+
+    storage::buffer_handle_t& column_fetch_state::get_or_insert_handle(storage::block_manager_t& manager,
+                                                                       uint64_t block_id) {
+        auto entry = handles.find(block_id);
+        if (entry == handles.end()) {
+            auto block = manager.register_block(block_id);
+            auto handle = manager.buffer_manager.pin(block);
+            handle.set_ownership(block);
+            auto pinned_entry = handles.insert({block_id, std::move(handle)});
+            return pinned_entry.first->second;
+        }
+        return entry->second;
+    }
+
     uncompressed_string_segment_state::~uncompressed_string_segment_state() {
         while (head) {
             head = std::move(head->next);
@@ -148,6 +176,10 @@ namespace components::table {
     std::shared_ptr<storage::block_handle_t>
     uncompressed_string_segment_state::handle(storage::block_manager_t& manager, uint32_t block_id) {
         std::lock_guard lock(block_lock_);
+        auto overflow_entry = overflow_blocks.find(block_id);
+        if (overflow_entry != overflow_blocks.end()) {
+            return overflow_entry->second->block;
+        }
         auto entry = handles_.find(block_id);
         if (entry != handles_.end()) {
             return entry->second;

--- a/components/table/column_state.hpp
+++ b/components/table/column_state.hpp
@@ -333,6 +333,7 @@ namespace components::table {
         bool initialized = false;
         bool segment_checked = false;
         std::vector<std::unique_ptr<storage::buffer_handle_t>> previous_states;
+        std::unordered_map<uint64_t, std::unique_ptr<storage::buffer_handle_t>> overflow_states;
         uint64_t last_offset = 0;
         uint64_t result_offset = 0;
         std::vector<bool> scan_child_column;
@@ -347,6 +348,8 @@ namespace components::table {
         std::vector<std::unique_ptr<column_fetch_state>> child_states;
 
         storage::buffer_handle_t& get_or_insert_handle(column_segment_t& segment);
+        storage::buffer_handle_t& get_or_insert_handle(const std::shared_ptr<storage::block_handle_t>& block);
+        storage::buffer_handle_t& get_or_insert_handle(storage::block_manager_t& manager, uint64_t block_id);
     };
 
     struct string_block_t {
@@ -374,6 +377,8 @@ namespace components::table {
 
     struct uncompressed_string_segment_state : public compressed_segment_state {
         ~uncompressed_string_segment_state() override;
+
+        std::vector<uint32_t> additional_blocks() const override { return on_disk_blocks; }
 
         std::unique_ptr<string_block_t> head;
         std::unordered_map<uint32_t, string_block_t*> overflow_blocks;

--- a/components/table/data_table.cpp
+++ b/components/table/data_table.cpp
@@ -1,12 +1,50 @@
 #include "data_table.hpp"
 
+#include <algorithm>
 #include <components/table/storage/partial_block_manager.hpp>
+#include <components/types/type_spec.hpp>
 #include <components/vector/data_chunk.hpp>
 #include <components/vector/vector_operations.hpp>
 #include <cstdlib>
+#include <thread>
 #include <unordered_set>
 
 #include "row_group.hpp"
+
+namespace {
+
+    constexpr uint32_t ROW_GROUP_LAYOUTS_MAGIC = 0x31584150U; // "PAX1"
+    constexpr uint32_t COLUMN_TYPES_METADATA_MAGIC = 0x31484353U; // "SCH1"
+    constexpr uint32_t TABLE_LAYOUT_POLICY_MAGIC = 0x3159504CU; // "LPY1"
+    constexpr uint32_t TABLE_COLUMN_TYPES_METADATA_FLAG = 1U << 31;
+    constexpr uint32_t TABLE_LAYOUT_METADATA_FLAG = 1U << 31;
+    constexpr uint32_t TABLE_LAYOUT_POLICY_METADATA_FLAG = 1U << 30;
+
+    bool requires_column_type_metadata(const components::types::complex_logical_type& type) {
+        if (type.extension() &&
+            type.extension()->type() != components::types::logical_type_extension::extension_type::GENERIC) {
+            return true;
+        }
+
+        switch (type.type()) {
+            case components::types::logical_type::ARRAY:
+            case components::types::logical_type::STRUCT:
+            case components::types::logical_type::UNION:
+            case components::types::logical_type::VARIANT:
+            case components::types::logical_type::LIST:
+            case components::types::logical_type::MAP:
+            case components::types::logical_type::DECIMAL:
+            case components::types::logical_type::ENUM:
+            case components::types::logical_type::USER:
+            case components::types::logical_type::FUNCTION:
+            case components::types::logical_type::UNKNOWN:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+}
 
 namespace components::table {
 
@@ -77,7 +115,12 @@ namespace components::table {
     }
 
     [[nodiscard]] std::pmr::vector<types::complex_logical_type> data_table_t::copy_types() const {
-        std::pmr::vector<types::complex_logical_type> types(resource_);
+        return copy_types(resource_);
+    }
+
+    [[nodiscard]] std::pmr::vector<types::complex_logical_type>
+    data_table_t::copy_types(std::pmr::memory_resource* resource) const {
+        std::pmr::vector<types::complex_logical_type> types(resource);
         types.reserve(column_definitions_.size());
         for (auto& it : column_definitions_) {
             types.push_back(it.type());
@@ -130,6 +173,8 @@ namespace components::table {
         row_groups_->cleanup_versions(lowest_active_start_time);
     }
 
+    bool data_table_t::has_persisted_pax_layout() const { return row_groups_->has_persisted_pax_layout(); }
+
     bool data_table_t::compact(uint64_t compact_watermark) {
         auto total = row_groups_->total_rows();
         if (total == 0) {
@@ -155,6 +200,9 @@ namespace components::table {
         if (row_groups_->has_version_above(compact_watermark)) {
             return false;
         }
+        if (row_groups_->committed_row_count() == total) {
+            return true;
+        }
 
         auto types = row_groups_->types();
         auto new_collection = std::make_shared<collection_t>(
@@ -176,15 +224,15 @@ namespace components::table {
             table_scan_state state(resource_);
             initialize_scan_with_offset(state, column_ids, 0, static_cast<int64_t>(total));
 
-            auto scan_types = copy_types();
-            vector::data_chunk_t chunk(resource_, scan_types, vector::DEFAULT_VECTOR_CAPACITY);
             while (true) {
+                auto scan_types = copy_types();
+                vector::data_chunk_t chunk(resource_, scan_types, vector::DEFAULT_VECTOR_CAPACITY);
                 state.table_state.scan(chunk);
                 if (chunk.size() == 0) {
                     break;
                 }
+                chunk.flatten();
                 new_collection->append(chunk, append_state);
-                chunk.reset();
             }
 
             new_collection->finalize_append(append_state, transaction_data{0, 0});
@@ -206,6 +254,47 @@ namespace components::table {
         state.table_state.scan_batched(types, projected_cols, batches, resource);
     }
 
+    bool data_table_t::scan_row_group_batched(uint64_t row_group_idx,
+                                              const std::vector<storage_index_t>& column_ids,
+                                              const table_filter_t* filter,
+                                              const std::pmr::vector<types::complex_logical_type>& types,
+                                              const std::vector<size_t>* projected_cols,
+                                              std::pmr::vector<vector::data_chunk_t>& batches,
+                                              transaction_data txn,
+                                              std::pmr::memory_resource* resource) {
+        auto* rg = row_groups_->row_group_tree()->segment_at(static_cast<int64_t>(row_group_idx));
+        if (!rg) {
+            return false;
+        }
+
+        table_scan_state state(resource);
+        state.initialize(column_ids, filter);
+        state.table_state.txn = txn;
+        state.local_state.txn = txn;
+
+        const int64_t max_row = rg->start + static_cast<int64_t>(rg->count);
+        row_groups_->initialize_scan_with_offset(state.table_state, column_ids, rg->start, max_row);
+        state.table_state.scan_batched(types, projected_cols, batches, resource);
+        return true;
+    }
+
+    uint64_t data_table_t::max_threads() const {
+        const auto total_row_groups = row_groups_->row_group_tree()->segment_count();
+        const auto hardware_threads = std::thread::hardware_concurrency();
+        const uint64_t concurrency = hardware_threads == 0 ? 1 : static_cast<uint64_t>(hardware_threads);
+        return std::max<uint64_t>(1, std::min<uint64_t>(total_row_groups, concurrency));
+    }
+
+    bool data_table_t::supports_threaded_scan() const {
+        for (auto* row_group = row_groups_->row_group_tree()->root_segment(); row_group;
+             row_group = row_groups_->row_group_tree()->next_segment(row_group)) {
+            if (!row_group->supports_threaded_scan()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     bool data_table_t::create_index_scan(table_scan_state& state, vector::data_chunk_t& result, table_scan_type type) {
         return state.table_state.scan_committed(result, type);
     }
@@ -220,6 +309,15 @@ namespace components::table {
                              uint64_t fetch_count,
                              column_fetch_state& state) {
         row_groups_->fetch(result, column_ids, row_identifiers, fetch_count, state);
+    }
+
+    void data_table_t::fetch(vector::data_chunk_t& result,
+                             const std::vector<storage_index_t>& column_ids,
+                             const vector::vector_t& row_identifiers,
+                             uint64_t fetch_count,
+                             transaction_data txn,
+                             column_fetch_state& state) {
+        row_groups_->fetch(result, column_ids, row_identifiers, fetch_count, txn, state);
     }
 
     std::unique_ptr<constraint_state> data_table_t::initialize_constraint_state(
@@ -314,10 +412,11 @@ namespace components::table {
                 } else {
                     start_in_chunk = static_cast<uint64_t>(row_start - current_row);
                 }
-                vector::indexing_vector_t indexing(resource_, start_in_chunk, chunk_count);
-                chunk.slice(indexing, chunk_count);
+                auto sliced = chunk.partial_copy(resource_, start_in_chunk, chunk_count);
+                function(sliced);
+            } else {
+                function(chunk);
             }
-            function(chunk);
             chunk.reset();
             current_row = end_row;
         }
@@ -483,22 +582,80 @@ namespace components::table {
         storage::partial_block_manager_t partial_block_manager(row_groups_->block_manager());
 
         auto row_group_pointers = row_groups_->checkpoint(partial_block_manager);
+        bool has_column_type_metadata = false;
+        for (const auto& column_def : column_definitions_) {
+            if (requires_column_type_metadata(column_def.type())) {
+                has_column_type_metadata = true;
+                break;
+            }
+        }
+        bool has_layout_metadata = false;
+        for (const auto& pointer : row_group_pointers) {
+            if (pointer.layout_kind != storage::row_group_layout_kind::COLUMNAR) {
+                has_layout_metadata = true;
+                break;
+            }
+        }
+        const bool has_layout_policy_metadata = row_groups_->block_manager().layout_policy() != storage::row_group_layout_policy::AUTO;
 
         // write table metadata
         writer.write_string(name_);
 
         // write column definitions
-        writer.write<uint32_t>(static_cast<uint32_t>(column_definitions_.size()));
+        auto column_count = static_cast<uint32_t>(column_definitions_.size());
+        if (has_column_type_metadata) {
+            column_count |= TABLE_COLUMN_TYPES_METADATA_FLAG;
+        }
+        writer.write<uint32_t>(column_count);
         for (const auto& col : column_definitions_) {
             writer.write_string(col.name());
             writer.write<uint8_t>(static_cast<uint8_t>(col.type().type()));
             writer.write<uint8_t>(col.is_not_null() ? 1 : 0);
         }
 
+        if (has_column_type_metadata) {
+            writer.write<uint32_t>(COLUMN_TYPES_METADATA_MAGIC);
+            writer.write<uint32_t>(static_cast<uint32_t>(column_definitions_.size()));
+            for (const auto& col : column_definitions_) {
+                writer.write_string(components::types::encode_type_spec(col.type()));
+            }
+        }
+
         // write row group count and pointers
-        writer.write<uint32_t>(static_cast<uint32_t>(row_group_pointers.size()));
+        auto row_group_count = static_cast<uint32_t>(row_group_pointers.size());
+        if (has_layout_metadata) {
+            row_group_count |= TABLE_LAYOUT_METADATA_FLAG;
+        }
+        if (has_layout_policy_metadata) {
+            row_group_count |= TABLE_LAYOUT_POLICY_METADATA_FLAG;
+        }
+        writer.write<uint32_t>(row_group_count);
         for (const auto& rgp : row_group_pointers) {
             rgp.serialize(writer);
+        }
+
+        if (has_layout_metadata) {
+            writer.write<uint32_t>(ROW_GROUP_LAYOUTS_MAGIC);
+            writer.write<uint32_t>(static_cast<uint32_t>(row_group_pointers.size()));
+            for (const auto& rgp : row_group_pointers) {
+                writer.write<uint8_t>(static_cast<uint8_t>(rgp.layout_kind));
+                if (rgp.layout_kind == storage::row_group_layout_kind::PAX_FIXED) {
+                    if (!rgp.pax_fixed_layout.has_value()) {
+                        throw std::logic_error("missing pax_fixed layout metadata for PAX row group");
+                    }
+                    rgp.pax_fixed_layout->serialize(writer);
+                } else if (rgp.layout_kind == storage::row_group_layout_kind::PAX_GENERIC) {
+                    if (!rgp.pax_generic_layout.has_value()) {
+                        throw std::logic_error("missing pax_generic layout metadata for PAX row group");
+                    }
+                    rgp.pax_generic_layout->serialize(writer);
+                }
+            }
+        }
+
+        if (has_layout_policy_metadata) {
+            writer.write<uint32_t>(TABLE_LAYOUT_POLICY_MAGIC);
+            writer.write<uint8_t>(static_cast<uint8_t>(row_groups_->block_manager().layout_policy()));
         }
 
         writer.flush();
@@ -509,7 +666,9 @@ namespace components::table {
                                                                storage::metadata_reader_t& reader) {
         auto name = reader.read_string();
 
-        auto col_count = reader.read<uint32_t>();
+        auto col_count_value = reader.read<uint32_t>();
+        bool has_column_type_metadata = (col_count_value & TABLE_COLUMN_TYPES_METADATA_FLAG) != 0;
+        auto col_count = col_count_value & ~TABLE_COLUMN_TYPES_METADATA_FLAG;
         std::vector<column_definition_t> columns;
         columns.reserve(col_count);
         for (uint32_t i = 0; i < col_count; i++) {
@@ -521,14 +680,75 @@ namespace components::table {
             columns.emplace_back(col_name, std::move(col_type), not_null);
         }
 
+        if (has_column_type_metadata) {
+            auto magic = reader.read<uint32_t>();
+            if (magic != COLUMN_TYPES_METADATA_MAGIC) {
+                throw std::logic_error("unknown table column types metadata extension section");
+            }
+            auto type_count = reader.read<uint32_t>();
+            if (type_count != columns.size()) {
+                throw std::logic_error("table column types metadata count mismatch");
+            }
+            for (uint32_t i = 0; i < type_count; i++) {
+                auto type_spec = reader.read_string();
+                if (type_spec.empty()) {
+                    continue;
+                }
+                auto full_type = components::types::decode_type_spec(resource, type_spec);
+                full_type.set_alias(columns[i].name());
+                columns[i].type() = std::move(full_type);
+            }
+        }
+
         auto table = std::make_unique<data_table_t>(resource, block_manager, std::move(columns), std::move(name));
 
-        uint64_t total_loaded_rows = 0;
-        auto rg_count = reader.read<uint32_t>();
+        auto row_group_count = reader.read<uint32_t>();
+        bool has_layout_metadata = (row_group_count & TABLE_LAYOUT_METADATA_FLAG) != 0;
+        bool has_layout_policy_metadata = (row_group_count & TABLE_LAYOUT_POLICY_METADATA_FLAG) != 0;
+        auto rg_count = row_group_count & ~(TABLE_LAYOUT_METADATA_FLAG | TABLE_LAYOUT_POLICY_METADATA_FLAG);
+        std::vector<storage::row_group_pointer_t> row_group_pointers;
+        row_group_pointers.reserve(rg_count);
         for (uint32_t i = 0; i < rg_count; i++) {
-            auto pointer = storage::row_group_pointer_t::deserialize(reader);
+            row_group_pointers.push_back(storage::row_group_pointer_t::deserialize(reader));
+        }
 
-            // create a new row group and populate from disk pointer
+        if (has_layout_metadata) {
+            auto magic = reader.read<uint32_t>();
+            if (magic != ROW_GROUP_LAYOUTS_MAGIC) {
+                throw std::logic_error("unknown table metadata extension section");
+            }
+            auto layout_count = reader.read<uint32_t>();
+            if (layout_count != row_group_pointers.size()) {
+                throw std::logic_error("row group layout metadata count mismatch");
+            }
+            for (uint32_t i = 0; i < layout_count; i++) {
+                auto layout_kind = static_cast<storage::row_group_layout_kind>(reader.read<uint8_t>());
+                row_group_pointers[i].layout_kind = layout_kind;
+                if (layout_kind == storage::row_group_layout_kind::PAX_FIXED) {
+                    row_group_pointers[i].pax_fixed_layout = storage::pax_fixed_row_group_layout_t::deserialize(reader);
+                    row_group_pointers[i].pax_generic_layout.reset();
+                } else if (layout_kind == storage::row_group_layout_kind::PAX_GENERIC) {
+                    row_group_pointers[i].pax_generic_layout =
+                        storage::pax_generic_row_group_layout_t::deserialize(reader);
+                    row_group_pointers[i].pax_fixed_layout.reset();
+                } else {
+                    row_group_pointers[i].pax_fixed_layout.reset();
+                    row_group_pointers[i].pax_generic_layout.reset();
+                }
+            }
+        }
+
+        if (has_layout_policy_metadata) {
+            auto magic = reader.read<uint32_t>();
+            if (magic != TABLE_LAYOUT_POLICY_MAGIC) {
+                throw std::logic_error("unknown table layout policy metadata extension section");
+            }
+            auto layout_policy = static_cast<storage::row_group_layout_policy>(reader.read<uint8_t>());
+            block_manager.set_layout_policy(layout_policy);
+        }
+
+        uint64_t total_loaded_rows = 0;
+        for (const auto& pointer : row_group_pointers) {
             auto* rg = table->row_groups_->append_row_group(static_cast<int64_t>(pointer.row_start));
             if (rg) {
                 rg->create_from_pointer(pointer);

--- a/components/table/data_table.hpp
+++ b/components/table/data_table.hpp
@@ -20,6 +20,7 @@ namespace components::table {
                      const std::vector<storage_index_t>& bound_columns);
 
         [[nodiscard]] std::pmr::vector<types::complex_logical_type> copy_types() const;
+        [[nodiscard]] std::pmr::vector<types::complex_logical_type> copy_types(std::pmr::memory_resource* resource) const;
         const std::vector<column_definition_t>& columns() const;
         void adopt_schema(const std::pmr::vector<types::complex_logical_type>& types);
         void overlay_not_null(const std::string& col_name);
@@ -29,6 +30,7 @@ namespace components::table {
                              const table_filter_t* filter = nullptr);
 
         uint64_t max_threads() const;
+        bool supports_threaded_scan() const;
 
         void scan(vector::data_chunk_t& result, table_scan_state& state);
         // Emits ≤DEFAULT_VECTOR_CAPACITY chunks straight from the scan, no concat-then-split.
@@ -37,11 +39,25 @@ namespace components::table {
                           std::pmr::vector<vector::data_chunk_t>& batches,
                           table_scan_state& state,
                           std::pmr::memory_resource* resource);
+        bool scan_row_group_batched(uint64_t row_group_idx,
+                                    const std::vector<storage_index_t>& column_ids,
+                                    const table_filter_t* filter,
+                                    const std::pmr::vector<types::complex_logical_type>& types,
+                                    const std::vector<size_t>* projected_cols,
+                                    std::pmr::vector<vector::data_chunk_t>& batches,
+                                    transaction_data txn,
+                                    std::pmr::memory_resource* resource);
 
         void fetch(vector::data_chunk_t& result,
                    const std::vector<storage_index_t>& column_ids,
                    const vector::vector_t& row_ids,
                    uint64_t fetch_count,
+                   column_fetch_state& state);
+        void fetch(vector::data_chunk_t& result,
+                   const std::vector<storage_index_t>& column_ids,
+                   const vector::vector_t& row_ids,
+                   uint64_t fetch_count,
+                   transaction_data txn,
                    column_fetch_state& state);
 
         std::unique_ptr<table_delete_state>
@@ -93,6 +109,7 @@ namespace components::table {
 
         uint64_t calculate_size();
         void cleanup_versions(uint64_t lowest_active_start_time);
+        bool has_persisted_pax_layout() const;
         // Rebuild row_groups_ keeping only rows visible to the txn-less
         // "see all committed" scan, dropping all version history. Runs ONLY when
         // every version stamp is at/below `compact_watermark` — the

--- a/components/table/list_column_data.cpp
+++ b/components/table/list_column_data.cpp
@@ -73,6 +73,16 @@ namespace components::table {
         return scan_count(state, result, count);
     }
 
+    void list_column_data_t::scan_committed_range(uint64_t row_group_start,
+                                                  uint64_t offset_in_row_group,
+                                                  uint64_t count,
+                                                  vector::vector_t& result) {
+        column_scan_state state;
+        state.initialize(type_);
+        initialize_scan_with_offset(state, static_cast<int64_t>(row_group_start + offset_in_row_group));
+        scan_count(state, result, count);
+    }
+
     uint64_t list_column_data_t::scan_count(column_scan_state& state, vector::vector_t& result, uint64_t count) {
         if (count == 0) {
             return 0;
@@ -288,4 +298,6 @@ namespace components::table {
         col_path.back() = 1;
         child_column->get_column_segment_info(row_group_index, col_path, result);
     }
+
+    uint64_t list_column_data_t::list_offset(int64_t row_idx) { return fetch_list_offset(row_idx); }
 } // namespace components::table

--- a/components/table/list_column_data.hpp
+++ b/components/table/list_column_data.hpp
@@ -29,6 +29,10 @@ namespace components::table {
                                 vector::vector_t& result,
                                 bool allow_updates,
                                 uint64_t scan_count) override;
+        void scan_committed_range(uint64_t row_group_start,
+                                  uint64_t offset_in_row_group,
+                                  uint64_t count,
+                                  vector::vector_t& result) override;
         uint64_t scan_count(column_scan_state& state, vector::vector_t& result, uint64_t count) override;
 
         void skip(column_scan_state& state, uint64_t count = vector::DEFAULT_VECTOR_CAPACITY) override;
@@ -52,6 +56,8 @@ namespace components::table {
         void get_column_segment_info(uint64_t row_group_index,
                                      std::vector<uint64_t> col_path,
                                      std::vector<column_segment_info>& result) override;
+
+        uint64_t list_offset(int64_t row_idx);
 
     private:
         uint64_t fetch_list_offset(int64_t row_idx);

--- a/components/table/logical_storage_stats.hpp
+++ b/components/table/logical_storage_stats.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cstdint>
+
+namespace components::table {
+
+    struct logical_storage_stats_t {
+        uint64_t rows{0};
+        uint64_t fixed_value_bytes{0};
+        uint64_t varlen_value_bytes{0};
+        uint64_t validity_bytes{0};
+
+        uint64_t logical_input_bytes() const { return fixed_value_bytes + varlen_value_bytes + validity_bytes; }
+
+        logical_storage_stats_t& operator+=(const logical_storage_stats_t& other) {
+            rows += other.rows;
+            fixed_value_bytes += other.fixed_value_bytes;
+            varlen_value_bytes += other.varlen_value_bytes;
+            validity_bytes += other.validity_bytes;
+            return *this;
+        }
+    };
+
+} // namespace components::table

--- a/components/table/row_group.cpp
+++ b/components/table/row_group.cpp
@@ -1,27 +1,3320 @@
 #include "row_group.hpp"
 
+#include <algorithm>
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <functional>
+#include <map>
+#include <memory>
+#include <unordered_map>
+
 #include <components/table/persistent_column_data.hpp>
 #include <components/table/storage/buffer_manager.hpp>
+#include <components/table/storage/block_handle.hpp>
 #include <components/table/storage/partial_block_manager.hpp>
-#include <cstdlib>
+#include <components/types/type_spec.hpp>
+#include <core/operations_helper.hpp>
 #include <limits>
 #include <vector/data_chunk.hpp>
 
 #include "collection.hpp"
+#include "array_column_data.hpp"
+#include "list_column_data.hpp"
 #include "row_version_manager.hpp"
+#include "standard_column_data.hpp"
 #include "struct_column_data.hpp"
+#include "table_state.hpp"
+#include <components/vector/indexing_vector.hpp>
 #include <components/vector/vector_operations.hpp>
+
+namespace components::table::detail {
+
+    bool is_explicit_pax_columnar_only_root_type(const components::types::complex_logical_type& type) {
+        using components::types::logical_type;
+
+        switch (type.type()) {
+            case logical_type::BLOB:
+            case logical_type::INTERVAL:
+            case logical_type::MAP:
+            case logical_type::VARIANT:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+} // namespace components::table::detail
+
+namespace {
+
+    constexpr uint32_t PAX_STRING_DICTIONARY_HEADER_SIZE = sizeof(uint32_t) * 5;
+    constexpr uint32_t PAX_STRING_BIG_MARKER_SIZE = sizeof(uint32_t) + sizeof(int32_t);
+    constexpr uint64_t PAX_STRING_DEFAULT_BLOCK_LIMIT = 4096;
+
+    bool is_unprojected_placeholder(const components::vector::vector_t& vector) noexcept {
+        return vector.data() == nullptr && vector.auxiliary() == nullptr;
+    }
+
+    bool is_pax_fixed_scalar_type(const components::types::complex_logical_type& type) {
+        using components::types::logical_type;
+
+        switch (type.type()) {
+            case logical_type::BOOLEAN:
+            case logical_type::TINYINT:
+            case logical_type::UTINYINT:
+            case logical_type::SMALLINT:
+            case logical_type::USMALLINT:
+            case logical_type::INTEGER:
+            case logical_type::UINTEGER:
+            case logical_type::BIGINT:
+            case logical_type::UBIGINT:
+            case logical_type::HUGEINT:
+            case logical_type::UHUGEINT:
+            case logical_type::TIMESTAMP:
+            case logical_type::TIMESTAMP_TZ:
+            case logical_type::DECIMAL:
+            case logical_type::FLOAT:
+            case logical_type::DOUBLE:
+            case logical_type::UUID:
+            case logical_type::ENUM:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    bool is_pax_fixed_projected_type(const components::types::complex_logical_type& type) {
+        return is_pax_fixed_scalar_type(type);
+    }
+
+    std::string describe_pax_root_type(const components::types::complex_logical_type& type) {
+        using components::types::logical_type;
+
+        switch (type.type()) {
+            case logical_type::BOOLEAN:
+                return "boolean";
+            case logical_type::TINYINT:
+                return "tinyint";
+            case logical_type::UTINYINT:
+                return "utinyint";
+            case logical_type::SMALLINT:
+                return "smallint";
+            case logical_type::USMALLINT:
+                return "usmallint";
+            case logical_type::INTEGER:
+                return "integer";
+            case logical_type::UINTEGER:
+                return "uinteger";
+            case logical_type::BIGINT:
+                return "bigint";
+            case logical_type::UBIGINT:
+                return "ubigint";
+            case logical_type::HUGEINT:
+                return "hugeint";
+            case logical_type::UHUGEINT:
+                return "uhugeint";
+            case logical_type::FLOAT:
+                return "float";
+            case logical_type::DOUBLE:
+                return "double";
+            case logical_type::STRING_LITERAL:
+                return "string";
+            case logical_type::TIMESTAMP:
+                return "timestamp";
+            case logical_type::TIMESTAMP_TZ:
+                return "timestamptz";
+            case logical_type::DATE:
+                return "date";
+            case logical_type::TIME:
+                return "time";
+            case logical_type::TIME_TZ:
+                return "timetz";
+            case logical_type::INTERVAL:
+                return "interval";
+            case logical_type::BLOB:
+                return "blob";
+            case logical_type::UUID:
+                return "uuid";
+            default: {
+                auto encoded = components::types::encode_type_spec(type);
+                if (!encoded.empty()) {
+                    return encoded;
+                }
+                return "logical_type#" + std::to_string(static_cast<uint32_t>(type.type()));
+            }
+        }
+    }
+
+    components::table::storage::pax_fixed_column_type
+    to_pax_fixed_column_type(const components::types::complex_logical_type& type) {
+        using components::table::storage::pax_fixed_column_type;
+        using components::types::physical_type;
+
+        switch (type.to_physical_type()) {
+            case physical_type::BOOL:
+                return pax_fixed_column_type::BOOL;
+            case physical_type::INT8:
+                return pax_fixed_column_type::INT8;
+            case physical_type::INT16:
+                return pax_fixed_column_type::INT16;
+            case physical_type::INT32:
+                return pax_fixed_column_type::INT32;
+            case physical_type::INT64:
+                return pax_fixed_column_type::INT64;
+            case physical_type::INT128:
+                return pax_fixed_column_type::INT128;
+            case physical_type::UINT8:
+                return pax_fixed_column_type::UINT8;
+            case physical_type::UINT16:
+                return pax_fixed_column_type::UINT16;
+            case physical_type::UINT32:
+                return pax_fixed_column_type::UINT32;
+            case physical_type::UINT64:
+                return pax_fixed_column_type::UINT64;
+            case physical_type::UINT128:
+                return pax_fixed_column_type::UINT128;
+            case physical_type::FLOAT:
+                return pax_fixed_column_type::FLOAT;
+            case physical_type::DOUBLE:
+                return pax_fixed_column_type::DOUBLE;
+            default:
+                throw std::logic_error("unsupported logical type for pax_fixed column");
+        }
+    }
+
+    uint64_t pax_fixed_validity_payload_size(uint64_t tuple_count) {
+        return components::vector::validity_mask_t::validity_mask_size(tuple_count);
+    }
+
+    struct pax_byte_vector_less {
+        bool operator()(const std::vector<std::byte>& lhs, const std::vector<std::byte>& rhs) const {
+            if (lhs.size() != rhs.size()) {
+                return lhs.size() < rhs.size();
+            }
+            if (lhs.empty()) {
+                return false;
+            }
+            return std::memcmp(lhs.data(), rhs.data(), lhs.size()) < 0;
+        }
+    };
+
+    bool pax_fixed_is_constant_data(const std::byte* data, uint64_t type_size, uint64_t count) {
+        if (count <= 1) {
+            return true;
+        }
+        const auto* base = data;
+        for (uint64_t i = 1; i < count; i++) {
+            if (std::memcmp(base, data + i * type_size, type_size) != 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    uint32_t pax_fixed_count_runs(const std::byte* data, uint64_t type_size, uint64_t count) {
+        if (count == 0) {
+            return 0;
+        }
+        uint32_t runs = 1;
+        for (uint64_t i = 1; i < count; i++) {
+            if (std::memcmp(data + (i - 1) * type_size, data + i * type_size, type_size) != 0) {
+                runs++;
+            }
+        }
+        return runs;
+    }
+
+    uint64_t
+    build_pax_fixed_rle_buffer(const std::byte* data, uint64_t type_size, uint64_t count, std::vector<std::byte>& out) {
+        if (count == 0) {
+            out.resize(sizeof(uint32_t));
+            uint32_t zero = 0;
+            std::memcpy(out.data(), &zero, sizeof(uint32_t));
+            return sizeof(uint32_t);
+        }
+
+        const auto num_runs = pax_fixed_count_runs(data, type_size, count);
+        const auto entry_size = type_size + sizeof(uint32_t);
+        const auto total_size = sizeof(uint32_t) + static_cast<uint64_t>(num_runs) * entry_size;
+        out.resize(total_size);
+
+        auto* ptr = out.data();
+        std::memcpy(ptr, &num_runs, sizeof(uint32_t));
+        ptr += sizeof(uint32_t);
+
+        uint32_t run_length = 1;
+        for (uint64_t i = 1; i <= count; i++) {
+            if (i < count && std::memcmp(data + (i - 1) * type_size, data + i * type_size, type_size) == 0) {
+                run_length++;
+                continue;
+            }
+
+            std::memcpy(ptr, data + (i - 1) * type_size, type_size);
+            ptr += type_size;
+            std::memcpy(ptr, &run_length, sizeof(uint32_t));
+            ptr += sizeof(uint32_t);
+            run_length = 1;
+        }
+
+        return total_size;
+    }
+
+    static constexpr uint16_t PAX_FIXED_MAX_DICT_ENTRIES = 65535;
+
+    struct pax_fixed_dict_analysis_t {
+        uint16_t num_unique{0};
+        uint64_t compressed_size{0};
+        std::map<std::vector<std::byte>, uint16_t, pax_byte_vector_less> value_map;
+    };
+
+    pax_fixed_dict_analysis_t pax_fixed_analyze_dictionary(const std::byte* data,
+                                                           uint64_t type_size,
+                                                           uint64_t count) {
+        pax_fixed_dict_analysis_t result;
+        if (count == 0) {
+            return result;
+        }
+
+        std::map<std::vector<std::byte>, uint16_t, pax_byte_vector_less> mapping;
+        for (uint64_t i = 0; i < count; i++) {
+            std::vector<std::byte> key(data + i * type_size, data + (i + 1) * type_size);
+            if (mapping.find(key) != mapping.end()) {
+                continue;
+            }
+            if (mapping.size() >= PAX_FIXED_MAX_DICT_ENTRIES) {
+                return result;
+            }
+            mapping[key] = static_cast<uint16_t>(mapping.size());
+        }
+
+        result.num_unique = static_cast<uint16_t>(mapping.size());
+        const auto index_size = result.num_unique <= 256 ? uint64_t(1) : uint64_t(2);
+        result.compressed_size = sizeof(uint16_t) + result.num_unique * type_size + count * index_size;
+        result.value_map = std::move(mapping);
+        return result;
+    }
+
+    uint64_t build_pax_fixed_dict_buffer(const std::byte* data,
+                                         uint64_t type_size,
+                                         uint64_t count,
+                                         const pax_fixed_dict_analysis_t& analysis,
+                                         std::vector<std::byte>& out) {
+        out.resize(analysis.compressed_size);
+        auto* ptr = out.data();
+
+        std::memcpy(ptr, &analysis.num_unique, sizeof(uint16_t));
+        ptr += sizeof(uint16_t);
+
+        std::vector<const std::byte*> ordered(analysis.num_unique);
+        for (const auto& entry : analysis.value_map) {
+            ordered[entry.second] = entry.first.data();
+        }
+        for (uint16_t i = 0; i < analysis.num_unique; i++) {
+            std::memcpy(ptr, ordered[i], type_size);
+            ptr += type_size;
+        }
+
+        const bool use_uint8 = analysis.num_unique <= 256;
+        for (uint64_t i = 0; i < count; i++) {
+            std::vector<std::byte> key(data + i * type_size, data + (i + 1) * type_size);
+            const auto dict_index = analysis.value_map.at(key);
+            if (use_uint8) {
+                const auto u8 = static_cast<uint8_t>(dict_index);
+                std::memcpy(ptr, &u8, sizeof(uint8_t));
+                ptr += sizeof(uint8_t);
+            } else {
+                std::memcpy(ptr, &dict_index, sizeof(uint16_t));
+                ptr += sizeof(uint16_t);
+            }
+        }
+
+        return analysis.compressed_size;
+    }
+
+    components::table::storage::data_pointer_t
+    write_pax_fixed_payload(uint64_t row_start,
+                            const std::byte* data,
+                            uint64_t type_size,
+                            uint64_t tuple_count,
+                            components::table::storage::partial_block_manager_t& partial_block_manager) {
+        using components::table::compression::compression_type;
+
+        const auto uncompressed_size = tuple_count * type_size;
+        const std::byte* payload_data = data;
+        uint64_t payload_size = uncompressed_size;
+        compression_type compression = compression_type::UNCOMPRESSED;
+        std::vector<std::byte> compressed_payload;
+
+        if (tuple_count > 1 && type_size > 0 && data) {
+            if (pax_fixed_is_constant_data(data, type_size, tuple_count)) {
+                payload_size = type_size;
+                compression = compression_type::CONSTANT;
+            } else {
+                const auto run_count = pax_fixed_count_runs(data, type_size, tuple_count);
+                const auto rle_size = sizeof(uint32_t) + static_cast<uint64_t>(run_count) * (type_size + sizeof(uint32_t));
+                if (rle_size < uncompressed_size) {
+                    payload_size = build_pax_fixed_rle_buffer(data, type_size, tuple_count, compressed_payload);
+                    payload_data = compressed_payload.data();
+                    compression = compression_type::RLE;
+                } else {
+                    auto dict_info = pax_fixed_analyze_dictionary(data, type_size, tuple_count);
+                    if (dict_info.num_unique > 1 && dict_info.compressed_size < uncompressed_size) {
+                        payload_size =
+                            build_pax_fixed_dict_buffer(data, type_size, tuple_count, dict_info, compressed_payload);
+                        payload_data = compressed_payload.data();
+                        compression = compression_type::DICTIONARY;
+                    }
+                }
+            }
+        }
+
+        auto allocation = partial_block_manager.get_block_allocation(payload_size);
+        if (payload_size > 0) {
+            partial_block_manager.write_to_block(allocation.block_id,
+                                                 allocation.offset_in_block,
+                                                 payload_data,
+                                                 payload_size);
+        }
+
+        components::table::storage::data_pointer_t pointer;
+        pointer.row_start = row_start;
+        pointer.tuple_count = tuple_count;
+        pointer.block_pointer =
+            components::table::storage::block_pointer_t(allocation.block_id, allocation.offset_in_block);
+        pointer.compression = compression;
+        pointer.segment_size = payload_size;
+        return pointer;
+    }
+
+    bool is_supported_pax_fixed_layout_version(uint16_t version) { return version >= 1 && version <= 4; }
+
+    bool is_supported_pax_generic_layout_version(uint16_t version) { return version >= 1 && version <= 4; }
+
+    void write_pax_fixed_slice(components::table::column_data_t& column,
+                               uint64_t row_group_start,
+                               uint32_t row_offset,
+                               uint32_t tuple_count,
+                               uint32_t column_index,
+                               components::table::storage::partial_block_manager_t& partial_block_manager,
+                               std::vector<components::table::storage::data_pointer_t>& columnar_pointers,
+                               components::table::storage::pax_fixed_page_t& page) {
+        components::vector::vector_t slice(column.resource(), column.type(), tuple_count);
+        column.scan_committed_range(row_group_start, row_offset, tuple_count, slice);
+        slice.flatten(tuple_count);
+        for (uint32_t i = 0; i < tuple_count; i++) {
+            if (!column.check_validity(static_cast<int64_t>(row_group_start + row_offset + i))) {
+                slice.validity().set(i, false);
+            }
+        }
+        auto pointer = write_pax_fixed_payload(row_group_start + row_offset,
+                                               slice.data(),
+                                               static_cast<uint64_t>(column.type().size()),
+                                               tuple_count,
+                                               partial_block_manager);
+
+        columnar_pointers.push_back(pointer);
+
+        components::table::storage::pax_fixed_slice_t slice_desc;
+        slice_desc.column_index = column_index;
+        slice_desc.column_type = to_pax_fixed_column_type(column.type());
+        slice_desc.data_pointer = pointer;
+        components::table::base_statistics_t page_stats(column.resource(), column.type().type());
+        page_stats.update(slice, tuple_count);
+        slice_desc.statistics = std::move(page_stats);
+
+        const auto valid_count = slice.validity().count_valid(tuple_count);
+        if (valid_count == tuple_count) {
+            slice_desc.validity_kind = components::table::storage::pax_fixed_validity_kind::ALL_VALID;
+        } else if (valid_count == 0) {
+            slice_desc.validity_kind = components::table::storage::pax_fixed_validity_kind::ALL_INVALID;
+        } else {
+            const auto validity_size = pax_fixed_validity_payload_size(tuple_count);
+            auto validity_allocation = partial_block_manager.get_block_allocation(validity_size);
+            partial_block_manager.write_to_block(validity_allocation.block_id,
+                                                 validity_allocation.offset_in_block,
+                                                 slice.validity().data(),
+                                                 validity_size);
+
+            components::table::storage::data_pointer_t validity_pointer;
+            validity_pointer.row_start = row_group_start + row_offset;
+            validity_pointer.tuple_count = tuple_count;
+            validity_pointer.block_pointer = components::table::storage::block_pointer_t(validity_allocation.block_id,
+                                                                                         validity_allocation.offset_in_block);
+            validity_pointer.compression =
+                components::table::compression::compression_type::VALIDITY_UNCOMPRESSED;
+            validity_pointer.segment_size = validity_size;
+
+            slice_desc.validity_kind = components::table::storage::pax_fixed_validity_kind::BITMASK;
+            slice_desc.validity_data_pointer = validity_pointer;
+        }
+
+        page.slices.push_back(std::move(slice_desc));
+    }
+
+    bool is_pax_generic_string_type(const components::types::complex_logical_type& type) {
+        return type.type() == components::types::logical_type::STRING_LITERAL;
+    }
+
+    bool is_pax_generic_struct_type(const components::types::complex_logical_type& type) {
+        using components::types::logical_type;
+
+        switch (type.type()) {
+            case logical_type::STRUCT:
+            case logical_type::UNION:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    bool is_pax_generic_collection_type(const components::types::complex_logical_type& type) {
+        using components::types::logical_type;
+
+        switch (type.type()) {
+            case logical_type::LIST:
+            case logical_type::ARRAY:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    bool is_pax_generic_fixed_plain_type(const components::types::complex_logical_type& type) {
+        using components::types::physical_type;
+
+        switch (type.to_physical_type()) {
+            case physical_type::BOOL:
+            case physical_type::INT8:
+            case physical_type::INT16:
+            case physical_type::INT32:
+            case physical_type::INT64:
+            case physical_type::INT128:
+            case physical_type::UINT8:
+            case physical_type::UINT16:
+            case physical_type::UINT32:
+            case physical_type::UINT64:
+            case physical_type::UINT128:
+            case physical_type::FLOAT:
+            case physical_type::DOUBLE:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    bool is_supported_pax_generic_column_type(const components::types::complex_logical_type& type) {
+        if (is_pax_generic_string_type(type) || is_pax_generic_fixed_plain_type(type)) {
+            return true;
+        }
+        if (is_pax_generic_collection_type(type)) {
+            return is_supported_pax_generic_column_type(type.child_type());
+        }
+        if (!is_pax_generic_struct_type(type)) {
+            return false;
+        }
+        for (const auto& child_type : type.child_types()) {
+            if (!is_supported_pax_generic_column_type(child_type)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+} // namespace
+
+namespace components::table::detail {
+
+    explicit_pax_root_kind classify_explicit_pax_root_type(const components::types::complex_logical_type& type) {
+        if (is_explicit_pax_columnar_only_root_type(type)) {
+            return explicit_pax_root_kind::COLUMNAR_ONLY;
+        }
+        if (is_pax_generic_string_type(type) || is_pax_generic_struct_type(type) || is_pax_generic_collection_type(type)) {
+            return is_supported_pax_generic_column_type(type) ? explicit_pax_root_kind::GENERIC
+                                                              : explicit_pax_root_kind::UNSUPPORTED;
+        }
+        if (is_pax_fixed_scalar_type(type)) {
+            return explicit_pax_root_kind::FIXED;
+        }
+        return explicit_pax_root_kind::UNSUPPORTED;
+    }
+
+    bool supports_explicit_pax_schema(const std::vector<column_definition_t>& columns, std::string* error_message) {
+        if (columns.empty()) {
+            if (error_message) {
+                *error_message = "USING PAX requires a declared schema";
+            }
+            return false;
+        }
+
+        for (const auto& column : columns) {
+            const auto kind = classify_explicit_pax_root_type(column.type());
+            if (kind == explicit_pax_root_kind::COLUMNAR_ONLY || kind == explicit_pax_root_kind::UNSUPPORTED) {
+                if (error_message) {
+                    *error_message = "column '" + column.name() + "' of type '" +
+                                     describe_pax_root_type(column.type()) + "' is not supported by USING PAX";
+                }
+                return false;
+            }
+        }
+        return true;
+    }
+
+} // namespace components::table::detail
+
+namespace {
+
+    uint64_t pax_string_block_limit(uint64_t block_size) {
+        return std::min((block_size / 4) / 8 * 8, PAX_STRING_DEFAULT_BLOCK_LIMIT);
+    }
+
+    // Bounds-check a disk-derived [offset, offset+length) slice against the pinned block: the CRC
+    // proves the bytes are intact, not that an offset/length decoded from them is in range. Checks
+    // are ordered so offset+length is only evaluated once both are <= block_size (no overflow).
+    inline std::byte* checked_pax_block_ptr(components::table::storage::buffer_handle_t& handle,
+                                            uint64_t offset,
+                                            uint64_t length,
+                                            uint64_t block_size) {
+        if (offset > block_size || length > block_size || offset + length > block_size) {
+            throw std::logic_error("pax decode: block slice out of bounds (corrupt on-disk pointer)");
+        }
+        return handle.ptr() + offset;
+    }
+
+    const std::vector<uint16_t>& empty_pax_generic_field_path() {
+        static const std::vector<uint16_t> EMPTY_FIELD_PATH;
+        return EMPTY_FIELD_PATH;
+    }
+
+    void append_unique_block_id(std::vector<uint32_t>& block_ids, uint32_t block_id) {
+        if (std::find(block_ids.begin(), block_ids.end(), block_id) == block_ids.end()) {
+            block_ids.push_back(block_id);
+        }
+    }
+
+    void append_unique_block_id(std::vector<uint64_t>& block_ids, uint64_t block_id) {
+        if (std::find(block_ids.begin(), block_ids.end(), block_id) == block_ids.end()) {
+            block_ids.push_back(block_id);
+        }
+    }
+
+    struct pax_generic_string_page_write_result_t {
+        components::table::storage::data_pointer_t main_pointer;
+        std::vector<uint32_t> extra_block_ids;
+        components::table::storage::pax_generic_codec_kind validity_codec{
+            components::table::storage::pax_generic_codec_kind::VALIDITY_ALL_VALID};
+        std::optional<components::table::storage::data_pointer_t> validity_pointer;
+        std::optional<components::table::base_statistics_t> statistics;
+    };
+
+    struct pax_generic_fixed_page_write_result_t {
+        components::table::storage::data_pointer_t main_pointer;
+        components::table::storage::pax_generic_codec_kind validity_codec{
+            components::table::storage::pax_generic_codec_kind::VALIDITY_ALL_VALID};
+        std::optional<components::table::storage::data_pointer_t> validity_pointer;
+        std::optional<components::table::base_statistics_t> statistics;
+    };
+
+    struct pax_generic_validity_write_result_t {
+        components::table::storage::pax_generic_codec_kind validity_codec{
+            components::table::storage::pax_generic_codec_kind::VALIDITY_ALL_VALID};
+        std::optional<components::table::storage::data_pointer_t> validity_pointer;
+    };
+
+    struct pax_generic_plain_payload_write_result_t {
+        components::table::storage::data_pointer_t main_pointer;
+    };
+
+    pax_generic_plain_payload_write_result_t
+    write_pax_generic_plain_payload(uint64_t absolute_row_start,
+                                    uint32_t tuple_count,
+                                    const std::byte* data,
+                                    uint64_t type_size,
+                                    components::table::storage::partial_block_manager_t& partial_block_manager) {
+        using components::table::compression::compression_type;
+        using components::table::storage::block_pointer_t;
+
+        const auto payload_size = static_cast<uint64_t>(tuple_count) * type_size;
+        auto allocation = partial_block_manager.get_block_allocation(payload_size);
+        if (payload_size > 0) {
+            partial_block_manager.write_to_block(allocation.block_id, allocation.offset_in_block, data, payload_size);
+        }
+
+        pax_generic_plain_payload_write_result_t result;
+        result.main_pointer.row_start = absolute_row_start;
+        result.main_pointer.tuple_count = tuple_count;
+        result.main_pointer.block_pointer = block_pointer_t(allocation.block_id, allocation.offset_in_block);
+        result.main_pointer.compression = compression_type::UNCOMPRESSED;
+        result.main_pointer.segment_size = payload_size;
+        return result;
+    }
+
+    pax_generic_string_page_write_result_t
+    write_pax_generic_string_page(components::table::column_data_t& column,
+                                  uint64_t row_group_start,
+                                  uint32_t row_offset,
+                                  uint32_t tuple_count,
+                                  components::table::storage::partial_block_manager_t& partial_block_manager) {
+        using components::table::compression::compression_type;
+        using components::table::storage::block_pointer_t;
+        using components::table::storage::data_pointer_t;
+        using components::table::storage::pax_generic_codec_kind;
+
+        components::vector::vector_t slice(column.resource(), column.type(), tuple_count);
+        column.scan_committed_range(row_group_start, row_offset, tuple_count, slice);
+        slice.flatten(tuple_count);
+        for (uint32_t i = 0; i < tuple_count; i++) {
+            if (!column.check_validity(static_cast<int64_t>(row_group_start + row_offset + i))) {
+                slice.validity().set(i, false);
+            }
+        }
+
+        auto* values = slice.data<std::string_view>();
+        const auto block_size = column.block_manager().block_size();
+        const auto offset_bytes = static_cast<uint64_t>(tuple_count) * sizeof(int32_t);
+        const auto header_and_offsets = static_cast<uint64_t>(PAX_STRING_DICTIONARY_HEADER_SIZE) + offset_bytes;
+        if (header_and_offsets > block_size) {
+            throw std::logic_error("pax_generic string page header exceeds block size");
+        }
+
+        std::vector<int32_t> offsets(tuple_count, 0);
+        std::vector<std::vector<std::byte>> dictionary_entries;
+        dictionary_entries.reserve(tuple_count);
+        uint64_t total_dictionary_bytes = 0;
+        std::vector<uint32_t> extra_block_ids;
+
+        int32_t current_dict_size = 0;
+        uint64_t remaining = block_size - header_and_offsets;
+        for (uint32_t i = 0; i < tuple_count; i++) {
+            if (!slice.validity().row_is_valid(i)) {
+                offsets[i] = i == 0 ? 0 : offsets[i - 1];
+                dictionary_entries.emplace_back();
+                continue;
+            }
+
+            const auto value = values[i];
+            bool use_overflow = static_cast<uint64_t>(value.size()) >= pax_string_block_limit(block_size);
+            uint64_t required_space = use_overflow ? PAX_STRING_BIG_MARKER_SIZE : value.size();
+            if (required_space > remaining) {
+                use_overflow = true;
+                required_space = PAX_STRING_BIG_MARKER_SIZE;
+            }
+            if (required_space > remaining) {
+                throw std::logic_error("pax_generic string page overflow marker exceeds remaining page space");
+            }
+
+            if (use_overflow) {
+                const auto overflow_size = static_cast<uint64_t>(sizeof(uint32_t) + value.size());
+                auto overflow_allocation = partial_block_manager.get_block_allocation(overflow_size);
+                std::vector<std::byte> overflow_payload(overflow_size);
+                auto string_size = static_cast<uint32_t>(value.size());
+                std::memcpy(overflow_payload.data(), &string_size, sizeof(uint32_t));
+                if (!value.empty()) {
+                    std::memcpy(overflow_payload.data() + sizeof(uint32_t), value.data(), value.size());
+                }
+                partial_block_manager.write_to_block(overflow_allocation.block_id,
+                                                     overflow_allocation.offset_in_block,
+                                                     overflow_payload.data(),
+                                                     overflow_payload.size());
+
+                auto marker_offset = static_cast<int32_t>(overflow_allocation.offset_in_block);
+                auto marker_block_id = static_cast<uint32_t>(overflow_allocation.block_id);
+                std::vector<std::byte> marker(PAX_STRING_BIG_MARKER_SIZE);
+                std::memcpy(marker.data(), &marker_block_id, sizeof(uint32_t));
+                std::memcpy(marker.data() + sizeof(uint32_t), &marker_offset, sizeof(int32_t));
+                total_dictionary_bytes += marker.size();
+                dictionary_entries.push_back(std::move(marker));
+                append_unique_block_id(extra_block_ids, marker_block_id);
+                current_dict_size += static_cast<int32_t>(PAX_STRING_BIG_MARKER_SIZE);
+                offsets[i] = -current_dict_size;
+            } else {
+                std::vector<std::byte> inline_value(value.size());
+                if (!value.empty()) {
+                    std::memcpy(inline_value.data(), value.data(), value.size());
+                }
+                total_dictionary_bytes += inline_value.size();
+                dictionary_entries.push_back(std::move(inline_value));
+                current_dict_size += static_cast<int32_t>(value.size());
+                offsets[i] = current_dict_size;
+            }
+
+            remaining -= required_space;
+        }
+
+        std::vector<std::byte> dictionary_bytes;
+        dictionary_bytes.reserve(total_dictionary_bytes);
+        for (auto it = dictionary_entries.rbegin(); it != dictionary_entries.rend(); ++it) {
+            dictionary_bytes.insert(dictionary_bytes.end(), it->begin(), it->end());
+        }
+
+        std::vector<std::byte> payload(header_and_offsets + dictionary_bytes.size(), std::byte{0});
+        auto dict_size = static_cast<uint32_t>(dictionary_bytes.size());
+        auto dict_end = static_cast<uint32_t>(payload.size());
+        std::memcpy(payload.data(), &dict_size, sizeof(uint32_t));
+        std::memcpy(payload.data() + sizeof(uint32_t), &dict_end, sizeof(uint32_t));
+        if (tuple_count > 0) {
+            std::memcpy(payload.data() + PAX_STRING_DICTIONARY_HEADER_SIZE, offsets.data(), offset_bytes);
+        }
+        if (!dictionary_bytes.empty()) {
+            std::memcpy(payload.data() + header_and_offsets, dictionary_bytes.data(), dictionary_bytes.size());
+        }
+
+        auto allocation = partial_block_manager.get_block_allocation(payload.size());
+        if (!payload.empty()) {
+            partial_block_manager.write_to_block(allocation.block_id,
+                                                 allocation.offset_in_block,
+                                                 payload.data(),
+                                                 payload.size());
+        }
+
+        pax_generic_string_page_write_result_t result;
+        result.main_pointer.row_start = row_group_start + row_offset;
+        result.main_pointer.tuple_count = tuple_count;
+        result.main_pointer.block_pointer = block_pointer_t(allocation.block_id, allocation.offset_in_block);
+        result.main_pointer.compression = compression_type::UNCOMPRESSED;
+        result.main_pointer.segment_size = payload.size();
+        result.extra_block_ids = std::move(extra_block_ids);
+        components::table::base_statistics_t page_stats(column.resource(), column.type().type());
+        page_stats.update(slice, tuple_count);
+        result.statistics = std::move(page_stats);
+
+        const auto valid_count = slice.validity().count_valid(tuple_count);
+        if (valid_count == tuple_count) {
+            result.validity_codec = pax_generic_codec_kind::VALIDITY_ALL_VALID;
+        } else if (valid_count == 0) {
+            result.validity_codec = pax_generic_codec_kind::VALIDITY_ALL_INVALID;
+        } else {
+            const auto validity_size = pax_fixed_validity_payload_size(tuple_count);
+            auto validity_allocation = partial_block_manager.get_block_allocation(validity_size);
+            partial_block_manager.write_to_block(validity_allocation.block_id,
+                                                 validity_allocation.offset_in_block,
+                                                 slice.validity().data(),
+                                                 validity_size);
+
+            data_pointer_t validity_pointer;
+            validity_pointer.row_start = row_group_start + row_offset;
+            validity_pointer.tuple_count = tuple_count;
+            validity_pointer.block_pointer = block_pointer_t(validity_allocation.block_id,
+                                                             validity_allocation.offset_in_block);
+            validity_pointer.compression = compression_type::VALIDITY_UNCOMPRESSED;
+            validity_pointer.segment_size = validity_size;
+
+            result.validity_codec = pax_generic_codec_kind::VALIDITY_BITMASK;
+            result.validity_pointer = std::move(validity_pointer);
+        }
+
+        return result;
+    }
+
+    pax_generic_fixed_page_write_result_t
+    write_pax_generic_fixed_page(components::table::column_data_t& column,
+                                 uint64_t row_group_start,
+                                 uint32_t row_offset,
+                                 uint32_t tuple_count,
+                                 components::table::storage::partial_block_manager_t& partial_block_manager) {
+        using components::table::compression::compression_type;
+        using components::table::storage::block_pointer_t;
+        using components::table::storage::data_pointer_t;
+        using components::table::storage::pax_generic_codec_kind;
+
+        components::vector::vector_t slice(column.resource(), column.type(), tuple_count);
+        column.scan_committed_range(row_group_start, row_offset, tuple_count, slice);
+        slice.flatten(tuple_count);
+        for (uint32_t i = 0; i < tuple_count; i++) {
+            if (!column.check_validity(static_cast<int64_t>(row_group_start + row_offset + i))) {
+                slice.validity().set(i, false);
+            }
+        }
+
+        const auto slice_size = static_cast<uint64_t>(tuple_count) * column.type().size();
+        auto allocation = partial_block_manager.get_block_allocation(slice_size);
+        if (slice_size > 0) {
+            partial_block_manager.write_to_block(allocation.block_id,
+                                                 allocation.offset_in_block,
+                                                 slice.data(),
+                                                 slice_size);
+        }
+
+        pax_generic_fixed_page_write_result_t result;
+        result.main_pointer.row_start = row_group_start + row_offset;
+        result.main_pointer.tuple_count = tuple_count;
+        result.main_pointer.block_pointer = block_pointer_t(allocation.block_id, allocation.offset_in_block);
+        result.main_pointer.compression = compression_type::UNCOMPRESSED;
+        result.main_pointer.segment_size = slice_size;
+        components::table::base_statistics_t page_stats(column.resource(), column.type().type());
+        page_stats.update(slice, tuple_count);
+        result.statistics = std::move(page_stats);
+
+        const auto valid_count = slice.validity().count_valid(tuple_count);
+        if (valid_count == tuple_count) {
+            result.validity_codec = pax_generic_codec_kind::VALIDITY_ALL_VALID;
+        } else if (valid_count == 0) {
+            result.validity_codec = pax_generic_codec_kind::VALIDITY_ALL_INVALID;
+        } else {
+            const auto validity_size = pax_fixed_validity_payload_size(tuple_count);
+            auto validity_allocation = partial_block_manager.get_block_allocation(validity_size);
+            partial_block_manager.write_to_block(validity_allocation.block_id,
+                                                 validity_allocation.offset_in_block,
+                                                 slice.validity().data(),
+                                                 validity_size);
+
+            data_pointer_t validity_pointer;
+            validity_pointer.row_start = row_group_start + row_offset;
+            validity_pointer.tuple_count = tuple_count;
+            validity_pointer.block_pointer =
+                block_pointer_t(validity_allocation.block_id, validity_allocation.offset_in_block);
+            validity_pointer.compression = compression_type::VALIDITY_UNCOMPRESSED;
+            validity_pointer.segment_size = validity_size;
+
+            result.validity_codec = pax_generic_codec_kind::VALIDITY_BITMASK;
+            result.validity_pointer = std::move(validity_pointer);
+        }
+
+        return result;
+    }
+
+    pax_generic_validity_write_result_t
+    write_pax_generic_validity_page(components::table::column_data_t& column,
+                                    uint64_t row_group_start,
+                                    uint32_t row_offset,
+                                    uint32_t tuple_count,
+                                    components::table::storage::partial_block_manager_t& partial_block_manager) {
+        using components::table::compression::compression_type;
+        using components::table::storage::block_pointer_t;
+        using components::table::storage::data_pointer_t;
+        using components::table::storage::pax_generic_codec_kind;
+
+        components::vector::validity_mask_t validity(column.resource(), tuple_count);
+        uint64_t valid_count = 0;
+        for (uint32_t i = 0; i < tuple_count; i++) {
+            const auto is_valid = column.check_validity(static_cast<int64_t>(row_group_start + row_offset + i));
+            validity.set(i, is_valid);
+            valid_count += static_cast<uint64_t>(is_valid);
+        }
+
+        pax_generic_validity_write_result_t result;
+        if (valid_count == tuple_count) {
+            result.validity_codec = pax_generic_codec_kind::VALIDITY_ALL_VALID;
+        } else if (valid_count == 0) {
+            result.validity_codec = pax_generic_codec_kind::VALIDITY_ALL_INVALID;
+        } else {
+            const auto validity_size = pax_fixed_validity_payload_size(tuple_count);
+            auto allocation = partial_block_manager.get_block_allocation(validity_size);
+            partial_block_manager.write_to_block(allocation.block_id,
+                                                 allocation.offset_in_block,
+                                                 validity.data(),
+                                                 validity_size);
+
+            data_pointer_t validity_pointer;
+            validity_pointer.row_start = row_group_start + row_offset;
+            validity_pointer.tuple_count = tuple_count;
+            validity_pointer.block_pointer = block_pointer_t(allocation.block_id, allocation.offset_in_block);
+            validity_pointer.compression = compression_type::VALIDITY_UNCOMPRESSED;
+            validity_pointer.segment_size = validity_size;
+
+            result.validity_codec = pax_generic_codec_kind::VALIDITY_BITMASK;
+            result.validity_pointer = std::move(validity_pointer);
+        }
+
+        return result;
+    }
+
+    void append_pax_generic_validity_slice(components::table::storage::pax_generic_page_t& page,
+                                           uint32_t root_column_index,
+                                           const std::vector<uint16_t>& field_path,
+                                           const pax_generic_validity_write_result_t& validity_result) {
+        components::table::storage::pax_generic_slice_t validity_slice;
+        validity_slice.column_index = root_column_index;
+        validity_slice.slice_kind = components::table::storage::pax_generic_slice_kind::VALIDITY;
+        validity_slice.codec_kind = validity_result.validity_codec;
+        validity_slice.field_path = field_path;
+        if (validity_result.validity_pointer.has_value()) {
+            validity_slice.payload = components::table::storage::pax_block_payload_t{*validity_result.validity_pointer,
+                                                                                     {}};
+        }
+        page.slices.push_back(std::move(validity_slice));
+    }
+
+    void write_pax_generic_column_page(components::table::column_data_t& column,
+                                       uint32_t root_column_index,
+                                       const std::vector<uint16_t>& field_path,
+                                       uint64_t row_group_start,
+                                       uint32_t row_offset,
+                                       uint32_t tuple_count,
+                                       components::table::storage::partial_block_manager_t& partial_block_manager,
+                                       components::table::storage::pax_generic_page_t& page) {
+        using components::table::storage::pax_block_payload_t;
+        using components::table::storage::pax_generic_codec_kind;
+        using components::table::storage::pax_generic_slice_kind;
+        using components::types::logical_type;
+
+        if (is_pax_generic_struct_type(column.type())) {
+            auto validity_result =
+                write_pax_generic_validity_page(column, row_group_start, row_offset, tuple_count, partial_block_manager);
+            append_pax_generic_validity_slice(page, root_column_index, field_path, validity_result);
+
+            auto& struct_column = dynamic_cast<components::table::struct_column_data_t&>(column);
+            for (uint16_t child_index = 0; child_index < struct_column.sub_columns.size(); child_index++) {
+                auto child_path = field_path;
+                child_path.push_back(child_index);
+                write_pax_generic_column_page(*struct_column.sub_columns[child_index],
+                                              root_column_index,
+                                              child_path,
+                                              row_group_start,
+                                              row_offset,
+                                              tuple_count,
+                                              partial_block_manager,
+                                              page);
+            }
+            return;
+        }
+
+        if (is_pax_generic_collection_type(column.type())) {
+            auto validity_result =
+                write_pax_generic_validity_page(column, row_group_start, row_offset, tuple_count, partial_block_manager);
+            append_pax_generic_validity_slice(page, root_column_index, field_path, validity_result);
+
+            if (column.type().type() == logical_type::LIST) {
+                auto& list_column = dynamic_cast<components::table::list_column_data_t&>(column);
+                const auto page_row_start = static_cast<int64_t>(row_group_start + row_offset);
+                std::vector<uint64_t> offsets(tuple_count, 0);
+                for (uint32_t i = 0; i < tuple_count; i++) {
+                    offsets[i] = list_column.list_offset(page_row_start + static_cast<int64_t>(i));
+                }
+
+                auto offsets_payload = write_pax_generic_plain_payload(row_group_start + row_offset,
+                                                                       tuple_count,
+                                                                       reinterpret_cast<const std::byte*>(offsets.data()),
+                                                                       sizeof(uint64_t),
+                                                                       partial_block_manager);
+
+                components::table::storage::pax_generic_slice_t offsets_slice;
+                offsets_slice.column_index = root_column_index;
+                offsets_slice.slice_kind = pax_generic_slice_kind::FIXED_VALUES;
+                offsets_slice.codec_kind = pax_generic_codec_kind::FIXED_PLAIN;
+                offsets_slice.field_path = field_path;
+                offsets_slice.fixed_logical_type = logical_type::UBIGINT;
+                offsets_slice.payload = pax_block_payload_t{offsets_payload.main_pointer, {}};
+                page.slices.push_back(std::move(offsets_slice));
+
+                const auto previous_offset =
+                    page_row_start == list_column.start() ? 0 : list_column.list_offset(page_row_start - 1);
+                const auto child_tuple_count =
+                    offsets.empty() ? 0 : static_cast<uint32_t>(offsets.back() - previous_offset);
+                if (child_tuple_count > 0) {
+                    auto child_path = field_path;
+                    child_path.push_back(0);
+                    write_pax_generic_column_page(*list_column.child_column,
+                                                  root_column_index,
+                                                  child_path,
+                                                  row_group_start + previous_offset,
+                                                  0,
+                                                  child_tuple_count,
+                                                  partial_block_manager,
+                                                  page);
+                }
+                return;
+            }
+
+            auto& array_column = dynamic_cast<components::table::array_column_data_t&>(column);
+            auto child_path = field_path;
+            child_path.push_back(0);
+            const auto child_tuple_count = static_cast<uint32_t>(static_cast<uint64_t>(tuple_count) * array_column.array_size());
+            if (child_tuple_count > 0) {
+                const auto child_row_start =
+                    row_group_start + static_cast<uint64_t>(row_offset) * static_cast<uint64_t>(array_column.array_size());
+                write_pax_generic_column_page(*array_column.child_column,
+                                              root_column_index,
+                                              child_path,
+                                              child_row_start,
+                                              0,
+                                              child_tuple_count,
+                                              partial_block_manager,
+                                              page);
+            }
+            return;
+        }
+
+        if (is_pax_generic_string_type(column.type())) {
+            auto page_result = write_pax_generic_string_page(column,
+                                                             row_group_start,
+                                                             row_offset,
+                                                             tuple_count,
+                                                             partial_block_manager);
+
+            components::table::storage::pax_generic_slice_t value_slice;
+            value_slice.column_index = root_column_index;
+            value_slice.slice_kind = pax_generic_slice_kind::STRING_VALUES;
+            value_slice.codec_kind = pax_generic_codec_kind::STRING_SEGMENT;
+            value_slice.field_path = field_path;
+            value_slice.payload = pax_block_payload_t{page_result.main_pointer, page_result.extra_block_ids};
+            value_slice.statistics = std::move(page_result.statistics);
+            page.slices.push_back(std::move(value_slice));
+
+            append_pax_generic_validity_slice(page,
+                                              root_column_index,
+                                              field_path,
+                                              {page_result.validity_codec, page_result.validity_pointer});
+            return;
+        }
+
+        if (is_pax_generic_fixed_plain_type(column.type())) {
+            auto page_result = write_pax_generic_fixed_page(column,
+                                                            row_group_start,
+                                                            row_offset,
+                                                            tuple_count,
+                                                            partial_block_manager);
+
+            components::table::storage::pax_generic_slice_t value_slice;
+            value_slice.column_index = root_column_index;
+            value_slice.slice_kind = pax_generic_slice_kind::FIXED_VALUES;
+            value_slice.codec_kind = pax_generic_codec_kind::FIXED_PLAIN;
+            value_slice.field_path = field_path;
+            value_slice.fixed_logical_type = column.type().type();
+            value_slice.payload = pax_block_payload_t{page_result.main_pointer, {}};
+            value_slice.statistics = std::move(page_result.statistics);
+            page.slices.push_back(std::move(value_slice));
+
+            append_pax_generic_validity_slice(page,
+                                              root_column_index,
+                                              field_path,
+                                              {page_result.validity_codec, page_result.validity_pointer});
+            return;
+        }
+
+        throw std::logic_error("unsupported column type for pax_generic page writer");
+    }
+
+    bool is_supported_pax_projected_filter_compare(components::expressions::compare_type type) {
+        using components::expressions::compare_type;
+
+        switch (type) {
+            case compare_type::eq:
+            case compare_type::ne:
+            case compare_type::gt:
+            case compare_type::gte:
+            case compare_type::lt:
+            case compare_type::lte:
+            case compare_type::is_null:
+            case compare_type::is_not_null:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    const components::table::storage::pax_fixed_slice_t*
+    find_pax_fixed_slice(const components::table::storage::pax_fixed_page_t& page, uint32_t column_index) {
+        for (const auto& slice : page.slices) {
+            if (slice.column_index == column_index) {
+                return &slice;
+            }
+        }
+        return nullptr;
+    }
+
+    const components::table::storage::pax_generic_slice_t*
+    find_pax_generic_slice(const components::table::storage::pax_generic_page_t& page,
+                           uint32_t column_index,
+                           components::table::storage::pax_generic_slice_kind slice_kind,
+                           const std::vector<uint16_t>& field_path = empty_pax_generic_field_path()) {
+        for (const auto& slice : page.slices) {
+            if (slice.column_index == column_index && slice.slice_kind == slice_kind &&
+                slice.field_path == field_path) {
+                return &slice;
+            }
+        }
+        return nullptr;
+    }
+
+    uint64_t pax_fixed_layout_tuple_count(const components::table::storage::pax_fixed_row_group_layout_t& layout) {
+        uint64_t total = 0;
+        for (const auto& page : layout.pages) {
+            total += page.tuple_count;
+        }
+        return total;
+    }
+
+    uint64_t pax_generic_layout_tuple_count(const components::table::storage::pax_generic_row_group_layout_t& layout) {
+        uint64_t total = 0;
+        for (const auto& page : layout.pages) {
+            total += page.tuple_count;
+        }
+        return total;
+    }
+
+    bool validate_pax_fixed_slice(const components::table::storage::pax_fixed_slice_t& slice,
+                                  const components::table::storage::pax_fixed_column_type expected_type,
+                                  uint32_t tuple_count,
+                                  uint64_t type_size,
+                                  uint16_t layout_version) {
+        if (slice.column_type != expected_type) {
+            return false;
+        }
+        if (slice.data_pointer.tuple_count != tuple_count) {
+            return false;
+        }
+
+        using components::table::compression::compression_type;
+        switch (slice.data_pointer.compression) {
+            case compression_type::UNCOMPRESSED:
+                if (slice.data_pointer.segment_size != static_cast<uint64_t>(tuple_count) * type_size) {
+                    return false;
+                }
+                break;
+            case compression_type::CONSTANT:
+                if (slice.data_pointer.segment_size != type_size) {
+                    return false;
+                }
+                break;
+            case compression_type::RLE: {
+                const auto entry_size = type_size + sizeof(uint32_t);
+                if (slice.data_pointer.segment_size < sizeof(uint32_t) ||
+                    (slice.data_pointer.segment_size - sizeof(uint32_t)) % entry_size != 0) {
+                    return false;
+                }
+                break;
+            }
+            case compression_type::DICTIONARY:
+                if (slice.data_pointer.segment_size < sizeof(uint16_t) + type_size + tuple_count) {
+                    return false;
+                }
+                break;
+            default:
+                return false;
+        }
+        if (layout_version < 2) {
+            return true;
+        }
+
+        switch (slice.validity_kind) {
+            case components::table::storage::pax_fixed_validity_kind::ALL_VALID:
+            case components::table::storage::pax_fixed_validity_kind::ALL_INVALID:
+                return !slice.validity_data_pointer.has_value();
+            case components::table::storage::pax_fixed_validity_kind::BITMASK:
+                if (!slice.validity_data_pointer.has_value()) {
+                    return false;
+                }
+                return slice.validity_data_pointer->compression ==
+                           components::table::compression::compression_type::VALIDITY_UNCOMPRESSED &&
+                       slice.validity_data_pointer->tuple_count == tuple_count &&
+                       slice.validity_data_pointer->segment_size == pax_fixed_validity_payload_size(tuple_count);
+            case components::table::storage::pax_fixed_validity_kind::RLE:
+            default:
+                return false;
+        }
+    }
+
+    bool validate_pax_generic_string_slice(const components::table::storage::pax_generic_slice_t& slice,
+                                           uint32_t tuple_count) {
+        if (slice.slice_kind != components::table::storage::pax_generic_slice_kind::STRING_VALUES ||
+            slice.codec_kind != components::table::storage::pax_generic_codec_kind::STRING_SEGMENT ||
+            !slice.payload.has_value()) {
+            return false;
+        }
+
+        const auto& pointer = slice.payload->main_pointer;
+        return pointer.compression == components::table::compression::compression_type::UNCOMPRESSED &&
+               pointer.tuple_count == tuple_count &&
+               pointer.segment_size >=
+                   static_cast<uint64_t>(PAX_STRING_DICTIONARY_HEADER_SIZE) +
+                       static_cast<uint64_t>(tuple_count) * sizeof(int32_t);
+    }
+
+    bool validate_pax_generic_validity_slice(const components::table::storage::pax_generic_slice_t& slice,
+                                             uint32_t tuple_count) {
+        if (slice.slice_kind != components::table::storage::pax_generic_slice_kind::VALIDITY) {
+            return false;
+        }
+
+        switch (slice.codec_kind) {
+            case components::table::storage::pax_generic_codec_kind::VALIDITY_ALL_VALID:
+            case components::table::storage::pax_generic_codec_kind::VALIDITY_ALL_INVALID:
+                return !slice.payload.has_value();
+            case components::table::storage::pax_generic_codec_kind::VALIDITY_BITMASK:
+                if (!slice.payload.has_value()) {
+                    return false;
+                }
+                return slice.payload->extra_block_ids.empty() &&
+                       slice.payload->main_pointer.compression ==
+                           components::table::compression::compression_type::VALIDITY_UNCOMPRESSED &&
+                       slice.payload->main_pointer.tuple_count == tuple_count &&
+                       slice.payload->main_pointer.segment_size == pax_fixed_validity_payload_size(tuple_count);
+            case components::table::storage::pax_generic_codec_kind::STRING_SEGMENT:
+            case components::table::storage::pax_generic_codec_kind::FIXED_PLAIN:
+            default:
+                return false;
+        }
+    }
+
+    bool validate_pax_generic_fixed_slice(const components::table::storage::pax_generic_slice_t& slice,
+                                          uint32_t tuple_count,
+                                          const components::types::complex_logical_type& type) {
+        if (slice.slice_kind != components::table::storage::pax_generic_slice_kind::FIXED_VALUES ||
+            slice.codec_kind != components::table::storage::pax_generic_codec_kind::FIXED_PLAIN ||
+            !slice.payload.has_value() || !slice.payload->extra_block_ids.empty()) {
+            return false;
+        }
+        if (slice.fixed_logical_type != components::types::logical_type::INVALID &&
+            slice.fixed_logical_type != type.type()) {
+            return false;
+        }
+
+        const auto& pointer = slice.payload->main_pointer;
+        return pointer.compression == components::table::compression::compression_type::UNCOMPRESSED &&
+               pointer.tuple_count == tuple_count &&
+               pointer.segment_size == static_cast<uint64_t>(tuple_count) * static_cast<uint64_t>(type.size());
+    }
+
+    bool is_pax_generic_root_projected_type(const components::types::complex_logical_type& type) {
+        return is_pax_generic_string_type(type) || is_pax_generic_fixed_plain_type(type);
+    }
+
+    using pax_fixed_block_cache_t =
+        std::unordered_map<uint64_t, components::table::storage::buffer_handle_t>;
+
+    components::table::storage::buffer_handle_t&
+    get_or_pin_pax_fixed_block(components::table::row_group_t& row_group,
+                               uint64_t block_id,
+                               pax_fixed_block_cache_t& block_cache) {
+        auto entry = block_cache.find(block_id);
+        if (entry != block_cache.end()) {
+            return entry->second;
+        }
+
+        auto block = row_group.block_manager().register_block(block_id);
+        auto handle = row_group.block_manager().buffer_manager.pin(block);
+        handle.set_ownership(block);
+        return block_cache.emplace(block_id, std::move(handle)).first->second;
+    }
+
+    using pax_generic_block_cache_t =
+        std::unordered_map<uint64_t, components::table::storage::buffer_handle_t>;
+
+    components::table::storage::buffer_handle_t&
+    get_or_pin_pax_generic_block(components::table::row_group_t& row_group,
+                                 uint64_t block_id,
+                                 pax_generic_block_cache_t& block_cache) {
+        auto entry = block_cache.find(block_id);
+        if (entry != block_cache.end()) {
+            return entry->second;
+        }
+
+        auto block = row_group.block_manager().register_block(block_id);
+        auto handle = row_group.block_manager().buffer_manager.pin(block);
+        handle.set_ownership(block);
+        return block_cache.emplace(block_id, std::move(handle)).first->second;
+    }
+
+    template<typename Page>
+    struct pax_page_window_t {
+        const Page* page{nullptr};
+        uint64_t overlap_start{0};
+        uint64_t overlap_end{0};
+        uint64_t page_count{0};
+        uint64_t page_offset_in_window{0};
+    };
+
+    template<typename Page>
+    std::vector<pax_page_window_t<Page>>
+    collect_pax_page_windows(const std::vector<Page>& pages, uint64_t window_start, uint64_t window_end) {
+        std::vector<pax_page_window_t<Page>> windows;
+        for (const auto& page : pages) {
+            const auto page_start = static_cast<uint64_t>(page.row_offset_in_group);
+            const auto page_end = page_start + static_cast<uint64_t>(page.tuple_count);
+            if (page_end <= window_start || page_start >= window_end) {
+                continue;
+            }
+
+            const auto overlap_start = std::max(window_start, page_start);
+            const auto overlap_end = std::min(window_end, page_end);
+            windows.push_back({&page,
+                               overlap_start,
+                               overlap_end,
+                               overlap_end - overlap_start,
+                               overlap_start - window_start});
+        }
+        return windows;
+    }
+
+    void collect_pax_fixed_slice_blocks(const components::table::storage::pax_fixed_slice_t& slice,
+                                        std::vector<uint64_t>& block_ids) {
+        append_unique_block_id(block_ids, slice.data_pointer.block_pointer.block_id);
+        if (slice.validity_data_pointer.has_value()) {
+            append_unique_block_id(block_ids, slice.validity_data_pointer->block_pointer.block_id);
+        }
+    }
+
+    bool collect_pax_fixed_page_column_blocks(const components::table::storage::pax_fixed_page_t& page,
+                                              uint32_t column_index,
+                                              std::vector<uint64_t>& block_ids) {
+        const auto* slice = find_pax_fixed_slice(page, column_index);
+        if (!slice) {
+            return false;
+        }
+        collect_pax_fixed_slice_blocks(*slice, block_ids);
+        return true;
+    }
+
+    bool collect_pax_generic_string_column_blocks(const components::table::storage::pax_generic_page_t& page,
+                                                  uint32_t column_index,
+                                                  std::vector<uint64_t>& block_ids) {
+        using components::table::storage::pax_generic_codec_kind;
+        using components::table::storage::pax_generic_slice_kind;
+
+        const auto* value_slice = find_pax_generic_slice(page, column_index, pax_generic_slice_kind::STRING_VALUES);
+        const auto* validity_slice = find_pax_generic_slice(page, column_index, pax_generic_slice_kind::VALIDITY);
+        if (!value_slice || !validity_slice || !value_slice->payload.has_value()) {
+            return false;
+        }
+
+        append_unique_block_id(block_ids, value_slice->payload->main_pointer.block_pointer.block_id);
+        for (auto block_id : value_slice->payload->extra_block_ids) {
+            append_unique_block_id(block_ids, static_cast<uint64_t>(block_id));
+        }
+
+        if (validity_slice->codec_kind == pax_generic_codec_kind::VALIDITY_BITMASK) {
+            if (!validity_slice->payload.has_value()) {
+                return false;
+            }
+            append_unique_block_id(block_ids, validity_slice->payload->main_pointer.block_pointer.block_id);
+        }
+        return true;
+    }
+
+    bool collect_pax_generic_fixed_column_blocks(const components::table::storage::pax_generic_page_t& page,
+                                                 uint32_t column_index,
+                                                 const components::types::complex_logical_type& type,
+                                                 std::vector<uint64_t>& block_ids) {
+        using components::table::storage::pax_generic_codec_kind;
+        using components::table::storage::pax_generic_slice_kind;
+
+        const auto* value_slice = find_pax_generic_slice(page, column_index, pax_generic_slice_kind::FIXED_VALUES);
+        const auto* validity_slice = find_pax_generic_slice(page, column_index, pax_generic_slice_kind::VALIDITY);
+        if (!value_slice || !validity_slice || !validate_pax_generic_fixed_slice(*value_slice, page.tuple_count, type) ||
+            !validate_pax_generic_validity_slice(*validity_slice, page.tuple_count)) {
+            return false;
+        }
+
+        append_unique_block_id(block_ids, value_slice->payload->main_pointer.block_pointer.block_id);
+        if (validity_slice->codec_kind == pax_generic_codec_kind::VALIDITY_BITMASK) {
+            if (!validity_slice->payload.has_value()) {
+                return false;
+            }
+            append_unique_block_id(block_ids, validity_slice->payload->main_pointer.block_pointer.block_id);
+        }
+        return true;
+    }
+
+    bool collect_pax_generic_root_column_blocks(const components::table::storage::pax_generic_page_t& page,
+                                                uint32_t column_index,
+                                                const components::types::complex_logical_type& type,
+                                                std::vector<uint64_t>& block_ids) {
+        if (is_pax_generic_string_type(type)) {
+            return collect_pax_generic_string_column_blocks(page, column_index, block_ids);
+        }
+        if (is_pax_generic_fixed_plain_type(type)) {
+            return collect_pax_generic_fixed_column_blocks(page, column_index, type, block_ids);
+        }
+        return false;
+    }
+
+    bool validate_pax_generic_root_column_slices(const components::table::storage::pax_generic_page_t& page,
+                                                 uint32_t column_index,
+                                                 const components::types::complex_logical_type& type) {
+        using components::table::storage::pax_generic_slice_kind;
+
+        if (is_pax_generic_string_type(type)) {
+            const auto* value_slice = find_pax_generic_slice(page, column_index, pax_generic_slice_kind::STRING_VALUES);
+            const auto* validity_slice = find_pax_generic_slice(page, column_index, pax_generic_slice_kind::VALIDITY);
+            return value_slice && validity_slice &&
+                   validate_pax_generic_string_slice(*value_slice, page.tuple_count) &&
+                   validate_pax_generic_validity_slice(*validity_slice, page.tuple_count);
+        }
+        if (is_pax_generic_fixed_plain_type(type)) {
+            const auto* value_slice = find_pax_generic_slice(page, column_index, pax_generic_slice_kind::FIXED_VALUES);
+            const auto* validity_slice = find_pax_generic_slice(page, column_index, pax_generic_slice_kind::VALIDITY);
+            return value_slice && validity_slice &&
+                   validate_pax_generic_fixed_slice(*value_slice, page.tuple_count, type) &&
+                   validate_pax_generic_validity_slice(*validity_slice, page.tuple_count);
+        }
+        return false;
+    }
+
+    template<typename BlockCache>
+    uint64_t prefetch_and_pin_pax_blocks(components::table::row_group_t& row_group,
+                                         const std::vector<uint64_t>& block_ids,
+                                         BlockCache& block_cache) {
+        std::vector<std::shared_ptr<components::table::storage::block_handle_t>> handles;
+        handles.reserve(block_ids.size());
+
+        for (auto block_id : block_ids) {
+            if (block_cache.find(block_id) != block_cache.end()) {
+                continue;
+            }
+            bool already_planned = false;
+            for (const auto& handle : handles) {
+                if (handle->block_id() == block_id) {
+                    already_planned = true;
+                    break;
+                }
+            }
+            if (!already_planned) {
+                handles.push_back(row_group.block_manager().register_block(block_id));
+            }
+        }
+
+        if (handles.empty()) {
+            return 0;
+        }
+
+        row_group.block_manager().buffer_manager.prefetch(handles);
+        uint64_t pinned_count = 0;
+        for (auto& block : handles) {
+            const auto block_id = block->block_id();
+            if (block_cache.find(block_id) != block_cache.end()) {
+                continue;
+            }
+            auto handle = row_group.block_manager().buffer_manager.pin(block);
+            handle.set_ownership(block);
+            block_cache.emplace(block_id, std::move(handle));
+            pinned_count++;
+        }
+        return pinned_count;
+    }
+
+    void mark_vector_range_valid(components::vector::vector_t& result, uint64_t offset, uint64_t count) {
+        auto& validity = result.validity();
+        for (uint64_t i = 0; i < count; i++) {
+            validity.set(offset + i, true);
+        }
+    }
+
+    std::vector<uint8_t> build_pax_visibility_mask(const components::vector::indexing_vector_t& visible_indexing,
+                                                   uint64_t visible_count,
+                                                   uint64_t max_count) {
+        std::vector<uint8_t> mask(max_count, 0);
+        for (uint64_t i = 0; i < visible_count; i++) {
+            const auto row_offset = visible_indexing.get_index(i);
+            assert(row_offset < max_count);
+            mask[row_offset] = 1;
+        }
+        return mask;
+    }
+
+    uint64_t apply_pax_visibility_mask(const std::vector<uint8_t>& visible_mask,
+                                       uint64_t page_offset_in_window,
+                                       components::vector::indexing_vector_t& page_indexing,
+                                       uint64_t page_approved_count) {
+        if (visible_mask.empty()) {
+            return page_approved_count;
+        }
+
+        uint64_t result_count = 0;
+        for (uint64_t i = 0; i < page_approved_count; i++) {
+            const auto page_row_offset = page_indexing.get_index(i);
+            const auto window_row_offset = page_offset_in_window + page_row_offset;
+            assert(window_row_offset < visible_mask.size());
+            if (visible_mask[window_row_offset] != 0) {
+                page_indexing.set_index(result_count++, page_row_offset);
+            }
+        }
+        return result_count;
+    }
+
+    bool fill_projected_row_id_columns(const std::vector<components::table::storage_index_t>& column_ids,
+                                       components::vector::data_chunk_t& result,
+                                       uint64_t result_offset,
+                                       uint64_t count) {
+        auto* row_ids = result.row_ids.data<int64_t>();
+        for (uint64_t column_pos = 0; column_pos < column_ids.size(); column_pos++) {
+            if (!column_ids[column_pos].is_row_id_column()) {
+                continue;
+            }
+            if (column_pos >= result.data.size()) {
+                return false;
+            }
+            if (is_unprojected_placeholder(result.data[column_pos])) {
+                continue;
+            }
+            if (!result.data[column_pos].data() || result.data[column_pos].type().type() !=
+                                                       components::types::logical_type::BIGINT) {
+                return false;
+            }
+            result.data[column_pos].set_vector_type(components::vector::vector_type::FLAT);
+            auto* output = result.data[column_pos].data<int64_t>();
+            for (uint64_t i = 0; i < count; i++) {
+                output[result_offset + i] = row_ids[result_offset + i];
+            }
+            mark_vector_range_valid(result.data[column_pos], result_offset, count);
+        }
+        return true;
+    }
+
+    void apply_pax_committed_updates(components::table::column_data_t& column_data,
+                                     uint64_t row_offset_in_group,
+                                     uint64_t count,
+                                     components::vector::vector_t& result,
+                                     uint64_t result_offset = 0) {
+        if (count == 0) {
+            return;
+        }
+        if (!column_data.has_updates()) {
+            return;
+        }
+        column_data.fetch_committed_updates_range(row_offset_in_group, count, result, result_offset);
+    }
+
+    void advance_pax_fixed_scan_state(components::table::column_scan_state& state, uint64_t count) {
+        state.row_index += static_cast<int64_t>(count);
+        state.internal_index = state.row_index;
+        for (auto& child_state : state.child_states) {
+            advance_pax_fixed_scan_state(child_state, count);
+        }
+    }
+
+    uint64_t current_pax_fixed_row_offset(const components::table::row_group_t& row_group,
+                                          const components::table::collection_scan_state& state) {
+        if (state.row_offset_override_active) {
+            if (state.vector_index_relative_to_row_group) {
+                return state.row_offset_override;
+            }
+            if (state.row_offset_override < static_cast<uint64_t>(row_group.start)) {
+                return 0;
+            }
+            return state.row_offset_override - static_cast<uint64_t>(row_group.start);
+        }
+
+        for (const auto& column_state : state.column_scans) {
+            if (column_state.current) {
+                return static_cast<uint64_t>(column_state.row_index - row_group.start);
+            }
+        }
+
+        uint64_t local_vector_index = state.vector_index;
+        if (!state.vector_index_relative_to_row_group) {
+            const auto start_vector =
+                static_cast<uint64_t>(row_group.start) / components::vector::DEFAULT_VECTOR_CAPACITY;
+            local_vector_index -= start_vector;
+        }
+        return local_vector_index * components::vector::DEFAULT_VECTOR_CAPACITY;
+    }
+
+    void set_pax_scan_row_offset(components::table::row_group_t& row_group,
+                                 components::table::collection_scan_state& state,
+                                 uint64_t row_offset_in_group) {
+        const auto absolute_row_offset = static_cast<uint64_t>(row_group.start) + row_offset_in_group;
+        state.vector_index =
+            (state.vector_index_relative_to_row_group ? row_offset_in_group : absolute_row_offset) /
+            components::vector::DEFAULT_VECTOR_CAPACITY;
+        state.row_offset_override_active = true;
+        state.row_offset_override =
+            state.vector_index_relative_to_row_group ? row_offset_in_group : absolute_row_offset;
+    }
+
+    uint64_t current_local_vector_index(const components::table::row_group_t& row_group,
+                                        const components::table::collection_scan_state& state) {
+        uint64_t local_vector_index = state.vector_index;
+        if (!state.vector_index_relative_to_row_group) {
+            const auto start_vector =
+                static_cast<uint64_t>(row_group.start) / components::vector::DEFAULT_VECTOR_CAPACITY;
+            local_vector_index -= start_vector;
+        }
+        return local_vector_index;
+    }
+
+    uint64_t current_version_vector_index(const components::table::row_group_t& row_group,
+                                          const components::table::collection_scan_state& state) {
+        if (!state.vector_index_relative_to_row_group) {
+            return state.vector_index;
+        }
+        const auto start_vector =
+            static_cast<uint64_t>(row_group.start) / components::vector::DEFAULT_VECTOR_CAPACITY;
+        return start_vector + state.vector_index;
+    }
+
+    int64_t current_regular_row_id_base(const components::table::row_group_t& row_group,
+                                        const components::table::collection_scan_state& state) {
+        for (const auto& column_state : state.column_scans) {
+            if (column_state.current) {
+                return column_state.row_index;
+            }
+        }
+
+        const auto local_vector_index = current_local_vector_index(row_group, state);
+        return row_group.start +
+               static_cast<int64_t>(local_vector_index * components::vector::DEFAULT_VECTOR_CAPACITY);
+    }
+
+    // A PAX validity bitmask sits at an arbitrary, possibly-unaligned byte offset in its block, but
+    // validity_mask_t reads it as uint64_t (misaligned load is UB). Copy it into the 8-aligned `out`.
+    // The returned mask aliases out.data(), so `out` must outlive every use of the mask.
+    inline void copy_aligned_pax_validity(const std::byte* raw, uint64_t byte_size, std::vector<uint64_t>& out) {
+        out.assign(static_cast<size_t>((byte_size + sizeof(uint64_t) - 1) / sizeof(uint64_t)), 0);
+        std::memcpy(out.data(), raw, static_cast<size_t>(byte_size));
+    }
+
+    bool apply_pax_fixed_validity_window(components::table::row_group_t& row_group,
+                                         const components::table::storage::pax_fixed_slice_t& slice,
+                                         uint64_t page_row_offset,
+                                         uint64_t copy_count,
+                                         components::vector::vector_t& result,
+                                         uint64_t result_offset,
+                                         pax_fixed_block_cache_t& block_cache) {
+        using components::table::storage::pax_fixed_validity_kind;
+
+        switch (slice.validity_kind) {
+            case pax_fixed_validity_kind::ALL_VALID:
+                return true;
+            case pax_fixed_validity_kind::ALL_INVALID:
+                for (uint64_t i = 0; i < copy_count; i++) {
+                    result.validity().set(result_offset + i, false);
+                }
+                return true;
+            case pax_fixed_validity_kind::BITMASK: {
+                if (!slice.validity_data_pointer.has_value()) {
+                    return false;
+                }
+                auto& validity_pointer = *slice.validity_data_pointer;
+                auto& block_handle =
+                    get_or_pin_pax_fixed_block(row_group, validity_pointer.block_pointer.block_id, block_cache);
+                std::vector<uint64_t> aligned; // must outlive source_mask (which aliases it)
+                copy_aligned_pax_validity(checked_pax_block_ptr(block_handle,
+                                                                validity_pointer.block_pointer.offset,
+                                                                validity_pointer.segment_size,
+                                                                row_group.block_manager().block_size()),
+                                          validity_pointer.segment_size,
+                                          aligned);
+                components::vector::validity_mask_t source_mask(result.resource(), aligned.data());
+                result.validity().slice_in_place(source_mask, result_offset, page_row_offset, copy_count);
+                return true;
+            }
+            case pax_fixed_validity_kind::RLE:
+            default:
+                return false;
+        }
+    }
+
+    // Broadcast a single fixed-width value into `count` contiguous slots at `dst`. Common
+    // power-of-two widths use a typed std::fill; other widths fall back to a memcpy loop.
+    inline void fill_fixed_value(std::byte* dst, const std::byte* value, uint64_t type_size, uint64_t count) {
+        switch (type_size) {
+            case 1:
+                std::memset(dst, static_cast<int>(std::to_integer<unsigned char>(value[0])), count);
+                return;
+            case 2: {
+                uint16_t v;
+                std::memcpy(&v, value, sizeof(v));
+                std::fill_n(reinterpret_cast<uint16_t*>(dst), count, v);
+                return;
+            }
+            case 4: {
+                uint32_t v;
+                std::memcpy(&v, value, sizeof(v));
+                std::fill_n(reinterpret_cast<uint32_t*>(dst), count, v);
+                return;
+            }
+            case 8: {
+                uint64_t v;
+                std::memcpy(&v, value, sizeof(v));
+                std::fill_n(reinterpret_cast<uint64_t*>(dst), count, v);
+                return;
+            }
+            case 16: {
+                __uint128_t v;
+                std::memcpy(&v, value, sizeof(v));
+                std::fill_n(reinterpret_cast<__uint128_t*>(dst), count, v);
+                return;
+            }
+            default:
+                for (uint64_t i = 0; i < count; i++) {
+                    std::memcpy(dst + i * type_size, value, type_size);
+                }
+                return;
+        }
+    }
+
+    bool decode_pax_fixed_uncompressed_window(const components::table::storage::data_pointer_t& pointer,
+                                              const std::byte* source,
+                                              uint64_t type_size,
+                                              uint64_t page_tuple_count,
+                                              uint64_t page_row_offset,
+                                              uint64_t copy_count,
+                                              components::vector::vector_t& result,
+                                              uint64_t result_offset) {
+        if (pointer.segment_size != page_tuple_count * type_size) {
+            return false;
+        }
+
+        const auto byte_offset = page_row_offset * type_size;
+        const auto byte_count = copy_count * type_size;
+        auto* target_ptr = result.data() + result_offset * type_size;
+        std::memcpy(target_ptr, source + byte_offset, byte_count);
+        return true;
+    }
+
+    bool decode_pax_fixed_constant_window(const components::table::storage::data_pointer_t& pointer,
+                                          const std::byte* source,
+                                          uint64_t type_size,
+                                          uint64_t copy_count,
+                                          components::vector::vector_t& result,
+                                          uint64_t result_offset) {
+        if (pointer.segment_size != type_size) {
+            return false;
+        }
+
+        auto* target_ptr = result.data() + result_offset * type_size;
+        fill_fixed_value(target_ptr, source, type_size, copy_count);
+        return true;
+    }
+
+    bool decode_pax_fixed_rle_window(const components::table::storage::data_pointer_t& pointer,
+                                     const std::byte* source,
+                                     uint64_t type_size,
+                                     uint64_t page_tuple_count,
+                                     uint64_t page_row_offset,
+                                     uint64_t copy_count,
+                                     components::vector::vector_t& result,
+                                     uint64_t result_offset) {
+        if (pointer.segment_size < sizeof(uint32_t)) {
+            return false;
+        }
+
+        uint32_t run_count = 0;
+        std::memcpy(&run_count, source, sizeof(uint32_t));
+        const auto entry_size = type_size + sizeof(uint32_t);
+        const auto expected_size = sizeof(uint32_t) + static_cast<uint64_t>(run_count) * entry_size;
+        if (pointer.segment_size != expected_size) {
+            return false;
+        }
+
+        const auto window_end = page_row_offset + copy_count;
+        auto* target_ptr = result.data() + result_offset * type_size;
+        const auto* ptr = source + sizeof(uint32_t);
+        uint64_t logical_offset = 0;
+        uint64_t copied_rows = 0;
+
+        for (uint32_t run = 0; run < run_count; run++) {
+            const auto* value_ptr = ptr;
+            ptr += type_size;
+
+            uint32_t run_length = 0;
+            std::memcpy(&run_length, ptr, sizeof(uint32_t));
+            ptr += sizeof(uint32_t);
+            if (run_length == 0) {
+                return false;
+            }
+
+            const auto run_start = logical_offset;
+            const auto run_end = run_start + static_cast<uint64_t>(run_length);
+            if (run_end < run_start || run_end > page_tuple_count) {
+                return false;
+            }
+
+            const auto overlap_start = std::max(page_row_offset, run_start);
+            const auto overlap_end = std::min(window_end, run_end);
+            if (overlap_start < overlap_end) {
+                const auto output_start = overlap_start - page_row_offset;
+                const auto output_count = overlap_end - overlap_start;
+                fill_fixed_value(target_ptr + output_start * type_size, value_ptr, type_size, output_count);
+                copied_rows += output_count;
+            }
+
+            logical_offset = run_end;
+        }
+
+        return logical_offset == page_tuple_count && copied_rows == copy_count;
+    }
+
+    bool decode_pax_fixed_dictionary_window(const components::table::storage::data_pointer_t& pointer,
+                                            const std::byte* source,
+                                            uint64_t type_size,
+                                            uint64_t page_tuple_count,
+                                            uint64_t page_row_offset,
+                                            uint64_t copy_count,
+                                            components::vector::vector_t& result,
+                                            uint64_t result_offset) {
+        if (pointer.segment_size < sizeof(uint16_t)) {
+            return false;
+        }
+
+        uint16_t num_unique = 0;
+        std::memcpy(&num_unique, source, sizeof(uint16_t));
+        if (num_unique == 0) {
+            return false;
+        }
+
+        const auto index_size = num_unique <= 256 ? uint64_t(1) : uint64_t(2);
+        const auto dictionary_bytes = static_cast<uint64_t>(num_unique) * type_size;
+        const auto expected_size = sizeof(uint16_t) + dictionary_bytes + page_tuple_count * index_size;
+        if (pointer.segment_size != expected_size) {
+            return false;
+        }
+
+        const auto* dictionary_values = source + sizeof(uint16_t);
+        const auto* indices = dictionary_values + dictionary_bytes;
+        auto* target_ptr = result.data() + result_offset * type_size;
+
+        // Hoist the index-width branch out of the gather loop so each width is its own typed-store loop.
+        if (index_size == 1) {
+            const auto* idx = reinterpret_cast<const uint8_t*>(indices) + page_row_offset;
+            for (uint64_t i = 0; i < copy_count; i++) {
+                const uint16_t dict_index = idx[i];
+                if (dict_index >= num_unique) {
+                    return false;
+                }
+                std::memcpy(target_ptr + i * type_size,
+                            dictionary_values + static_cast<uint64_t>(dict_index) * type_size,
+                            type_size);
+            }
+        } else {
+            const auto* idx = indices + page_row_offset * sizeof(uint16_t);
+            for (uint64_t i = 0; i < copy_count; i++) {
+                uint16_t dict_index = 0;
+                std::memcpy(&dict_index, idx + i * sizeof(uint16_t), sizeof(uint16_t));
+                if (dict_index >= num_unique) {
+                    return false;
+                }
+                std::memcpy(target_ptr + i * type_size,
+                            dictionary_values + static_cast<uint64_t>(dict_index) * type_size,
+                            type_size);
+            }
+        }
+        return true;
+    }
+
+    bool decode_pax_fixed_values_window(components::table::row_group_t& row_group,
+                                        const components::table::storage::pax_fixed_slice_t& slice,
+                                        uint64_t type_size,
+                                        uint64_t page_tuple_count,
+                                        uint64_t page_row_offset,
+                                        uint64_t copy_count,
+                                        components::vector::vector_t& result,
+                                        uint64_t result_offset,
+                                        pax_fixed_block_cache_t& block_cache) {
+        using components::table::compression::compression_type;
+
+        const auto& pointer = slice.data_pointer;
+        if (pointer.tuple_count != page_tuple_count) {
+            return false;
+        }
+
+        auto& block_handle = get_or_pin_pax_fixed_block(row_group, pointer.block_pointer.block_id, block_cache);
+        const auto* source = checked_pax_block_ptr(block_handle,
+                                                   pointer.block_pointer.offset,
+                                                   pointer.segment_size,
+                                                   row_group.block_manager().block_size());
+
+        switch (pointer.compression) {
+            case compression_type::UNCOMPRESSED:
+                return decode_pax_fixed_uncompressed_window(pointer,
+                                                            source,
+                                                            type_size,
+                                                            page_tuple_count,
+                                                            page_row_offset,
+                                                            copy_count,
+                                                            result,
+                                                            result_offset);
+            case compression_type::CONSTANT:
+                return decode_pax_fixed_constant_window(pointer, source, type_size, copy_count, result, result_offset);
+            case compression_type::RLE:
+                return decode_pax_fixed_rle_window(pointer,
+                                                   source,
+                                                   type_size,
+                                                   page_tuple_count,
+                                                   page_row_offset,
+                                                   copy_count,
+                                                   result,
+                                                   result_offset);
+            case compression_type::DICTIONARY:
+                return decode_pax_fixed_dictionary_window(pointer,
+                                                          source,
+                                                          type_size,
+                                                          page_tuple_count,
+                                                          page_row_offset,
+                                                          copy_count,
+                                                          result,
+                                                          result_offset);
+            default:
+                return false;
+        }
+    }
+
+    bool decode_pax_fixed_window(components::table::row_group_t& row_group,
+                                 const components::table::storage::pax_fixed_row_group_layout_t& layout,
+                                 uint32_t column_index,
+                                 const components::types::complex_logical_type& type,
+                                 uint64_t window_row_offset,
+                                 uint64_t window_count,
+                                 components::vector::vector_t& result,
+                                 uint64_t result_offset,
+                                 pax_fixed_block_cache_t& block_cache) {
+        if (window_count == 0) {
+            return true;
+        }
+
+        const auto type_size = static_cast<uint64_t>(type.size());
+        const auto expected_column_type = to_pax_fixed_column_type(type);
+        const auto window_end = window_row_offset + window_count;
+
+        result.set_vector_type(components::vector::vector_type::FLAT);
+
+        uint64_t copied_rows = 0;
+        for (const auto& page : layout.pages) {
+            const auto page_start = static_cast<uint64_t>(page.row_offset_in_group);
+            const auto page_end = page_start + static_cast<uint64_t>(page.tuple_count);
+            if (page_end <= window_row_offset || page_start >= window_end) {
+                continue;
+            }
+
+            const auto* slice = find_pax_fixed_slice(page, column_index);
+            if (!slice || slice->column_type != expected_column_type) {
+                return false;
+            }
+
+            const auto overlap_start = std::max(window_row_offset, page_start);
+            const auto overlap_end = std::min(window_end, page_end);
+            const auto copy_count = overlap_end - overlap_start;
+            const auto page_row_offset = overlap_start - page_start;
+            const auto window_result_offset = result_offset + (overlap_start - window_row_offset);
+
+            if (!decode_pax_fixed_values_window(row_group,
+                                                *slice,
+                                                type_size,
+                                                page.tuple_count,
+                                                page_row_offset,
+                                                copy_count,
+                                                result,
+                                                window_result_offset,
+                                                block_cache)) {
+                return false;
+            }
+            if (!apply_pax_fixed_validity_window(row_group,
+                                                 *slice,
+                                                 page_row_offset,
+                                                 copy_count,
+                                                 result,
+                                                 window_result_offset,
+                                                 block_cache)) {
+                return false;
+            }
+            copied_rows += copy_count;
+        }
+
+        return copied_rows == window_count;
+    }
+
+    template<typename T>
+    bool apply_compare(components::expressions::compare_type type, const T& lhs, const T& rhs) {
+        using components::expressions::compare_type;
+
+        switch (type) {
+            case compare_type::eq:
+                if constexpr (std::is_floating_point_v<T>) {
+                    return core::is_equals(lhs, rhs);
+                } else {
+                    return lhs == rhs;
+                }
+            case compare_type::ne:
+                if constexpr (std::is_floating_point_v<T>) {
+                    return !core::is_equals(lhs, rhs);
+                } else {
+                    return lhs != rhs;
+                }
+            case compare_type::gt:
+                return lhs > rhs;
+            case compare_type::gte:
+                return lhs >= rhs;
+            case compare_type::lt:
+                return lhs < rhs;
+            case compare_type::lte:
+                return lhs <= rhs;
+            default:
+                return false;
+        }
+    }
+
+    components::table::filter_propagate_result_t
+    check_pax_statistics(const std::optional<components::table::base_statistics_t>& statistics,
+                         uint32_t tuple_count,
+                         const components::table::table_filter_t& filter) {
+        using components::expressions::compare_type;
+        using components::table::filter_propagate_result_t;
+
+        if (!statistics.has_value()) {
+            return filter_propagate_result_t::NO_PRUNING_POSSIBLE;
+        }
+
+        const auto& stats = *statistics;
+        if (filter.filter_type == compare_type::is_null) {
+            if (stats.null_count() == 0) {
+                return filter_propagate_result_t::ALWAYS_FALSE;
+            }
+            if (stats.null_count() == tuple_count) {
+                return filter_propagate_result_t::ALWAYS_TRUE;
+            }
+            return filter_propagate_result_t::NO_PRUNING_POSSIBLE;
+        }
+        if (filter.filter_type == compare_type::is_not_null) {
+            if (stats.null_count() == tuple_count) {
+                return filter_propagate_result_t::ALWAYS_FALSE;
+            }
+            if (stats.null_count() == 0) {
+                return filter_propagate_result_t::ALWAYS_TRUE;
+            }
+            return filter_propagate_result_t::NO_PRUNING_POSSIBLE;
+        }
+
+        if (stats.null_count() == tuple_count) {
+            return filter_propagate_result_t::ALWAYS_FALSE;
+        }
+        if (!stats.has_stats() || stats.min_value().is_null() || stats.max_value().is_null()) {
+            return filter_propagate_result_t::NO_PRUNING_POSSIBLE;
+        }
+
+        if (filter.filter_type != compare_type::eq && filter.filter_type != compare_type::ne &&
+            filter.filter_type != compare_type::gt && filter.filter_type != compare_type::gte &&
+            filter.filter_type != compare_type::lt && filter.filter_type != compare_type::lte) {
+            return filter_propagate_result_t::NO_PRUNING_POSSIBLE;
+        }
+
+        const auto& constant_filter = filter.cast<components::table::constant_filter_t>();
+        const auto& constant = constant_filter.constant;
+        const auto& min = stats.min_value();
+        const auto& max = stats.max_value();
+
+        switch (filter.filter_type) {
+            case compare_type::eq:
+                if (constant < min || constant > max) {
+                    return filter_propagate_result_t::ALWAYS_FALSE;
+                }
+                if (stats.null_count() == 0 && min == constant && max == constant) {
+                    return filter_propagate_result_t::ALWAYS_TRUE;
+                }
+                break;
+            case compare_type::ne:
+                if (min == constant && max == constant) {
+                    return filter_propagate_result_t::ALWAYS_FALSE;
+                }
+                break;
+            case compare_type::gt:
+                if (max <= constant) {
+                    return filter_propagate_result_t::ALWAYS_FALSE;
+                }
+                if (stats.null_count() == 0 && min > constant) {
+                    return filter_propagate_result_t::ALWAYS_TRUE;
+                }
+                break;
+            case compare_type::gte:
+                if (max < constant) {
+                    return filter_propagate_result_t::ALWAYS_FALSE;
+                }
+                if (stats.null_count() == 0 && min >= constant) {
+                    return filter_propagate_result_t::ALWAYS_TRUE;
+                }
+                break;
+            case compare_type::lt:
+                if (min >= constant) {
+                    return filter_propagate_result_t::ALWAYS_FALSE;
+                }
+                if (stats.null_count() == 0 && max < constant) {
+                    return filter_propagate_result_t::ALWAYS_TRUE;
+                }
+                break;
+            case compare_type::lte:
+                if (min > constant) {
+                    return filter_propagate_result_t::ALWAYS_FALSE;
+                }
+                if (stats.null_count() == 0 && max <= constant) {
+                    return filter_propagate_result_t::ALWAYS_TRUE;
+                }
+                break;
+            default:
+                break;
+        }
+
+        return filter_propagate_result_t::NO_PRUNING_POSSIBLE;
+    }
+
+    components::table::filter_propagate_result_t
+    check_pax_fixed_page_statistics(const components::table::storage::pax_fixed_page_t& page,
+                                    uint32_t column_index,
+                                    const components::table::table_filter_t& filter) {
+        const auto* slice = find_pax_fixed_slice(page, column_index);
+        if (!slice) {
+            return components::table::filter_propagate_result_t::NO_PRUNING_POSSIBLE;
+        }
+        return check_pax_statistics(slice->statistics, page.tuple_count, filter);
+    }
+
+    components::table::filter_propagate_result_t
+    check_pax_generic_page_statistics(const components::table::storage::pax_generic_page_t& page,
+                                      uint32_t column_index,
+                                      const components::table::table_filter_t& filter) {
+        const auto* slice = find_pax_generic_slice(page,
+                                                   column_index,
+                                                   components::table::storage::pax_generic_slice_kind::STRING_VALUES);
+        if (!slice) {
+            slice = find_pax_generic_slice(page,
+                                           column_index,
+                                           components::table::storage::pax_generic_slice_kind::FIXED_VALUES);
+        }
+        if (!slice) {
+            return components::table::filter_propagate_result_t::NO_PRUNING_POSSIBLE;
+        }
+        return check_pax_statistics(slice->statistics, page.tuple_count, filter);
+    }
+
+    components::table::filter_propagate_result_t check_pax_generic_page_statistics(
+        const components::table::storage::pax_generic_page_t& page,
+        uint32_t column_index,
+        const std::vector<const components::table::table_filter_t*>& filters) {
+        using components::table::filter_propagate_result_t;
+
+        if (filters.empty()) {
+            return filter_propagate_result_t::ALWAYS_TRUE;
+        }
+
+        bool all_true = true;
+        for (const auto* filter : filters) {
+            const auto result = check_pax_generic_page_statistics(page, column_index, *filter);
+            if (result == filter_propagate_result_t::ALWAYS_FALSE) {
+                return filter_propagate_result_t::ALWAYS_FALSE;
+            }
+            if (result != filter_propagate_result_t::ALWAYS_TRUE) {
+                all_true = false;
+            }
+        }
+        return all_true ? filter_propagate_result_t::ALWAYS_TRUE
+                        : filter_propagate_result_t::NO_PRUNING_POSSIBLE;
+    }
+
+    template<typename T>
+    uint64_t apply_pax_fixed_constant_filter_value(const components::vector::vector_t& values,
+                                                   components::expressions::compare_type compare_type,
+                                                   const T& constant_value,
+                                                   uint64_t count,
+                                                   components::vector::indexing_vector_t& indexing) {
+        const auto* data = values.data<T>();
+        const auto& validity = values.validity();
+        uint64_t approved_count = 0;
+        for (uint64_t i = 0; i < count; i++) {
+            if (!validity.row_is_valid(i)) {
+                continue;
+            }
+            if (apply_compare(compare_type, data[i], constant_value)) {
+                indexing.set_index(approved_count++, i);
+            }
+        }
+        return approved_count;
+    }
+
+    template<typename T>
+    uint64_t apply_pax_fixed_constant_filter_typed(const components::vector::vector_t& values,
+                                                   const components::table::constant_filter_t& filter,
+                                                   uint64_t count,
+                                                   components::vector::indexing_vector_t& indexing) {
+        return apply_pax_fixed_constant_filter_value(values,
+                                                     filter.filter_type,
+                                                     filter.constant.value<T>(),
+                                                     count,
+                                                     indexing);
+    }
+
+    uint64_t apply_pax_fixed_constant_filter(const components::vector::vector_t& values,
+                                             const components::table::constant_filter_t& filter,
+                                             uint64_t count,
+                                             components::vector::indexing_vector_t& indexing) {
+        using components::types::logical_type;
+
+        switch (values.type().type()) {
+            case logical_type::BOOLEAN:
+                return apply_pax_fixed_constant_filter_typed<bool>(values, filter, count, indexing);
+            case logical_type::TINYINT:
+                return apply_pax_fixed_constant_filter_typed<int8_t>(values, filter, count, indexing);
+            case logical_type::UTINYINT:
+                return apply_pax_fixed_constant_filter_typed<uint8_t>(values, filter, count, indexing);
+            case logical_type::SMALLINT:
+                return apply_pax_fixed_constant_filter_typed<int16_t>(values, filter, count, indexing);
+            case logical_type::USMALLINT:
+                return apply_pax_fixed_constant_filter_typed<uint16_t>(values, filter, count, indexing);
+            case logical_type::INTEGER:
+            case logical_type::ENUM:
+                return apply_pax_fixed_constant_filter_typed<int32_t>(values, filter, count, indexing);
+            case logical_type::UINTEGER:
+                return apply_pax_fixed_constant_filter_typed<uint32_t>(values, filter, count, indexing);
+            case logical_type::BIGINT:
+                return apply_pax_fixed_constant_filter_typed<int64_t>(values, filter, count, indexing);
+            case logical_type::UBIGINT:
+                return apply_pax_fixed_constant_filter_typed<uint64_t>(values, filter, count, indexing);
+            case logical_type::HUGEINT:
+                return apply_pax_fixed_constant_filter_typed<components::types::int128_t>(values,
+                                                                                           filter,
+                                                                                           count,
+                                                                                           indexing);
+            case logical_type::UHUGEINT:
+                return apply_pax_fixed_constant_filter_typed<components::types::uint128_t>(values,
+                                                                                            filter,
+                                                                                            count,
+                                                                                            indexing);
+            case logical_type::UUID:
+                return apply_pax_fixed_constant_filter_typed<components::types::int128_t>(values,
+                                                                                           filter,
+                                                                                           count,
+                                                                                           indexing);
+            case logical_type::FLOAT:
+                return apply_pax_fixed_constant_filter_typed<float>(values, filter, count, indexing);
+            case logical_type::DOUBLE:
+                return apply_pax_fixed_constant_filter_typed<double>(values, filter, count, indexing);
+            case logical_type::TIMESTAMP:
+                return apply_pax_fixed_constant_filter_value(values,
+                                                             filter.filter_type,
+                                                             filter.constant.value<core::date::timestamp_t>().value.count(),
+                                                             count,
+                                                             indexing);
+            case logical_type::TIMESTAMP_TZ:
+                return apply_pax_fixed_constant_filter_value(values,
+                                                             filter.filter_type,
+                                                             filter.constant.value<core::date::timestamptz_t>().value.count(),
+                                                             count,
+                                                             indexing);
+            case logical_type::DECIMAL:
+                if (values.type().to_physical_type() == components::types::physical_type::INT128) {
+                    return apply_pax_fixed_constant_filter_value(values,
+                                                                 filter.filter_type,
+                                                                 filter.constant.value<components::types::int128_t>(),
+                                                                 count,
+                                                                 indexing);
+                }
+                return apply_pax_fixed_constant_filter_value(values,
+                                                             filter.filter_type,
+                                                             filter.constant.value<int64_t>(),
+                                                             count,
+                                                             indexing);
+            default:
+                return 0;
+        }
+    }
+
+    uint64_t apply_pax_validity_filter(const components::vector::vector_t& values,
+                                       components::expressions::compare_type compare_type,
+                                       uint64_t count,
+                                       components::vector::indexing_vector_t& indexing) {
+        const auto& validity = values.validity();
+        const bool select_valid = compare_type == components::expressions::compare_type::is_not_null;
+        uint64_t approved_count = 0;
+        for (uint64_t i = 0; i < count; i++) {
+            if (validity.row_is_valid(i) == select_valid) {
+                indexing.set_index(approved_count++, i);
+            }
+        }
+        return approved_count;
+    }
+
+    uint64_t apply_pax_fixed_single_filter(const components::vector::vector_t& values,
+                                           const components::table::table_filter_t& filter,
+                                           uint64_t count,
+                                           components::vector::indexing_vector_t& indexing) {
+        if (filter.filter_type == components::expressions::compare_type::is_null ||
+            filter.filter_type == components::expressions::compare_type::is_not_null) {
+            return apply_pax_validity_filter(values, filter.filter_type, count, indexing);
+        }
+
+        const auto* constant_filter = dynamic_cast<const components::table::constant_filter_t*>(&filter);
+        if (!constant_filter) {
+            return 0;
+        }
+        return apply_pax_fixed_constant_filter(values, *constant_filter, count, indexing);
+    }
+
+    uint64_t apply_pax_fixed_filter_list(const components::vector::vector_t& values,
+                                         const std::vector<const components::table::table_filter_t*>& filters,
+                                         uint64_t count,
+                                         components::vector::indexing_vector_t& indexing) {
+        if (filters.empty()) {
+            indexing = components::vector::indexing_vector_t(values.resource(), 0, count);
+            return count;
+        }
+
+        if (filters.size() == 1) {
+            return apply_pax_fixed_single_filter(values, *filters.front(), count, indexing);
+        }
+
+        std::vector<uint8_t> approved(count, 1);
+        std::vector<uint8_t> matched(count, 0);
+        for (const auto* filter : filters) {
+            std::fill(matched.begin(), matched.end(), uint8_t{0});
+
+            components::vector::indexing_vector_t filter_indexing(values.resource(), count);
+            const auto filter_count = apply_pax_fixed_single_filter(values, *filter, count, filter_indexing);
+            if (filter_count == 0) {
+                return 0;
+            }
+            for (uint64_t i = 0; i < filter_count; i++) {
+                matched[filter_indexing.get_index(i)] = 1;
+            }
+
+            for (uint64_t i = 0; i < count; i++) {
+                approved[i] = approved[i] && matched[i];
+            }
+        }
+
+        uint64_t approved_count = 0;
+        for (uint64_t i = 0; i < count; i++) {
+            if (approved[i]) {
+                indexing.set_index(approved_count++, i);
+            }
+        }
+        return approved_count;
+    }
+
+    components::table::filter_propagate_result_t check_pax_fixed_page_statistics(
+        const components::table::storage::pax_fixed_page_t& page,
+        uint32_t column_index,
+        const std::vector<const components::table::table_filter_t*>& filters) {
+        using components::table::filter_propagate_result_t;
+
+        if (filters.empty()) {
+            return filter_propagate_result_t::ALWAYS_TRUE;
+        }
+
+        bool all_true = true;
+        for (const auto* filter : filters) {
+            const auto result = check_pax_fixed_page_statistics(page, column_index, *filter);
+            if (result == filter_propagate_result_t::ALWAYS_FALSE) {
+                return filter_propagate_result_t::ALWAYS_FALSE;
+            }
+            if (result != filter_propagate_result_t::ALWAYS_TRUE) {
+                all_true = false;
+            }
+        }
+        return all_true ? filter_propagate_result_t::ALWAYS_TRUE
+                        : filter_propagate_result_t::NO_PRUNING_POSSIBLE;
+    }
+
+    bool extract_pax_fixed_simple_filter_column(const components::table::table_filter_t* filter,
+                                                uint32_t& column_index) {
+        if (!filter || !is_supported_pax_projected_filter_compare(filter->filter_type)) {
+            return false;
+        }
+
+        if (filter->filter_type == components::expressions::compare_type::is_null ||
+            filter->filter_type == components::expressions::compare_type::is_not_null) {
+            auto* null_filter = dynamic_cast<const components::table::is_null_filter_t*>(filter);
+            if (!null_filter || null_filter->table_indices.size() != 1) {
+                return false;
+            }
+            column_index = static_cast<uint32_t>(null_filter->table_indices.front());
+            return true;
+        }
+
+        auto* constant_filter = dynamic_cast<const components::table::constant_filter_t*>(filter);
+        if (!constant_filter || constant_filter->table_indices.size() != 1) {
+            return false;
+        }
+        column_index = static_cast<uint32_t>(constant_filter->table_indices.front());
+        return true;
+    }
+
+    bool is_pax_fixed_conjunction_filter_tree(const components::table::table_filter_t* filter) {
+        if (!filter) {
+            return true;
+        }
+
+        if (filter->filter_type == components::expressions::compare_type::union_and) {
+            auto* and_filter = dynamic_cast<const components::table::conjunction_and_filter_t*>(filter);
+            if (!and_filter || and_filter->child_filters.empty()) {
+                return false;
+            }
+            for (const auto& child_filter : and_filter->child_filters) {
+                if (!is_pax_fixed_conjunction_filter_tree(child_filter.get())) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        uint32_t column_index = 0;
+        return extract_pax_fixed_simple_filter_column(filter, column_index);
+    }
+
+    void append_unique_column_index(std::vector<uint32_t>& columns, uint32_t column_index) {
+        if (std::find(columns.begin(), columns.end(), column_index) == columns.end()) {
+            columns.push_back(column_index);
+        }
+    }
+
+    bool collect_pax_fixed_filter_tree(const components::table::table_filter_t* filter,
+                                       std::vector<const components::table::table_filter_t*>& simple_filters,
+                                       std::vector<uint32_t>& filter_columns) {
+        using components::expressions::compare_type;
+
+        if (!filter) {
+            return true;
+        }
+
+        switch (filter->filter_type) {
+            case compare_type::union_and:
+            case compare_type::union_or:
+            case compare_type::union_not: {
+                auto* conjunction = dynamic_cast<const components::table::conjunction_filter_t*>(filter);
+                if (!conjunction || conjunction->child_filters.empty()) {
+                    return false;
+                }
+                for (const auto& child_filter : conjunction->child_filters) {
+                    if (!collect_pax_fixed_filter_tree(child_filter.get(), simple_filters, filter_columns)) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            default: {
+                uint32_t column_index = 0;
+                if (!extract_pax_fixed_simple_filter_column(filter, column_index)) {
+                    return false;
+                }
+                simple_filters.push_back(filter);
+                append_unique_column_index(filter_columns, column_index);
+                return true;
+            }
+        }
+    }
+
+    components::table::filter_propagate_result_t check_pax_fixed_filter_tree_statistics(
+        const components::table::storage::pax_fixed_page_t& page,
+        const components::table::table_filter_t* filter,
+        const std::function<bool(uint32_t)>& column_has_updates) {
+        using components::expressions::compare_type;
+        using components::table::filter_propagate_result_t;
+
+        if (!filter) {
+            return filter_propagate_result_t::ALWAYS_TRUE;
+        }
+
+        switch (filter->filter_type) {
+            case compare_type::union_and: {
+                auto* and_filter = dynamic_cast<const components::table::conjunction_and_filter_t*>(filter);
+                if (!and_filter || and_filter->child_filters.empty()) {
+                    return filter_propagate_result_t::NO_PRUNING_POSSIBLE;
+                }
+
+                bool all_true = true;
+                for (const auto& child_filter : and_filter->child_filters) {
+                    const auto child_result =
+                        check_pax_fixed_filter_tree_statistics(page, child_filter.get(), column_has_updates);
+                    if (child_result == filter_propagate_result_t::ALWAYS_FALSE) {
+                        return filter_propagate_result_t::ALWAYS_FALSE;
+                    }
+                    if (child_result != filter_propagate_result_t::ALWAYS_TRUE) {
+                        all_true = false;
+                    }
+                }
+                return all_true ? filter_propagate_result_t::ALWAYS_TRUE
+                                : filter_propagate_result_t::NO_PRUNING_POSSIBLE;
+            }
+            case compare_type::union_or: {
+                auto* or_filter = dynamic_cast<const components::table::conjunction_or_filter_t*>(filter);
+                if (!or_filter || or_filter->child_filters.empty()) {
+                    return filter_propagate_result_t::NO_PRUNING_POSSIBLE;
+                }
+
+                bool all_false = true;
+                for (const auto& child_filter : or_filter->child_filters) {
+                    const auto child_result =
+                        check_pax_fixed_filter_tree_statistics(page, child_filter.get(), column_has_updates);
+                    if (child_result == filter_propagate_result_t::ALWAYS_TRUE) {
+                        return filter_propagate_result_t::ALWAYS_TRUE;
+                    }
+                    if (child_result != filter_propagate_result_t::ALWAYS_FALSE) {
+                        all_false = false;
+                    }
+                }
+                return all_false ? filter_propagate_result_t::ALWAYS_FALSE
+                                 : filter_propagate_result_t::NO_PRUNING_POSSIBLE;
+            }
+            case compare_type::union_not:
+                return filter_propagate_result_t::NO_PRUNING_POSSIBLE;
+            default: {
+                uint32_t column_index = 0;
+                if (!extract_pax_fixed_simple_filter_column(filter, column_index) || column_has_updates(column_index)) {
+                    return filter_propagate_result_t::NO_PRUNING_POSSIBLE;
+                }
+                return check_pax_fixed_page_statistics(page, column_index, *filter);
+            }
+        }
+    }
+
+    components::table::filter_propagate_result_t check_pax_generic_filter_tree_statistics(
+        const components::table::storage::pax_generic_page_t& page,
+        const components::table::table_filter_t* filter,
+        const std::function<bool(uint32_t)>& column_has_updates) {
+        using components::expressions::compare_type;
+        using components::table::filter_propagate_result_t;
+
+        if (!filter) {
+            return filter_propagate_result_t::ALWAYS_TRUE;
+        }
+
+        switch (filter->filter_type) {
+            case compare_type::union_and: {
+                auto* and_filter = dynamic_cast<const components::table::conjunction_and_filter_t*>(filter);
+                if (!and_filter || and_filter->child_filters.empty()) {
+                    return filter_propagate_result_t::NO_PRUNING_POSSIBLE;
+                }
+
+                bool all_true = true;
+                for (const auto& child_filter : and_filter->child_filters) {
+                    const auto child_result =
+                        check_pax_generic_filter_tree_statistics(page, child_filter.get(), column_has_updates);
+                    if (child_result == filter_propagate_result_t::ALWAYS_FALSE) {
+                        return filter_propagate_result_t::ALWAYS_FALSE;
+                    }
+                    if (child_result != filter_propagate_result_t::ALWAYS_TRUE) {
+                        all_true = false;
+                    }
+                }
+                return all_true ? filter_propagate_result_t::ALWAYS_TRUE
+                                : filter_propagate_result_t::NO_PRUNING_POSSIBLE;
+            }
+            case compare_type::union_or: {
+                auto* or_filter = dynamic_cast<const components::table::conjunction_or_filter_t*>(filter);
+                if (!or_filter || or_filter->child_filters.empty()) {
+                    return filter_propagate_result_t::NO_PRUNING_POSSIBLE;
+                }
+
+                bool all_false = true;
+                for (const auto& child_filter : or_filter->child_filters) {
+                    const auto child_result =
+                        check_pax_generic_filter_tree_statistics(page, child_filter.get(), column_has_updates);
+                    if (child_result == filter_propagate_result_t::ALWAYS_TRUE) {
+                        return filter_propagate_result_t::ALWAYS_TRUE;
+                    }
+                    if (child_result != filter_propagate_result_t::ALWAYS_FALSE) {
+                        all_false = false;
+                    }
+                }
+                return all_false ? filter_propagate_result_t::ALWAYS_FALSE
+                                 : filter_propagate_result_t::NO_PRUNING_POSSIBLE;
+            }
+            case compare_type::union_not:
+                return filter_propagate_result_t::NO_PRUNING_POSSIBLE;
+            default: {
+                uint32_t column_index = 0;
+                if (!extract_pax_fixed_simple_filter_column(filter, column_index) || column_has_updates(column_index)) {
+                    return filter_propagate_result_t::NO_PRUNING_POSSIBLE;
+                }
+                return check_pax_generic_page_statistics(page, column_index, *filter);
+            }
+        }
+    }
+
+    struct pax_fixed_decoded_filter_column_t {
+        uint32_t column_index{0};
+        // Non-owning: points into the per-scan reusable decode-buffer pool, not a per-page allocation.
+        components::vector::vector_t* values{nullptr};
+    };
+
+    const components::vector::vector_t*
+    find_pax_fixed_decoded_filter_column(const std::vector<pax_fixed_decoded_filter_column_t>& decoded_columns,
+                                         uint32_t column_index) {
+        for (const auto& decoded_column : decoded_columns) {
+            if (decoded_column.column_index == column_index) {
+                return decoded_column.values;
+            }
+        }
+        return nullptr;
+    }
+
+    uint64_t apply_pax_fixed_filter_conjunction(
+        const std::vector<const components::table::table_filter_t*>& simple_filters,
+        const std::vector<pax_fixed_decoded_filter_column_t>& decoded_filter_columns,
+        uint64_t count,
+        components::vector::indexing_vector_t& indexing) {
+        if (simple_filters.empty()) {
+            indexing = components::vector::indexing_vector_t(indexing.resource(), 0, count);
+            return count;
+        }
+
+        // `approved` starts all-zero and the first filter writes its matches straight into it.
+        // `matched` is only needed from the second filter onward, so allocate it lazily.
+        std::vector<uint8_t> approved(count, 0);
+        std::vector<uint8_t> matched;
+        bool first_filter = true;
+        for (const auto* simple_filter : simple_filters) {
+            uint32_t column_index = 0;
+            if (!extract_pax_fixed_simple_filter_column(simple_filter, column_index)) {
+                return 0;
+            }
+
+            const auto* values = find_pax_fixed_decoded_filter_column(decoded_filter_columns, column_index);
+            if (!values) {
+                return 0;
+            }
+
+            components::vector::indexing_vector_t filter_indexing(values->resource(), count);
+            const auto filter_count = apply_pax_fixed_single_filter(*values, *simple_filter, count, filter_indexing);
+            if (filter_count == 0) {
+                return 0;
+            }
+
+            if (first_filter) {
+                for (uint64_t i = 0; i < filter_count; i++) {
+                    approved[filter_indexing.get_index(i)] = 1;
+                }
+                first_filter = false;
+            } else {
+                if (matched.empty()) {
+                    matched.assign(count, 0);
+                } else {
+                    std::fill(matched.begin(), matched.end(), uint8_t{0});
+                }
+                for (uint64_t i = 0; i < filter_count; i++) {
+                    matched[filter_indexing.get_index(i)] = 1;
+                }
+                for (uint64_t row = 0; row < count; row++) {
+                    approved[row] = approved[row] && matched[row];
+                }
+            }
+        }
+
+        uint64_t approved_count = 0;
+        for (uint64_t row = 0; row < count; row++) {
+            if (approved[row]) {
+                indexing.set_index(approved_count++, row);
+            }
+        }
+        return approved_count;
+    }
+
+    bool evaluate_pax_fixed_filter_tree_row(
+        const components::table::table_filter_t* filter,
+        uint64_t row_index,
+        const std::unordered_map<const components::table::table_filter_t*, std::vector<uint8_t>>& simple_filter_masks) {
+        using components::expressions::compare_type;
+
+        if (!filter) {
+            return true;
+        }
+
+        switch (filter->filter_type) {
+            case compare_type::union_and: {
+                auto* and_filter = dynamic_cast<const components::table::conjunction_and_filter_t*>(filter);
+                if (!and_filter) {
+                    return false;
+                }
+                for (const auto& child_filter : and_filter->child_filters) {
+                    if (!evaluate_pax_fixed_filter_tree_row(child_filter.get(), row_index, simple_filter_masks)) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            case compare_type::union_or: {
+                auto* or_filter = dynamic_cast<const components::table::conjunction_or_filter_t*>(filter);
+                if (!or_filter) {
+                    return false;
+                }
+                for (const auto& child_filter : or_filter->child_filters) {
+                    if (evaluate_pax_fixed_filter_tree_row(child_filter.get(), row_index, simple_filter_masks)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+            case compare_type::union_not: {
+                auto* not_filter = dynamic_cast<const components::table::conjunction_not_filter_t*>(filter);
+                if (!not_filter) {
+                    return false;
+                }
+                for (const auto& child_filter : not_filter->child_filters) {
+                    if (evaluate_pax_fixed_filter_tree_row(child_filter.get(), row_index, simple_filter_masks)) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            default: {
+                const auto it = simple_filter_masks.find(filter);
+                return it != simple_filter_masks.end() && row_index < it->second.size() && it->second[row_index] != 0;
+            }
+        }
+    }
+
+    uint64_t apply_pax_fixed_filter_tree(
+        const components::table::table_filter_t* filter,
+        const std::vector<const components::table::table_filter_t*>& simple_filters,
+        const std::vector<pax_fixed_decoded_filter_column_t>& decoded_filter_columns,
+        uint64_t count,
+        components::vector::indexing_vector_t& indexing) {
+        std::unordered_map<const components::table::table_filter_t*, std::vector<uint8_t>> simple_filter_masks;
+        simple_filter_masks.reserve(simple_filters.size());
+
+        for (const auto* simple_filter : simple_filters) {
+            uint32_t column_index = 0;
+            if (!extract_pax_fixed_simple_filter_column(simple_filter, column_index)) {
+                return 0;
+            }
+            const auto* values = find_pax_fixed_decoded_filter_column(decoded_filter_columns, column_index);
+            if (!values) {
+                return 0;
+            }
+
+            components::vector::indexing_vector_t filter_indexing(values->resource(), count);
+            const auto filter_count = apply_pax_fixed_single_filter(*values, *simple_filter, count, filter_indexing);
+            std::vector<uint8_t> mask(count, 0);
+            for (uint64_t i = 0; i < filter_count; i++) {
+                mask[filter_indexing.get_index(i)] = 1;
+            }
+            simple_filter_masks.emplace(simple_filter, std::move(mask));
+        }
+
+        uint64_t approved_count = 0;
+        for (uint64_t row = 0; row < count; row++) {
+            if (evaluate_pax_fixed_filter_tree_row(filter, row, simple_filter_masks)) {
+                indexing.set_index(approved_count++, row);
+            }
+        }
+        return approved_count;
+    }
+
+    bool apply_pax_generic_validity_window(components::table::row_group_t& row_group,
+                                           const components::table::storage::pax_generic_slice_t& validity_slice,
+                                           uint64_t page_row_offset,
+                                           uint64_t copy_count,
+                                           components::vector::vector_t& result,
+                                           uint64_t result_offset,
+                                           pax_generic_block_cache_t& block_cache) {
+        using components::table::storage::pax_generic_codec_kind;
+
+        switch (validity_slice.codec_kind) {
+            case pax_generic_codec_kind::VALIDITY_ALL_VALID:
+                return true;
+            case pax_generic_codec_kind::VALIDITY_ALL_INVALID:
+                for (uint64_t i = 0; i < copy_count; i++) {
+                    result.validity().set(result_offset + i, false);
+                }
+                return true;
+            case pax_generic_codec_kind::VALIDITY_BITMASK: {
+                if (!validity_slice.payload.has_value()) {
+                    return false;
+                }
+                auto& validity_pointer = validity_slice.payload->main_pointer;
+                auto& block_handle =
+                    get_or_pin_pax_generic_block(row_group, validity_pointer.block_pointer.block_id, block_cache);
+                std::vector<uint64_t> aligned; // must outlive source_mask (which aliases it)
+                copy_aligned_pax_validity(checked_pax_block_ptr(block_handle,
+                                                                validity_pointer.block_pointer.offset,
+                                                                validity_pointer.segment_size,
+                                                                row_group.block_manager().block_size()),
+                                          validity_pointer.segment_size,
+                                          aligned);
+                components::vector::validity_mask_t source_mask(result.resource(), aligned.data());
+                result.validity().slice_in_place(source_mask, result_offset, page_row_offset, copy_count);
+                return true;
+            }
+            case pax_generic_codec_kind::STRING_SEGMENT:
+            case pax_generic_codec_kind::FIXED_PLAIN:
+            default:
+                return false;
+        }
+    }
+
+    bool decode_pax_generic_fixed_window(components::table::row_group_t& row_group,
+                                         const components::table::storage::pax_generic_row_group_layout_t& layout,
+                                         uint32_t column_index,
+                                         const components::types::complex_logical_type& type,
+                                         uint64_t window_row_offset,
+                                         uint64_t window_count,
+                                         components::vector::vector_t& result,
+                                         uint64_t result_offset,
+                                         pax_generic_block_cache_t& block_cache) {
+        using components::table::storage::pax_generic_slice_kind;
+
+        if (window_count == 0) {
+            return true;
+        }
+        if (!is_pax_generic_fixed_plain_type(type) || result.type() != type) {
+            return false;
+        }
+
+        const auto type_size = static_cast<uint64_t>(type.size());
+        const auto window_end = window_row_offset + window_count;
+        result.set_vector_type(components::vector::vector_type::FLAT);
+        mark_vector_range_valid(result, result_offset, window_count);
+
+        uint64_t copied_rows = 0;
+        for (const auto& page : layout.pages) {
+            const auto page_start = static_cast<uint64_t>(page.row_offset_in_group);
+            const auto page_end = page_start + static_cast<uint64_t>(page.tuple_count);
+            if (page_end <= window_row_offset || page_start >= window_end) {
+                continue;
+            }
+
+            const auto* value_slice = find_pax_generic_slice(page, column_index, pax_generic_slice_kind::FIXED_VALUES);
+            const auto* validity_slice = find_pax_generic_slice(page, column_index, pax_generic_slice_kind::VALIDITY);
+            if (!value_slice || !validity_slice ||
+                !validate_pax_generic_fixed_slice(*value_slice, page.tuple_count, type) ||
+                !validate_pax_generic_validity_slice(*validity_slice, page.tuple_count)) {
+                return false;
+            }
+
+            const auto overlap_start = std::max(window_row_offset, page_start);
+            const auto overlap_end = std::min(window_end, page_end);
+            const auto copy_count = overlap_end - overlap_start;
+            const auto page_row_offset = overlap_start - page_start;
+            const auto window_result_offset = result_offset + (overlap_start - window_row_offset);
+
+            auto& value_pointer = value_slice->payload->main_pointer;
+            auto& block_handle =
+                get_or_pin_pax_generic_block(row_group, value_pointer.block_pointer.block_id, block_cache);
+            auto* source = checked_pax_block_ptr(block_handle,
+                                                 value_pointer.block_pointer.offset,
+                                                 value_pointer.segment_size,
+                                                 row_group.block_manager().block_size()) +
+                           page_row_offset * type_size;
+            auto* target = result.data() + window_result_offset * type_size;
+            std::memcpy(target, source, copy_count * type_size);
+
+            if (!apply_pax_generic_validity_window(row_group,
+                                                   *validity_slice,
+                                                   page_row_offset,
+                                                   copy_count,
+                                                   result,
+                                                   window_result_offset,
+                                                   block_cache)) {
+                return false;
+            }
+            copied_rows += copy_count;
+        }
+
+        return copied_rows == window_count;
+    }
+
+    std::string_view materialize_pax_generic_string(components::vector::vector_t& result,
+                                                    uint64_t row_index,
+                                                    const std::string_view& value) {
+        auto* auxiliary = static_cast<components::vector::string_vector_buffer_t*>(result.auxiliary().get());
+        if (!auxiliary) {
+            throw std::logic_error("missing string auxiliary buffer for pax_generic decode");
+        }
+
+        auto* result_data = result.data<std::string_view>();
+        if (value.empty()) {
+            auto* empty = auxiliary->empty_string(0);
+            result_data[row_index] = std::string_view(reinterpret_cast<char*>(empty), 0);
+        } else {
+            auto* stored = auxiliary->insert(value.data(), value.size());
+            result_data[row_index] = std::string_view(reinterpret_cast<char*>(stored), value.size());
+        }
+        return result_data[row_index];
+    }
+
+    bool decode_pax_generic_string_window(components::table::row_group_t& row_group,
+                                          const components::table::storage::pax_generic_row_group_layout_t& layout,
+                                          uint32_t column_index,
+                                          uint64_t window_row_offset,
+                                          uint64_t window_count,
+                                          components::vector::vector_t& result,
+                                          uint64_t result_offset,
+                                          pax_generic_block_cache_t& block_cache) {
+        using components::table::storage::pax_generic_codec_kind;
+        using components::table::storage::pax_generic_slice_kind;
+
+        if (window_count == 0) {
+            return true;
+        }
+        if (result.type().to_physical_type() != components::types::physical_type::STRING) {
+            return false;
+        }
+
+        result.set_vector_type(components::vector::vector_type::FLAT);
+        mark_vector_range_valid(result, result_offset, window_count);
+
+        const auto window_end = window_row_offset + window_count;
+        uint64_t copied_rows = 0;
+        for (const auto& page : layout.pages) {
+            const auto page_start = static_cast<uint64_t>(page.row_offset_in_group);
+            const auto page_end = page_start + static_cast<uint64_t>(page.tuple_count);
+            if (page_end <= window_row_offset || page_start >= window_end) {
+                continue;
+            }
+
+            const auto* value_slice = find_pax_generic_slice(page, column_index, pax_generic_slice_kind::STRING_VALUES);
+            const auto* validity_slice = find_pax_generic_slice(page, column_index, pax_generic_slice_kind::VALIDITY);
+            if (!value_slice || !validity_slice || !validate_pax_generic_string_slice(*value_slice, page.tuple_count) ||
+                !validate_pax_generic_validity_slice(*validity_slice, page.tuple_count)) {
+                return false;
+            }
+
+            auto& value_pointer = value_slice->payload->main_pointer;
+            auto& block_handle =
+                get_or_pin_pax_generic_block(row_group, value_pointer.block_pointer.block_id, block_cache);
+            auto* base_ptr = checked_pax_block_ptr(block_handle,
+                                                   value_pointer.block_pointer.offset,
+                                                   value_pointer.segment_size,
+                                                   row_group.block_manager().block_size());
+            uint32_t dict_size = 0;
+            uint32_t dict_end = 0;
+            std::memcpy(&dict_size, base_ptr, sizeof(uint32_t));
+            std::memcpy(&dict_end, base_ptr + sizeof(uint32_t), sizeof(uint32_t));
+
+            const auto offset_bytes = static_cast<uint64_t>(page.tuple_count) * sizeof(int32_t);
+            const auto minimum_payload_size =
+                static_cast<uint64_t>(PAX_STRING_DICTIONARY_HEADER_SIZE) + offset_bytes;
+            if (value_pointer.segment_size < minimum_payload_size || dict_end > value_pointer.segment_size ||
+                dict_size > dict_end || dict_end < minimum_payload_size) {
+                return false;
+            }
+
+            std::optional<components::vector::validity_mask_t> page_validity_mask;
+            std::vector<uint64_t> page_validity_aligned; // must outlive page_validity_mask (aliased below)
+            if (validity_slice->codec_kind == pax_generic_codec_kind::VALIDITY_BITMASK) {
+                auto& validity_pointer = validity_slice->payload->main_pointer;
+                auto& validity_handle =
+                    get_or_pin_pax_generic_block(row_group, validity_pointer.block_pointer.block_id, block_cache);
+                copy_aligned_pax_validity(checked_pax_block_ptr(validity_handle,
+                                                                validity_pointer.block_pointer.offset,
+                                                                validity_pointer.segment_size,
+                                                                row_group.block_manager().block_size()),
+                                          validity_pointer.segment_size,
+                                          page_validity_aligned);
+                page_validity_mask.emplace(result.resource(), page_validity_aligned.data());
+            }
+
+            // The int32 offset array sits at a possibly-unaligned byte offset, so load each entry
+            // via memcpy rather than dereferencing an int32_t* (misaligned load is UB).
+            const auto* page_offsets_raw = base_ptr + PAX_STRING_DICTIONARY_HEADER_SIZE;
+            const auto load_page_offset = [page_offsets_raw](uint64_t idx) {
+                int32_t v;
+                std::memcpy(&v, page_offsets_raw + idx * sizeof(int32_t), sizeof(int32_t));
+                return v;
+            };
+            const auto overlap_start = std::max(window_row_offset, page_start);
+            const auto overlap_end = std::min(window_end, page_end);
+            const auto copy_count = overlap_end - overlap_start;
+            const auto page_row_offset = overlap_start - page_start;
+
+            for (uint64_t i = 0; i < copy_count; i++) {
+                const auto page_index = static_cast<uint64_t>(page_row_offset + i);
+                const auto target_index = result_offset + (overlap_start - window_row_offset) + i;
+
+                bool is_valid = true;
+                switch (validity_slice->codec_kind) {
+                    case pax_generic_codec_kind::VALIDITY_ALL_VALID:
+                        break;
+                    case pax_generic_codec_kind::VALIDITY_ALL_INVALID:
+                        is_valid = false;
+                        break;
+                    case pax_generic_codec_kind::VALIDITY_BITMASK:
+                        is_valid = page_validity_mask->row_is_valid(page_index);
+                        break;
+                    case pax_generic_codec_kind::STRING_SEGMENT:
+                    default:
+                        return false;
+                }
+
+                if (!is_valid) {
+                    result.validity().set(target_index, false);
+                    result.data<std::string_view>()[target_index] = std::string_view(nullptr, 0);
+                    continue;
+                }
+
+                const auto dict_offset = load_page_offset(page_index);
+                const auto prev_offset = page_index == 0 ? 0 : load_page_offset(page_index - 1);
+                const auto abs_dict_offset = static_cast<uint64_t>(std::abs(dict_offset));
+                const auto abs_prev_offset = static_cast<uint64_t>(std::abs(prev_offset));
+                if (abs_dict_offset < abs_prev_offset || abs_dict_offset > dict_end) {
+                    return false;
+                }
+
+                const auto string_length =
+                    static_cast<uint32_t>(abs_dict_offset - abs_prev_offset);
+                if (dict_offset < 0) {
+                    if (abs_dict_offset < PAX_STRING_BIG_MARKER_SIZE) {
+                        return false;
+                    }
+                    auto* marker_ptr = base_ptr + dict_end - abs_dict_offset;
+                    uint32_t overflow_block_id = 0;
+                    int32_t overflow_offset = 0;
+                    std::memcpy(&overflow_block_id, marker_ptr, sizeof(uint32_t));
+                    std::memcpy(&overflow_offset, marker_ptr + sizeof(uint32_t), sizeof(int32_t));
+                    if (overflow_offset < 0 ||
+                        std::find(value_slice->payload->extra_block_ids.begin(),
+                                  value_slice->payload->extra_block_ids.end(),
+                                  overflow_block_id) == value_slice->payload->extra_block_ids.end()) {
+                        return false;
+                    }
+
+                    auto& overflow_handle =
+                        get_or_pin_pax_generic_block(row_group, overflow_block_id, block_cache);
+                    const uint64_t overflow_bs = row_group.block_manager().block_size();
+                    const uint64_t overflow_pos = static_cast<uint64_t>(overflow_offset);
+                    // Bound the disk-derived offset/length against the overflow block before reading
+                    // the length prefix and the string bytes.
+                    if (overflow_pos + sizeof(uint32_t) > overflow_bs) {
+                        return false;
+                    }
+                    auto* overflow_ptr = overflow_handle.ptr() + overflow_pos;
+                    uint32_t overflow_length = 0;
+                    std::memcpy(&overflow_length, overflow_ptr, sizeof(uint32_t));
+                    if (overflow_pos + sizeof(uint32_t) + static_cast<uint64_t>(overflow_length) > overflow_bs) {
+                        return false;
+                    }
+                    materialize_pax_generic_string(result,
+                                                  target_index,
+                                                  std::string_view(reinterpret_cast<char*>(overflow_ptr + sizeof(uint32_t)),
+                                                                   overflow_length));
+                } else {
+                    auto* source_ptr = reinterpret_cast<char*>(base_ptr + dict_end - abs_dict_offset);
+                    materialize_pax_generic_string(result,
+                                                  target_index,
+                                                  std::string_view(source_ptr, string_length));
+                }
+            }
+            copied_rows += copy_count;
+        }
+
+        return copied_rows == window_count;
+    }
+
+    uint64_t apply_pax_generic_string_constant_filter(const components::vector::vector_t& values,
+                                                      const components::table::constant_filter_t& filter,
+                                                      uint64_t count,
+                                                      components::vector::indexing_vector_t& indexing) {
+        const auto* data = values.data<std::string_view>();
+        const auto& validity = values.validity();
+        uint64_t approved_count = 0;
+        for (uint64_t i = 0; i < count; i++) {
+            if (!validity.row_is_valid(i)) {
+                continue;
+            }
+            if (filter.compare(data[i])) {
+                indexing.set_index(approved_count++, i);
+            }
+        }
+        return approved_count;
+    }
+
+    bool decode_pax_generic_root_window(components::table::row_group_t& row_group,
+                                        const components::table::storage::pax_generic_row_group_layout_t& layout,
+                                        uint32_t column_index,
+                                        const components::types::complex_logical_type& type,
+                                        uint64_t window_row_offset,
+                                        uint64_t window_count,
+                                        components::vector::vector_t& result,
+                                        uint64_t result_offset,
+                                        pax_generic_block_cache_t& block_cache) {
+        if (is_pax_generic_string_type(type)) {
+            return decode_pax_generic_string_window(row_group,
+                                                    layout,
+                                                    column_index,
+                                                    window_row_offset,
+                                                    window_count,
+                                                    result,
+                                                    result_offset,
+                                                    block_cache);
+        }
+        if (is_pax_generic_fixed_plain_type(type)) {
+            return decode_pax_generic_fixed_window(row_group,
+                                                   layout,
+                                                   column_index,
+                                                   type,
+                                                   window_row_offset,
+                                                   window_count,
+                                                   result,
+                                                   result_offset,
+                                                   block_cache);
+        }
+        return false;
+    }
+
+    uint64_t apply_pax_generic_root_single_filter(const components::vector::vector_t& values,
+                                                  const components::table::table_filter_t& filter,
+                                                  uint64_t count,
+                                                  components::vector::indexing_vector_t& indexing) {
+        if (filter.filter_type == components::expressions::compare_type::is_null ||
+            filter.filter_type == components::expressions::compare_type::is_not_null) {
+            return apply_pax_validity_filter(values, filter.filter_type, count, indexing);
+        }
+
+        const auto* constant_filter = dynamic_cast<const components::table::constant_filter_t*>(&filter);
+        if (!constant_filter) {
+            return 0;
+        }
+        if (values.type().to_physical_type() == components::types::physical_type::STRING) {
+            return apply_pax_generic_string_constant_filter(values, *constant_filter, count, indexing);
+        }
+        if (is_pax_generic_fixed_plain_type(values.type())) {
+            return apply_pax_fixed_constant_filter(values, *constant_filter, count, indexing);
+        }
+        return 0;
+    }
+
+    struct pax_generic_decoded_filter_column_t {
+        uint32_t column_index{0};
+        std::unique_ptr<components::vector::vector_t> values;
+    };
+
+    const components::vector::vector_t*
+    find_pax_generic_decoded_filter_column(const std::vector<pax_generic_decoded_filter_column_t>& decoded_columns,
+                                           uint32_t column_index) {
+        for (const auto& decoded_column : decoded_columns) {
+            if (decoded_column.column_index == column_index) {
+                return decoded_column.values.get();
+            }
+        }
+        return nullptr;
+    }
+
+    uint64_t apply_pax_generic_root_filter_list(
+        const components::vector::vector_t& values,
+        const std::vector<const components::table::table_filter_t*>& filters,
+        uint64_t count,
+        components::vector::indexing_vector_t& indexing) {
+        if (filters.empty()) {
+            indexing = components::vector::indexing_vector_t(values.resource(), 0, count);
+            return count;
+        }
+
+        if (filters.size() == 1) {
+            return apply_pax_generic_root_single_filter(values, *filters.front(), count, indexing);
+        }
+
+        std::vector<uint8_t> approved(count, 1);
+        std::vector<uint8_t> matched(count, 0);
+        for (const auto* filter : filters) {
+            std::fill(matched.begin(), matched.end(), uint8_t{0});
+
+            components::vector::indexing_vector_t filter_indexing(values.resource(), count);
+            const auto filter_count = apply_pax_generic_root_single_filter(values, *filter, count, filter_indexing);
+            if (filter_count == 0) {
+                return 0;
+            }
+            for (uint64_t i = 0; i < filter_count; i++) {
+                matched[filter_indexing.get_index(i)] = 1;
+            }
+
+            for (uint64_t row = 0; row < count; row++) {
+                approved[row] = approved[row] && matched[row];
+            }
+        }
+
+        uint64_t approved_count = 0;
+        for (uint64_t row = 0; row < count; row++) {
+            if (approved[row]) {
+                indexing.set_index(approved_count++, row);
+            }
+        }
+        return approved_count;
+    }
+
+    uint64_t apply_pax_generic_root_filter_conjunction(
+        const std::vector<const components::table::table_filter_t*>& simple_filters,
+        const std::vector<pax_generic_decoded_filter_column_t>& decoded_filter_columns,
+        uint64_t count,
+        components::vector::indexing_vector_t& indexing) {
+        if (simple_filters.empty()) {
+            indexing = components::vector::indexing_vector_t(indexing.resource(), 0, count);
+            return count;
+        }
+
+        std::vector<uint8_t> approved(count, 1);
+        std::vector<uint8_t> matched(count, 0);
+        for (const auto* simple_filter : simple_filters) {
+            uint32_t column_index = 0;
+            if (!extract_pax_fixed_simple_filter_column(simple_filter, column_index)) {
+                return 0;
+            }
+
+            const auto* values = find_pax_generic_decoded_filter_column(decoded_filter_columns, column_index);
+            if (!values) {
+                return 0;
+            }
+
+            std::fill(matched.begin(), matched.end(), uint8_t{0});
+            components::vector::indexing_vector_t filter_indexing(values->resource(), count);
+            const auto filter_count =
+                apply_pax_generic_root_single_filter(*values, *simple_filter, count, filter_indexing);
+            if (filter_count == 0) {
+                return 0;
+            }
+            for (uint64_t i = 0; i < filter_count; i++) {
+                matched[filter_indexing.get_index(i)] = 1;
+            }
+
+            for (uint64_t row = 0; row < count; row++) {
+                approved[row] = approved[row] && matched[row];
+            }
+        }
+
+        uint64_t approved_count = 0;
+        for (uint64_t row = 0; row < count; row++) {
+            if (approved[row]) {
+                indexing.set_index(approved_count++, row);
+            }
+        }
+        return approved_count;
+    }
+
+    bool evaluate_pax_generic_filter_tree_row(
+        const components::table::table_filter_t* filter,
+        uint64_t row_index,
+        const std::unordered_map<const components::table::table_filter_t*, std::vector<uint8_t>>& simple_filter_masks) {
+        return evaluate_pax_fixed_filter_tree_row(filter, row_index, simple_filter_masks);
+    }
+
+    uint64_t apply_pax_generic_root_filter_tree(
+        const components::table::table_filter_t* filter,
+        const std::vector<const components::table::table_filter_t*>& simple_filters,
+        const std::vector<pax_generic_decoded_filter_column_t>& decoded_filter_columns,
+        uint64_t count,
+        components::vector::indexing_vector_t& indexing) {
+        std::unordered_map<const components::table::table_filter_t*, std::vector<uint8_t>> simple_filter_masks;
+        simple_filter_masks.reserve(simple_filters.size());
+
+        for (const auto* simple_filter : simple_filters) {
+            uint32_t column_index = 0;
+            if (!extract_pax_fixed_simple_filter_column(simple_filter, column_index)) {
+                return 0;
+            }
+            const auto* values = find_pax_generic_decoded_filter_column(decoded_filter_columns, column_index);
+            if (!values) {
+                return 0;
+            }
+
+            components::vector::indexing_vector_t filter_indexing(values->resource(), count);
+            const auto filter_count =
+                apply_pax_generic_root_single_filter(*values, *simple_filter, count, filter_indexing);
+            std::vector<uint8_t> mask(count, 0);
+            for (uint64_t i = 0; i < filter_count; i++) {
+                mask[filter_indexing.get_index(i)] = 1;
+            }
+            simple_filter_masks.emplace(simple_filter, std::move(mask));
+        }
+
+        uint64_t approved_count = 0;
+        for (uint64_t row = 0; row < count; row++) {
+            if (evaluate_pax_generic_filter_tree_row(filter, row, simple_filter_masks)) {
+                indexing.set_index(approved_count++, row);
+            }
+        }
+        return approved_count;
+    }
+
+} // namespace
 
 namespace components::table {
 
     row_group_t::row_group_t(collection_t* collection, int64_t start, uint64_t count)
         : segment_base_t(start, count)
         , collection_(collection)
+        , deletes_is_loaded_(true)
         , allocation_size_(0) {}
 
     void row_group_t::move_to_collection(collection_t* collection, int64_t new_start) {
         collection_ = collection;
         start = new_start;
+        mark_dirty();
         for (auto& column : columns()) {
             column->set_start(new_start);
         }
@@ -75,6 +3368,8 @@ namespace components::table {
         auto& column_ids = state.column_ids();
         state.row_group = this;
         state.vector_index = vector_offset;
+        state.row_offset_override_active = false;
+        state.row_offset_override = 0;
         state.max_row_group_row =
             start > state.max_row ? 0 : std::min(static_cast<int64_t>(count.load()), state.max_row - start);
         auto row_number = start + static_cast<int64_t>(vector_offset * vector::DEFAULT_VECTOR_CAPACITY);
@@ -97,8 +3392,16 @@ namespace components::table {
     bool row_group_t::initialize_scan(collection_scan_state& state) {
         auto& column_ids = state.column_ids();
         state.row_group = this;
-        state.max_row_group_row +=
+        state.row_offset_override_active = false;
+        state.row_offset_override = 0;
+        const auto row_group_limit =
             start > state.max_row ? 0 : std::min(static_cast<int64_t>(count.load()), state.max_row - start);
+        if (state.vector_index_relative_to_row_group) {
+            state.vector_index = 0;
+            state.max_row_group_row = row_group_limit;
+        } else {
+            state.max_row_group_row += row_group_limit;
+        }
         if (state.max_row_group_row == 0) {
             return false;
         }
@@ -147,6 +3450,7 @@ namespace components::table {
         row_group->current_version_ = current_version_;
         row_group->columns_ = columns();
         row_group->columns_.push_back(std::move(added_column));
+        row_group->mark_dirty();
 
         return row_group;
     }
@@ -163,6 +3467,7 @@ namespace components::table {
                 row_group->columns_.push_back(cols[i]);
             }
         }
+        row_group->mark_dirty();
 
         return row_group;
     }
@@ -240,6 +3545,16 @@ namespace components::table {
         if (!f) {
             return true;
         }
+        std::vector<const table_filter_t*> simple_filters;
+        std::vector<uint32_t> filter_columns;
+        if (collect_pax_fixed_filter_tree(f, simple_filters, filter_columns)) {
+            for (const auto column_index : filter_columns) {
+                if (column_index < get_column_count() &&
+                    get_column(column_index).has_updates()) {
+                    return true;
+                }
+            }
+        }
         // For constant comparison filters, check if any column's zonemap prunes this segment
         if (f->filter_type == expressions::compare_type::eq || f->filter_type == expressions::compare_type::gt ||
             f->filter_type == expressions::compare_type::gte || f->filter_type == expressions::compare_type::lt ||
@@ -263,7 +3578,7 @@ namespace components::table {
     }
 
     void row_group_t::filter_indexing(std::pmr::memory_resource* resource,
-                                      uint64_t vector_index,
+                                      int64_t row_id_base,
                                       vector::indexing_vector_t& indexing,
                                       const table_filter_t* filter,
                                       uint64_t& approved_tuple_count) {
@@ -272,11 +3587,978 @@ namespace components::table {
         for (uint64_t i = 0; i < approved_tuple_count; i++) {
             auto idx = indexing.get_index(i);
             new_indexing.set_index(result_count, idx);
-            result_count +=
-                check_predicate(static_cast<int64_t>(idx + vector_index * vector::DEFAULT_VECTOR_CAPACITY), filter);
+            result_count += check_predicate(row_id_base + static_cast<int64_t>(idx), filter);
         }
         indexing = new_indexing;
         approved_tuple_count = result_count;
+    }
+
+
+	    bool row_group_t::try_scan_pax_generic_projected(collection_scan_state& state, vector::data_chunk_t& result) {
+	        const bool has_persisted_pax_layout =
+	            layout_kind_ == storage::row_group_layout_kind::PAX_GENERIC && pax_generic_layout_.has_value();
+	        if (!has_persisted_pax_layout) {
+	            return false;
+	        }
+	        const bool transaction_scan = state.txn.transaction_id != 0 || state.txn.start_time != 0;
+		        const bool apply_visibility_filter = requires_pax_version_visibility(transaction_scan);
+
+        const auto& column_ids = state.column_ids();
+        if (column_ids.empty()) {
+            return false;
+        }
+
+        auto* filter = state.filter();
+        std::vector<const table_filter_t*> generic_simple_filters;
+        std::vector<uint32_t> generic_filter_columns;
+        if (filter && !collect_pax_fixed_filter_tree(filter, generic_simple_filters, generic_filter_columns)) {
+            return false;
+        }
+        const bool has_filter = filter != nullptr;
+        const bool conjunction_filter = has_filter && is_pax_fixed_conjunction_filter_tree(filter);
+        const bool single_column_conjunction_filter = conjunction_filter && generic_filter_columns.size() == 1;
+
+        std::vector<uint32_t> required_generic_columns;
+        for (const auto& column_index : generic_filter_columns) {
+            append_unique_column_index(required_generic_columns, column_index);
+        }
+
+        for (uint64_t i = 0; i < column_ids.size(); i++) {
+            const auto& column = column_ids[i];
+            if (column.has_children()) {
+                return false;
+            }
+            if (column.is_row_id_column()) {
+                continue;
+            }
+
+            const auto column_index = column.primary_index();
+            if (column_index >= get_column_count()) {
+                return false;
+            }
+
+	            auto& column_data = get_column(column_index);
+	            if (!is_pax_generic_root_projected_type(column_data.type())) {
+	                return false;
+	            }
+	            if (transaction_scan && column_data.has_uncommitted_updates()) {
+	                return false;
+	            }
+	            append_unique_column_index(required_generic_columns, static_cast<uint32_t>(column_index));
+	        }
+
+        for (const auto column_index : generic_filter_columns) {
+            if (column_index >= get_column_count()) {
+                return false;
+            }
+            auto& filter_column = get_column(column_index);
+	            if (!is_pax_generic_root_projected_type(filter_column.type())) {
+	                return false;
+	            }
+	            if (transaction_scan && filter_column.has_uncommitted_updates()) {
+	                return false;
+	            }
+	        }
+
+
+        const auto& layout = *pax_generic_layout_;
+        if (!is_supported_pax_generic_layout_version(layout.version) || layout.rows_per_page == 0 ||
+            layout.pages.empty()) {
+            return false;
+        }
+
+        uint64_t expected_row_offset = 0;
+        for (const auto& page : layout.pages) {
+            if (page.tuple_count == 0 || page.row_offset_in_group != expected_row_offset ||
+                page.tuple_count > layout.rows_per_page) {
+                return false;
+            }
+            expected_row_offset += page.tuple_count;
+        }
+        const auto pax_tuple_count = pax_generic_layout_tuple_count(layout);
+        const auto row_group_tuple_count = count.load();
+        if (expected_row_offset != pax_tuple_count || pax_tuple_count > row_group_tuple_count) {
+            return false;
+        }
+        const auto row_group_scan_limit =
+            start > state.max_row ? uint64_t(0)
+                                  : static_cast<uint64_t>(std::min(static_cast<int64_t>(row_group_tuple_count),
+                                                                   state.max_row - start));
+        if (row_group_scan_limit > pax_tuple_count &&
+            pax_tuple_count % vector::DEFAULT_VECTOR_CAPACITY != 0) {
+            return false;
+        }
+
+        for (const auto column_index : required_generic_columns) {
+            const auto& column_type = get_column(column_index).type();
+            for (const auto& page : layout.pages) {
+                if (!validate_pax_generic_root_column_slices(page, column_index, column_type)) {
+                    return false;
+                }
+            }
+        }
+
+        for (auto& column_state : state.column_scans) {
+            column_state.result_offset = result.size();
+        }
+
+        pax_generic_block_cache_t block_cache;
+        const auto local_max_row_group_row = std::min(row_group_scan_limit, pax_tuple_count);
+
+        while (true) {
+            const auto current_row = current_pax_fixed_row_offset(*this, state);
+            if (current_row >= local_max_row_group_row) {
+                if (row_group_scan_limit > pax_tuple_count && current_row >= pax_tuple_count) {
+                    return false;
+                }
+                return true;
+            }
+
+            const auto max_count =
+                std::min<uint64_t>(vector::DEFAULT_VECTOR_CAPACITY, local_max_row_group_row - current_row);
+
+            if (!check_zonemap_segments(state)) {
+                continue;
+            }
+
+            vector::indexing_vector_t visible_indexing(result.resource(), max_count);
+            const auto visible_count = apply_visibility_filter
+                                           ? pax_visibility_indexing(state,
+                                                                    current_row,
+                                                                    max_count,
+                                                                    visible_indexing,
+                                                                    transaction_scan)
+                                           : max_count;
+            if (visible_count == 0) {
+                state.vector_index++;
+                set_pax_scan_row_offset(*this, state, current_row + max_count);
+                for (auto& column_state : state.column_scans) {
+                    advance_pax_fixed_scan_state(column_state, max_count);
+                }
+                continue;
+            }
+            const auto visible_mask = visible_count == max_count
+                                          ? std::vector<uint8_t>{}
+                                          : build_pax_visibility_mask(visible_indexing, visible_count, max_count);
+
+            const auto window_end = current_row + max_count;
+            const auto page_windows = collect_pax_page_windows(layout.pages, current_row, window_end);
+            const auto result_offset = result.size();
+            if (!has_filter) {
+                std::vector<uint64_t> prefetch_blocks;
+                for (const auto& page_window : page_windows) {
+                    const auto& page = *page_window.page;
+                    for (const auto& column : column_ids) {
+                        if (column.is_row_id_column()) {
+                            continue;
+                        }
+                        if (!collect_pax_generic_root_column_blocks(page,
+                                                                    static_cast<uint32_t>(column.primary_index()),
+                                                                    get_column(column).type(),
+                                                                    prefetch_blocks)) {
+                            return false;
+                        }
+                    }
+                }
+                const auto prefetched = prefetch_and_pin_pax_blocks(*this, prefetch_blocks, block_cache);
+                if (prefetched > 0 && scan_path_counts_enabled_.load(std::memory_order_relaxed)) {
+                    pax_generic_prefetched_block_count_.fetch_add(prefetched, std::memory_order_relaxed);
+                }
+
+                validate_chunk_capacity(result, result_offset + visible_count);
+                if (visible_count == max_count) {
+                    for (const auto& column : column_ids) {
+                        if (column.is_row_id_column()) {
+                            continue;
+                        }
+                        const auto out_idx = column.primary_index();
+                        if (out_idx >= result.data.size()) {
+                            return false;
+                        }
+                        if (is_unprojected_placeholder(result.data[out_idx])) {
+                            continue;
+                        }
+                        if (!result.data[out_idx].data()) {
+                            return false;
+                        }
+                        if (!decode_pax_generic_root_window(*this,
+                                                            layout,
+                                                            static_cast<uint32_t>(column.primary_index()),
+                                                            get_column(column).type(),
+                                                            current_row,
+                                                            max_count,
+                                                            result.data[out_idx],
+                                                            result_offset,
+                                                            block_cache)) {
+                            return false;
+                        }
+                        apply_pax_committed_updates(get_column(column),
+                                                    current_row,
+                                                    max_count,
+                                                    result.data[out_idx],
+                                                    result_offset);
+                    }
+                } else {
+                    for (const auto& column : column_ids) {
+                        if (column.is_row_id_column()) {
+                            continue;
+                        }
+                        const auto out_idx = column.primary_index();
+                        if (out_idx >= result.data.size()) {
+                            return false;
+                        }
+                        if (is_unprojected_placeholder(result.data[out_idx])) {
+                            continue;
+                        }
+                        if (!result.data[out_idx].data()) {
+                            return false;
+                        }
+                        vector::vector_t temp_values(result.resource(), get_column(column).type(), max_count);
+                        if (!decode_pax_generic_root_window(*this,
+                                                            layout,
+                                                            static_cast<uint32_t>(column.primary_index()),
+                                                            get_column(column).type(),
+                                                            current_row,
+                                                            max_count,
+                                                            temp_values,
+                                                            0,
+                                                            block_cache)) {
+                            return false;
+                        }
+                        apply_pax_committed_updates(get_column(column), current_row, max_count, temp_values);
+                        vector::vector_ops::copy(temp_values,
+                                                 result.data[out_idx],
+                                                 visible_indexing,
+                                                 visible_count,
+                                                 0,
+                                                 result_offset);
+                    }
+                }
+
+                result.row_ids.set_vector_type(vector::vector_type::FLAT);
+                auto* row_ids = result.row_ids.data<int64_t>();
+                for (uint64_t i = 0; i < visible_count; i++) {
+                    const auto row_offset = visible_count == max_count ? i : visible_indexing.get_index(i);
+                    row_ids[result_offset + i] = start + static_cast<int64_t>(current_row + row_offset);
+                }
+                mark_vector_range_valid(result.row_ids, result_offset, visible_count);
+                if (!fill_projected_row_id_columns(column_ids, result, result_offset, visible_count)) {
+                    return false;
+                }
+
+                result.set_cardinality(result_offset + visible_count);
+                state.valid_indexing = visible_count == max_count
+                                           ? vector::indexing_vector_t(result.resource(), 0, result.capacity())
+                                           : visible_indexing;
+                state.vector_index++;
+                set_pax_scan_row_offset(*this, state, current_row + max_count);
+                for (auto& column_state : state.column_scans) {
+                    advance_pax_fixed_scan_state(column_state, max_count);
+                    column_state.result_offset += visible_count;
+                }
+                return true;
+            }
+
+            vector::indexing_vector_t indexing(result.resource(), max_count);
+            uint64_t approved_count = 0;
+
+            for (const auto& page_window : page_windows) {
+                const auto& page = *page_window.page;
+                const auto page_filter_result =
+                    single_column_conjunction_filter
+                        ? (get_column(generic_filter_columns.front()).has_updates()
+                               ? filter_propagate_result_t::NO_PRUNING_POSSIBLE
+                               : check_pax_generic_page_statistics(page,
+                                                                   generic_filter_columns.front(),
+                                                                   generic_simple_filters))
+                        : check_pax_generic_filter_tree_statistics(
+                              page,
+                              filter,
+                              [&](uint32_t column_index) {
+                                  return get_column(column_index).has_updates();
+                              });
+                if (page_filter_result == filter_propagate_result_t::ALWAYS_FALSE) {
+                    if (scan_path_counts_enabled_.load(std::memory_order_relaxed)) {
+                        pax_generic_pruned_page_count_.fetch_add(1, std::memory_order_relaxed);
+                        pax_generic_skipped_payload_page_count_.fetch_add(1, std::memory_order_relaxed);
+                    }
+                    continue;
+                }
+
+                std::vector<uint64_t> filter_prefetch_blocks;
+                for (const auto column_index : generic_filter_columns) {
+                    if (!collect_pax_generic_root_column_blocks(page,
+                                                                column_index,
+                                                                get_column(column_index).type(),
+                                                                filter_prefetch_blocks)) {
+                        return false;
+                    }
+                }
+                const auto filter_prefetched =
+                    prefetch_and_pin_pax_blocks(*this, filter_prefetch_blocks, block_cache);
+                if (filter_prefetched > 0 && scan_path_counts_enabled_.load(std::memory_order_relaxed)) {
+                    pax_generic_prefetched_block_count_.fetch_add(filter_prefetched, std::memory_order_relaxed);
+                }
+
+                std::vector<pax_generic_decoded_filter_column_t> decoded_filter_columns;
+                decoded_filter_columns.reserve(generic_filter_columns.size());
+                for (const auto column_index : generic_filter_columns) {
+                    auto values = std::make_unique<vector::vector_t>(result.resource(),
+                                                                     get_column(column_index).type(),
+                                                                     page_window.page_count);
+                    if (!decode_pax_generic_root_window(*this,
+                                                        layout,
+                                                        column_index,
+                                                        get_column(column_index).type(),
+                                                        page_window.overlap_start,
+                                                        page_window.page_count,
+                                                        *values,
+                                                        0,
+                                                        block_cache)) {
+                        return false;
+                    }
+                    apply_pax_committed_updates(get_column(column_index),
+                                                page_window.overlap_start,
+                                                page_window.page_count,
+                                                *values);
+                    decoded_filter_columns.push_back({column_index, std::move(values)});
+                }
+
+                vector::indexing_vector_t page_indexing(result.resource(), page_window.page_count);
+                const auto page_approved_count =
+                    single_column_conjunction_filter
+                        ? apply_pax_generic_root_filter_list(*decoded_filter_columns.front().values,
+                                                             generic_simple_filters,
+                                                             page_window.page_count,
+                                                             page_indexing)
+                    : conjunction_filter
+                        ? apply_pax_generic_root_filter_conjunction(generic_simple_filters,
+                                                                    decoded_filter_columns,
+                                                                    page_window.page_count,
+                                                                    page_indexing)
+                        : apply_pax_generic_root_filter_tree(filter,
+                                                             generic_simple_filters,
+                                                             decoded_filter_columns,
+                                                             page_window.page_count,
+                                                             page_indexing);
+                const auto visible_page_approved_count =
+                    apply_pax_visibility_mask(visible_mask,
+                                              page_window.page_offset_in_window,
+                                              page_indexing,
+                                              page_approved_count);
+                if (visible_page_approved_count == 0) {
+                    if (scan_path_counts_enabled_.load(std::memory_order_relaxed)) {
+                        pax_generic_skipped_payload_page_count_.fetch_add(1, std::memory_order_relaxed);
+                    }
+                    continue;
+                }
+
+                std::vector<uint64_t> projected_prefetch_blocks;
+                for (uint64_t i = 0; i < column_ids.size(); i++) {
+                    const auto& column = column_ids[i];
+                    if (column.is_row_id_column()) {
+                        continue;
+                    }
+                    if (find_pax_generic_decoded_filter_column(decoded_filter_columns,
+                                                               static_cast<uint32_t>(column.primary_index()))) {
+                        continue;
+                    }
+                    if (!collect_pax_generic_root_column_blocks(page,
+                                                                static_cast<uint32_t>(column.primary_index()),
+                                                                get_column(column).type(),
+                                                                projected_prefetch_blocks)) {
+                        return false;
+                    }
+                }
+                const auto projected_prefetched =
+                    prefetch_and_pin_pax_blocks(*this, projected_prefetch_blocks, block_cache);
+                if (projected_prefetched > 0 && scan_path_counts_enabled_.load(std::memory_order_relaxed)) {
+                    pax_generic_prefetched_block_count_.fetch_add(projected_prefetched, std::memory_order_relaxed);
+                }
+
+                validate_chunk_capacity(result, result_offset + approved_count + visible_page_approved_count);
+                for (uint64_t i = 0; i < column_ids.size(); i++) {
+                    const auto& column = column_ids[i];
+                    if (column.is_row_id_column()) {
+                        continue;
+                    }
+                    const auto out_idx = column.primary_index();
+                    if (out_idx >= result.data.size()) {
+                        return false;
+                    }
+                    if (is_unprojected_placeholder(result.data[out_idx])) {
+                        continue;
+                    }
+                    if (!result.data[out_idx].data()) {
+                        return false;
+                    }
+
+                    if (const auto* decoded_values =
+                            find_pax_generic_decoded_filter_column(decoded_filter_columns,
+                                                                   static_cast<uint32_t>(column.primary_index()))) {
+                        vector::vector_ops::copy(*decoded_values,
+                                                 result.data[out_idx],
+                                                 page_indexing,
+                                                 visible_page_approved_count,
+                                                 0,
+                                                 result_offset + approved_count);
+                        continue;
+                    }
+
+                    vector::vector_t temp_values(result.resource(), get_column(column).type(), page_window.page_count);
+                    if (!decode_pax_generic_root_window(*this,
+                                                        layout,
+                                                        static_cast<uint32_t>(column.primary_index()),
+                                                        get_column(column).type(),
+                                                        page_window.overlap_start,
+                                                        page_window.page_count,
+                                                        temp_values,
+                                                        0,
+                                                        block_cache)) {
+                        return false;
+                    }
+                    apply_pax_committed_updates(get_column(column),
+                                                page_window.overlap_start,
+                                                page_window.page_count,
+                                                temp_values);
+                    vector::vector_ops::copy(temp_values,
+                                             result.data[out_idx],
+                                             page_indexing,
+                                             visible_page_approved_count,
+                                             0,
+                                             result_offset + approved_count);
+                }
+
+                result.row_ids.set_vector_type(vector::vector_type::FLAT);
+                auto* row_ids = result.row_ids.data<int64_t>();
+                for (uint64_t i = 0; i < visible_page_approved_count; i++) {
+                    const auto row_offset = page_window.page_offset_in_window + page_indexing.get_index(i);
+                    indexing.set_index(approved_count + i, row_offset);
+                    row_ids[result_offset + approved_count + i] =
+                        start + static_cast<int64_t>(current_row + row_offset);
+                }
+                mark_vector_range_valid(result.row_ids,
+                                        result_offset + approved_count,
+                                        visible_page_approved_count);
+                if (!fill_projected_row_id_columns(column_ids,
+                                                   result,
+                                                   result_offset + approved_count,
+                                                   visible_page_approved_count)) {
+                    return false;
+                }
+
+                approved_count += visible_page_approved_count;
+            }
+
+            state.vector_index++;
+            set_pax_scan_row_offset(*this, state, current_row + max_count);
+            for (auto& column_state : state.column_scans) {
+                advance_pax_fixed_scan_state(column_state, max_count);
+                column_state.result_offset += approved_count;
+            }
+            if (approved_count == 0) {
+                continue;
+            }
+
+            result.set_cardinality(result_offset + approved_count);
+            state.valid_indexing = indexing;
+            return true;
+        }
+    }
+
+	    bool row_group_t::try_scan_pax_fixed_projected(collection_scan_state& state, vector::data_chunk_t& result) {
+	        const bool has_persisted_pax_layout =
+	            layout_kind_ == storage::row_group_layout_kind::PAX_FIXED && pax_fixed_layout_.has_value();
+	        if (!has_persisted_pax_layout) {
+	            return false;
+	        }
+	        const bool transaction_scan = state.txn.transaction_id != 0 || state.txn.start_time != 0;
+		        const bool apply_visibility_filter = requires_pax_version_visibility(transaction_scan);
+
+        const auto& column_ids = state.column_ids();
+        if (column_ids.empty()) {
+            return false;
+        }
+
+        auto* filter = state.filter();
+        std::vector<const table_filter_t*> fixed_simple_filters;
+        std::vector<uint32_t> fixed_filter_columns;
+        if (filter && !collect_pax_fixed_filter_tree(filter, fixed_simple_filters, fixed_filter_columns)) {
+            return false;
+        }
+        const bool has_filter = filter != nullptr;
+        const bool conjunction_filter = has_filter && is_pax_fixed_conjunction_filter_tree(filter);
+        const bool single_column_conjunction_filter = conjunction_filter && fixed_filter_columns.size() == 1;
+
+        std::vector<uint32_t> required_fixed_columns;
+        for (const auto& column_index : fixed_filter_columns) {
+            append_unique_column_index(required_fixed_columns, column_index);
+        }
+
+        for (const auto& column : column_ids) {
+            if (column.has_children()) {
+                return false;
+            }
+            if (column.is_row_id_column()) {
+                continue;
+            }
+            auto column_index = column.primary_index();
+            if (column_index >= get_column_count()) {
+                return false;
+            }
+	            auto& column_data = get_column(column_index);
+	            if (!is_pax_fixed_projected_type(column_data.type())) {
+	                return false;
+	            }
+	            if (transaction_scan && column_data.has_uncommitted_updates()) {
+	                return false;
+	            }
+	            append_unique_column_index(required_fixed_columns, static_cast<uint32_t>(column_index));
+	        }
+
+	        for (const auto column_index : fixed_filter_columns) {
+            if (column_index >= get_column_count()) {
+                return false;
+            }
+	            auto& filter_column = get_column(column_index);
+	            if (!is_pax_fixed_projected_type(filter_column.type())) {
+	                return false;
+	            }
+	            if (transaction_scan && filter_column.has_uncommitted_updates()) {
+	                return false;
+	            }
+	        }
+
+
+        const auto& layout = *pax_fixed_layout_;
+        if (!is_supported_pax_fixed_layout_version(layout.version) || layout.rows_per_page == 0 ||
+            layout.pages.empty()) {
+            return false;
+        }
+
+        uint64_t expected_row_offset = 0;
+        for (const auto& page : layout.pages) {
+            if (page.tuple_count == 0 || page.row_offset_in_group != expected_row_offset ||
+                page.tuple_count > layout.rows_per_page) {
+                return false;
+            }
+            expected_row_offset += page.tuple_count;
+        }
+        const auto pax_tuple_count = pax_fixed_layout_tuple_count(layout);
+        const auto row_group_tuple_count = count.load();
+        if (expected_row_offset != pax_tuple_count || pax_tuple_count > row_group_tuple_count) {
+            return false;
+        }
+        const auto row_group_scan_limit =
+            start > state.max_row ? uint64_t(0)
+                                  : static_cast<uint64_t>(std::min(static_cast<int64_t>(row_group_tuple_count),
+                                                                   state.max_row - start));
+        if (row_group_scan_limit > pax_tuple_count &&
+            pax_tuple_count % vector::DEFAULT_VECTOR_CAPACITY != 0) {
+            return false;
+        }
+
+        for (const auto column_index : required_fixed_columns) {
+            const auto expected_type = to_pax_fixed_column_type(get_column(column_index).type());
+            const auto type_size = static_cast<uint64_t>(get_column(column_index).type().size());
+            for (const auto& page : layout.pages) {
+                const auto* slice = find_pax_fixed_slice(page, column_index);
+                if (!slice ||
+                    !validate_pax_fixed_slice(*slice, expected_type, page.tuple_count, type_size, layout.version)) {
+                    return false;
+                }
+            }
+        }
+
+        for (auto& column_state : state.column_scans) {
+            column_state.result_offset = result.size();
+        }
+
+        pax_fixed_block_cache_t block_cache;
+        const auto local_max_row_group_row = std::min(row_group_scan_limit, pax_tuple_count);
+
+        // One reusable decode buffer per distinct column, shared across all pages of this scan.
+        // Capacity is the full vector capacity so any page window fits. Validity carries over
+        // between uses, so reset it to all-valid on each hand-out before the decoder re-applies it.
+        std::unordered_map<uint32_t, std::unique_ptr<vector::vector_t>> decode_buffers;
+        auto decode_buffer_for = [&](uint32_t column) -> vector::vector_t& {
+            auto it = decode_buffers.find(column);
+            if (it == decode_buffers.end()) {
+                it = decode_buffers
+                         .emplace(column,
+                                  std::make_unique<vector::vector_t>(result.resource(),
+                                                                     get_column(column).type(),
+                                                                     vector::DEFAULT_VECTOR_CAPACITY))
+                         .first;
+            }
+            auto& buffer = *it->second;
+            buffer.validity().reset();
+            return buffer;
+        };
+
+        // Whether a filter column carries committed updates is fixed for the whole scan, so
+        // compute it once here rather than calling has_updates() per leaf per page below.
+        std::unordered_map<uint32_t, bool> filter_column_has_updates;
+        for (const auto column_index : fixed_filter_columns) {
+            filter_column_has_updates.emplace(column_index,
+                                              get_column(column_index).has_updates());
+        }
+        auto column_has_updates_cached = [&](uint32_t column_index) -> bool {
+            auto it = filter_column_has_updates.find(column_index);
+            if (it != filter_column_has_updates.end()) {
+                return it->second;
+            }
+            return get_column(column_index).has_updates();
+        };
+
+        while (true) {
+            const auto current_row = current_pax_fixed_row_offset(*this, state);
+            if (current_row >= local_max_row_group_row) {
+                if (row_group_scan_limit > pax_tuple_count && current_row >= pax_tuple_count) {
+                    return false;
+                }
+                return true;
+            }
+
+            const auto max_count =
+                std::min<uint64_t>(vector::DEFAULT_VECTOR_CAPACITY, local_max_row_group_row - current_row);
+
+            if (!check_zonemap_segments(state)) {
+                continue;
+            }
+
+            vector::indexing_vector_t visible_indexing(result.resource(), max_count);
+            const auto visible_count = apply_visibility_filter
+                                           ? pax_visibility_indexing(state,
+                                                                    current_row,
+                                                                    max_count,
+                                                                    visible_indexing,
+                                                                    transaction_scan)
+                                           : max_count;
+            if (visible_count == 0) {
+                state.vector_index++;
+                set_pax_scan_row_offset(*this, state, current_row + max_count);
+                for (auto& column_state : state.column_scans) {
+                    advance_pax_fixed_scan_state(column_state, max_count);
+                }
+                continue;
+            }
+            const auto visible_mask = visible_count == max_count
+                                          ? std::vector<uint8_t>{}
+                                          : build_pax_visibility_mask(visible_indexing, visible_count, max_count);
+
+            const auto window_end = current_row + max_count;
+            const auto page_windows = collect_pax_page_windows(layout.pages, current_row, window_end);
+            const auto result_offset = result.size();
+
+            if (!has_filter) {
+                std::vector<uint64_t> prefetch_blocks;
+                for (const auto& page_window : page_windows) {
+                    const auto& page = *page_window.page;
+                    for (const auto& column : column_ids) {
+                        if (column.is_row_id_column()) {
+                            continue;
+                        }
+                        if (!collect_pax_fixed_page_column_blocks(page,
+                                                                  static_cast<uint32_t>(column.primary_index()),
+                                                                  prefetch_blocks)) {
+                            return false;
+                        }
+                    }
+                }
+                const auto prefetched = prefetch_and_pin_pax_blocks(*this, prefetch_blocks, block_cache);
+                if (prefetched > 0 && scan_path_counts_enabled_.load(std::memory_order_relaxed)) {
+                    pax_fixed_prefetched_block_count_.fetch_add(prefetched, std::memory_order_relaxed);
+                }
+
+                validate_chunk_capacity(result, result_offset + visible_count);
+                if (visible_count == max_count) {
+                    for (const auto& column : column_ids) {
+                        if (column.is_row_id_column()) {
+                            continue;
+                        }
+                        const auto out_idx = column.primary_index();
+                        if (out_idx >= result.data.size()) {
+                            return false;
+                        }
+                        if (is_unprojected_placeholder(result.data[out_idx])) {
+                            continue;
+                        }
+                        if (!result.data[out_idx].data()) {
+                            return false;
+                        }
+                        if (!decode_pax_fixed_window(*this,
+                                                     layout,
+                                                     static_cast<uint32_t>(column.primary_index()),
+                                                     get_column(column).type(),
+                                                     current_row,
+                                                     max_count,
+                                                     result.data[out_idx],
+                                                     result_offset,
+                                                     block_cache)) {
+                            return false;
+                        }
+                        apply_pax_committed_updates(get_column(column),
+                                                    current_row,
+                                                    max_count,
+                                                    result.data[out_idx],
+                                                    result_offset);
+                    }
+                } else {
+                    for (const auto& column : column_ids) {
+                        if (column.is_row_id_column()) {
+                            continue;
+                        }
+                        const auto out_idx = column.primary_index();
+                        if (out_idx >= result.data.size()) {
+                            return false;
+                        }
+                        if (is_unprojected_placeholder(result.data[out_idx])) {
+                            continue;
+                        }
+                        if (!result.data[out_idx].data()) {
+                            return false;
+                        }
+                        auto& temp_values = decode_buffer_for(static_cast<uint32_t>(column.primary_index()));
+                        if (!decode_pax_fixed_window(*this,
+                                                     layout,
+                                                     static_cast<uint32_t>(column.primary_index()),
+                                                     get_column(column).type(),
+                                                     current_row,
+                                                     max_count,
+                                                     temp_values,
+                                                     0,
+                                                     block_cache)) {
+                            return false;
+                        }
+                        apply_pax_committed_updates(get_column(column), current_row, max_count, temp_values);
+                        vector::vector_ops::copy(temp_values,
+                                                 result.data[out_idx],
+                                                 visible_indexing,
+                                                 visible_count,
+                                                 0,
+                                                 result_offset);
+                    }
+                }
+
+                result.row_ids.set_vector_type(vector::vector_type::FLAT);
+                auto* row_ids = result.row_ids.data<int64_t>();
+                for (uint64_t i = 0; i < visible_count; i++) {
+                    const auto row_offset = visible_count == max_count ? i : visible_indexing.get_index(i);
+                    row_ids[result_offset + i] = start + static_cast<int64_t>(current_row + row_offset);
+                }
+                mark_vector_range_valid(result.row_ids, result_offset, visible_count);
+                if (!fill_projected_row_id_columns(column_ids, result, result_offset, visible_count)) {
+                    return false;
+                }
+
+                result.set_cardinality(result_offset + visible_count);
+                state.valid_indexing = visible_count == max_count
+                                           ? vector::indexing_vector_t(result.resource(), 0, result.capacity())
+                                           : visible_indexing;
+                state.vector_index++;
+                set_pax_scan_row_offset(*this, state, current_row + max_count);
+                for (auto& column_state : state.column_scans) {
+                    advance_pax_fixed_scan_state(column_state, max_count);
+                    column_state.result_offset += visible_count;
+                }
+                return true;
+            }
+
+            vector::indexing_vector_t indexing(result.resource(), max_count);
+            uint64_t approved_count = 0;
+
+            for (const auto& page_window : page_windows) {
+                const auto& page = *page_window.page;
+                const auto page_filter_result =
+                    single_column_conjunction_filter
+                        ? (column_has_updates_cached(fixed_filter_columns.front())
+                               ? filter_propagate_result_t::NO_PRUNING_POSSIBLE
+                               : check_pax_fixed_page_statistics(page,
+                                                                 fixed_filter_columns.front(),
+                                                                 fixed_simple_filters))
+                        : check_pax_fixed_filter_tree_statistics(page, filter, column_has_updates_cached);
+                if (page_filter_result == filter_propagate_result_t::ALWAYS_FALSE) {
+                    if (scan_path_counts_enabled_.load(std::memory_order_relaxed)) {
+                        pax_fixed_pruned_page_count_.fetch_add(1, std::memory_order_relaxed);
+                        pax_fixed_skipped_payload_page_count_.fetch_add(1, std::memory_order_relaxed);
+                    }
+                    continue;
+                }
+
+                std::vector<uint64_t> filter_prefetch_blocks;
+                for (const auto column_index : fixed_filter_columns) {
+                    if (!collect_pax_fixed_page_column_blocks(page, column_index, filter_prefetch_blocks)) {
+                        return false;
+                    }
+                }
+                const auto filter_prefetched =
+                    prefetch_and_pin_pax_blocks(*this, filter_prefetch_blocks, block_cache);
+                if (filter_prefetched > 0 && scan_path_counts_enabled_.load(std::memory_order_relaxed)) {
+                    pax_fixed_prefetched_block_count_.fetch_add(filter_prefetched, std::memory_order_relaxed);
+                }
+
+                std::vector<pax_fixed_decoded_filter_column_t> decoded_filter_columns;
+                decoded_filter_columns.reserve(fixed_filter_columns.size());
+                for (const auto column_index : fixed_filter_columns) {
+                    auto& values = decode_buffer_for(column_index);
+                    if (!decode_pax_fixed_window(*this,
+                                                 layout,
+                                                 column_index,
+                                                 get_column(column_index).type(),
+                                                 page_window.overlap_start,
+                                                 page_window.page_count,
+                                                 values,
+                                                 0,
+                                                 block_cache)) {
+                        return false;
+                    }
+                    apply_pax_committed_updates(get_column(column_index),
+                                                page_window.overlap_start,
+                                                page_window.page_count,
+                                                values);
+                    decoded_filter_columns.push_back({column_index, &values});
+                }
+
+                vector::indexing_vector_t page_indexing(result.resource(), page_window.page_count);
+                const auto page_approved_count =
+                    single_column_conjunction_filter
+                        ? apply_pax_fixed_filter_list(*decoded_filter_columns.front().values,
+                                                      fixed_simple_filters,
+                                                      page_window.page_count,
+                                                      page_indexing)
+                    : conjunction_filter
+                        ? apply_pax_fixed_filter_conjunction(fixed_simple_filters,
+                                                             decoded_filter_columns,
+                                                             page_window.page_count,
+                                                             page_indexing)
+                        : apply_pax_fixed_filter_tree(filter,
+                                                      fixed_simple_filters,
+                                                      decoded_filter_columns,
+                                                      page_window.page_count,
+                                                      page_indexing);
+                const auto visible_page_approved_count =
+                    apply_pax_visibility_mask(visible_mask,
+                                              page_window.page_offset_in_window,
+                                              page_indexing,
+                                              page_approved_count);
+                if (visible_page_approved_count == 0) {
+                    if (scan_path_counts_enabled_.load(std::memory_order_relaxed)) {
+                        pax_fixed_skipped_payload_page_count_.fetch_add(1, std::memory_order_relaxed);
+                    }
+                    continue;
+                }
+
+                std::vector<uint64_t> projected_prefetch_blocks;
+                for (uint64_t i = 0; i < column_ids.size(); i++) {
+                    const auto& column = column_ids[i];
+                    if (column.is_row_id_column()) {
+                        continue;
+                    }
+                    if (find_pax_fixed_decoded_filter_column(decoded_filter_columns,
+                                                             static_cast<uint32_t>(column.primary_index()))) {
+                        continue;
+                    }
+                    if (!collect_pax_fixed_page_column_blocks(page,
+                                                              static_cast<uint32_t>(column.primary_index()),
+                                                              projected_prefetch_blocks)) {
+                        return false;
+                    }
+                }
+                const auto projected_prefetched =
+                    prefetch_and_pin_pax_blocks(*this, projected_prefetch_blocks, block_cache);
+                if (projected_prefetched > 0 && scan_path_counts_enabled_.load(std::memory_order_relaxed)) {
+                    pax_fixed_prefetched_block_count_.fetch_add(projected_prefetched, std::memory_order_relaxed);
+                }
+
+                validate_chunk_capacity(result, result_offset + approved_count + visible_page_approved_count);
+                for (uint64_t i = 0; i < column_ids.size(); i++) {
+                    const auto& column = column_ids[i];
+                    if (column.is_row_id_column()) {
+                        continue;
+                    }
+                    const auto out_idx = column.primary_index();
+                    if (out_idx >= result.data.size()) {
+                        return false;
+                    }
+                    if (is_unprojected_placeholder(result.data[out_idx])) {
+                        continue;
+                    }
+                    if (!result.data[out_idx].data()) {
+                        return false;
+                    }
+
+                    if (const auto* decoded_values =
+                            find_pax_fixed_decoded_filter_column(decoded_filter_columns,
+                                                                 static_cast<uint32_t>(column.primary_index()))) {
+                        vector::vector_ops::copy(*decoded_values,
+                                                 result.data[out_idx],
+                                                 page_indexing,
+                                                 visible_page_approved_count,
+                                                 0,
+                                                 result_offset + approved_count);
+                        continue;
+                    }
+
+                    auto& temp_values = decode_buffer_for(static_cast<uint32_t>(column.primary_index()));
+                    if (!decode_pax_fixed_window(*this,
+                                                 layout,
+                                                 static_cast<uint32_t>(column.primary_index()),
+                                                 get_column(column).type(),
+                                                 page_window.overlap_start,
+                                                 page_window.page_count,
+                                                 temp_values,
+                                                 0,
+                                                 block_cache)) {
+                        return false;
+                    }
+                    apply_pax_committed_updates(get_column(column),
+                                                page_window.overlap_start,
+                                                page_window.page_count,
+                                                temp_values);
+                    vector::vector_ops::copy(temp_values,
+                                             result.data[out_idx],
+                                             page_indexing,
+                                             visible_page_approved_count,
+                                             0,
+                                             result_offset + approved_count);
+                }
+
+                result.row_ids.set_vector_type(vector::vector_type::FLAT);
+                auto* row_ids = result.row_ids.data<int64_t>();
+                for (uint64_t i = 0; i < visible_page_approved_count; i++) {
+                    const auto row_offset = page_window.page_offset_in_window + page_indexing.get_index(i);
+                    indexing.set_index(approved_count + i, row_offset);
+                    row_ids[result_offset + approved_count + i] =
+                        start + static_cast<int64_t>(current_row + row_offset);
+                }
+                mark_vector_range_valid(result.row_ids,
+                                        result_offset + approved_count,
+                                        visible_page_approved_count);
+                if (!fill_projected_row_id_columns(column_ids,
+                                                   result,
+                                                   result_offset + approved_count,
+                                                   visible_page_approved_count)) {
+                    return false;
+                }
+
+                approved_count += visible_page_approved_count;
+            }
+
+            state.vector_index++;
+            set_pax_scan_row_offset(*this, state, current_row + max_count);
+            for (auto& column_state : state.column_scans) {
+                advance_pax_fixed_scan_state(column_state, max_count);
+                column_state.result_offset += approved_count;
+            }
+            if (approved_count == 0) {
+                continue;
+            }
+
+            result.set_cardinality(result_offset + approved_count);
+            state.valid_indexing = indexing;
+            return true;
+        }
     }
 
     template<table_scan_type TYPE>
@@ -300,11 +4582,22 @@ namespace components::table {
             }
 
             uint64_t count;
+            // valid_indexing is reused across row groups and an earlier projected scan may have left
+            // it undersized. The visibility path below writes up to max_count entries, so ensure
+            // capacity first.
+            if (state.valid_indexing.capacity() < max_count) {
+                state.valid_indexing = vector::indexing_vector_t(result.resource(), vector::DEFAULT_VECTOR_CAPACITY);
+            }
+            const auto version_vector_idx = current_version_vector_index(*this, state);
             if (TYPE == table_scan_type::REGULAR) {
                 // REGULAR scans have no see-all fallback: state.txn must be a real
                 // transaction_data, as its snapshot fields drive MVCC visibility.
-                count =
-                    state.row_group->indexing_vector(state.txn, state.vector_index, state.valid_indexing, max_count);
+                // version_vector_idx maps state.vector_index to the row-group-relative
+                // (or absolute) version index expected by the version manager.
+                count = state.row_group->indexing_vector(state.txn,
+                                                         version_vector_idx,
+                                                         state.valid_indexing,
+                                                         max_count);
                 if (count == 0) {
                     next_vector(state);
                     continue;
@@ -312,6 +4605,7 @@ namespace components::table {
             } else {
                 count = max_count;
             }
+            const int64_t row_id_base = current_regular_row_id_base(*this, state);
             validate_chunk_capacity(result, result.size() + count);
 
             if (count == max_count && !filter) {
@@ -322,7 +4616,7 @@ namespace components::table {
                     size_t out_idx = column.is_row_id_column() ? i : column.primary_index();
                     if (column.is_row_id_column()) {
                         assert(result.data[out_idx].type().type() == types::logical_type::BIGINT);
-                        result.data[out_idx].sequence(static_cast<int64_t>(start + current_row), 1, count);
+                        result.data[out_idx].sequence(row_id_base, 1, count);
                     } else {
                         auto& col_data = get_column(column);
                         if (TYPE == table_scan_type::REGULAR) {
@@ -346,11 +4640,7 @@ namespace components::table {
                 }
                 if (filter) {
                     assert(ALLOW_UPDATES);
-                    filter_indexing(collection_->resource(),
-                                    state.vector_index,
-                                    indexing,
-                                    filter,
-                                    approved_tuple_count);
+                    filter_indexing(collection_->resource(), row_id_base, indexing, filter, approved_tuple_count);
                 }
                 if (approved_tuple_count == 0) {
                     for (uint64_t i = 0; i < column_ids.size(); i++) {
@@ -372,33 +4662,35 @@ namespace components::table {
                         result.data[out_idx].set_vector_type(vector::vector_type::FLAT);
                         auto result_data = result.data[out_idx].data<int64_t>();
                         for (size_t indexing_idx = 0; indexing_idx < approved_tuple_count; indexing_idx++) {
-                            result_data[indexing_idx] =
-                                start + current_row + static_cast<int64_t>(indexing.get_index(indexing_idx));
+                            result_data[indexing_idx] = row_id_base + static_cast<int64_t>(indexing.get_index(indexing_idx));
                         }
                     } else {
                         auto& col_data = get_column(column);
+                        vector::vector_t scan_vector(result.resource(), result.data[out_idx].type(), max_count);
+                        auto prev_offset = state.column_scans[i].result_offset;
+                        state.column_scans[i].result_offset = 0;
                         if (TYPE == table_scan_type::REGULAR) {
-                            vector::vector_t select_vector(result.resource(), result.data[out_idx].type(), max_count);
-                            auto prev_offset = state.column_scans[i].result_offset;
-                            state.column_scans[i].result_offset = 0;
-                            col_data.select(state.vector_index,
-                                            state.column_scans[i],
-                                            select_vector,
-                                            indexing,
-                                            approved_tuple_count);
+                            col_data.scan(state.vector_index, state.column_scans[i], scan_vector, max_count);
                             state.column_scans[i].result_offset = prev_offset;
-                            vector::vector_ops::copy(select_vector,
+                            vector::vector_ops::copy(scan_vector,
                                                      result.data[out_idx],
+                                                     indexing,
                                                      approved_tuple_count,
                                                      0,
                                                      state.column_scans[i].result_offset);
                         } else {
-                            col_data.select_committed(state.vector_index,
-                                                      state.column_scans[i],
-                                                      result.data[out_idx],
-                                                      indexing,
-                                                      approved_tuple_count,
-                                                      ALLOW_UPDATES);
+                            col_data.scan_committed(state.vector_index,
+                                                    state.column_scans[i],
+                                                    scan_vector,
+                                                    ALLOW_UPDATES,
+                                                    max_count);
+                            state.column_scans[i].result_offset = prev_offset;
+                            vector::vector_ops::copy(scan_vector,
+                                                     result.data[out_idx],
+                                                     indexing,
+                                                     approved_tuple_count,
+                                                     0,
+                                                     state.column_scans[i].result_offset);
                         }
                     }
                 }
@@ -408,7 +4700,6 @@ namespace components::table {
                 state.valid_indexing = indexing;
             }
             auto* row_ids_data = result.row_ids.data<int64_t>();
-            const int64_t row_id_base = static_cast<int64_t>(state.vector_index * vector::DEFAULT_VECTOR_CAPACITY);
             const uint64_t write_start = result.size();
             for (uint64_t i = 0; i < count; i++) {
                 row_ids_data[write_start + i] = row_id_base + static_cast<int64_t>(state.valid_indexing.get_index(i));
@@ -423,8 +4714,106 @@ namespace components::table {
     }
 
     void row_group_t::scan(collection_scan_state& state, vector::data_chunk_t& result) {
+        if (try_scan_pax_generic_projected(state, result)) {
+            if (scan_path_counts_enabled_.load(std::memory_order_relaxed)) {
+                pax_generic_projected_scan_count_.fetch_add(1, std::memory_order_relaxed);
+            }
+            return;
+        }
+        if (try_scan_pax_fixed_projected(state, result)) {
+            if (scan_path_counts_enabled_.load(std::memory_order_relaxed)) {
+                pax_fixed_projected_scan_count_.fetch_add(1, std::memory_order_relaxed);
+            }
+            return;
+        }
+        if (scan_path_counts_enabled_.load(std::memory_order_relaxed)) {
+            regular_scan_count_.fetch_add(1, std::memory_order_relaxed);
+        }
         templated_scan<table_scan_type::REGULAR>(state, result);
     }
+
+    void row_group_t::reset_scan_path_counts() {
+        scan_path_counts_enabled_.store(true, std::memory_order_relaxed);
+        pax_generic_projected_scan_count_.store(0, std::memory_order_relaxed);
+        pax_generic_pruned_page_count_.store(0, std::memory_order_relaxed);
+        pax_generic_prefetched_block_count_.store(0, std::memory_order_relaxed);
+        pax_generic_skipped_payload_page_count_.store(0, std::memory_order_relaxed);
+        pax_fixed_projected_scan_count_.store(0, std::memory_order_relaxed);
+        pax_fixed_pruned_page_count_.store(0, std::memory_order_relaxed);
+        pax_fixed_prefetched_block_count_.store(0, std::memory_order_relaxed);
+        pax_fixed_skipped_payload_page_count_.store(0, std::memory_order_relaxed);
+        regular_scan_count_.store(0, std::memory_order_relaxed);
+    }
+
+    row_group_scan_path_counts_t row_group_t::scan_path_counts() const {
+        return {pax_generic_projected_scan_count_.load(std::memory_order_relaxed),
+                pax_generic_pruned_page_count_.load(std::memory_order_relaxed),
+                pax_generic_prefetched_block_count_.load(std::memory_order_relaxed),
+                pax_generic_skipped_payload_page_count_.load(std::memory_order_relaxed),
+                pax_fixed_projected_scan_count_.load(std::memory_order_relaxed),
+                pax_fixed_pruned_page_count_.load(std::memory_order_relaxed),
+                pax_fixed_prefetched_block_count_.load(std::memory_order_relaxed),
+                pax_fixed_skipped_payload_page_count_.load(std::memory_order_relaxed),
+                regular_scan_count_.load(std::memory_order_relaxed)};
+    }
+
+	    uint64_t row_group_t::pax_visibility_indexing(const collection_scan_state& state,
+	                                                  uint64_t row_offset_in_group,
+	                                                  uint64_t max_count,
+	                                                  vector::indexing_vector_t& result_indexing,
+	                                                  bool transaction_scan) {
+        if (version_info() == nullptr) {
+            return max_count;
+        }
+
+        uint64_t visible_count = 0;
+        uint64_t consumed = 0;
+        auto absolute_row = static_cast<uint64_t>(start) + row_offset_in_group;
+        while (consumed < max_count) {
+            const auto vector_idx = absolute_row / vector::DEFAULT_VECTOR_CAPACITY;
+            const auto offset_in_vector = absolute_row % vector::DEFAULT_VECTOR_CAPACITY;
+            const auto chunk_count =
+                std::min<uint64_t>(max_count - consumed, vector::DEFAULT_VECTOR_CAPACITY - offset_in_vector);
+            const auto prefix_count = offset_in_vector + chunk_count;
+
+            vector::indexing_vector_t prefix_indexing(result_indexing.resource(), prefix_count);
+            // Non-transaction (committed) scans want every committed row: a
+            // default-constructed transaction_data is the see-all-committed
+            // snapshot (horizon = UINT64_MAX, empty in-flight set) under the
+            // snapshot-horizon visibility model.
+            const auto prefix_visible_count =
+                transaction_scan ? indexing_vector(state.txn, vector_idx, prefix_indexing, prefix_count)
+                                 : indexing_vector(transaction_data{}, vector_idx, prefix_indexing, prefix_count);
+
+            if (prefix_visible_count == prefix_count) {
+                for (uint64_t i = 0; i < chunk_count; i++) {
+                    result_indexing.set_index(visible_count++, consumed + i);
+                }
+            } else {
+                const auto window_end = offset_in_vector + chunk_count;
+                for (uint64_t i = 0; i < prefix_visible_count; i++) {
+                    const auto idx = prefix_indexing.get_index(i);
+                    if (idx < offset_in_vector || idx >= window_end) {
+                        continue;
+                    }
+                    const auto local_idx = consumed + idx - offset_in_vector;
+                    result_indexing.set_index(visible_count++, local_idx);
+                }
+            }
+
+            consumed += chunk_count;
+            absolute_row += chunk_count;
+        }
+	        return visible_count;
+	    }
+
+	    bool row_group_t::requires_pax_version_visibility(bool transaction_scan) {
+	        auto* vinfo = version_info();
+	        if (!vinfo) {
+	            return false;
+	        }
+	        return transaction_scan ? vinfo->has_version_entries() : vinfo->has_visibility_changes();
+	    }
 
     void row_group_t::scan_committed(collection_scan_state& state, vector::data_chunk_t& result, table_scan_type type) {
         switch (type) {
@@ -465,7 +4854,40 @@ namespace components::table {
         }
     }
 
+    bool row_group_t::row_visible(transaction_data txn, int64_t row_id) {
+        auto vinfo = version_info();
+        if (!vinfo) {
+            return true;
+        }
+
+        auto vector_idx = static_cast<uint64_t>(row_id) / vector::DEFAULT_VECTOR_CAPACITY;
+        auto row_in_vector = static_cast<uint64_t>(row_id) % vector::DEFAULT_VECTOR_CAPACITY;
+        vector::indexing_vector_t visible_rows(collection().resource(), row_in_vector + 1);
+
+        // A (0, 0) txn is the see-all-committed sentinel (no MVCC snapshot). Under
+        // the snapshot-horizon visibility model, a default-constructed transaction_data
+        // already means "see every committed row" (horizon = UINT64_MAX, empty
+        // in-flight set), so the committed path just uses that see-all snapshot.
+        transaction_data visibility_txn = txn;
+        if (txn.transaction_id == 0 && txn.start_time == 0) {
+            visibility_txn = transaction_data{};
+        }
+        uint64_t visible_count = indexing_vector(visibility_txn, vector_idx, visible_rows, row_in_vector + 1);
+        if (visible_count == row_in_vector + 1) {
+            return true;
+        }
+        for (uint64_t i = 0; i < visible_count; i++) {
+            if (visible_rows.get_index(i) == row_in_vector) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     void row_group_t::append_version_info(transaction_data txn, uint64_t count) {
+        if (count > 0) {
+            mark_dirty();
+        }
         uint64_t row_group_start = this->count.load();
         uint64_t row_group_end = row_group_start + count;
         if (row_group_end > row_group_size()) {
@@ -487,6 +4909,7 @@ namespace components::table {
     }
 
     void row_group_t::revert_append(uint64_t row_group_start) {
+        mark_dirty();
         auto vinfo = version_info();
         if (vinfo) {
             vinfo->revert_append(row_group_start);
@@ -508,6 +4931,9 @@ namespace components::table {
 
     void row_group_t::append(row_group_append_state& state, vector::data_chunk_t& chunk, uint64_t append_count) {
         assert(chunk.column_count() == get_column_count());
+        if (append_count > 0) {
+            mark_dirty();
+        }
         for (uint64_t i = 0; i < get_column_count(); i++) {
             auto& col_data = get_column(i);
             auto prev_allocation_size = col_data.allocation_size();
@@ -522,11 +4948,15 @@ namespace components::table {
                              uint64_t offset,
                              uint64_t count,
                              const std::vector<uint64_t>& column_ids) {
+        if (count > 0 && !column_ids.empty()) {
+            mark_dirty();
+        }
         for (uint64_t i = 0; i < column_ids.size(); i++) {
             auto column = column_ids[i];
             assert(column != std::numeric_limits<uint64_t>::max());
             auto& col_data = get_column(column);
             assert(col_data.type().type() == update_chunk.data[i].type().type());
+
             if (offset > 0) {
                 vector::vector_t sliced_vector(update_chunk.data[i], offset, count);
                 sliced_vector.flatten(count);
@@ -546,16 +4976,58 @@ namespace components::table {
         auto primary_column_idx = column_path[0];
         assert(primary_column_idx != std::numeric_limits<uint64_t>::max());
         assert(primary_column_idx < columns_.size());
+        if (updates.size() > 0) {
+            mark_dirty();
+        }
         auto& col_data = get_column(primary_column_idx);
+
         col_data.update_column(column_path, updates.data[0], ids, updates.size(), 1);
     }
 
     uint64_t row_group_t::committed_row_count() {
         auto* vi = version_info_.load();
         if (vi) {
-            return count - vi->committed_deleted_count(count);
+            const auto version_deleted = std::min<uint64_t>(count.load(), vi->committed_deleted_count(count));
+            return count - version_deleted;
         }
         return count;
+    }
+
+    bool row_group_t::has_persisted_pax_layout() const {
+        return persisted_pointer_.has_value() &&
+               (layout_kind_ == storage::row_group_layout_kind::PAX_FIXED ||
+                layout_kind_ == storage::row_group_layout_kind::PAX_GENERIC);
+    }
+
+    bool row_group_t::can_append_mutable_tail() const {
+        return !has_persisted_pax_layout();
+    }
+
+#if defined(DEV_MODE)
+    void row_group_t::debug_set_unloaded_deletes_for_test(bool enabled) {
+        if (enabled) {
+            if (deletes_pointers_.empty()) {
+                deletes_pointers_.emplace_back();
+            }
+            deletes_is_loaded_ = false;
+            return;
+        }
+        deletes_pointers_.clear();
+        deletes_is_loaded_ = true;
+    }
+#endif
+
+    bool row_group_t::supports_threaded_scan() const {
+        auto* version_info = const_cast<row_group_t*>(this)->version_info();
+        if (version_info && !version_info->supports_threaded_scan()) {
+            return false;
+        }
+        for (const auto& column : columns_) {
+            if (column && column->has_uncommitted_updates()) {
+                return false;
+            }
+        }
+        return true;
     }
 
     bool row_group_t::has_version_above(uint64_t watermark) {
@@ -615,6 +5087,9 @@ namespace components::table {
     uint64_t row_group_t::delete_rows(uint64_t vector_idx, int64_t rows[], uint64_t count) {
         const auto delete_id = ++current_version_;
         auto deleted = get_or_create_version_info().delete_rows(vector_idx, delete_id, rows, count);
+        if (deleted > 0) {
+            mark_dirty();
+        }
         ++current_version_;
         return deleted;
     }
@@ -629,6 +5104,9 @@ namespace components::table {
             del_state.delete_row(ids[i]);
         }
         del_state.flush();
+        if (del_state.delete_count > 0) {
+            mark_dirty();
+        }
         return del_state.delete_count;
     }
 
@@ -645,7 +5123,7 @@ namespace components::table {
             vinfo->commit_all_deletes(txn_id, commit_id);
         }
         // Advance current_version_ past commit_id so that committed deletes
-        // are visible to scans using committed_version_operator
+        // are reflected in see-all-committed scans
         if (commit_id >= current_version_) {
             current_version_ = commit_id + 1;
         }
@@ -714,7 +5192,23 @@ namespace components::table {
         if (!has_unloaded_deletes()) {
             return version_info_;
         }
-        set_version_info(nullptr);
+        auto loaded_info = std::make_shared<row_version_manager_t>(start);
+        for (const auto& pointer : deletes_pointers_) {
+            if (pointer.compression != compression::compression_type::UNCOMPRESSED) {
+                throw std::logic_error("unsupported committed delete snapshot compression");
+            }
+            if (pointer.segment_size == 0) {
+                continue;
+            }
+            auto source_block = block_manager().register_block(pointer.block_pointer.block_id);
+            auto source_handle = block_manager().buffer_manager.pin(source_block);
+            auto* source_ptr = checked_pax_block_ptr(source_handle,
+                                                     pointer.block_pointer.offset,
+                                                     pointer.segment_size,
+                                                     block_manager().block_size());
+            loaded_info->deserialize_committed_deletes(source_ptr, pointer.segment_size);
+        }
+        set_version_info(std::move(loaded_info));
         deletes_is_loaded_ = true;
         return version_info_;
     }
@@ -723,6 +5217,39 @@ namespace components::table {
         owned_version_info_ = std::move(version);
         version_info_ = owned_version_info_.get();
     }
+
+    void row_group_t::mark_dirty() {
+        is_dirty_ = true;
+        persisted_pointer_.reset();
+    }
+
+    bool row_group_t::can_reuse_persisted_pointer() {
+        if (is_dirty_ || !persisted_pointer_.has_value()) {
+            return false;
+        }
+        if (persisted_pointer_->row_start != static_cast<uint64_t>(start) || persisted_pointer_->tuple_count != count) {
+            return false;
+        }
+        const auto current_policy = block_manager().layout_policy();
+        if (persisted_layout_policy_ != current_policy) {
+            return false;
+        }
+        if (current_policy == storage::row_group_layout_policy::COLUMNAR_ONLY &&
+            persisted_pointer_->layout_kind != storage::row_group_layout_kind::COLUMNAR) {
+            return false;
+        }
+        return true;
+    }
+
+    storage::row_group_pointer_t row_group_t::remember_persisted_pointer(storage::row_group_pointer_t pointer) {
+        persisted_layout_policy_ = block_manager().layout_policy();
+        deletes_pointers_ = pointer.deletes_pointers;
+        deletes_is_loaded_ = true;
+        persisted_pointer_ = pointer;
+        is_dirty_ = false;
+        return pointer;
+    }
+
 
     void version_delete_state::delete_row(int64_t row_id) {
         assert(row_id >= 0);
@@ -751,32 +5278,731 @@ namespace components::table {
         delete_count += actual_delete_count;
         count = 0;
     }
+
     storage::row_group_pointer_t row_group_t::write_to_disk(storage::partial_block_manager_t& partial_block_manager) {
+        if (can_reuse_persisted_pointer()) {
+            return *persisted_pointer_;
+        }
+
         storage::row_group_pointer_t pointer;
         pointer.row_start = static_cast<uint64_t>(start);
         pointer.tuple_count = count;
 
         auto col_count = get_column_count();
-        pointer.data_pointers.resize(col_count);
+        pointer.columnar_data_pointers.resize(col_count);
+        pointer.columnar_validity_pointers.resize(col_count);
+
+        // Persist a columnar column's validity child alongside its data, otherwise the reopened
+        // column reads back all-valid. Only standard columns carry a validity child.
+        auto persist_columnar_validity = [&](uint64_t column_index, column_data_t& column) {
+            auto* standard_column = dynamic_cast<standard_column_data_t*>(&column);
+            if (!standard_column) {
+                return;
+            }
+            auto validity_persistent = standard_column->validity.checkpoint(partial_block_manager);
+            pointer.columnar_validity_pointers[column_index] = std::move(validity_persistent.data_pointers);
+        };
+
+        auto checkpoint_committed_deletes = [&]() {
+            auto* vinfo = version_info();
+            if (!vinfo) {
+                return;
+            }
+            auto payload = vinfo->serialize_committed_deletes(count);
+            if (payload.empty()) {
+                return;
+            }
+            auto allocation = partial_block_manager.get_block_allocation(payload.size());
+            partial_block_manager.write_to_block(allocation.block_id,
+                                                 allocation.offset_in_block,
+                                                 payload.data(),
+                                                 payload.size());
+
+            storage::data_pointer_t pointer_info;
+            pointer_info.row_start = static_cast<uint64_t>(start);
+            pointer_info.tuple_count = count;
+            pointer_info.block_pointer =
+                storage::block_pointer_t(allocation.block_id, allocation.offset_in_block);
+            pointer_info.compression = compression::compression_type::UNCOMPRESSED;
+            pointer_info.segment_size = payload.size();
+            pointer.deletes_pointers.push_back(pointer_info);
+        };
+
+        const bool force_columnar =
+            block_manager().layout_policy() == storage::row_group_layout_policy::COLUMNAR_ONLY;
+        const bool force_pax = block_manager().layout_policy() == storage::row_group_layout_policy::PAX_ONLY;
+
+        std::vector<uint64_t> pax_generic_columns;
+        pax_generic_columns.reserve(col_count);
+        std::vector<uint64_t> pax_fixed_columns;
+        pax_fixed_columns.reserve(col_count);
+        bool pax_generic_requires_v4 = false;
+        bool pax_generic_requires_v2 = false;
+        bool pax_generic_requires_v3 = false;
+
+        // The columnar checkpoint flushes only a column's own top-level data segments plus its
+        // validity child. A nested column's data-bearing children (struct fields, list/array
+        // elements) are not persisted, so reject them rather than write a lossy checkpoint.
+        auto reject_nested_columnar = [](column_data_t& column) {
+            if (dynamic_cast<struct_column_data_t*>(&column) != nullptr ||
+                dynamic_cast<list_column_data_t*>(&column) != nullptr ||
+                dynamic_cast<array_column_data_t*>(&column) != nullptr) {
+                throw std::logic_error("columnar checkpoint cannot persist nested column '" +
+                                       column.type().alias() +
+                                       "': child columns are not flushed and would be lost on reopen");
+            }
+        };
+
+        auto checkpoint_columnar_or_throw = [&](uint64_t column_index) {
+            auto& column = get_column(column_index);
+            if (force_pax) {
+                throw std::logic_error("explicit PAX layout cannot persist column '" + column.type().alias() +
+                                       "' through the columnar fallback path");
+            }
+            reject_nested_columnar(column);
+            auto persistent = column.checkpoint(partial_block_manager);
+            pointer.columnar_data_pointers[column_index] = std::move(persistent.data_pointers);
+            persist_columnar_validity(column_index, column);
+        };
 
         for (uint64_t i = 0; i < col_count; i++) {
-            auto persistent = columns_[i]->checkpoint(partial_block_manager);
-            pointer.data_pointers[i] = std::move(persistent.data_pointers);
+            auto& column = get_column(i);
+            if (force_columnar || components::table::detail::is_explicit_pax_columnar_only_root_type(column.type())) {
+                checkpoint_columnar_or_throw(i);
+            } else if (is_pax_generic_string_type(column.type())) {
+                pax_generic_columns.push_back(i);
+                pax_generic_requires_v4 = true;
+            } else if (is_pax_generic_struct_type(column.type())) {
+                if (!is_supported_pax_generic_column_type(column.type())) {
+                    checkpoint_columnar_or_throw(i);
+                    continue;
+                }
+                pax_generic_columns.push_back(i);
+                pax_generic_requires_v2 = true;
+            } else if (is_pax_generic_collection_type(column.type())) {
+                if (!is_supported_pax_generic_column_type(column.type())) {
+                    checkpoint_columnar_or_throw(i);
+                    continue;
+                }
+                pax_generic_columns.push_back(i);
+                pax_generic_requires_v3 = true;
+            } else if (is_pax_fixed_scalar_type(column.type())) {
+                pax_fixed_columns.push_back(i);
+            } else {
+                checkpoint_columnar_or_throw(i);
+            }
         }
 
-        return pointer;
+        if (!pax_generic_columns.empty() && !pax_fixed_columns.empty()) {
+            for (auto column_index : pax_fixed_columns) {
+                if (std::find(pax_generic_columns.begin(), pax_generic_columns.end(), column_index) ==
+                    pax_generic_columns.end()) {
+                    pax_generic_columns.push_back(column_index);
+                }
+            }
+            pax_fixed_columns.clear();
+            pax_generic_requires_v2 = true;
+        }
+
+        if (force_pax && pax_generic_columns.empty() && pax_fixed_columns.empty() && pointer.tuple_count > 0) {
+            throw std::logic_error("explicit PAX layout did not find a supported root-column family");
+        }
+
+        if (force_pax && pointer.tuple_count > 0) {
+            for (uint64_t i = 0; i < col_count; i++) {
+                if (!pointer.columnar_data_pointers[i].empty()) {
+                    throw std::logic_error("explicit PAX layout wrote unexpected columnar fallback metadata");
+                }
+            }
+        }
+
+        if (!pax_generic_columns.empty() && pointer.tuple_count > 0) {
+            for (uint64_t i = 0; i < col_count; i++) {
+                if (!pointer.columnar_data_pointers[i].empty()) {
+                    continue;
+                }
+                if (std::find(pax_generic_columns.begin(), pax_generic_columns.end(), i) != pax_generic_columns.end()) {
+                    continue;
+                }
+                checkpoint_columnar_or_throw(i);
+            }
+
+            storage::pax_generic_row_group_layout_t pax_layout;
+            pax_layout.version =
+                pax_generic_requires_v4 ? 4 : (pax_generic_requires_v3 ? 3 : (pax_generic_requires_v2 ? 2 : 1));
+            const auto pax_rows_per_page = block_manager().pax_rows_per_page();
+            pax_layout.rows_per_page = pax_rows_per_page;
+
+            for (uint64_t row_offset = 0; row_offset < pointer.tuple_count; row_offset += pax_rows_per_page) {
+                storage::pax_generic_page_t page;
+                page.row_offset_in_group = static_cast<uint32_t>(row_offset);
+                page.tuple_count = static_cast<uint32_t>(std::min<uint64_t>(pax_rows_per_page,
+                                                                            pointer.tuple_count - row_offset));
+
+                for (auto column_index : pax_generic_columns) {
+                    auto& column = get_column(column_index);
+                    if (is_pax_generic_string_type(column.type())) {
+                        auto page_result = write_pax_generic_string_page(column,
+                                                                         pointer.row_start,
+                                                                         page.row_offset_in_group,
+                                                                         page.tuple_count,
+                                                                         partial_block_manager);
+                        pointer.columnar_data_pointers[column_index].push_back(page_result.main_pointer);
+
+                        storage::pax_generic_slice_t value_slice;
+                        value_slice.column_index = static_cast<uint32_t>(column_index);
+                        value_slice.slice_kind = storage::pax_generic_slice_kind::STRING_VALUES;
+                        value_slice.codec_kind = storage::pax_generic_codec_kind::STRING_SEGMENT;
+                        value_slice.payload = storage::pax_block_payload_t{page_result.main_pointer,
+                                                                           page_result.extra_block_ids};
+                        value_slice.statistics = std::move(page_result.statistics);
+                        page.slices.push_back(std::move(value_slice));
+
+                        append_pax_generic_validity_slice(page,
+                                                          static_cast<uint32_t>(column_index),
+                                                          empty_pax_generic_field_path(),
+                                                          {page_result.validity_codec, page_result.validity_pointer});
+                    } else {
+                        write_pax_generic_column_page(column,
+                                                      static_cast<uint32_t>(column_index),
+                                                      empty_pax_generic_field_path(),
+                                                      pointer.row_start,
+                                                      page.row_offset_in_group,
+                                                      page.tuple_count,
+                                                      partial_block_manager,
+                                                      page);
+                    }
+                }
+
+                pax_layout.pages.push_back(std::move(page));
+            }
+
+            pointer.layout_kind = storage::row_group_layout_kind::PAX_GENERIC;
+            pointer.pax_fixed_layout.reset();
+            pointer.pax_generic_layout = pax_layout;
+            layout_kind_ = pointer.layout_kind;
+            pax_fixed_layout_.reset();
+            pax_generic_layout_ = std::move(pax_layout);
+            checkpoint_committed_deletes();
+            return remember_persisted_pointer(std::move(pointer));
+        }
+
+        if (pax_fixed_columns.empty() || pointer.tuple_count == 0) {
+            for (uint64_t i = 0; i < col_count; i++) {
+                if (!pointer.columnar_data_pointers[i].empty()) {
+                    continue;
+                }
+                auto& column = get_column(i);
+                reject_nested_columnar(column);
+                auto persistent = column.checkpoint(partial_block_manager);
+                pointer.columnar_data_pointers[i] = std::move(persistent.data_pointers);
+                persist_columnar_validity(i, column);
+            }
+            pointer.layout_kind = storage::row_group_layout_kind::COLUMNAR;
+            pax_fixed_layout_.reset();
+            pax_generic_layout_.reset();
+            layout_kind_ = pointer.layout_kind;
+            checkpoint_committed_deletes();
+            return remember_persisted_pointer(std::move(pointer));
+        }
+
+        storage::pax_fixed_row_group_layout_t pax_layout;
+        pax_layout.version = 4;
+        const auto pax_rows_per_page = block_manager().pax_rows_per_page();
+        pax_layout.rows_per_page = pax_rows_per_page;
+
+        for (uint64_t row_offset = 0; row_offset < pointer.tuple_count; row_offset += pax_rows_per_page) {
+            storage::pax_fixed_page_t page;
+            page.row_offset_in_group = static_cast<uint32_t>(row_offset);
+            page.tuple_count = static_cast<uint32_t>(std::min<uint64_t>(pax_rows_per_page,
+                                                                        pointer.tuple_count - row_offset));
+
+            for (auto column_index : pax_fixed_columns) {
+                auto& column = get_column(column_index);
+                write_pax_fixed_slice(column,
+                                      pointer.row_start,
+                                      page.row_offset_in_group,
+                                      page.tuple_count,
+                                      static_cast<uint32_t>(column_index),
+                                      partial_block_manager,
+                                      pointer.columnar_data_pointers[column_index],
+                                      page);
+            }
+
+            pax_layout.pages.push_back(std::move(page));
+        }
+
+        pointer.layout_kind = storage::row_group_layout_kind::PAX_FIXED;
+        pointer.pax_fixed_layout = pax_layout;
+        pointer.pax_generic_layout.reset();
+        layout_kind_ = pointer.layout_kind;
+        pax_fixed_layout_ = std::move(pax_layout);
+        pax_generic_layout_.reset();
+        checkpoint_committed_deletes();
+        return remember_persisted_pointer(std::move(pointer));
     }
 
     void row_group_t::create_from_pointer(const storage::row_group_pointer_t& pointer) {
         count = pointer.tuple_count;
+        layout_kind_ = pointer.layout_kind;
+        pax_fixed_layout_ = pointer.pax_fixed_layout;
+        pax_generic_layout_ = pointer.pax_generic_layout;
+        persisted_pointer_ = pointer;
+        persisted_layout_policy_ = block_manager().layout_policy();
+        deletes_pointers_ = pointer.deletes_pointers;
+        deletes_is_loaded_ = deletes_pointers_.empty();
+        is_dirty_ = false;
         auto col_count = get_column_count();
-        auto ptrs_count = pointer.data_pointers.size();
+        auto ptrs_count = pointer.columnar_data_pointers.size();
         auto min_count = std::min(col_count, static_cast<uint64_t>(ptrs_count));
 
         for (uint64_t i = 0; i < min_count; i++) {
             persistent_column_data_t pcd(columns_[i]->resource());
-            pcd.data_pointers = pointer.data_pointers[i];
+            pcd.data_pointers = pointer.columnar_data_pointers[i];
+            // Pass the persisted validity-child pointers as a child column so a columnar column
+            // restores its real null mask. Empty for PAX columns (validity comes from the page layout).
+            if (i < pointer.columnar_validity_pointers.size() && !pointer.columnar_validity_pointers[i].empty()) {
+                auto validity_child = std::make_unique<persistent_column_data_t>(columns_[i]->resource());
+                validity_child->data_pointers = pointer.columnar_validity_pointers[i];
+                pcd.child_columns.push_back(std::move(validity_child));
+            }
             columns_[i]->initialize_column(pcd);
+        }
+
+        if (layout_kind_ == storage::row_group_layout_kind::PAX_FIXED && pax_fixed_layout_.has_value()) {
+            if (!is_supported_pax_fixed_layout_version(pax_fixed_layout_->version)) {
+                throw std::logic_error("unsupported pax_fixed layout version");
+            }
+
+            for (uint64_t column_index = 0; column_index < min_count; column_index++) {
+                auto* standard_column = dynamic_cast<standard_column_data_t*>(columns_[column_index].get());
+                if (!standard_column) {
+                    continue;
+                }
+
+                auto validity_lock = standard_column->validity.data_.lock();
+                for (uint64_t page_index = 0; page_index < pax_fixed_layout_->pages.size(); page_index++) {
+                    const auto& page = pax_fixed_layout_->pages[page_index];
+                    const auto* slice = find_pax_fixed_slice(page, static_cast<uint32_t>(column_index));
+                    if (!slice) {
+                        continue;
+                    }
+
+                    auto* validity_segment = standard_column->validity.data_.segment_at(validity_lock,
+                                                                                        static_cast<int64_t>(page_index));
+                    if (!validity_segment) {
+                        throw std::logic_error("missing validity segment for pax_fixed load");
+                    }
+
+                    auto validity_handle = block_manager().buffer_manager.pin(validity_segment->block);
+                    auto* target_ptr = validity_handle.ptr() + validity_segment->block_offset();
+                    switch (slice->validity_kind) {
+                        case storage::pax_fixed_validity_kind::ALL_VALID:
+                            std::memset(target_ptr, 0xFF, validity_segment->segment_size());
+                            break;
+                        case storage::pax_fixed_validity_kind::ALL_INVALID:
+                            std::memset(target_ptr, 0, validity_segment->segment_size());
+                            break;
+                        case storage::pax_fixed_validity_kind::BITMASK: {
+                            if (!slice->validity_data_pointer.has_value()) {
+                                throw std::logic_error("missing pax_fixed validity payload");
+                            }
+                            const uint64_t vsize = slice->validity_data_pointer->segment_size;
+                            const uint64_t voffset = slice->validity_data_pointer->block_pointer.offset;
+                            // Validate the disk-derived copy length against both the destination
+                            // validity buffer and the source block before the memcpy.
+                            if (vsize > validity_segment->segment_size() ||
+                                voffset > block_manager().block_size() ||
+                                voffset + vsize > block_manager().block_size()) {
+                                throw std::logic_error("pax_fixed validity payload out of bounds");
+                            }
+                            auto source_block =
+                                block_manager().register_block(slice->validity_data_pointer->block_pointer.block_id);
+                            auto source_handle = block_manager().buffer_manager.pin(source_block);
+                            auto* source_ptr = source_handle.ptr() + voffset;
+                            std::memcpy(target_ptr, source_ptr, vsize);
+                            break;
+                        }
+                        case storage::pax_fixed_validity_kind::RLE:
+                        default:
+                            throw std::logic_error("invalid pax_fixed validity codec");
+                    }
+                }
+            }
+            return;
+        }
+
+        if (layout_kind_ != storage::row_group_layout_kind::PAX_GENERIC || !pax_generic_layout_.has_value()) {
+            return;
+        }
+
+        if (!is_supported_pax_generic_layout_version(pax_generic_layout_->version)) {
+            throw std::logic_error("unsupported pax_generic layout version");
+        }
+
+        struct pax_generic_validity_page_info_t {
+            uint64_t row_start;
+            uint32_t tuple_count;
+            storage::pax_generic_codec_kind codec_kind;
+            std::optional<storage::pax_block_payload_t> payload;
+        };
+
+        struct pax_generic_window_t {
+            uint64_t row_start;
+            uint32_t tuple_count;
+        };
+
+        std::vector<pax_generic_window_t> root_windows;
+        root_windows.reserve(pax_generic_layout_->pages.size());
+        for (const auto& page : pax_generic_layout_->pages) {
+            root_windows.push_back({static_cast<uint64_t>(start) + page.row_offset_in_group, page.tuple_count});
+        }
+
+        auto collect_generic_slices =
+            [&](uint32_t root_column_index,
+                const std::vector<uint16_t>& field_path,
+                storage::pax_generic_slice_kind slice_kind) -> std::vector<const storage::pax_generic_slice_t*> {
+            std::vector<const storage::pax_generic_slice_t*> slices;
+            for (const auto& page : pax_generic_layout_->pages) {
+                const auto* slice = find_pax_generic_slice(page, root_column_index, slice_kind, field_path);
+                if (slice) {
+                    slices.push_back(slice);
+                }
+            }
+            return slices;
+        };
+
+        auto collect_generic_validity_infos =
+            [&](uint32_t root_column_index,
+                const std::vector<uint16_t>& field_path,
+                const std::vector<pax_generic_window_t>& windows) -> std::vector<pax_generic_validity_page_info_t> {
+            std::vector<pax_generic_validity_page_info_t> infos;
+            infos.reserve(windows.size());
+            uint64_t window_index = 0;
+            for (const auto& page : pax_generic_layout_->pages) {
+                const auto* slice =
+                    find_pax_generic_slice(page, root_column_index, storage::pax_generic_slice_kind::VALIDITY, field_path);
+                if (!slice) {
+                    continue;
+                }
+                if (window_index >= windows.size()) {
+                    throw std::logic_error("pax_generic validity window count mismatch");
+                }
+                infos.push_back(
+                    {windows[window_index].row_start, windows[window_index].tuple_count, slice->codec_kind, slice->payload});
+                window_index++;
+            }
+            if (window_index != windows.size()) {
+                throw std::logic_error("missing pax_generic validity slices for expected windows");
+            }
+            return infos;
+        };
+
+        auto apply_validity_infos = [&](column_data_t& validity_column,
+                                        const std::vector<pax_generic_validity_page_info_t>& infos,
+                                        bool initialize_segments) {
+            if (infos.empty()) {
+                return;
+            }
+
+            if (initialize_segments) {
+                persistent_column_data_t pcd(validity_column.resource());
+                pcd.data_pointers.reserve(infos.size());
+                for (const auto& info : infos) {
+                    storage::data_pointer_t pointer_info;
+                    pointer_info.row_start = info.row_start;
+                    pointer_info.tuple_count = info.tuple_count;
+                    pointer_info.segment_size = vector::validity_mask_t::validity_mask_size(info.tuple_count);
+                    pcd.data_pointers.push_back(pointer_info);
+                }
+                validity_column.initialize_column_validity(pcd);
+            }
+
+            auto validity_lock = validity_column.data_.lock();
+            for (uint64_t segment_index = 0; segment_index < infos.size(); segment_index++) {
+                const auto& info = infos[segment_index];
+                auto* validity_segment = validity_column.data_.segment_at(validity_lock,
+                                                                         static_cast<int64_t>(segment_index));
+                if (!validity_segment) {
+                    throw std::logic_error("missing validity segment for pax_generic load");
+                }
+
+                auto validity_handle = block_manager().buffer_manager.pin(validity_segment->block);
+                auto* target_ptr = validity_handle.ptr() + validity_segment->block_offset();
+                switch (info.codec_kind) {
+                    case storage::pax_generic_codec_kind::VALIDITY_ALL_VALID:
+                        break;
+                    case storage::pax_generic_codec_kind::VALIDITY_ALL_INVALID:
+                        std::memset(target_ptr, 0, validity_segment->segment_size());
+                        break;
+                    case storage::pax_generic_codec_kind::VALIDITY_BITMASK: {
+                        if (!info.payload.has_value()) {
+                            throw std::logic_error("missing pax_generic validity payload");
+                        }
+                        const uint64_t vsize = info.payload->main_pointer.segment_size;
+                        const uint64_t voffset = info.payload->main_pointer.block_pointer.offset;
+                        // Bound the disk-derived copy length against the destination validity buffer
+                        // and the source block before the memcpy.
+                        if (vsize > validity_segment->segment_size() || voffset > block_manager().block_size() ||
+                            voffset + vsize > block_manager().block_size()) {
+                            throw std::logic_error("pax_generic validity payload out of bounds");
+                        }
+                        auto source_block =
+                            block_manager().register_block(info.payload->main_pointer.block_pointer.block_id);
+                        auto source_handle = block_manager().buffer_manager.pin(source_block);
+                        auto* source_ptr = source_handle.ptr() + voffset;
+                        std::memcpy(target_ptr, source_ptr, vsize);
+                        break;
+                    }
+                    case storage::pax_generic_codec_kind::STRING_SEGMENT:
+                    case storage::pax_generic_codec_kind::FIXED_PLAIN:
+                    default:
+                        throw std::logic_error("invalid pax_generic validity codec");
+                }
+            }
+        };
+
+        auto register_string_blocks =
+            [&](standard_column_data_t& standard_column,
+                const std::vector<const storage::pax_generic_slice_t*>& slices) {
+            auto data_lock = standard_column.data_.lock();
+            for (uint64_t segment_index = 0; segment_index < slices.size(); segment_index++) {
+                const auto* slice = slices[segment_index];
+                if (!slice->payload.has_value()) {
+                    throw std::logic_error("missing pax_generic string payload");
+                }
+
+                auto* segment = standard_column.data_.segment_at(data_lock, static_cast<int64_t>(segment_index));
+                if (!segment || !segment->segment_state()) {
+                    throw std::logic_error("missing string segment state for pax_generic load");
+                }
+                auto& string_state = segment->segment_state()->cast<uncompressed_string_segment_state>();
+                for (auto block_id : slice->payload->extra_block_ids) {
+                    string_state.register_block(block_manager(), block_id);
+                }
+            }
+        };
+
+        std::function<void(column_data_t&,
+                           uint32_t,
+                           const std::vector<uint16_t>&,
+                           bool,
+                           const std::vector<pax_generic_window_t>&)>
+            load_generic_column;
+        load_generic_column = [&](column_data_t& column,
+                                  uint32_t root_column_index,
+                                  const std::vector<uint16_t>& field_path,
+                                  bool is_top_level,
+                                  const std::vector<pax_generic_window_t>& windows) {
+            if (is_pax_generic_struct_type(column.type())) {
+                auto* struct_column = dynamic_cast<struct_column_data_t*>(&column);
+                if (!struct_column) {
+                    throw std::logic_error("pax_generic struct column is not a struct column");
+                }
+
+                auto validity_infos = collect_generic_validity_infos(root_column_index, field_path, windows);
+                apply_validity_infos(struct_column->validity, validity_infos, true);
+                uint64_t struct_count = 0;
+                for (const auto& window : windows) {
+                    struct_count += window.tuple_count;
+                }
+                struct_column->count_ = struct_count;
+
+                for (uint16_t child_index = 0; child_index < struct_column->sub_columns.size(); child_index++) {
+                    auto child_path = field_path;
+                    child_path.push_back(child_index);
+                    load_generic_column(*struct_column->sub_columns[child_index],
+                                        root_column_index,
+                                        child_path,
+                                        false,
+                                        windows);
+                }
+                return;
+            }
+
+            if (is_pax_generic_string_type(column.type())) {
+                auto* standard_column = dynamic_cast<standard_column_data_t*>(&column);
+                if (!standard_column) {
+                    throw std::logic_error("pax_generic string column is not a standard column");
+                }
+
+                auto value_slices =
+                    collect_generic_slices(root_column_index, field_path, storage::pax_generic_slice_kind::STRING_VALUES);
+                if (value_slices.empty()) {
+                    throw std::logic_error("missing pax_generic string slices");
+                }
+
+                const bool already_initialized =
+                    is_top_level && root_column_index < pointer.columnar_data_pointers.size() &&
+                    !pointer.columnar_data_pointers[root_column_index].empty();
+                if (!already_initialized) {
+                    persistent_column_data_t pcd(standard_column->resource());
+                    pcd.data_pointers.reserve(value_slices.size());
+                    for (const auto* slice : value_slices) {
+                        if (slice->codec_kind != storage::pax_generic_codec_kind::STRING_SEGMENT ||
+                            !slice->payload.has_value()) {
+                            throw std::logic_error("invalid pax_generic string slice payload");
+                        }
+                        pcd.data_pointers.push_back(slice->payload->main_pointer);
+                    }
+                    standard_column->initialize_column(pcd);
+                }
+
+                register_string_blocks(*standard_column, value_slices);
+                auto validity_infos = collect_generic_validity_infos(root_column_index, field_path, windows);
+                apply_validity_infos(standard_column->validity, validity_infos, false);
+                return;
+            }
+
+            if (is_pax_generic_fixed_plain_type(column.type())) {
+                auto* standard_column = dynamic_cast<standard_column_data_t*>(&column);
+                if (!standard_column) {
+                    throw std::logic_error("pax_generic fixed column is not a standard column");
+                }
+
+                auto value_slices =
+                    collect_generic_slices(root_column_index, field_path, storage::pax_generic_slice_kind::FIXED_VALUES);
+                if (value_slices.empty()) {
+                    throw std::logic_error("missing pax_generic fixed slices");
+                }
+
+                persistent_column_data_t pcd(standard_column->resource());
+                pcd.data_pointers.reserve(value_slices.size());
+                for (const auto* slice : value_slices) {
+                    if (slice->codec_kind != storage::pax_generic_codec_kind::FIXED_PLAIN ||
+                        !slice->payload.has_value()) {
+                        throw std::logic_error("invalid pax_generic fixed slice payload");
+                    }
+                    if (pax_generic_layout_->version >= 2 && slice->fixed_logical_type != column.type().type()) {
+                        throw std::logic_error("pax_generic fixed slice type mismatch");
+                    }
+                    pcd.data_pointers.push_back(slice->payload->main_pointer);
+                }
+                standard_column->initialize_column(pcd);
+
+                auto validity_infos = collect_generic_validity_infos(root_column_index, field_path, windows);
+                apply_validity_infos(standard_column->validity, validity_infos, false);
+                return;
+            }
+
+            if (is_pax_generic_collection_type(column.type())) {
+                if (column.type().type() == types::logical_type::LIST) {
+                    auto* list_column = dynamic_cast<list_column_data_t*>(&column);
+                    if (!list_column) {
+                        throw std::logic_error("pax_generic list column is not a list column");
+                    }
+
+                    auto value_slices =
+                        collect_generic_slices(root_column_index, field_path, storage::pax_generic_slice_kind::FIXED_VALUES);
+                    if (value_slices.empty()) {
+                        throw std::logic_error("missing pax_generic list offset slices");
+                    }
+
+                    persistent_column_data_t pcd(list_column->resource());
+                    pcd.data_pointers.reserve(value_slices.size());
+                    for (const auto* slice : value_slices) {
+                        if (slice->codec_kind != storage::pax_generic_codec_kind::FIXED_PLAIN ||
+                            !slice->payload.has_value() ||
+                            (pax_generic_layout_->version >= 2 && slice->fixed_logical_type != types::logical_type::UBIGINT)) {
+                            throw std::logic_error("invalid pax_generic list offset slice payload");
+                        }
+                        pcd.data_pointers.push_back(slice->payload->main_pointer);
+                    }
+                    list_column->initialize_column(pcd);
+
+                    auto validity_infos = collect_generic_validity_infos(root_column_index, field_path, windows);
+                    apply_validity_infos(list_column->validity, validity_infos, true);
+
+                    std::vector<pax_generic_window_t> child_windows;
+                    child_windows.reserve(windows.size());
+                    for (const auto& window : windows) {
+                        if (window.tuple_count == 0) {
+                            continue;
+                        }
+                        const auto row_start = static_cast<int64_t>(window.row_start);
+                        const auto previous_offset =
+                            row_start == list_column->start() ? 0 : list_column->list_offset(row_start - 1);
+                        const auto current_offset =
+                            list_column->list_offset(row_start + static_cast<int64_t>(window.tuple_count) - 1);
+                        const auto child_tuple_count = static_cast<uint32_t>(current_offset - previous_offset);
+                        if (child_tuple_count == 0) {
+                            continue;
+                        }
+                        child_windows.push_back({static_cast<uint64_t>(list_column->start()) + previous_offset,
+                                                 child_tuple_count});
+                    }
+
+                    if (!child_windows.empty()) {
+                        auto child_path = field_path;
+                        child_path.push_back(0);
+                        load_generic_column(*list_column->child_column,
+                                            root_column_index,
+                                            child_path,
+                                            false,
+                                            child_windows);
+                    } else {
+                        list_column->child_column->count_ = 0;
+                    }
+                    return;
+                }
+
+                auto* array_column = dynamic_cast<array_column_data_t*>(&column);
+                if (!array_column) {
+                    throw std::logic_error("pax_generic array column is not an array column");
+                }
+
+                auto validity_infos = collect_generic_validity_infos(root_column_index, field_path, windows);
+                apply_validity_infos(array_column->validity, validity_infos, true);
+                uint64_t array_count = 0;
+                for (const auto& window : windows) {
+                    array_count += window.tuple_count;
+                }
+                array_column->count_ = array_count;
+
+                std::vector<pax_generic_window_t> child_windows;
+                child_windows.reserve(windows.size());
+                const auto array_size = static_cast<uint64_t>(array_column->array_size());
+                for (const auto& window : windows) {
+                    if (window.tuple_count == 0) {
+                        continue;
+                    }
+                    child_windows.push_back(
+                        {static_cast<uint64_t>(array_column->start()) +
+                             (window.row_start - static_cast<uint64_t>(array_column->start())) * array_size,
+                         static_cast<uint32_t>(static_cast<uint64_t>(window.tuple_count) * array_size)});
+                }
+
+                if (!child_windows.empty()) {
+                    auto child_path = field_path;
+                    child_path.push_back(0);
+                    load_generic_column(*array_column->child_column,
+                                        root_column_index,
+                                        child_path,
+                                        false,
+                                        child_windows);
+                } else {
+                    array_column->child_column->count_ = 0;
+                }
+                return;
+            }
+
+            throw std::logic_error("unsupported column type in pax_generic load");
+        };
+
+        std::vector<bool> initialized_roots(col_count, false);
+        for (const auto& page : pax_generic_layout_->pages) {
+            for (const auto& slice : page.slices) {
+                const auto column_index = static_cast<uint64_t>(slice.column_index);
+                if (column_index >= columns_.size() || initialized_roots[column_index]) {
+                    continue;
+                }
+                load_generic_column(*columns_[column_index],
+                                    slice.column_index,
+                                    empty_pax_generic_field_path(),
+                                    true,
+                                    root_windows);
+                initialized_roots[column_index] = true;
+            }
         }
     }
 

--- a/components/table/row_group.hpp
+++ b/components/table/row_group.hpp
@@ -1,8 +1,14 @@
 #pragma once
 #include "column_data.hpp"
 #include "row_version_manager.hpp"
+#include "storage/block_manager.hpp"
 #include "storage/data_pointer.hpp"
+#include <components/vector/data_chunk.hpp>
+#include <atomic>
+#include <memory>
 #include <optional>
+#include <string>
+#include <unordered_set>
 
 namespace components::vector {
     class data_chunk_t;
@@ -10,6 +16,23 @@ namespace components::vector {
 
 namespace components::table {
     class row_version_manager_t;
+    struct row_group_test_access_t;
+    class column_definition_t;
+
+    namespace detail {
+        enum class explicit_pax_root_kind : uint8_t
+        {
+            FIXED = 0,
+            GENERIC = 1,
+            COLUMNAR_ONLY = 2,
+            UNSUPPORTED = 3
+        };
+
+        bool is_explicit_pax_columnar_only_root_type(const types::complex_logical_type& type);
+        explicit_pax_root_kind classify_explicit_pax_root_type(const types::complex_logical_type& type);
+        bool supports_explicit_pax_schema(const std::vector<column_definition_t>& columns,
+                                          std::string* error_message = nullptr);
+    } // namespace detail
 
     constexpr static uint64_t MAX_ROW_GROUP_SIZE = uint64_t(1) << 30;
 
@@ -17,12 +40,24 @@ namespace components::table {
     enum class table_scan_type : uint8_t;
     class scan_filter_info;
     class collection_scan_state;
-    class column_definition_t;
     class collection_t;
+
+    struct row_group_scan_path_counts_t {
+        uint64_t pax_generic_projected{0};
+        uint64_t pax_generic_pruned_pages{0};
+        uint64_t pax_generic_prefetched_blocks{0};
+        uint64_t pax_generic_skipped_payload_pages{0};
+        uint64_t pax_fixed_projected{0};
+        uint64_t pax_fixed_pruned_pages{0};
+        uint64_t pax_fixed_prefetched_blocks{0};
+        uint64_t pax_fixed_skipped_payload_pages{0};
+        uint64_t regular{0};
+    };
 
     class row_group_t : public segment_base_t<row_group_t> {
     public:
         friend class column_data_t;
+        friend struct row_group_test_access_t;
 
         row_group_t(collection_t* collection, int64_t start, uint64_t count);
         ~row_group_t() = default;
@@ -33,6 +68,22 @@ namespace components::table {
         std::shared_ptr<row_version_manager_t> owned_version_info_;
         uint64_t current_version_ = 0;
         std::vector<std::shared_ptr<column_data_t>> columns_;
+        storage::row_group_layout_kind layout_kind_ = storage::row_group_layout_kind::COLUMNAR;
+        std::optional<storage::pax_fixed_row_group_layout_t> pax_fixed_layout_;
+        std::optional<storage::pax_generic_row_group_layout_t> pax_generic_layout_;
+        std::optional<storage::row_group_pointer_t> persisted_pointer_;
+        storage::row_group_layout_policy persisted_layout_policy_{storage::row_group_layout_policy::AUTO};
+        bool is_dirty_{true};
+        std::atomic<bool> scan_path_counts_enabled_{false};
+        std::atomic<uint64_t> pax_generic_projected_scan_count_{0};
+        std::atomic<uint64_t> pax_generic_pruned_page_count_{0};
+        std::atomic<uint64_t> pax_generic_prefetched_block_count_{0};
+        std::atomic<uint64_t> pax_generic_skipped_payload_page_count_{0};
+        std::atomic<uint64_t> pax_fixed_projected_scan_count_{0};
+        std::atomic<uint64_t> pax_fixed_pruned_page_count_{0};
+        std::atomic<uint64_t> pax_fixed_prefetched_block_count_{0};
+        std::atomic<uint64_t> pax_fixed_skipped_payload_page_count_{0};
+        std::atomic<uint64_t> regular_scan_count_{0};
 
     public:
         void move_to_collection(collection_t* collection, int64_t new_start);
@@ -58,6 +109,7 @@ namespace components::table {
         void scan_committed(collection_scan_state& state, vector::data_chunk_t& result, table_scan_type type);
 
         bool check_predicate(int64_t row_id, const table_filter_t* filter);
+        bool row_visible(transaction_data txn, int64_t row_id);
 
         void fetch_row(column_fetch_state& state,
                        const std::vector<storage_index_t>& column_ids,
@@ -77,6 +129,9 @@ namespace components::table {
         void revert_all_deletes(uint64_t txn_id);
 
         uint64_t committed_row_count();
+        bool has_persisted_pax_layout() const;
+        bool can_append_mutable_tail() const;
+        bool supports_threaded_scan() const;
         // True when any version stamp in this row group is above `watermark`
         // (pending txn id or commit id newer than the visible-to-all horizon).
         bool has_version_above(uint64_t watermark);
@@ -108,11 +163,31 @@ namespace components::table {
 
         uint64_t calculate_size();
 
+#if defined(DEV_MODE)
+        void debug_set_unloaded_deletes_for_test(bool enabled);
+        storage::row_group_layout_kind debug_layout_kind_for_test() const { return layout_kind_; }
+        void debug_reset_scan_path_counts_for_test() { reset_scan_path_counts(); }
+        row_group_scan_path_counts_t debug_scan_path_counts_for_test() const { return scan_path_counts(); }
+#endif
+        void reset_scan_path_counts_for_benchmark() { reset_scan_path_counts(); }
+        void ensure_scan_path_counts_enabled_for_benchmark() {
+            if (!scan_path_counts_enabled_.load(std::memory_order_relaxed)) {
+                reset_scan_path_counts();
+            }
+        }
+        row_group_scan_path_counts_t scan_path_counts_for_benchmark() const { return scan_path_counts(); }
+
     private:
         uint64_t indexing_vector(transaction_data txn,
                                  uint64_t vector_idx,
                                  vector::indexing_vector_t& indexing_vector,
                                  uint64_t max_count);
+        uint64_t pax_visibility_indexing(const collection_scan_state& state,
+                                         uint64_t row_offset_in_group,
+                                         uint64_t max_count,
+                                         vector::indexing_vector_t& result_indexing,
+                                         bool transaction_scan);
+        bool requires_pax_version_visibility(bool transaction_scan);
         std::shared_ptr<row_version_manager_t> get_or_create_version_info_internal();
         row_version_manager_t* version_info();
         void set_version_info(std::shared_ptr<row_version_manager_t> version);
@@ -122,21 +197,29 @@ namespace components::table {
         std::vector<std::shared_ptr<column_data_t>>& columns();
 
         void filter_indexing(std::pmr::memory_resource* resource,
-                             uint64_t vector_index,
+                             int64_t row_id_base,
                              vector::indexing_vector_t& indexing,
                              const table_filter_t* filter,
                              uint64_t& approved_tuple_count);
+        bool try_scan_pax_generic_projected(collection_scan_state& state, vector::data_chunk_t& result);
+        bool try_scan_pax_fixed_projected(collection_scan_state& state, vector::data_chunk_t& result);
+        void reset_scan_path_counts();
+        row_group_scan_path_counts_t scan_path_counts() const;
 
         template<table_scan_type TYPE>
         void templated_scan(collection_scan_state& state, vector::data_chunk_t& result);
 
         bool has_unloaded_deletes() const;
+        void mark_dirty();
+        bool can_reuse_persisted_pointer();
+        storage::row_group_pointer_t remember_persisted_pointer(storage::row_group_pointer_t pointer);
 
         std::mutex row_group_lock_;
         std::vector<storage::meta_block_pointer_t> column_pointers_;
         std::unique_ptr<std::atomic<bool>[]> is_loaded_;
-        std::vector<storage::meta_block_pointer_t> deletes_pointers_;
+        std::vector<storage::data_pointer_t> deletes_pointers_;
         std::atomic<bool> deletes_is_loaded_;
         uint64_t allocation_size_;
+
     };
 } // namespace components::table

--- a/components/table/row_version_manager.cpp
+++ b/components/table/row_version_manager.cpp
@@ -1,7 +1,12 @@
 #include "row_version_manager.hpp"
 
+#include <algorithm>
 #include <cassert>
 #include <cstdlib>
+#include <cstring>
+#include <limits>
+#include <stdexcept>
+#include <type_traits>
 
 #include "collection.hpp"
 
@@ -38,6 +43,37 @@ namespace components::table {
 
     static bool use_version(const transaction_data& transaction, uint64_t id) {
         return transaction_version_operator::use_inserted_version(transaction, id);
+    }
+
+    static bool is_committed_version(uint64_t id) {
+        return id < TRANSACTION_ID_START;
+    }
+
+    static bool is_committed_or_not_deleted(uint64_t id) {
+        return id == NOT_DELETED_ID || is_committed_version(id);
+    }
+
+    static constexpr uint32_t COMMITTED_DELETE_SNAPSHOT_MAGIC = 0x50445844; // "DXDP"
+    static constexpr uint16_t COMMITTED_DELETE_SNAPSHOT_VERSION = 1;
+
+    template<class T>
+    void append_snapshot_value(std::vector<std::byte>& out, T value) {
+        static_assert(std::is_trivially_copyable_v<T>);
+        const auto offset = out.size();
+        out.resize(offset + sizeof(T));
+        std::memcpy(out.data() + offset, &value, sizeof(T));
+    }
+
+    template<class T>
+    T read_snapshot_value(const std::byte*& ptr, const std::byte* end) {
+        static_assert(std::is_trivially_copyable_v<T>);
+        if (ptr + sizeof(T) > end) {
+            throw std::logic_error("corrupt committed delete snapshot");
+        }
+        T value;
+        std::memcpy(&value, ptr, sizeof(T));
+        ptr += sizeof(T);
+        return value;
     }
 
     bool chunk_info::cleanup(uint64_t /* lowest_transaction */, std::unique_ptr<chunk_info>& /* result */) const {
@@ -346,17 +382,278 @@ namespace components::table {
     uint64_t row_version_manager_t::committed_deleted_count(uint64_t count) {
         std::lock_guard l(version_lock_);
         uint64_t deleted_count = 0;
-        for (uint64_t r = 0, i = 0; r < count; r += vector::DEFAULT_VECTOR_CAPACITY, i++) {
-            if (i >= vector_info_.size() || !vector_info_[i]) {
+        if (count == 0) {
+            return deleted_count;
+        }
+        const auto row_group_start = static_cast<uint64_t>(start_);
+        const auto row_group_end = row_group_start + count;
+        const auto start_vector_idx = row_group_start / vector::DEFAULT_VECTOR_CAPACITY;
+        const auto end_vector_idx = (row_group_end - 1) / vector::DEFAULT_VECTOR_CAPACITY;
+        for (uint64_t vector_idx = start_vector_idx; vector_idx <= end_vector_idx; vector_idx++) {
+            if (vector_idx >= vector_info_.size() || !vector_info_[vector_idx]) {
                 continue;
             }
-            uint64_t max_count = std::min<uint64_t>(vector::DEFAULT_VECTOR_CAPACITY, count - r);
+            const auto vector_end = (vector_idx + 1) * vector::DEFAULT_VECTOR_CAPACITY;
+            const auto max_count = std::min<uint64_t>(vector::DEFAULT_VECTOR_CAPACITY,
+                                                      row_group_end > vector_end
+                                                          ? vector::DEFAULT_VECTOR_CAPACITY
+                                                          : row_group_end - vector_idx * vector::DEFAULT_VECTOR_CAPACITY);
             if (max_count == 0) {
                 break;
             }
-            deleted_count += vector_info_[i]->committed_deleted_count(max_count);
+            deleted_count += vector_info_[vector_idx]->committed_deleted_count(max_count);
         }
         return deleted_count;
+    }
+
+    bool row_version_manager_t::supports_threaded_scan() const {
+	        std::lock_guard lock(version_lock_);
+	        for (const auto& info : vector_info_) {
+            if (!info) {
+                continue;
+            }
+            switch (info->type) {
+                case chunk_info_type::CONSTANT_INFO: {
+                    const auto& constant = info->cast<chunk_constant_info>();
+                    if (!is_committed_version(constant.insert_id) ||
+                        !is_committed_or_not_deleted(constant.delete_id)) {
+                        return false;
+                    }
+                    break;
+                }
+                case chunk_info_type::VECTOR_INFO: {
+                    const auto& vector = info->cast<chunk_vector_info>();
+                    if (vector.same_inserted_id) {
+                        if (!is_committed_version(vector.insert_id)) {
+                            return false;
+                        }
+                    } else {
+                        for (uint64_t i = 0; i < vector::DEFAULT_VECTOR_CAPACITY; ++i) {
+                            if (!is_committed_version(vector.inserted[i])) {
+                                return false;
+                            }
+                        }
+                    }
+                    if (vector.any_deleted) {
+                        for (uint64_t i = 0; i < vector::DEFAULT_VECTOR_CAPACITY; ++i) {
+                            if (!is_committed_or_not_deleted(vector.deleted[i])) {
+                                return false;
+                            }
+                        }
+                    }
+                    break;
+                }
+                default:
+                    return false;
+            }
+        }
+	        return true;
+	    }
+
+	    bool row_version_manager_t::has_version_entries() const {
+	        std::lock_guard lock(version_lock_);
+	        return std::any_of(vector_info_.begin(), vector_info_.end(), [](const auto& info) { return info != nullptr; });
+	    }
+
+	    bool row_version_manager_t::has_visibility_changes() const {
+	        std::lock_guard lock(version_lock_);
+	        for (const auto& info : vector_info_) {
+	            if (!info) {
+	                continue;
+	            }
+	            switch (info->type) {
+	                case chunk_info_type::CONSTANT_INFO: {
+	                    const auto& constant = info->cast<chunk_constant_info>();
+	                    if (!is_committed_version(constant.insert_id) || constant.delete_id != NOT_DELETED_ID) {
+	                        return true;
+	                    }
+	                    break;
+	                }
+	                case chunk_info_type::VECTOR_INFO: {
+	                    const auto& vector = info->cast<chunk_vector_info>();
+	                    if (vector.any_deleted) {
+	                        return true;
+	                    }
+	                    if (vector.same_inserted_id) {
+	                        if (!is_committed_version(vector.insert_id)) {
+	                            return true;
+	                        }
+	                    } else {
+	                        for (uint64_t i = 0; i < vector::DEFAULT_VECTOR_CAPACITY; ++i) {
+	                            if (!is_committed_version(vector.inserted[i])) {
+	                                return true;
+	                            }
+	                        }
+	                    }
+	                    break;
+	                }
+	                default:
+	                    return true;
+	            }
+	        }
+	        return false;
+	    }
+
+	    std::vector<std::byte> row_version_manager_t::serialize_committed_deletes(uint64_t row_count) const {
+        std::lock_guard lock(version_lock_);
+        std::vector<std::byte> payload;
+        if (row_count == 0) {
+            return payload;
+        }
+
+        append_snapshot_value<uint32_t>(payload, COMMITTED_DELETE_SNAPSHOT_MAGIC);
+        append_snapshot_value<uint16_t>(payload, COMMITTED_DELETE_SNAPSHOT_VERSION);
+        append_snapshot_value<uint64_t>(payload, static_cast<uint64_t>(start_));
+        append_snapshot_value<uint64_t>(payload, row_count);
+        const auto entry_count_offset = payload.size();
+        append_snapshot_value<uint64_t>(payload, uint64_t(0));
+
+        uint64_t entry_count = 0;
+        const auto row_group_start = static_cast<uint64_t>(start_);
+        const auto row_group_end = row_group_start + row_count;
+        const auto start_vector_idx = row_group_start / vector::DEFAULT_VECTOR_CAPACITY;
+        const auto end_vector_idx = (row_group_end - 1) / vector::DEFAULT_VECTOR_CAPACITY;
+
+        for (uint64_t vector_idx = start_vector_idx; vector_idx <= end_vector_idx; vector_idx++) {
+            if (vector_idx >= vector_info_.size() || !vector_info_[vector_idx]) {
+                continue;
+            }
+
+            const auto vector_start = vector_idx * vector::DEFAULT_VECTOR_CAPACITY;
+            const auto row_begin = std::max<uint64_t>(row_group_start, vector_start) - vector_start;
+            const auto row_end = std::min<uint64_t>(row_group_end,
+                                                    vector_start + vector::DEFAULT_VECTOR_CAPACITY) -
+                                 vector_start;
+            const auto& info = *vector_info_[vector_idx];
+            switch (info.type) {
+                case chunk_info_type::CONSTANT_INFO: {
+                    const auto& constant = info.cast<chunk_constant_info>();
+                    if (!is_committed_version(constant.insert_id) ||
+                        !is_committed_or_not_deleted(constant.delete_id)) {
+                        return {};
+                    }
+                    if (constant.delete_id == NOT_DELETED_ID) {
+                        break;
+                    }
+                    for (uint64_t row = row_begin; row < row_end; row++) {
+                        append_snapshot_value<uint64_t>(payload, vector_idx);
+                        append_snapshot_value<uint16_t>(payload, static_cast<uint16_t>(row));
+                        append_snapshot_value<uint64_t>(payload, constant.delete_id);
+                        entry_count++;
+                    }
+                    break;
+                }
+                case chunk_info_type::VECTOR_INFO: {
+                    const auto& vector_info = info.cast<chunk_vector_info>();
+                    if (vector_info.same_inserted_id) {
+                        if (!is_committed_version(vector_info.insert_id)) {
+                            return {};
+                        }
+                    } else {
+                        for (uint64_t row = row_begin; row < row_end; row++) {
+                            if (!is_committed_version(vector_info.inserted[row])) {
+                                return {};
+                            }
+                        }
+                    }
+                    if (!vector_info.any_deleted) {
+                        break;
+                    }
+                    for (uint64_t row = row_begin; row < row_end; row++) {
+                        const auto delete_id = vector_info.deleted[row];
+                        if (delete_id == NOT_DELETED_ID) {
+                            continue;
+                        }
+                        if (!is_committed_version(delete_id)) {
+                            return {};
+                        }
+                        append_snapshot_value<uint64_t>(payload, vector_idx);
+                        append_snapshot_value<uint16_t>(payload, static_cast<uint16_t>(row));
+                        append_snapshot_value<uint64_t>(payload, delete_id);
+                        entry_count++;
+                    }
+                    break;
+                }
+                default:
+                    return {};
+            }
+        }
+
+        if (entry_count == 0) {
+            return {};
+        }
+        std::memcpy(payload.data() + entry_count_offset, &entry_count, sizeof(entry_count));
+        return payload;
+    }
+
+    void row_version_manager_t::deserialize_committed_deletes(const std::byte* data, uint64_t size) {
+        if (!data || size == 0) {
+            return;
+        }
+
+        const auto* ptr = data;
+        const auto* end = data + size;
+        const auto magic = read_snapshot_value<uint32_t>(ptr, end);
+        const auto version = read_snapshot_value<uint16_t>(ptr, end);
+        if (magic != COMMITTED_DELETE_SNAPSHOT_MAGIC || version != COMMITTED_DELETE_SNAPSHOT_VERSION) {
+            throw std::logic_error("unsupported committed delete snapshot");
+        }
+        const auto snapshot_start = read_snapshot_value<uint64_t>(ptr, end);
+        const auto row_count = read_snapshot_value<uint64_t>(ptr, end);
+        const auto entry_count = read_snapshot_value<uint64_t>(ptr, end);
+        if (snapshot_start != static_cast<uint64_t>(start_)) {
+            throw std::logic_error("committed delete snapshot row group start mismatch");
+        }
+        const auto snapshot_end = snapshot_start + row_count;
+        if (snapshot_end < snapshot_start) {
+            throw std::logic_error("committed delete snapshot row count overflow");
+        }
+
+        std::lock_guard lock(version_lock_);
+        for (uint64_t entry_idx = 0; entry_idx < entry_count; entry_idx++) {
+            const auto vector_idx = read_snapshot_value<uint64_t>(ptr, end);
+            const auto row_idx = read_snapshot_value<uint16_t>(ptr, end);
+            const auto delete_id = read_snapshot_value<uint64_t>(ptr, end);
+            if (row_idx >= vector::DEFAULT_VECTOR_CAPACITY || !is_committed_version(delete_id)) {
+                throw std::logic_error("invalid committed delete snapshot entry");
+            }
+            if (vector_idx > std::numeric_limits<uint64_t>::max() / vector::DEFAULT_VECTOR_CAPACITY) {
+                throw std::logic_error("committed delete snapshot row index overflow");
+            }
+            const auto absolute_row = vector_idx * vector::DEFAULT_VECTOR_CAPACITY + row_idx;
+            if (absolute_row < snapshot_start || absolute_row >= snapshot_end) {
+                throw std::logic_error("committed delete snapshot entry outside row group");
+            }
+
+            auto& info = vector_info(vector_idx);
+            const uint64_t restored_delete_id = 0;
+            if (info.deleted[row_idx] != NOT_DELETED_ID && info.deleted[row_idx] != restored_delete_id) {
+                throw std::logic_error("conflicting committed delete snapshot entry");
+            }
+            info.any_deleted = true;
+            info.deleted[row_idx] = restored_delete_id;
+        }
+        if (ptr != end) {
+            throw std::logic_error("committed delete snapshot has trailing bytes");
+        }
+        has_changes_ = false;
+    }
+
+    void row_version_manager_t::mark_committed_deleted(uint64_t absolute_row, uint64_t commit_id) {
+        if (!is_committed_version(commit_id)) {
+            throw std::logic_error("committed delete marker must use a committed id");
+        }
+
+        std::lock_guard lock(version_lock_);
+        const auto vector_idx = absolute_row / vector::DEFAULT_VECTOR_CAPACITY;
+        const auto row_idx = absolute_row % vector::DEFAULT_VECTOR_CAPACITY;
+        auto& info = vector_info(vector_idx);
+        if (info.deleted[row_idx] != NOT_DELETED_ID && info.deleted[row_idx] != commit_id) {
+            return;
+        }
+        info.any_deleted = true;
+        info.deleted[row_idx] = commit_id;
+        has_changes_ = true;
     }
 
     bool row_version_manager_t::has_version_above(uint64_t watermark, uint64_t count) {

--- a/components/table/row_version_manager.hpp
+++ b/components/table/row_version_manager.hpp
@@ -5,6 +5,7 @@
 #include <limits>
 
 #include <components/vector/indexing_vector.hpp>
+#include <cstddef>
 #include <stdexcept>
 #include <vector>
 
@@ -211,6 +212,12 @@ namespace components::table {
                                  vector::indexing_vector_t& indexing_vector,
                                  uint64_t max_count);
         bool fetch(const transaction_data& transaction, uint64_t row);
+        bool supports_threaded_scan() const;
+        bool has_version_entries() const;
+        bool has_visibility_changes() const;
+        std::vector<std::byte> serialize_committed_deletes(uint64_t row_count) const;
+        void deserialize_committed_deletes(const std::byte* data, uint64_t size);
+        void mark_committed_deleted(uint64_t absolute_row, uint64_t commit_id = 0);
 
         void append_version_info(transaction_data transaction,
                                  uint64_t count,
@@ -230,7 +237,7 @@ namespace components::table {
         chunk_vector_info& vector_info(uint64_t vector_idx);
         void fill_vector_info(uint64_t vector_idx);
 
-        std::mutex version_lock_;
+        mutable std::mutex version_lock_;
         int64_t start_;
         std::vector<std::unique_ptr<chunk_info>> vector_info_;
         bool has_changes_;

--- a/components/table/standard_column_data.cpp
+++ b/components/table/standard_column_data.cpp
@@ -51,6 +51,10 @@ namespace components::table {
                                           uint64_t target_count) {
         assert(state.row_index == state.child_states[0].row_index);
         auto scan_count = column_data_t::scan(vector_index, state, result, target_count);
+        // The scan driver doesn't sync the validity child's result_offset with the parent's,
+        // so mirror it here; otherwise multi-row-group scans into one chunk write the null mask
+        // over an earlier row group.
+        state.child_states[0].result_offset = state.result_offset;
         validity.scan(vector_index, state.child_states[0], result, target_count);
         return scan_count;
     }
@@ -62,8 +66,18 @@ namespace components::table {
                                                     uint64_t target_count) {
         assert(state.row_index == state.child_states[0].row_index);
         auto scan_count = column_data_t::scan_committed(vector_index, state, result, allow_updates, target_count);
+        // See scan(): keep the validity child's result_offset aligned with the parent.
+        state.child_states[0].result_offset = state.result_offset;
         validity.scan_committed(vector_index, state.child_states[0], result, allow_updates, target_count);
         return scan_count;
+    }
+
+    void standard_column_data_t::fetch_committed_updates_range(uint64_t offset_in_row_group,
+                                                               uint64_t count,
+                                                               vector::vector_t& result,
+                                                               uint64_t result_offset) {
+        column_data_t::fetch_committed_updates_range(offset_in_row_group, count, result, result_offset);
+        validity.fetch_committed_updates_range(offset_in_row_group, count, result, result_offset);
     }
 
     uint64_t standard_column_data_t::scan_count(column_scan_state& state, vector::vector_t& result, uint64_t count) {
@@ -144,8 +158,15 @@ namespace components::table {
     void standard_column_data_t::initialize_column(const persistent_column_data_t& persistent_data) {
         column_data_t::initialize_column(persistent_data);
 
-        // create matching transient validity segments for each data segment
-        validity.initialize_column_validity(persistent_data);
+        // Restore the validity child from its on-disk segments when persisted (COLUMNAR layout);
+        // otherwise fall back to matching all-valid transient segments (PAX restores validity
+        // separately via create_from_pointer, and all-valid columns have no persisted child).
+        if (!persistent_data.child_columns.empty() && persistent_data.child_columns[0] &&
+            !persistent_data.child_columns[0]->data_pointers.empty()) {
+            validity.initialize_column(*persistent_data.child_columns[0]);
+        } else {
+            validity.initialize_column_validity(persistent_data);
+        }
     }
 
 } // namespace components::table

--- a/components/table/standard_column_data.hpp
+++ b/components/table/standard_column_data.hpp
@@ -29,6 +29,10 @@ namespace components::table {
                                 vector::vector_t& result,
                                 bool allow_updates,
                                 uint64_t target_count) override;
+        void fetch_committed_updates_range(uint64_t offset_in_row_group,
+                                           uint64_t count,
+                                           vector::vector_t& result,
+                                           uint64_t result_offset = 0) override;
         uint64_t scan_count(column_scan_state& state, vector::vector_t& result, uint64_t count) override;
 
         void initialize_append(column_append_state& state) override;

--- a/components/table/storage/block_handle.cpp
+++ b/components/table/storage/block_handle.cpp
@@ -198,6 +198,14 @@ namespace components::table::storage {
         if (readers_ > 0) {
             return false;
         }
+        // Transient blocks (block_id_ >= MAXIMUM_BLOCK) have no backing store, so
+        // unloading discards their data. BLOCK-condition ones hold live, unrecoverable
+        // table data; pin them until checkpoint persists them. EVICTION-condition ones
+        // are disposable and must stay evictable to avoid exhausting the buffer pool.
+        if (block_id_ >= MAXIMUM_BLOCK &&
+            destroy_condition_.load() == destroy_buffer_condition::BLOCK) {
+            return false;
+        }
         return true;
     }
 

--- a/components/table/storage/block_manager.hpp
+++ b/components/table/storage/block_manager.hpp
@@ -11,6 +11,15 @@ namespace components::table::storage {
     class buffer_handle_t;
     class buffer_manager_t;
 
+    enum class row_group_layout_policy : uint8_t
+    {
+        AUTO = 0,
+        COLUMNAR_ONLY = 1,
+        PAX_ONLY = 2
+    };
+
+    inline constexpr uint16_t DEFAULT_PAX_ROWS_PER_PAGE = 256;
+
     class block_manager_t {
     public:
         block_manager_t() = delete;
@@ -49,6 +58,15 @@ namespace components::table::storage {
 
         uint64_t block_allocation_size() const { return block_alloc_size_; }
         uint64_t block_size() const { return block_alloc_size_ - DEFAULT_BLOCK_HEADER_SIZE; }
+        row_group_layout_policy layout_policy() const { return layout_policy_; }
+        void set_layout_policy(row_group_layout_policy policy) { layout_policy_ = policy; }
+        uint16_t pax_rows_per_page() const { return pax_rows_per_page_; }
+        void set_pax_rows_per_page(uint16_t rows_per_page) {
+            if (rows_per_page == 0) {
+                throw std::invalid_argument("PAX rows per page must be greater than zero");
+            }
+            pax_rows_per_page_ = rows_per_page;
+        }
         void set_block_allocation_size(uint64_t block_alloc_size) {
             if (block_alloc_size_ == INVALID_INDEX) {
                 throw std::runtime_error("the block allocation size must be set once");
@@ -60,6 +78,8 @@ namespace components::table::storage {
         std::mutex blocks_lock_;
         std::unordered_map<uint64_t, std::weak_ptr<block_handle_t>> blocks_;
         uint64_t block_alloc_size_;
+        row_group_layout_policy layout_policy_{row_group_layout_policy::AUTO};
+        uint16_t pax_rows_per_page_{DEFAULT_PAX_ROWS_PER_PAGE};
     };
 
 } // namespace components::table::storage

--- a/components/table/storage/buffer_pool.cpp
+++ b/components/table/storage/buffer_pool.cpp
@@ -51,6 +51,8 @@ namespace components::table::storage {
     }
 
     bool eviction_queue_t::add_to_eviction_queue(buffer_eviction_node_t&& node) {
+        // enqueue() pushes onto the lock-free queue and bumps approx_q_size_ atomically,
+        // so concurrent unpinning/eviction is already safe without taking purge_lock_ here.
         enqueue(std::move(node));
         return ++evict_queue_insertions_ % INSERT_INTERVAL == 0;
     }
@@ -138,8 +140,9 @@ namespace components::table::storage {
         for (;;) {
             buffer_eviction_node_t node;
             if (!try_dequeue(node)) {
-                // retry under purge_lock_: a concurrent purge may briefly
-                // hold alive nodes outside the queue (in purge_nodes_)
+                // Lock-free fast path was empty; retry under purge_lock_ so the
+                // pop is serialized against purge() (a concurrent purge may briefly
+                // hold alive nodes outside the queue, in purge_nodes_).
                 if (!try_dequeue_with_lock(node)) {
                     return;
                 }

--- a/components/table/storage/data_pointer.cpp
+++ b/components/table/storage/data_pointer.cpp
@@ -1,5 +1,8 @@
 #include "data_pointer.hpp"
 
+#include <memory_resource>
+#include <stdexcept>
+
 #include "metadata_reader.hpp"
 #include "metadata_writer.hpp"
 
@@ -25,14 +28,261 @@ namespace components::table::storage {
         return result;
     }
 
+    void pax_fixed_slice_t::serialize(metadata_writer_t& writer, uint16_t version) const {
+        writer.write<uint32_t>(column_index);
+        writer.write<uint8_t>(static_cast<uint8_t>(column_type));
+        data_pointer.serialize(writer);
+        if (version >= 2) {
+            writer.write<uint8_t>(static_cast<uint8_t>(validity_kind));
+            switch (validity_kind) {
+                case pax_fixed_validity_kind::ALL_VALID:
+                case pax_fixed_validity_kind::ALL_INVALID:
+                    break;
+                case pax_fixed_validity_kind::BITMASK:
+                case pax_fixed_validity_kind::RLE:
+                    if (!validity_data_pointer.has_value()) {
+                        throw std::logic_error("missing pax_fixed validity pointer");
+                    }
+                    validity_data_pointer->serialize(writer);
+                    break;
+                default:
+                    throw std::logic_error("unknown pax_fixed validity kind");
+            }
+        }
+        if (version >= 4) {
+            writer.write<uint8_t>(statistics.has_value() ? 1 : 0);
+            if (statistics.has_value()) {
+                statistics->serialize(writer);
+            }
+        }
+    }
+
+    pax_fixed_slice_t pax_fixed_slice_t::deserialize(metadata_reader_t& reader, uint16_t version) {
+        pax_fixed_slice_t result;
+        result.column_index = reader.read<uint32_t>();
+        result.column_type = static_cast<pax_fixed_column_type>(reader.read<uint8_t>());
+        result.data_pointer = data_pointer_t::deserialize(reader);
+        if (version >= 2) {
+            result.validity_kind = static_cast<pax_fixed_validity_kind>(reader.read<uint8_t>());
+            switch (result.validity_kind) {
+                case pax_fixed_validity_kind::ALL_VALID:
+                case pax_fixed_validity_kind::ALL_INVALID:
+                    break;
+                case pax_fixed_validity_kind::BITMASK:
+                case pax_fixed_validity_kind::RLE:
+                    result.validity_data_pointer = data_pointer_t::deserialize(reader);
+                    break;
+                default:
+                    throw std::logic_error("unknown pax_fixed validity kind");
+            }
+        } else {
+            result.validity_kind = pax_fixed_validity_kind::ALL_VALID;
+            result.validity_data_pointer.reset();
+        }
+        if (version >= 4) {
+            const bool has_statistics = reader.read<uint8_t>() != 0;
+            if (has_statistics) {
+                result.statistics = base_statistics_t::deserialize(std::pmr::get_default_resource(), reader);
+            }
+        }
+        return result;
+    }
+
+    void pax_fixed_page_t::serialize(metadata_writer_t& writer, uint16_t version) const {
+        writer.write<uint32_t>(row_offset_in_group);
+        writer.write<uint32_t>(tuple_count);
+        writer.write<uint32_t>(static_cast<uint32_t>(slices.size()));
+        for (const auto& slice : slices) {
+            slice.serialize(writer, version);
+        }
+    }
+
+    pax_fixed_page_t pax_fixed_page_t::deserialize(metadata_reader_t& reader, uint16_t version) {
+        pax_fixed_page_t result;
+        result.row_offset_in_group = reader.read<uint32_t>();
+        result.tuple_count = reader.read<uint32_t>();
+        auto slice_count = reader.read<uint32_t>();
+        result.slices.resize(slice_count);
+        for (uint32_t i = 0; i < slice_count; i++) {
+            result.slices[i] = pax_fixed_slice_t::deserialize(reader, version);
+        }
+        return result;
+    }
+
+    void pax_fixed_row_group_layout_t::serialize(metadata_writer_t& writer) const {
+        writer.write<uint16_t>(version);
+        writer.write<uint16_t>(rows_per_page);
+        writer.write<uint32_t>(static_cast<uint32_t>(pages.size()));
+        for (const auto& page : pages) {
+            page.serialize(writer, version);
+        }
+    }
+
+    pax_fixed_row_group_layout_t pax_fixed_row_group_layout_t::deserialize(metadata_reader_t& reader) {
+        pax_fixed_row_group_layout_t result;
+        result.version = reader.read<uint16_t>();
+        result.rows_per_page = reader.read<uint16_t>();
+        auto page_count = reader.read<uint32_t>();
+        result.pages.resize(page_count);
+        for (uint32_t i = 0; i < page_count; i++) {
+            result.pages[i] = pax_fixed_page_t::deserialize(reader, result.version);
+        }
+        return result;
+    }
+
+    void pax_block_payload_t::serialize(metadata_writer_t& writer) const {
+        main_pointer.serialize(writer);
+        writer.write<uint32_t>(static_cast<uint32_t>(extra_block_ids.size()));
+        for (auto block_id : extra_block_ids) {
+            writer.write<uint32_t>(block_id);
+        }
+    }
+
+    pax_block_payload_t pax_block_payload_t::deserialize(metadata_reader_t& reader) {
+        pax_block_payload_t result;
+        result.main_pointer = data_pointer_t::deserialize(reader);
+        auto block_count = reader.read<uint32_t>();
+        result.extra_block_ids.resize(block_count);
+        for (uint32_t i = 0; i < block_count; i++) {
+            result.extra_block_ids[i] = reader.read<uint32_t>();
+        }
+        return result;
+    }
+
+    void pax_generic_slice_t::serialize(metadata_writer_t& writer, uint16_t version) const {
+        writer.write<uint32_t>(column_index);
+        writer.write<uint8_t>(static_cast<uint8_t>(slice_kind));
+        writer.write<uint8_t>(static_cast<uint8_t>(codec_kind));
+        if (version >= 2) {
+            writer.write<uint16_t>(static_cast<uint16_t>(field_path.size()));
+            for (auto path_entry : field_path) {
+                writer.write<uint16_t>(path_entry);
+            }
+            if (slice_kind == pax_generic_slice_kind::FIXED_VALUES) {
+                writer.write<uint8_t>(static_cast<uint8_t>(fixed_logical_type));
+            }
+        }
+
+        switch (codec_kind) {
+            case pax_generic_codec_kind::STRING_SEGMENT:
+            case pax_generic_codec_kind::VALIDITY_BITMASK:
+            case pax_generic_codec_kind::FIXED_PLAIN:
+                if (!payload.has_value()) {
+                    throw std::logic_error("missing pax_generic payload");
+                }
+                payload->serialize(writer);
+                break;
+            case pax_generic_codec_kind::VALIDITY_ALL_VALID:
+            case pax_generic_codec_kind::VALIDITY_ALL_INVALID:
+                break;
+            default:
+                throw std::logic_error("unknown pax_generic codec kind");
+        }
+        if (version >= 4) {
+            writer.write<uint8_t>(statistics.has_value() ? 1 : 0);
+            if (statistics.has_value()) {
+                statistics->serialize(writer);
+            }
+        }
+    }
+
+    pax_generic_slice_t pax_generic_slice_t::deserialize(metadata_reader_t& reader, uint16_t version) {
+        pax_generic_slice_t result;
+        result.column_index = reader.read<uint32_t>();
+        result.slice_kind = static_cast<pax_generic_slice_kind>(reader.read<uint8_t>());
+        result.codec_kind = static_cast<pax_generic_codec_kind>(reader.read<uint8_t>());
+        if (version >= 2) {
+            auto path_count = reader.read<uint16_t>();
+            result.field_path.resize(path_count);
+            for (uint16_t i = 0; i < path_count; i++) {
+                result.field_path[i] = reader.read<uint16_t>();
+            }
+            if (result.slice_kind == pax_generic_slice_kind::FIXED_VALUES) {
+                result.fixed_logical_type = static_cast<types::logical_type>(reader.read<uint8_t>());
+            }
+        }
+
+        switch (result.codec_kind) {
+            case pax_generic_codec_kind::STRING_SEGMENT:
+            case pax_generic_codec_kind::VALIDITY_BITMASK:
+            case pax_generic_codec_kind::FIXED_PLAIN:
+                result.payload = pax_block_payload_t::deserialize(reader);
+                break;
+            case pax_generic_codec_kind::VALIDITY_ALL_VALID:
+            case pax_generic_codec_kind::VALIDITY_ALL_INVALID:
+                result.payload.reset();
+                break;
+            default:
+                throw std::logic_error("unknown pax_generic codec kind");
+        }
+        if (version >= 4) {
+            const bool has_statistics = reader.read<uint8_t>() != 0;
+            if (has_statistics) {
+                result.statistics = base_statistics_t::deserialize(std::pmr::get_default_resource(), reader);
+            }
+        }
+        return result;
+    }
+
+    void pax_generic_page_t::serialize(metadata_writer_t& writer, uint16_t version) const {
+        writer.write<uint32_t>(row_offset_in_group);
+        writer.write<uint32_t>(tuple_count);
+        writer.write<uint32_t>(static_cast<uint32_t>(slices.size()));
+        for (const auto& slice : slices) {
+            slice.serialize(writer, version);
+        }
+    }
+
+    pax_generic_page_t pax_generic_page_t::deserialize(metadata_reader_t& reader, uint16_t version) {
+        pax_generic_page_t result;
+        result.row_offset_in_group = reader.read<uint32_t>();
+        result.tuple_count = reader.read<uint32_t>();
+        auto slice_count = reader.read<uint32_t>();
+        result.slices.resize(slice_count);
+        for (uint32_t i = 0; i < slice_count; i++) {
+            result.slices[i] = pax_generic_slice_t::deserialize(reader, version);
+        }
+        return result;
+    }
+
+    void pax_generic_row_group_layout_t::serialize(metadata_writer_t& writer) const {
+        writer.write<uint16_t>(version);
+        writer.write<uint16_t>(rows_per_page);
+        writer.write<uint32_t>(static_cast<uint32_t>(pages.size()));
+        for (const auto& page : pages) {
+            page.serialize(writer, version);
+        }
+    }
+
+    pax_generic_row_group_layout_t pax_generic_row_group_layout_t::deserialize(metadata_reader_t& reader) {
+        pax_generic_row_group_layout_t result;
+        result.version = reader.read<uint16_t>();
+        result.rows_per_page = reader.read<uint16_t>();
+        auto page_count = reader.read<uint32_t>();
+        result.pages.resize(page_count);
+        for (uint32_t i = 0; i < page_count; i++) {
+            result.pages[i] = pax_generic_page_t::deserialize(reader, result.version);
+        }
+        return result;
+    }
+
     void row_group_pointer_t::serialize(metadata_writer_t& writer) const {
         writer.write<uint64_t>(row_start);
         writer.write<uint64_t>(tuple_count);
 
         // column count
-        writer.write<uint32_t>(static_cast<uint32_t>(data_pointers.size()));
-        for (const auto& column_ptrs : data_pointers) {
+        writer.write<uint32_t>(static_cast<uint32_t>(columnar_data_pointers.size()));
+        for (const auto& column_ptrs : columnar_data_pointers) {
             // segments per column
+            writer.write<uint32_t>(static_cast<uint32_t>(column_ptrs.size()));
+            for (const auto& dp : column_ptrs) {
+                dp.serialize(writer);
+            }
+        }
+
+        // per-column validity-child pointers; empty for PAX / columns without validity
+        writer.write<uint32_t>(static_cast<uint32_t>(columnar_validity_pointers.size()));
+        for (const auto& column_ptrs : columnar_validity_pointers) {
             writer.write<uint32_t>(static_cast<uint32_t>(column_ptrs.size()));
             for (const auto& dp : column_ptrs) {
                 dp.serialize(writer);
@@ -52,12 +302,22 @@ namespace components::table::storage {
         result.tuple_count = reader.read<uint64_t>();
 
         auto col_count = reader.read<uint32_t>();
-        result.data_pointers.resize(col_count);
+        result.columnar_data_pointers.resize(col_count);
         for (uint32_t i = 0; i < col_count; i++) {
             auto seg_count = reader.read<uint32_t>();
-            result.data_pointers[i].resize(seg_count);
+            result.columnar_data_pointers[i].resize(seg_count);
             for (uint32_t j = 0; j < seg_count; j++) {
-                result.data_pointers[i][j] = data_pointer_t::deserialize(reader);
+                result.columnar_data_pointers[i][j] = data_pointer_t::deserialize(reader);
+            }
+        }
+
+        auto vcol_count = reader.read<uint32_t>();
+        result.columnar_validity_pointers.resize(vcol_count);
+        for (uint32_t i = 0; i < vcol_count; i++) {
+            auto seg_count = reader.read<uint32_t>();
+            result.columnar_validity_pointers[i].resize(seg_count);
+            for (uint32_t j = 0; j < seg_count; j++) {
+                result.columnar_validity_pointers[i][j] = data_pointer_t::deserialize(reader);
             }
         }
 

--- a/components/table/storage/data_pointer.hpp
+++ b/components/table/storage/data_pointer.hpp
@@ -1,20 +1,67 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <vector>
 
+#include <components/table/base_statistics.hpp>
 #include <components/table/compression/compression_type.hpp>
+#include <components/types/types.hpp>
 
 #include "file_buffer.hpp"
-
-namespace components::table {
-    class base_statistics_t;
-} // namespace components::table
 
 namespace components::table::storage {
 
     class metadata_writer_t;
     class metadata_reader_t;
+
+    enum class row_group_layout_kind : uint8_t
+    {
+        COLUMNAR = 0,
+        PAX_FIXED = 1,
+        PAX_GENERIC = 2
+    };
+
+    enum class pax_fixed_column_type : uint8_t
+    {
+        INT8 = 0,
+        INT16 = 1,
+        INT32 = 2,
+        INT64 = 3,
+        UINT8 = 4,
+        UINT16 = 5,
+        UINT32 = 6,
+        UINT64 = 7,
+        BOOL = 8,
+        INT128 = 9,
+        UINT128 = 10,
+        FLOAT = 11,
+        DOUBLE = 12
+    };
+
+    enum class pax_fixed_validity_kind : uint8_t
+    {
+        ALL_VALID = 0,
+        ALL_INVALID = 1,
+        BITMASK = 2,
+        RLE = 3
+    };
+
+    enum class pax_generic_slice_kind : uint8_t
+    {
+        STRING_VALUES = 0,
+        VALIDITY = 1,
+        FIXED_VALUES = 2
+    };
+
+    enum class pax_generic_codec_kind : uint8_t
+    {
+        STRING_SEGMENT = 0,
+        VALIDITY_ALL_VALID = 1,
+        VALIDITY_ALL_INVALID = 2,
+        VALIDITY_BITMASK = 3,
+        FIXED_PLAIN = 4
+    };
 
     struct data_pointer_t {
         uint64_t row_start{0};
@@ -27,11 +74,87 @@ namespace components::table::storage {
         static data_pointer_t deserialize(metadata_reader_t& reader);
     };
 
+    struct pax_fixed_slice_t {
+        uint32_t column_index{0};
+        pax_fixed_column_type column_type{pax_fixed_column_type::INT8};
+        data_pointer_t data_pointer;
+        pax_fixed_validity_kind validity_kind{pax_fixed_validity_kind::ALL_VALID};
+        std::optional<data_pointer_t> validity_data_pointer;
+        std::optional<base_statistics_t> statistics;
+
+        void serialize(metadata_writer_t& writer, uint16_t version) const;
+        static pax_fixed_slice_t deserialize(metadata_reader_t& reader, uint16_t version);
+    };
+
+    struct pax_fixed_page_t {
+        uint32_t row_offset_in_group{0};
+        uint32_t tuple_count{0};
+        std::vector<pax_fixed_slice_t> slices;
+
+        void serialize(metadata_writer_t& writer, uint16_t version) const;
+        static pax_fixed_page_t deserialize(metadata_reader_t& reader, uint16_t version);
+    };
+
+    struct pax_fixed_row_group_layout_t {
+        uint16_t version{4};
+        uint16_t rows_per_page{0};
+        std::vector<pax_fixed_page_t> pages;
+
+        void serialize(metadata_writer_t& writer) const;
+        static pax_fixed_row_group_layout_t deserialize(metadata_reader_t& reader);
+    };
+
+    struct pax_block_payload_t {
+        data_pointer_t main_pointer;
+        std::vector<uint32_t> extra_block_ids;
+
+        void serialize(metadata_writer_t& writer) const;
+        static pax_block_payload_t deserialize(metadata_reader_t& reader);
+    };
+
+    struct pax_generic_slice_t {
+        uint32_t column_index{0};
+        pax_generic_slice_kind slice_kind{pax_generic_slice_kind::STRING_VALUES};
+        pax_generic_codec_kind codec_kind{pax_generic_codec_kind::STRING_SEGMENT};
+        std::vector<uint16_t> field_path;
+        types::logical_type fixed_logical_type{types::logical_type::INVALID};
+        std::optional<pax_block_payload_t> payload;
+        std::optional<base_statistics_t> statistics;
+
+        void serialize(metadata_writer_t& writer, uint16_t version) const;
+        static pax_generic_slice_t deserialize(metadata_reader_t& reader, uint16_t version);
+    };
+
+    struct pax_generic_page_t {
+        uint32_t row_offset_in_group{0};
+        uint32_t tuple_count{0};
+        std::vector<pax_generic_slice_t> slices;
+
+        void serialize(metadata_writer_t& writer, uint16_t version) const;
+        static pax_generic_page_t deserialize(metadata_reader_t& reader, uint16_t version);
+    };
+
+    struct pax_generic_row_group_layout_t {
+        uint16_t version{1};
+        uint16_t rows_per_page{0};
+        std::vector<pax_generic_page_t> pages;
+
+        void serialize(metadata_writer_t& writer) const;
+        static pax_generic_row_group_layout_t deserialize(metadata_reader_t& reader);
+    };
+
     struct row_group_pointer_t {
         uint64_t row_start{0};
         uint64_t tuple_count{0};
-        std::vector<std::vector<data_pointer_t>> data_pointers; // per-column data pointers
+        std::vector<std::vector<data_pointer_t>> columnar_data_pointers; // per-column data pointers
+        // Per-column validity-child pointers for the COLUMNAR layout, needed to restore NULLs on
+        // reopen. Empty for PAX columns (validity lives in the page layout) and columns with no
+        // validity child.
+        std::vector<std::vector<data_pointer_t>> columnar_validity_pointers;
         std::vector<data_pointer_t> deletes_pointers;
+        row_group_layout_kind layout_kind{row_group_layout_kind::COLUMNAR};
+        std::optional<pax_fixed_row_group_layout_t> pax_fixed_layout;
+        std::optional<pax_generic_row_group_layout_t> pax_generic_layout;
 
         void serialize(metadata_writer_t& writer) const;
         static row_group_pointer_t deserialize(metadata_reader_t& reader);

--- a/components/table/storage/metadata_manager.cpp
+++ b/components/table/storage/metadata_manager.cpp
@@ -10,7 +10,7 @@ namespace components::table::storage {
 
     metadata_manager_t::metadata_manager_t(block_manager_t& block_manager)
         : block_manager_(block_manager)
-        , sub_block_size_(block_manager.block_allocation_size() / META_SUB_BLOCKS_PER_BLOCK) {}
+        , sub_block_size_(block_manager.block_size() / META_SUB_BLOCKS_PER_BLOCK) {}
 
     meta_block_pointer_t metadata_manager_t::allocate_handle() {
         std::lock_guard lock(lock_);

--- a/components/table/storage/metadata_reader.cpp
+++ b/components/table/storage/metadata_reader.cpp
@@ -5,6 +5,14 @@
 #include <stdexcept>
 
 namespace components::table::storage {
+    namespace {
+        template<typename T>
+        T load_unaligned(const std::byte* ptr) {
+            T value;
+            std::memcpy(&value, ptr, sizeof(T));
+            return value;
+        }
+    } // namespace
 
     metadata_reader_t::metadata_reader_t(metadata_manager_t& manager, meta_block_pointer_t start)
         : manager_(manager)
@@ -19,11 +27,8 @@ namespace components::table::storage {
     }
 
     void metadata_reader_t::follow_chain() {
-        auto* next_ptr = reinterpret_cast<uint64_t*>(current_data_);
-        auto* next_off = reinterpret_cast<uint32_t*>(current_data_ + sizeof(uint64_t));
-
-        uint64_t next_bp = *next_ptr;
-        uint32_t next_offset = *next_off;
+        const auto next_bp = load_unaligned<uint64_t>(current_data_);
+        const auto next_offset = load_unaligned<uint32_t>(current_data_ + sizeof(uint64_t));
 
         if (next_bp == INVALID_INDEX) {
             finished_ = true;

--- a/components/table/storage/metadata_writer.cpp
+++ b/components/table/storage/metadata_writer.cpp
@@ -5,6 +5,12 @@
 #include <stdexcept>
 
 namespace components::table::storage {
+    namespace {
+        template<typename T>
+        void store_unaligned(std::byte* ptr, const T& value) {
+            std::memcpy(ptr, &value, sizeof(T));
+        }
+    } // namespace
 
     metadata_writer_t::metadata_writer_t(metadata_manager_t& manager)
         : manager_(manager)
@@ -14,10 +20,8 @@ namespace components::table::storage {
         current_data_ = manager_.pin(current_pointer_);
 
         // initialize sub-block header: next_ptr = INVALID, next_offset = 0
-        auto* next_ptr = reinterpret_cast<uint64_t*>(current_data_);
-        *next_ptr = INVALID_INDEX;
-        auto* next_off = reinterpret_cast<uint32_t*>(current_data_ + sizeof(uint64_t));
-        *next_off = 0;
+        store_unaligned<uint64_t>(current_data_, INVALID_INDEX);
+        store_unaligned<uint32_t>(current_data_ + sizeof(uint64_t), 0);
 
         current_offset_ = SUB_BLOCK_HEADER_SIZE;
     }
@@ -32,16 +36,12 @@ namespace components::table::storage {
         auto* new_data = manager_.pin(new_pointer);
 
         // initialize new sub-block header
-        auto* new_next_ptr = reinterpret_cast<uint64_t*>(new_data);
-        *new_next_ptr = INVALID_INDEX;
-        auto* new_next_off = reinterpret_cast<uint32_t*>(new_data + sizeof(uint64_t));
-        *new_next_off = 0;
+        store_unaligned<uint64_t>(new_data, INVALID_INDEX);
+        store_unaligned<uint32_t>(new_data + sizeof(uint64_t), 0);
 
         // update current sub-block header to point to new one
-        auto* curr_next_ptr = reinterpret_cast<uint64_t*>(current_data_);
-        *curr_next_ptr = new_pointer.block_pointer;
-        auto* curr_next_off = reinterpret_cast<uint32_t*>(current_data_ + sizeof(uint64_t));
-        *curr_next_off = new_pointer.offset;
+        store_unaligned<uint64_t>(current_data_, new_pointer.block_pointer);
+        store_unaligned<uint32_t>(current_data_ + sizeof(uint64_t), new_pointer.offset);
 
         current_pointer_ = new_pointer;
         current_data_ = new_data;

--- a/components/table/storage/single_file_block_manager.cpp
+++ b/components/table/storage/single_file_block_manager.cpp
@@ -1,6 +1,7 @@
 #include "single_file_block_manager.hpp"
 
 #include <cassert>
+#include <cstddef>
 #include <cstring>
 #include <stdexcept>
 
@@ -12,6 +13,15 @@
 #include <core/file/local_file_system.hpp>
 
 namespace components::table::storage {
+
+    namespace {
+        // CRC32c over the header fields before the checksum field (the field itself and trailing
+        // padding are excluded), so a torn or corrupted header is rejected on load.
+        uint64_t compute_header_checksum(const database_header_t& header) {
+            return static_cast<uint64_t>(static_cast<uint32_t>(absl::ComputeCrc32c(
+                {reinterpret_cast<const char*>(&header), offsetof(database_header_t, checksum)})));
+        }
+    } // namespace
 
     single_file_block_manager_t::single_file_block_manager_t(buffer_manager_t& buffer_manager,
                                                              core::filesystem::local_file_system_t& fs,
@@ -42,15 +52,17 @@ namespace components::table::storage {
 
         main_header_t main_header;
         main_header.initialize();
-        handle_->write(&main_header, sizeof(main_header), 0);
+        if (!handle_->write(&main_header, sizeof(main_header), 0)) {
+            throw std::runtime_error("create_new_database: failed to write main header");
+        }
 
         database_header_t db_header;
         db_header.initialize();
         db_header.block_alloc_size = block_allocation_size();
-        handle_->write(&db_header, sizeof(db_header), SECTOR_SIZE);
-        handle_->write(&db_header, sizeof(db_header), 2 * SECTOR_SIZE);
-
-        handle_->sync();
+        // Checksum the initial header too, so a create-then-reopen with no checkpoint still validates.
+        db_header.checksum = compute_header_checksum(db_header);
+        write_header_slot(db_header, SECTOR_SIZE);
+        write_header_slot(db_header, 2 * SECTOR_SIZE);
 
         iteration_ = 0;
         max_block_ = 0;
@@ -84,7 +96,17 @@ namespace components::table::storage {
             throw std::runtime_error("Failed to read database header 2");
         }
 
-        const database_header_t& active = (header1.iteration >= header2.iteration) ? header1 : header2;
+        // Pick the active header only from slots that pass the checksum; if one slot is torn, recover
+        // from the other intact one rather than promoting the torn slot by iteration.
+        const bool valid1 = header1.checksum == compute_header_checksum(header1);
+        const bool valid2 = header2.checksum == compute_header_checksum(header2);
+        if (!valid1 && !valid2) {
+            throw std::runtime_error(
+                "load_existing_database: both database header slots failed checksum (torn or corrupt header)");
+        }
+        const database_header_t& active = (valid1 && valid2)
+                                              ? ((header1.iteration >= header2.iteration) ? header1 : header2)
+                                              : (valid1 ? header1 : header2);
 
         iteration_ = active.iteration;
         meta_block_ = active.meta_block;
@@ -110,9 +132,28 @@ namespace components::table::storage {
         }
     }
 
-    void single_file_block_manager_t::read_blocks(file_buffer_t& buffer, uint64_t start_block, uint64_t /*count*/) {
+    void single_file_block_manager_t::read_blocks(file_buffer_t& buffer, uint64_t start_block, uint64_t block_count) {
         auto location = block_location(start_block);
         buffer.read(*handle_, location);
+
+        // Verify every block's CRC32c; the single-block read() path does this but the batch path
+        // didn't. Blocks sit at block_allocation_size() stride, each laid out as
+        // [8-byte checksum][block_size() payload]. The stride check guards against a short buffer.
+        auto* base = buffer.internal_buffer();
+        const auto stride = block_allocation_size();
+        const auto payload_size = block_size();
+        for (uint64_t i = 0; i < block_count; i++) {
+            if ((i + 1) * stride > buffer.allocation_size()) {
+                break;
+            }
+            auto* block_ptr = base + i * stride;
+            auto stored_checksum = *reinterpret_cast<uint64_t*>(block_ptr);
+            auto computed = static_cast<uint64_t>(static_cast<uint32_t>(absl::ComputeCrc32c(
+                {reinterpret_cast<const char*>(block_ptr + sizeof(uint64_t)), payload_size})));
+            if (stored_checksum != computed) {
+                throw std::runtime_error("Block checksum mismatch for block " + std::to_string(start_block + i));
+            }
+        }
     }
 
     void single_file_block_manager_t::write(file_buffer_t& buffer, uint64_t block_id) {
@@ -210,8 +251,13 @@ namespace components::table::storage {
             static_cast<uint32_t>(absl::ComputeCrc32c({reinterpret_cast<const char*>(payload), payload_size})));
         *checksum_slot = crc;
 
+        // A failed block write must abort the checkpoint; file_buffer_t::write drops the handle's
+        // bool result, so write directly and check it.
         auto location = block_location(block_id);
-        buffer.write(*handle_, location);
+        if (!handle_->write(data, alloc_size, location)) {
+            throw std::runtime_error("checksum_and_write: failed to write block " + std::to_string(block_id) +
+                                     " (checkpoint not durable)");
+        }
     }
 
     bool single_file_block_manager_t::verify_checksum(file_buffer_t& buffer) {
@@ -237,21 +283,35 @@ namespace components::table::storage {
         write_header.block_count = max_block_;
         write_header.block_alloc_size = block_allocation_size();
         write_header.meta_block = meta_block_;
+        // Checksum last, over the finalized fields; validated on load.
+        write_header.checksum = compute_header_checksum(write_header);
 
         // double-header protocol: alternate between slot 1 and slot 2
         uint64_t slot = (iteration_ % 2 == 1) ? SECTOR_SIZE : (2 * SECTOR_SIZE);
-        handle_->write(&write_header, sizeof(write_header), slot);
-        handle_->sync();
+        write_header_slot(write_header, slot);
 
         // write to the other slot as well for redundancy
         uint64_t other_slot = (slot == SECTOR_SIZE) ? (2 * SECTOR_SIZE) : SECTOR_SIZE;
-        handle_->write(&write_header, sizeof(write_header), other_slot);
-        handle_->sync();
+        write_header_slot(write_header, other_slot);
+    }
+
+    void single_file_block_manager_t::write_header_slot(const database_header_t& header, uint64_t slot) {
+        // write() and sync() return false on failure; propagate so a non-durable checkpoint can't
+        // report success.
+        if (!handle_->write(const_cast<database_header_t*>(&header), sizeof(header), slot)) {
+            throw std::runtime_error("write_header: failed to write database header slot");
+        }
+        if (!handle_->sync()) {
+            throw std::runtime_error("write_header: failed to fsync database header slot");
+        }
     }
 
     void single_file_block_manager_t::file_sync() {
         if (handle_) {
-            handle_->sync();
+            // Durability barrier for the checkpoint commit; propagate fsync failure.
+            if (!handle_->sync()) {
+                throw std::runtime_error("file_sync: fsync failed (checkpoint not durable)");
+            }
         }
     }
 

--- a/components/table/storage/single_file_block_manager.hpp
+++ b/components/table/storage/single_file_block_manager.hpp
@@ -103,6 +103,7 @@ namespace components::table::storage {
         uint64_t block_location(uint64_t block_id) const;
         void checksum_and_write(file_buffer_t& buffer, uint64_t block_id);
         bool verify_checksum(file_buffer_t& buffer);
+        void write_header_slot(const database_header_t& header, uint64_t slot);
 
         core::filesystem::local_file_system_t& fs_;
         std::string path_;

--- a/components/table/struct_column_data.cpp
+++ b/components/table/struct_column_data.cpp
@@ -109,6 +109,18 @@ namespace components::table {
         return scan_count;
     }
 
+    void struct_column_data_t::scan_committed_range(uint64_t row_group_start,
+                                                    uint64_t offset_in_row_group,
+                                                    uint64_t count,
+                                                    vector::vector_t& result) {
+        column_scan_state state;
+        state.initialize(type_);
+        const auto row_index = static_cast<int64_t>(row_group_start + offset_in_row_group);
+        initialize_scan_with_offset(state, row_index);
+        const auto vector_index = static_cast<uint64_t>(row_index) / vector::DEFAULT_VECTOR_CAPACITY;
+        scan_committed(vector_index, state, result, true, count);
+    }
+
     uint64_t struct_column_data_t::scan_count(column_scan_state& state, vector::vector_t& result, uint64_t count) {
         auto scan_count = validity.scan_count(state.child_states[0], result, count);
         auto& child_entries = result.entries();

--- a/components/table/struct_column_data.hpp
+++ b/components/table/struct_column_data.hpp
@@ -29,6 +29,10 @@ namespace components::table {
                                 vector::vector_t& result,
                                 bool allow_updates,
                                 uint64_t scan_count) override;
+        void scan_committed_range(uint64_t row_group_start,
+                                  uint64_t offset_in_row_group,
+                                  uint64_t count,
+                                  vector::vector_t& result) override;
         uint64_t scan_count(column_scan_state& state, vector::vector_t& result, uint64_t count) override;
 
         void skip(column_scan_state& state, uint64_t count = vector::DEFAULT_VECTOR_CAPACITY) override;

--- a/components/table/table_state.cpp
+++ b/components/table/table_state.cpp
@@ -2,10 +2,123 @@
 
 #include <components/vector/data_chunk.hpp>
 
+#include <cstdio>
+#include <cstdlib>
+#include <limits>
+#include <stdexcept>
+
 #include "collection.hpp"
 #include "row_group.hpp"
 
 namespace components::table {
+    namespace {
+        uint64_t read_scan_env_u64(const char* name, uint64_t default_value = 0) {
+            const char* raw = std::getenv(name);
+            if (!raw || raw[0] == '\0') {
+                return default_value;
+            }
+            char* end = nullptr;
+            auto value = std::strtoull(raw, &end, 10);
+            if (end == raw) {
+                return default_value;
+            }
+            return value;
+        }
+
+        uint64_t scan_current_row_offset(const collection_scan_state& state) {
+            if (!state.row_group) {
+                return std::numeric_limits<uint64_t>::max();
+            }
+            const auto coarse_offset = state.vector_index * vector::DEFAULT_VECTOR_CAPACITY;
+            if (state.row_offset_override_active) {
+                return state.row_offset_override;
+            }
+            if (!state.row_group->has_persisted_pax_layout()) {
+                return coarse_offset;
+            }
+            for (const auto& column_state : state.column_scans) {
+                if (!column_state.current) {
+                    continue;
+                }
+                const auto fine_offset = state.vector_index_relative_to_row_group
+                                             ? column_state.row_index - state.row_group->start
+                                             : column_state.row_index;
+                if (fine_offset < 0) {
+                    continue;
+                }
+                const auto fine_offset_u = static_cast<uint64_t>(fine_offset);
+                return fine_offset_u < coarse_offset ? fine_offset_u : coarse_offset;
+            }
+            return coarse_offset;
+        }
+
+        uint64_t scan_current_absolute_row(const collection_scan_state& state) {
+            if (!state.row_group) {
+                return std::numeric_limits<uint64_t>::max();
+            }
+            return static_cast<uint64_t>(state.row_group->start) + scan_current_row_offset(state);
+        }
+
+        void maybe_log_scan_progress(const collection_scan_state& state,
+                                     uint64_t emitted_rows,
+                                     uint64_t& next_trace_row,
+                                     uint64_t trace_every_rows) {
+            if (!state.row_group || trace_every_rows == 0) {
+                return;
+            }
+            const auto current_row = scan_current_absolute_row(state);
+            if (current_row < next_trace_row) {
+                return;
+            }
+            std::fprintf(stderr,
+                         "[SCAN] emitted=%llu rg_start=%lld rg_count=%llu vector_index=%llu row_offset=%llu "
+                         "abs_row=%llu max_row=%lld max_rg_row=%lld\n",
+                         static_cast<unsigned long long>(emitted_rows),
+                         static_cast<long long>(state.row_group->start),
+                         static_cast<unsigned long long>(state.row_group->count.load()),
+                         static_cast<unsigned long long>(state.vector_index),
+                         static_cast<unsigned long long>(scan_current_row_offset(state)),
+                         static_cast<unsigned long long>(current_row),
+                         static_cast<long long>(state.max_row),
+                         static_cast<long long>(state.max_row_group_row));
+            std::fflush(stderr);
+            while (next_trace_row <= current_row) {
+                next_trace_row += trace_every_rows;
+            }
+        }
+
+        void enforce_scan_progress(const collection_scan_state& state,
+                                   const row_group_t* before_row_group,
+                                   uint64_t before_vector_index,
+                                   uint64_t before_result_size,
+                                   uint64_t after_result_size,
+                                   const char* path) {
+            if (!state.row_group || state.row_group != before_row_group) {
+                return;
+            }
+            if (state.vector_index != before_vector_index || after_result_size != before_result_size) {
+                return;
+            }
+            const bool exhausted =
+                static_cast<int64_t>(scan_current_row_offset(state)) >= state.max_row_group_row;
+            if (exhausted) {
+                return;
+            }
+            char message[256];
+            std::snprintf(message,
+                          sizeof(message),
+                          "%s made no scan progress: rg_start=%lld rg_count=%llu vector_index=%llu "
+                          "row_offset=%llu max_rg_row=%lld",
+                          path,
+                          static_cast<long long>(state.row_group->start),
+                          static_cast<unsigned long long>(state.row_group->count.load()),
+                          static_cast<unsigned long long>(state.vector_index),
+                          static_cast<unsigned long long>(scan_current_row_offset(state)),
+                          static_cast<long long>(state.max_row_group_row));
+            throw std::runtime_error(message);
+        }
+    } // namespace
+
     void scan_filter_info::initialize(table_filter_set_t& filters, const std::vector<storage_index_t>& column_ids) {
         assert(!filters.filters.empty());
         table_filters_ = &filters;
@@ -152,10 +265,13 @@ namespace components::table {
     collection_scan_state::collection_scan_state(std::pmr::memory_resource* resource, table_scan_state& parent)
         : row_group(nullptr)
         , vector_index(0)
+        , vector_index_relative_to_row_group(false)
         , max_row_group_row(0)
         , row_groups(nullptr)
         , max_row(0)
         , batch_index(0)
+        , row_offset_override_active(false)
+        , row_offset_override(0)
         , valid_indexing(resource, vector::DEFAULT_VECTOR_CAPACITY)
         , parent_(parent) {}
 
@@ -176,10 +292,23 @@ namespace components::table {
     const table_filter_t* collection_scan_state::filter() { return parent_.filter; }
 
     bool collection_scan_state::scan(vector::data_chunk_t& result) {
+        const auto trace_every_rows = read_scan_env_u64("OTTERBRIX_SCAN_TRACE_EVERY_ROWS");
+        uint64_t next_trace_row = trace_every_rows;
+        uint64_t observed_rows = 0;
         while (row_group) {
+            auto* before_row_group = row_group;
+            const auto before_vector_index = vector_index;
+            const auto before_result_size = result.size();
             row_group->scan(*this, result);
-            const bool rg_exhausted =
-                static_cast<int64_t>(vector_index * vector::DEFAULT_VECTOR_CAPACITY) >= max_row_group_row;
+            observed_rows += result.size() > before_result_size ? result.size() - before_result_size : 0;
+            enforce_scan_progress(*this,
+                                  before_row_group,
+                                  before_vector_index,
+                                  before_result_size,
+                                  result.size(),
+                                  "collection_scan_state::scan");
+            maybe_log_scan_progress(*this, observed_rows, next_trace_row, trace_every_rows);
+            const bool rg_exhausted = static_cast<int64_t>(scan_current_row_offset(*this)) >= max_row_group_row;
             if (!rg_exhausted) {
                 continue;
             }
@@ -208,6 +337,10 @@ namespace components::table {
                                              const std::vector<size_t>* projected_cols,
                                              std::pmr::vector<vector::data_chunk_t>& batches,
                                              std::pmr::memory_resource* resource) {
+        const auto trace_every_rows = read_scan_env_u64("OTTERBRIX_SCAN_TRACE_EVERY_ROWS");
+        const auto max_rows = read_scan_env_u64("OTTERBRIX_SCAN_MAX_ROWS");
+        uint64_t next_trace_row = trace_every_rows;
+        uint64_t emitted_rows = 0;
         while (row_group) {
             vector::data_chunk_t batch =
                 projected_cols ? vector::data_chunk_t(resource, types, *projected_cols, vector::DEFAULT_VECTOR_CAPACITY)
@@ -215,12 +348,28 @@ namespace components::table {
             for (auto& cs : column_scans) {
                 cs.result_offset = 0;
             }
+            auto* before_row_group = row_group;
+            const auto before_vector_index = vector_index;
             row_group->scan(*this, batch);
+            enforce_scan_progress(*this,
+                                  before_row_group,
+                                  before_vector_index,
+                                  0,
+                                  batch.size(),
+                                  "collection_scan_state::scan_batched");
             if (batch.size() > 0) {
+                if (max_rows > 0 && emitted_rows + batch.size() > max_rows) {
+                    batch.set_cardinality(max_rows - emitted_rows);
+                }
+                emitted_rows += batch.size();
                 batches.push_back(std::move(batch));
+                if (max_rows > 0 && emitted_rows >= max_rows) {
+                    row_group = nullptr;
+                    return;
+                }
             }
-            const bool rg_exhausted =
-                static_cast<int64_t>(vector_index * vector::DEFAULT_VECTOR_CAPACITY) >= max_row_group_row;
+            maybe_log_scan_progress(*this, emitted_rows, next_trace_row, trace_every_rows);
+            const bool rg_exhausted = static_cast<int64_t>(scan_current_row_offset(*this)) >= max_row_group_row;
             if (!rg_exhausted) {
                 continue;
             }

--- a/components/table/table_state.hpp
+++ b/components/table/table_state.hpp
@@ -159,11 +159,14 @@ namespace components::table {
 
         row_group_t* row_group;
         uint64_t vector_index;
+        bool vector_index_relative_to_row_group;
         int64_t max_row_group_row;
         std::vector<column_scan_state> column_scans;
         row_group_segment_tree_t* row_groups;
         int64_t max_row;
         uint64_t batch_index;
+        bool row_offset_override_active;
+        uint64_t row_offset_override;
         vector::indexing_vector_t valid_indexing;
         transaction_data txn{0, 0};
 

--- a/components/table/test/CMakeLists.txt
+++ b/components/table/test/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(${PROJECT_NAME} main.cpp ${${PROJECT_NAME}_SOURCES})
 target_link_libraries(
     ${PROJECT_NAME} PRIVATE
     otterbrix::expressions
+    otterbrix::storage
     otterbrix::logical_plan
     otterbrix::table
     otterbrix::file
@@ -31,4 +32,4 @@ target_link_libraries(
 
 include(CTest)
 include(Catch)
-catch_discover_tests(${PROJECT_NAME})
+otterbrix_discover_tests(${PROJECT_NAME})

--- a/components/table/test/test_checkpoint_load.cpp
+++ b/components/table/test/test_checkpoint_load.cpp
@@ -1,17 +1,70 @@
 #include <catch2/catch.hpp>
 #include <components/table/data_table.hpp>
+#include <components/table/row_group.hpp>
 #include <components/table/storage/buffer_pool.hpp>
+#include <components/table/storage/data_pointer.hpp>
 #include <components/table/storage/metadata_manager.hpp>
 #include <components/table/storage/metadata_reader.hpp>
 #include <components/table/storage/metadata_writer.hpp>
 #include <components/table/storage/single_file_block_manager.hpp>
 #include <components/table/storage/standard_buffer_manager.hpp>
+#include <components/table/transaction_manager.hpp>
+#include <components/types/type_spec.hpp>
 #include <core/file/local_file_system.hpp>
 
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
 #include <functional>
+#include <map>
+#include <random>
+#include <set>
+#include <memory_resource>
+#include <optional>
 #include <unistd.h>
 
+namespace components::table {
+    struct row_group_test_access_t {
+        static bool try_scan_pax_generic_projected(row_group_t& row_group,
+                                                   collection_scan_state& state,
+                                                   vector::data_chunk_t& result) {
+            return row_group.try_scan_pax_generic_projected(state, result);
+        }
+        static bool try_scan_pax_fixed_projected(row_group_t& row_group,
+                                                 collection_scan_state& state,
+                                                 vector::data_chunk_t& result) {
+            return row_group.try_scan_pax_fixed_projected(state, result);
+        }
+        static void reset_scan_path_counts(row_group_t& row_group) { row_group.reset_scan_path_counts(); }
+        static row_group_scan_path_counts_t scan_path_counts(const row_group_t& row_group) {
+            return row_group.scan_path_counts();
+        }
+        static const std::optional<storage::pax_fixed_row_group_layout_t>&
+        pax_fixed_layout(const row_group_t& row_group) {
+            return row_group.pax_fixed_layout_;
+        }
+        static std::optional<storage::pax_fixed_row_group_layout_t>&
+        pax_fixed_layout_mutable(row_group_t& row_group) {
+            return row_group.pax_fixed_layout_;
+        }
+        static uint64_t delete_pointer_count(const row_group_t& row_group) {
+            return row_group.deletes_pointers_.size();
+        }
+    };
+} // namespace components::table
+
 namespace {
+    constexpr uint32_t COLUMN_TYPES_METADATA_MAGIC = 0x31484353U; // "SCH1"
+    constexpr uint32_t ROW_GROUP_LAYOUTS_MAGIC = 0x31584150U; // "PAX1"
+    constexpr uint32_t TABLE_LAYOUT_POLICY_MAGIC = 0x3159504CU; // "LPY1"
+    constexpr uint32_t TABLE_COLUMN_TYPES_METADATA_FLAG = 1U << 31;
+    constexpr uint32_t TABLE_LAYOUT_METADATA_FLAG = 1U << 31;
+    constexpr uint32_t TABLE_LAYOUT_POLICY_METADATA_FLAG = 1U << 30;
+
     std::string test_db_path() {
         static std::string path = "/tmp/test_otterbrix_checkpoint_load_" + std::to_string(::getpid()) + ".otbx";
         return path;
@@ -29,6 +82,202 @@ namespace {
             : buffer_pool(&resource, uint64_t(1) << 32, false, uint64_t(1) << 24)
             , buffer_manager(&resource, fs, buffer_pool) {}
     };
+
+    struct persisted_column_definition_t {
+        std::string name;
+        components::types::logical_type type_id{components::types::logical_type::INVALID};
+        bool not_null{false};
+    };
+
+    struct persisted_table_metadata_t {
+        std::string name;
+        bool has_column_type_metadata{false};
+        std::vector<persisted_column_definition_t> columns;
+        std::vector<std::string> column_type_payloads;
+        bool has_layout_metadata{false};
+        bool has_layout_policy_metadata{false};
+        components::table::storage::row_group_layout_policy layout_policy{
+            components::table::storage::row_group_layout_policy::AUTO};
+        std::vector<components::table::storage::row_group_pointer_t> row_groups;
+    };
+
+    persisted_table_metadata_t
+    read_persisted_table_metadata(components::table::storage::metadata_manager_t& meta_mgr,
+                                  components::table::storage::meta_block_pointer_t table_pointer) {
+        using namespace components::table::storage;
+
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        persisted_table_metadata_t result;
+        result.name = reader.read_string();
+
+        const auto column_count_value = reader.read<uint32_t>();
+        result.has_column_type_metadata = (column_count_value & TABLE_COLUMN_TYPES_METADATA_FLAG) != 0;
+        const auto column_count = column_count_value & ~TABLE_COLUMN_TYPES_METADATA_FLAG;
+        result.columns.reserve(column_count);
+        for (uint32_t i = 0; i < column_count; i++) {
+            persisted_column_definition_t column;
+            column.name = reader.read_string();
+            column.type_id = static_cast<components::types::logical_type>(reader.read<uint8_t>());
+            column.not_null = reader.read<uint8_t>() != 0;
+            result.columns.push_back(std::move(column));
+        }
+
+        if (result.has_column_type_metadata) {
+            if (reader.read<uint32_t>() != COLUMN_TYPES_METADATA_MAGIC) {
+                throw std::logic_error("unknown table column types metadata extension section");
+            }
+            const auto payload_count = reader.read<uint32_t>();
+            if (payload_count != result.columns.size()) {
+                throw std::logic_error("table column types metadata count mismatch");
+            }
+            result.column_type_payloads.reserve(payload_count);
+            for (uint32_t i = 0; i < payload_count; i++) {
+                result.column_type_payloads.push_back(reader.read_string());
+            }
+        }
+
+        const auto row_group_count_value = reader.read<uint32_t>();
+        result.has_layout_metadata = (row_group_count_value & TABLE_LAYOUT_METADATA_FLAG) != 0;
+        result.has_layout_policy_metadata = (row_group_count_value & TABLE_LAYOUT_POLICY_METADATA_FLAG) != 0;
+        const auto row_group_count =
+            row_group_count_value & ~(TABLE_LAYOUT_METADATA_FLAG | TABLE_LAYOUT_POLICY_METADATA_FLAG);
+        result.row_groups.reserve(row_group_count);
+        for (uint32_t i = 0; i < row_group_count; i++) {
+            result.row_groups.push_back(row_group_pointer_t::deserialize(reader));
+        }
+
+        if (result.has_layout_metadata) {
+            if (reader.read<uint32_t>() != ROW_GROUP_LAYOUTS_MAGIC) {
+                throw std::logic_error("unknown table metadata extension section");
+            }
+            const auto layout_count = reader.read<uint32_t>();
+            if (layout_count != result.row_groups.size()) {
+                throw std::logic_error("row group layout metadata count mismatch");
+            }
+            for (uint32_t i = 0; i < layout_count; i++) {
+                auto layout_kind = static_cast<row_group_layout_kind>(reader.read<uint8_t>());
+                result.row_groups[i].layout_kind = layout_kind;
+                result.row_groups[i].pax_fixed_layout.reset();
+                result.row_groups[i].pax_generic_layout.reset();
+                if (layout_kind == row_group_layout_kind::PAX_FIXED) {
+                    result.row_groups[i].pax_fixed_layout = pax_fixed_row_group_layout_t::deserialize(reader);
+                } else if (layout_kind == row_group_layout_kind::PAX_GENERIC) {
+                    result.row_groups[i].pax_generic_layout = pax_generic_row_group_layout_t::deserialize(reader);
+                }
+            }
+        }
+
+        if (result.has_layout_policy_metadata) {
+            if (reader.read<uint32_t>() != TABLE_LAYOUT_POLICY_MAGIC) {
+                throw std::logic_error("unknown table layout policy metadata extension section");
+            }
+            result.layout_policy = static_cast<row_group_layout_policy>(reader.read<uint8_t>());
+        }
+
+        return result;
+    }
+
+    components::table::storage::meta_block_pointer_t
+    write_persisted_table_metadata(components::table::storage::metadata_manager_t& meta_mgr,
+                                   const persisted_table_metadata_t& metadata) {
+        using namespace components::table::storage;
+
+        metadata_writer_t writer(meta_mgr);
+        writer.write_string(metadata.name);
+
+        auto column_count = static_cast<uint32_t>(metadata.columns.size());
+        if (metadata.has_column_type_metadata) {
+            column_count |= TABLE_COLUMN_TYPES_METADATA_FLAG;
+        }
+        writer.write<uint32_t>(column_count);
+        for (const auto& column : metadata.columns) {
+            writer.write_string(column.name);
+            writer.write<uint8_t>(static_cast<uint8_t>(column.type_id));
+            writer.write<uint8_t>(column.not_null ? 1 : 0);
+        }
+
+        if (metadata.has_column_type_metadata) {
+            if (metadata.column_type_payloads.size() != metadata.columns.size()) {
+                throw std::logic_error("column type payload count mismatch");
+            }
+            writer.write<uint32_t>(COLUMN_TYPES_METADATA_MAGIC);
+            writer.write<uint32_t>(static_cast<uint32_t>(metadata.column_type_payloads.size()));
+            for (const auto& payload : metadata.column_type_payloads) {
+                writer.write_string(payload);
+            }
+        }
+
+        auto row_group_count = static_cast<uint32_t>(metadata.row_groups.size());
+        if (metadata.has_layout_metadata) {
+            row_group_count |= TABLE_LAYOUT_METADATA_FLAG;
+        }
+        writer.write<uint32_t>(row_group_count);
+        for (const auto& row_group : metadata.row_groups) {
+            row_group.serialize(writer);
+        }
+
+        if (metadata.has_layout_metadata) {
+            writer.write<uint32_t>(ROW_GROUP_LAYOUTS_MAGIC);
+            writer.write<uint32_t>(static_cast<uint32_t>(metadata.row_groups.size()));
+            for (const auto& row_group : metadata.row_groups) {
+                writer.write<uint8_t>(static_cast<uint8_t>(row_group.layout_kind));
+                if (row_group.layout_kind == row_group_layout_kind::PAX_FIXED) {
+                    if (!row_group.pax_fixed_layout.has_value()) {
+                        throw std::logic_error("missing pax_fixed layout metadata");
+                    }
+                    row_group.pax_fixed_layout->serialize(writer);
+                } else if (row_group.layout_kind == row_group_layout_kind::PAX_GENERIC) {
+                    if (!row_group.pax_generic_layout.has_value()) {
+                        throw std::logic_error("missing pax_generic layout metadata");
+                    }
+                    row_group.pax_generic_layout->serialize(writer);
+                }
+            }
+        }
+
+        auto pointer = writer.get_block_pointer();
+        writer.flush();
+        return pointer;
+    }
+
+    components::table::storage::meta_block_pointer_t
+    rewrite_pax_fixed_layout_version(components::table::storage::metadata_manager_t& meta_mgr,
+                                     components::table::storage::meta_block_pointer_t table_pointer,
+                                     uint16_t target_version) {
+        using namespace components::table::storage;
+
+        if (target_version != 1 && target_version != 2) {
+            throw std::logic_error("unsupported legacy pax_fixed version rewrite target");
+        }
+
+        auto metadata = read_persisted_table_metadata(meta_mgr, table_pointer);
+        bool found_pax_fixed = false;
+        for (auto& row_group : metadata.row_groups) {
+            if (row_group.layout_kind != row_group_layout_kind::PAX_FIXED) {
+                continue;
+            }
+            if (!row_group.pax_fixed_layout.has_value()) {
+                throw std::logic_error("missing pax_fixed layout during legacy rewrite");
+            }
+            found_pax_fixed = true;
+            row_group.pax_fixed_layout->version = target_version;
+            if (target_version == 1) {
+                for (auto& page : row_group.pax_fixed_layout->pages) {
+                    for (auto& slice : page.slices) {
+                        if (slice.validity_kind != pax_fixed_validity_kind::ALL_VALID) {
+                            throw std::logic_error("pax_fixed v1 rewrite requires all-valid slices");
+                        }
+                        slice.validity_data_pointer.reset();
+                    }
+                }
+            }
+        }
+        if (!found_pax_fixed) {
+            throw std::logic_error("expected pax_fixed layout metadata");
+        }
+        metadata.has_layout_metadata = true;
+        return write_persisted_table_metadata(meta_mgr, metadata);
+    }
 
     void
     append_int64_data(components::table::data_table_t& table, std::pmr::memory_resource* resource, uint64_t count) {
@@ -104,6 +353,322 @@ namespace {
             offset += batch;
         }
     }
+
+    void append_fixed_integer_pair(components::table::data_table_t& table,
+                                   std::pmr::memory_resource* resource,
+                                   uint64_t count,
+                                   std::function<int64_t(uint64_t)> left_value_fn,
+                                   std::function<uint32_t(uint64_t)> right_value_fn) {
+        using namespace components::types;
+        using namespace components::vector;
+        using namespace components::table;
+
+        auto types = table.copy_types();
+        uint64_t offset = 0;
+        while (offset < count) {
+            uint64_t batch = std::min(count - offset, uint64_t(DEFAULT_VECTOR_CAPACITY));
+            data_chunk_t chunk(resource, types, batch);
+            chunk.set_cardinality(batch);
+            for (uint64_t i = 0; i < batch; i++) {
+                const auto row = offset + i;
+                chunk.set_value(0, i, logical_value_t{resource, left_value_fn(row)});
+                chunk.set_value(1, i, logical_value_t{resource, right_value_fn(row)});
+            }
+            table_append_state state(resource);
+            table.append_lock(state);
+            table.initialize_append(state);
+            table.append(chunk, state);
+            table.finalize_append(state, transaction_data{0, 0});
+            offset += batch;
+        }
+    }
+
+    void append_nullable_fixed_integer_pair(components::table::data_table_t& table,
+                                            std::pmr::memory_resource* resource,
+                                            uint64_t count,
+                                            std::function<std::optional<int64_t>(uint64_t)> left_value_fn,
+                                            std::function<std::optional<uint32_t>(uint64_t)> right_value_fn) {
+        using namespace components::types;
+        using namespace components::vector;
+        using namespace components::table;
+
+        auto types = table.copy_types();
+        uint64_t offset = 0;
+        while (offset < count) {
+            uint64_t batch = std::min(count - offset, uint64_t(DEFAULT_VECTOR_CAPACITY));
+            data_chunk_t chunk(resource, types, batch);
+            chunk.set_cardinality(batch);
+            for (uint64_t i = 0; i < batch; i++) {
+                const auto row = offset + i;
+                auto left_value = left_value_fn(row);
+                auto right_value = right_value_fn(row);
+                if (left_value.has_value()) {
+                    chunk.set_value(0, i, logical_value_t{resource, *left_value});
+                } else {
+                    chunk.set_value(0, i, logical_value_t{resource, nullptr});
+                }
+                if (right_value.has_value()) {
+                    chunk.set_value(1, i, logical_value_t{resource, *right_value});
+                } else {
+                    chunk.set_value(1, i, logical_value_t{resource, nullptr});
+                }
+            }
+            table_append_state state(resource);
+            table.append_lock(state);
+            table.initialize_append(state);
+            table.append(chunk, state);
+            table.finalize_append(state, transaction_data{0, 0});
+            offset += batch;
+        }
+    }
+
+    void append_nullable_string_data(components::table::data_table_t& table,
+                                     std::pmr::memory_resource* resource,
+                                     uint64_t count,
+                                     std::function<std::optional<std::string>(uint64_t)> value_fn) {
+        using namespace components::types;
+        using namespace components::vector;
+        using namespace components::table;
+
+        auto types = table.copy_types();
+        uint64_t offset = 0;
+        while (offset < count) {
+            uint64_t batch = std::min(count - offset, uint64_t(DEFAULT_VECTOR_CAPACITY));
+            data_chunk_t chunk(resource, types, batch);
+            chunk.set_cardinality(batch);
+            for (uint64_t i = 0; i < batch; i++) {
+                auto value = value_fn(offset + i);
+                if (value.has_value()) {
+                    chunk.set_value(0, i, logical_value_t{resource, *value});
+                } else {
+                    chunk.set_value(0, i, logical_value_t{resource, nullptr});
+                }
+            }
+            table_append_state state(resource);
+            table.append_lock(state);
+            table.initialize_append(state);
+            table.append(chunk, state);
+            table.finalize_append(state, transaction_data{0, 0});
+            offset += batch;
+        }
+    }
+
+    void delete_committed_rows(components::table::data_table_t& table,
+                               std::pmr::memory_resource* resource,
+                               const std::vector<uint64_t>& rows) {
+        using namespace components::table;
+        using namespace components::types;
+        using namespace components::vector;
+
+        vector_t row_ids(resource, logical_type::BIGINT, rows.size());
+        for (uint64_t i = 0; i < rows.size(); i++) {
+            row_ids.set_value(i, logical_value_t{resource, static_cast<int64_t>(rows[i])});
+        }
+
+        auto delete_state = table.initialize_delete({});
+        REQUIRE(table.delete_rows(*delete_state, row_ids, rows.size(), 0) == rows.size());
+    }
+
+    void update_fixed_column(components::table::data_table_t& table,
+                             std::pmr::memory_resource* resource,
+                             uint64_t column_index,
+                             const std::vector<uint64_t>& rows,
+                             const std::vector<components::types::logical_value_t>& values,
+                             components::types::logical_type type) {
+        using namespace components::table;
+        using namespace components::types;
+        using namespace components::vector;
+
+        REQUIRE(rows.size() == values.size());
+        vector_t row_ids(resource, logical_type::BIGINT, rows.size());
+        data_chunk_t updates(resource, {type}, rows.size());
+        updates.set_cardinality(rows.size());
+        for (uint64_t i = 0; i < rows.size(); i++) {
+            row_ids.set_value(i, logical_value_t{resource, static_cast<int64_t>(rows[i])});
+            updates.set_value(0, i, values[i]);
+        }
+        table.update_column(row_ids, {column_index}, updates);
+    }
+
+    void update_string_column(components::table::data_table_t& table,
+                              std::pmr::memory_resource* resource,
+                              uint64_t column_index,
+                              const std::vector<uint64_t>& rows,
+                              const std::vector<std::optional<std::string>>& values) {
+        using namespace components::table;
+        using namespace components::types;
+        using namespace components::vector;
+
+        REQUIRE(rows.size() == values.size());
+        vector_t row_ids(resource, logical_type::BIGINT, rows.size());
+        data_chunk_t updates(resource, {logical_type::STRING_LITERAL}, rows.size());
+        updates.set_cardinality(rows.size());
+        for (uint64_t i = 0; i < rows.size(); i++) {
+            row_ids.set_value(i, logical_value_t{resource, static_cast<int64_t>(rows[i])});
+            if (values[i].has_value()) {
+                updates.set_value(0, i, logical_value_t{resource, *values[i]});
+            } else {
+                updates.data[0].set_null(i, true);
+            }
+        }
+        table.update_column(row_ids, {column_index}, updates);
+    }
+
+    std::string padded_name(uint64_t row) {
+        auto digits = std::to_string(row);
+        if (digits.size() < 4) {
+            digits = std::string(4 - digits.size(), '0') + digits;
+        }
+        return "name_" + digits;
+    }
+
+    components::types::complex_logical_type make_person_struct_type() {
+        using namespace components::types;
+
+        std::pmr::vector<complex_logical_type> fields;
+        fields.emplace_back(logical_type::BOOLEAN, "flag");
+        fields.emplace_back(logical_type::BIGINT, "id");
+        fields.emplace_back(logical_type::STRING_LITERAL, "name");
+        return complex_logical_type::create_struct("person", fields, "person_struct");
+    }
+
+    components::types::complex_logical_type make_nested_struct_type() {
+        using namespace components::types;
+
+        std::pmr::vector<complex_logical_type> nested_fields;
+        nested_fields.emplace_back(logical_type::STRING_LITERAL, "name");
+        nested_fields.emplace_back(logical_type::BIGINT, "score");
+        auto meta_type = complex_logical_type::create_struct("meta", nested_fields, "meta_struct");
+
+        std::pmr::vector<complex_logical_type> root_fields;
+        root_fields.emplace_back(logical_type::BIGINT, "id");
+        root_fields.push_back(meta_type);
+        return complex_logical_type::create_struct("entry", root_fields, "entry_struct");
+    }
+
+    void append_struct_data(components::table::data_table_t& table,
+                            std::pmr::memory_resource* resource,
+                            uint64_t count,
+                            std::function<components::types::logical_value_t(uint64_t)> value_fn) {
+        using namespace components::vector;
+        using namespace components::table;
+
+        auto types = table.copy_types();
+        uint64_t offset = 0;
+        while (offset < count) {
+            uint64_t batch = std::min(count - offset, uint64_t(DEFAULT_VECTOR_CAPACITY));
+            data_chunk_t chunk(resource, types, batch);
+            chunk.set_cardinality(batch);
+            for (uint64_t i = 0; i < batch; i++) {
+                chunk.set_value(0, i, value_fn(offset + i));
+            }
+            table_append_state state(resource);
+            table.append_lock(state);
+            table.initialize_append(state);
+            table.append(chunk, state);
+            table.finalize_append(state, transaction_data{0, 0});
+            offset += batch;
+        }
+    }
+
+    template<typename FillRowFn>
+    void append_rows(components::table::data_table_t& table,
+                     std::pmr::memory_resource* resource,
+                     uint64_t count,
+                     FillRowFn&& fill_row) {
+        using namespace components::table;
+        using namespace components::vector;
+
+        auto types = table.copy_types();
+        uint64_t offset = 0;
+        while (offset < count) {
+            const auto batch = std::min(count - offset, uint64_t(DEFAULT_VECTOR_CAPACITY));
+            data_chunk_t chunk(resource, types, batch);
+            chunk.set_cardinality(batch);
+            for (uint64_t i = 0; i < batch; i++) {
+                fill_row(chunk, offset + i, i);
+            }
+            table_append_state state(resource);
+            table.append_lock(state);
+            table.initialize_append(state);
+            table.append(chunk, state);
+            table.finalize_append(state, transaction_data{0, 0});
+            offset += batch;
+        }
+    }
+
+    components::types::logical_value_t make_enum_entry(std::pmr::memory_resource* resource,
+                                                       int32_t value,
+                                                       std::string label) {
+        auto entry = components::types::logical_value_t{resource, value};
+        entry.set_alias(label);
+        return entry;
+    }
+
+    components::types::complex_logical_type make_status_enum_type(std::pmr::memory_resource* resource) {
+        using namespace components::types;
+
+        std::vector<logical_value_t> entries;
+        entries.emplace_back(make_enum_entry(resource, 0, "pending"));
+        entries.emplace_back(make_enum_entry(resource, 1, "ready"));
+        entries.emplace_back(make_enum_entry(resource, 2, "done"));
+        return complex_logical_type::create_enum("status_enum", std::move(entries), "status_enum");
+    }
+
+    components::types::complex_logical_type
+    make_extended_struct_type(std::pmr::memory_resource* resource) {
+        using namespace components::types;
+
+        auto enum_type = make_status_enum_type(resource);
+        std::pmr::vector<complex_logical_type> fields(resource);
+        fields.emplace_back(logical_type::BOOLEAN, "flag");
+        fields.emplace_back(logical_type::HUGEINT, "amount");
+        fields.emplace_back(logical_type::DOUBLE, "ratio");
+        fields.emplace_back(logical_type::STRING_LITERAL, "name");
+        fields.emplace_back(logical_type::TIMESTAMP, "event_ts");
+        fields.emplace_back(complex_logical_type::create_decimal(20, 4, "price"));
+        fields.emplace_back(enum_type);
+        fields.back().set_alias("status");
+        return complex_logical_type::create_struct("extended", fields, "extended_struct");
+    }
+
+    components::types::complex_logical_type make_pax_union_type() {
+        using namespace components::types;
+
+        std::pmr::vector<complex_logical_type> fields;
+        fields.emplace_back(logical_type::BOOLEAN, "flag");
+        fields.emplace_back(logical_type::HUGEINT, "amount");
+        fields.emplace_back(logical_type::STRING_LITERAL, "label");
+        return complex_logical_type::create_union(fields, "pax_union");
+    }
+
+    components::types::int128_t signed_huge_value(uint64_t row) {
+        using components::types::int128_t;
+
+        const auto base = (int128_t{1} << 90) + static_cast<int64_t>(row * 97);
+        return (row % 2 == 0) ? base : -base;
+    }
+
+    components::types::uint128_t unsigned_huge_value(uint64_t row) {
+        using components::types::uint128_t;
+
+        return (uint128_t{1} << 100) + static_cast<uint64_t>(row * 131 + 17);
+    }
+
+    components::types::int128_t uuid_like_value(uint64_t row) {
+        using components::types::int128_t;
+
+        return (int128_t{0x1234} << 96) + (int128_t{0x5678} << 64) + static_cast<int64_t>(row * 211 + 5);
+    }
+
+    components::types::complex_logical_type make_list_struct_type() {
+        using namespace components::types;
+
+        std::pmr::vector<complex_logical_type> fields;
+        fields.emplace_back(logical_type::BIGINT, "id");
+        fields.emplace_back(logical_type::STRING_LITERAL, "label");
+        return complex_logical_type::create_struct("list_entry", fields, "list_entry_struct");
+    }
 } // namespace
 
 TEST_CASE("checkpoint_load: single INT64 column, 1000 rows") {
@@ -138,6 +703,7 @@ TEST_CASE("checkpoint_load: single INT64 column, 1000 rows") {
         database_header_t header;
         header.initialize();
         bm.write_header(header);
+        bm.file_sync();
     }
 
     // read phase
@@ -163,6 +729,219 @@ TEST_CASE("checkpoint_load: single INT64 column, 1000 rows") {
         });
         REQUIRE(scanned == NUM_ROWS);
     }
+
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: point-lookup (fetch by row_id) on reopened PAX-fixed table") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 2500; // spans row groups (1024) and pages (256)
+    meta_block_pointer_t table_pointer;
+    const auto is_null = [](uint64_t r) { return (r % 7) == 0; };
+    const auto expected = [](uint64_t r) { return static_cast<uint32_t>(r * 2654435761u + 12345u); };
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+        bm.create_new_database();
+        bm.set_layout_policy(row_group_layout_policy::PAX_ONLY);
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("u", logical_type::UINTEGER);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pt");
+        auto types = table->copy_types();
+        uint64_t off = 0;
+        while (off < NUM_ROWS) {
+            const uint64_t b = std::min<uint64_t>(NUM_ROWS - off, DEFAULT_VECTOR_CAPACITY);
+            data_chunk_t chunk(&env.resource, types, b);
+            chunk.set_cardinality(b);
+            for (uint64_t i = 0; i < b; i++) {
+                const uint64_t r = off + i;
+                if (is_null(r)) {
+                    chunk.data[0].set_null(i, true);
+                } else {
+                    chunk.set_value(0, i, logical_value_t{&env.resource, expected(r)});
+                }
+            }
+            table_append_state st(&env.resource);
+            table->append_lock(st);
+            table->initialize_append(st);
+            table->append(chunk, st);
+            table->finalize_append(st, transaction_data{0, 0});
+            off += b;
+        }
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+        bm.file_sync();
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+        bm.load_existing_database();
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        REQUIRE(loaded->column_count() == 1);
+
+        // Scattered probe hitting page (256) and row-group (1024) boundaries, null and non-null.
+        const std::vector<uint64_t> probe = {0,   1,    6,    7,    8,    255,  256,  257,
+                                             511, 512,  1023, 1024, 1025, 1791, 2047, 2048,
+                                             2049, 2299, 2300, 2499};
+        const uint64_t n = probe.size();
+        std::vector<storage_index_t> column_ids;
+        column_ids.emplace_back(0);
+        vector_t rows(&env.resource, logical_type::BIGINT, n);
+        for (uint64_t i = 0; i < n; i++) {
+            rows.set_value(i, logical_value_t{&env.resource, static_cast<int64_t>(probe[i])});
+        }
+        data_chunk_t result(&env.resource, loaded->copy_types(), n);
+        column_fetch_state state;
+        loaded->fetch(result, column_ids, rows, n, state);
+
+        for (uint64_t i = 0; i < n; i++) {
+            const uint64_t r = probe[i];
+            INFO("probe row " << r);
+            if (is_null(r)) {
+                REQUIRE_FALSE(result.data[0].validity().row_is_valid(i));
+            } else {
+                REQUIRE(result.data[0].validity().row_is_valid(i));
+                REQUIRE(result.data[0].value(i).value<uint32_t>() == expected(r));
+            }
+        }
+    }
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: point-lookup (fetch by row_id) on reopened PAX-generic table") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 2500;
+    meta_block_pointer_t table_pointer;
+    // Mixed fixed+string schema routes to PAX_GENERIC: exercises string and fixed fetch
+    // under the generic layout on a reopened table.
+    const auto u_null = [](uint64_t r) { return (r % 7) == 0; };
+    const auto s_null = [](uint64_t r) { return (r % 11) == 0; };
+    const auto u_val = [](uint64_t r) { return static_cast<int32_t>(static_cast<uint32_t>(r) * 7u + 3u); };
+    const auto s_val = [](uint64_t r) { return std::string("row-") + std::to_string(r) + "-payload"; };
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+        bm.create_new_database();
+        bm.set_layout_policy(row_group_layout_policy::PAX_ONLY);
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("i", logical_type::INTEGER);
+        columns.emplace_back("s", logical_type::STRING_LITERAL);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "ptg");
+        auto types = table->copy_types();
+        uint64_t off = 0;
+        while (off < NUM_ROWS) {
+            const uint64_t b = std::min<uint64_t>(NUM_ROWS - off, DEFAULT_VECTOR_CAPACITY);
+            data_chunk_t chunk(&env.resource, types, b);
+            chunk.set_cardinality(b);
+            for (uint64_t i = 0; i < b; i++) {
+                const uint64_t r = off + i;
+                if (u_null(r)) {
+                    chunk.data[0].set_null(i, true);
+                } else {
+                    chunk.set_value(0, i, logical_value_t{&env.resource, u_val(r)});
+                }
+                if (s_null(r)) {
+                    chunk.data[1].set_null(i, true);
+                } else {
+                    chunk.set_value(1, i, logical_value_t{&env.resource, s_val(r)});
+                }
+            }
+            table_append_state st(&env.resource);
+            table->append_lock(st);
+            table->initialize_append(st);
+            table->append(chunk, st);
+            table->finalize_append(st, transaction_data{0, 0});
+            off += b;
+        }
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+        bm.file_sync();
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+        bm.load_existing_database();
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        REQUIRE(loaded->column_count() == 2);
+
+        const std::vector<uint64_t> probe = {0,   1,    6,    7,    11,   255,  256,  257,
+                                             511, 512,  1023, 1024, 1025, 1791, 2047, 2048,
+                                             2049, 2299, 2300, 2499};
+        const uint64_t n = probe.size();
+        std::vector<storage_index_t> column_ids;
+        column_ids.emplace_back(0);
+        column_ids.emplace_back(1);
+        vector_t rows(&env.resource, logical_type::BIGINT, n);
+        for (uint64_t i = 0; i < n; i++) {
+            rows.set_value(i, logical_value_t{&env.resource, static_cast<int64_t>(probe[i])});
+        }
+        data_chunk_t result(&env.resource, loaded->copy_types(), n);
+        column_fetch_state state;
+        loaded->fetch(result, column_ids, rows, n, state);
+
+        for (uint64_t i = 0; i < n; i++) {
+            const uint64_t r = probe[i];
+            INFO("probe row " << r);
+            if (u_null(r)) {
+                REQUIRE_FALSE(result.data[0].validity().row_is_valid(i));
+            } else {
+                REQUIRE(result.data[0].validity().row_is_valid(i));
+                REQUIRE(result.data[0].value(i).value<int32_t>() == u_val(r));
+            }
+            if (s_null(r)) {
+                REQUIRE_FALSE(result.data[1].validity().row_is_valid(i));
+            } else {
+                REQUIRE(result.data[1].validity().row_is_valid(i));
+                REQUIRE(*result.data[1].value(i).value<std::string*>() == s_val(r));
+            }
+        }
+    }
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: column_segment rejects out-of-block-bounds data pointer") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    cleanup_test_file();
+
+    test_env_t env;
+    // Transient block carries a block_manager so the segment can query block_size().
+    auto block = env.buffer_manager.register_transient_memory(1024, DEFAULT_BLOCK_ALLOC_SIZE);
+    const complex_logical_type t{logical_type::BIGINT};
+
+    // A small segment at offset 0 fits.
+    REQUIRE_NOTHROW(column_segment_t(block, t, 0, 0, INVALID_BLOCK, 0, 1024));
+    // A segment_size larger than the block must throw at construction, not slide off the buffer later.
+    REQUIRE_THROWS_AS(column_segment_t(block, t, 0, 0, INVALID_BLOCK, 0, uint64_t(1) << 30), std::logic_error);
+    // An offset past the block must also throw.
+    REQUIRE_THROWS_AS(column_segment_t(block, t, 0, 0, INVALID_BLOCK, uint64_t(1) << 30, 64), std::logic_error);
 
     cleanup_test_file();
 }
@@ -254,6 +1033,6518 @@ TEST_CASE("checkpoint_load: three columns INT64 + STRING + DOUBLE") {
         REQUIRE(scanned == NUM_ROWS);
     }
 
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: fixed integer columns are written as pax") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 300;
+
+    meta_block_pointer_t table_pointer;
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("id", logical_type::BIGINT);
+        columns.emplace_back("value", logical_type::UINTEGER);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_table");
+
+        auto types = table->copy_types();
+        uint64_t offset = 0;
+        while (offset < NUM_ROWS) {
+            auto batch = std::min<uint64_t>(NUM_ROWS - offset, DEFAULT_VECTOR_CAPACITY);
+            data_chunk_t chunk(&env.resource, types, batch);
+            chunk.set_cardinality(batch);
+            for (uint64_t i = 0; i < batch; i++) {
+                auto row = offset + i;
+                chunk.set_value(0, i, logical_value_t{&env.resource, static_cast<int64_t>(row)});
+                chunk.set_value(1, i, logical_value_t{&env.resource, static_cast<uint32_t>(row * 10)});
+            }
+            table_append_state state(&env.resource);
+            table->append_lock(state);
+            table->initialize_append(state);
+            table->append(chunk, state);
+            table->finalize_append(state, transaction_data{0, 0});
+            offset += batch;
+        }
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+
+        REQUIRE(reader.read_string() == "pax_table");
+        REQUIRE(reader.read<uint32_t>() == 2);
+        for (uint32_t i = 0; i < 2; i++) {
+            (void) reader.read_string();
+            (void) reader.read<uint8_t>();
+            (void) reader.read<uint8_t>();
+        }
+
+        auto row_group_count = reader.read<uint32_t>();
+        REQUIRE((row_group_count & TABLE_LAYOUT_METADATA_FLAG) != 0);
+        REQUIRE((row_group_count & ~TABLE_LAYOUT_METADATA_FLAG) == 1);
+
+        auto row_group = row_group_pointer_t::deserialize(reader);
+        REQUIRE(row_group.columnar_data_pointers.size() == 2);
+        REQUIRE(row_group.columnar_data_pointers[0].size() == 2);
+        REQUIRE(row_group.columnar_data_pointers[1].size() == 2);
+
+        REQUIRE(reader.read<uint32_t>() == ROW_GROUP_LAYOUTS_MAGIC);
+        REQUIRE(reader.read<uint32_t>() == 1);
+        auto layout_kind = static_cast<row_group_layout_kind>(reader.read<uint8_t>());
+        REQUIRE(layout_kind == row_group_layout_kind::PAX_FIXED);
+
+        auto pax_layout = pax_fixed_row_group_layout_t::deserialize(reader);
+        REQUIRE(pax_layout.rows_per_page == 256);
+        REQUIRE(pax_layout.pages.size() == 2);
+        REQUIRE(pax_layout.pages[0].slices.size() == 2);
+        REQUIRE(pax_layout.pages[0].slices[0].data_pointer.block_pointer.block_id ==
+                pax_layout.pages[0].slices[1].data_pointer.block_pointer.block_id);
+        REQUIRE(pax_layout.pages[0].slices[0].column_index == 0);
+        REQUIRE(pax_layout.pages[0].slices[1].column_index == 1);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+
+        uint64_t scanned = 0;
+        loaded->scan_table_segment(0, NUM_ROWS, [&](data_chunk_t& chunk) {
+            for (uint64_t i = 0; i < chunk.size(); i++) {
+                auto row = scanned + i;
+                REQUIRE(chunk.data[0].value(i).value<int64_t>() == static_cast<int64_t>(row));
+                REQUIRE(chunk.data[1].value(i).value<uint32_t>() == static_cast<uint32_t>(row * 10));
+            }
+            scanned += chunk.size();
+        });
+        REQUIRE(scanned == NUM_ROWS);
+    }
+
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: explicit columnar-only root support matrix excludes variant and unsupported roots") {
+    using namespace components::types;
+
+    REQUIRE(components::table::detail::is_explicit_pax_columnar_only_root_type(
+        complex_logical_type(logical_type::BLOB)));
+    REQUIRE(components::table::detail::is_explicit_pax_columnar_only_root_type(
+        complex_logical_type(logical_type::INTERVAL)));
+    REQUIRE(components::table::detail::is_explicit_pax_columnar_only_root_type(
+        complex_logical_type(logical_type::MAP)));
+    REQUIRE(components::table::detail::is_explicit_pax_columnar_only_root_type(
+        complex_logical_type::create_variant(std::pmr::get_default_resource(), "payload")));
+
+    REQUIRE_FALSE(components::table::detail::is_explicit_pax_columnar_only_root_type(
+        complex_logical_type(logical_type::STRING_LITERAL)));
+    std::pmr::vector<complex_logical_type> payload_fields;
+    payload_fields.emplace_back(logical_type::BIGINT, "id");
+    REQUIRE_FALSE(components::table::detail::is_explicit_pax_columnar_only_root_type(
+        complex_logical_type::create_struct("payload", payload_fields, "payload")));
+    REQUIRE_FALSE(components::table::detail::is_explicit_pax_columnar_only_root_type(make_pax_union_type()));
+    REQUIRE(to_physical_type(logical_type::BLOB) == physical_type::INVALID);
+    REQUIRE(to_physical_type(logical_type::INTERVAL) == physical_type::STRUCT);
+    REQUIRE(to_physical_type(logical_type::MAP) == physical_type::INVALID);
+
+    const auto variant_type = complex_logical_type::create_variant(std::pmr::get_default_resource(), "payload");
+    REQUIRE(variant_type.child_types().size() == 4);
+    REQUIRE(variant_type.child_types()[0].type() == logical_type::LIST);
+    REQUIRE(variant_type.child_types()[1].type() == logical_type::LIST);
+    REQUIRE(variant_type.child_types()[2].type() == logical_type::LIST);
+    REQUIRE(variant_type.child_types()[3].type() == logical_type::BLOB);
+}
+
+TEST_CASE("checkpoint_load: explicit pax support matrix accepts mixed and rejects fallback root schemas") {
+    using components::table::column_definition_t;
+    using components::table::detail::supports_explicit_pax_schema;
+    using namespace components::types;
+
+    std::vector<column_definition_t> fixed_columns;
+    fixed_columns.emplace_back("id", logical_type::BIGINT);
+    fixed_columns.emplace_back("score", logical_type::DOUBLE);
+    std::string error_message;
+    REQUIRE(supports_explicit_pax_schema(fixed_columns, &error_message));
+
+    std::vector<column_definition_t> generic_columns;
+    generic_columns.emplace_back("name", logical_type::STRING_LITERAL);
+    std::pmr::vector<complex_logical_type> payload_fields;
+    payload_fields.emplace_back(logical_type::BIGINT, "id");
+    generic_columns.emplace_back("payload", complex_logical_type::create_struct("payload", payload_fields, "payload"));
+    error_message.clear();
+    REQUIRE(supports_explicit_pax_schema(generic_columns, &error_message));
+
+    std::vector<column_definition_t> mixed_columns;
+    mixed_columns.emplace_back("name", logical_type::STRING_LITERAL);
+    mixed_columns.emplace_back("count", logical_type::BIGINT);
+    error_message.clear();
+    REQUIRE(supports_explicit_pax_schema(mixed_columns, &error_message));
+    REQUIRE(error_message.empty());
+
+    std::vector<column_definition_t> fallback_columns;
+    fallback_columns.emplace_back("gap", logical_type::INTERVAL);
+    error_message.clear();
+    REQUIRE_FALSE(supports_explicit_pax_schema(fallback_columns, &error_message));
+    REQUIRE(error_message.find("not supported by USING PAX") != std::string::npos);
+
+    const auto require_unsupported_label = [&](logical_type type, const char* label) {
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("unsupported", type);
+        error_message.clear();
+        REQUIRE_FALSE(supports_explicit_pax_schema(columns, &error_message));
+        REQUIRE(error_message.find("type '" + std::string(label) + "'") != std::string::npos);
+        REQUIRE(error_message.find("not supported by USING PAX") != std::string::npos);
+    };
+
+    require_unsupported_label(logical_type::DATE, "date");
+    require_unsupported_label(logical_type::TIME, "time");
+    require_unsupported_label(logical_type::TIME_TZ, "timetz");
+    require_unsupported_label(logical_type::BLOB, "blob");
+    require_unsupported_label(logical_type::INTERVAL, "interval");
+
+    const auto require_unsupported_complex = [&](complex_logical_type type) {
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("unsupported", std::move(type));
+        error_message.clear();
+        REQUIRE_FALSE(supports_explicit_pax_schema(columns, &error_message));
+        REQUIRE(error_message.find("not supported by USING PAX") != std::string::npos);
+    };
+
+    require_unsupported_complex(complex_logical_type::create_map(logical_type::INTEGER,
+                                                                 logical_type::STRING_LITERAL,
+                                                                 "map_payload"));
+    require_unsupported_complex(complex_logical_type::create_variant(std::pmr::get_default_resource(), "variant_payload"));
+}
+
+TEST_CASE("checkpoint_load: columnar-only layout policy disables pax routing") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    cleanup_test_file();
+
+    test_env_t env;
+    meta_block_pointer_t table_pointer;
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+        bm.set_layout_policy(row_group_layout_policy::COLUMNAR_ONLY);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("name", logical_type::STRING_LITERAL);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "columnar_only_layout");
+        append_nullable_string_data(*table,
+                                    &env.resource,
+                                    150,
+                                    [](uint64_t row) -> std::optional<std::string> { return padded_name(row); });
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+        auto metadata = read_persisted_table_metadata(meta_mgr, table_pointer);
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+        REQUIRE(metadata.row_groups.size() == 1);
+        REQUIRE(metadata.row_groups[0].layout_kind == row_group_layout_kind::COLUMNAR);
+        REQUIRE_FALSE(metadata.row_groups[0].pax_fixed_layout.has_value());
+        REQUIRE_FALSE(metadata.row_groups[0].pax_generic_layout.has_value());
+        REQUIRE(metadata.row_groups[0].columnar_data_pointers.size() == 1);
+        REQUIRE_FALSE(metadata.row_groups[0].columnar_data_pointers[0].empty());
+    }
+
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: explicit layout policy metadata restores pax-only tables") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    cleanup_test_file();
+
+    test_env_t env;
+    meta_block_pointer_t table_pointer;
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+        bm.set_layout_policy(row_group_layout_policy::PAX_ONLY);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("id", logical_type::BIGINT);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_only_layout");
+        append_int64_data(*table, &env.resource, 64);
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+        auto metadata = read_persisted_table_metadata(meta_mgr, table_pointer);
+
+        REQUIRE(metadata.has_layout_policy_metadata);
+        REQUIRE(metadata.layout_policy == row_group_layout_policy::PAX_ONLY);
+        REQUIRE(metadata.row_groups.size() == 1);
+        REQUIRE(metadata.row_groups[0].layout_kind == row_group_layout_kind::PAX_FIXED);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+        bm.set_layout_policy(row_group_layout_policy::AUTO);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+
+        REQUIRE(loaded);
+        REQUIRE(bm.layout_policy() == row_group_layout_policy::PAX_ONLY);
+    }
+
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: pax fixed v1 metadata reloads integer roots") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 260;
+    const auto table_path = test_db_path() + ".pax_fixed_v1_compat";
+    std::remove(table_path.c_str());
+
+    meta_block_pointer_t table_pointer;
+    meta_block_pointer_t legacy_pointer;
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("id", logical_type::BIGINT);
+        columns.emplace_back("score", logical_type::UINTEGER);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_fixed_v1");
+        append_fixed_integer_pair(*table,
+                                  &env.resource,
+                                  NUM_ROWS,
+                                  [](uint64_t row) { return static_cast<int64_t>(row * 9 + 1); },
+                                  [](uint64_t row) { return static_cast<uint32_t>(row * 7 + 3); });
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+        metadata_manager_t meta_mgr(bm);
+        legacy_pointer = rewrite_pax_fixed_layout_version(meta_mgr, table_pointer, 1);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        const auto metadata = read_persisted_table_metadata(meta_mgr, legacy_pointer);
+        REQUIRE(metadata.has_layout_metadata);
+        REQUIRE(metadata.row_groups.size() == 1);
+        REQUIRE(metadata.row_groups[0].layout_kind == row_group_layout_kind::PAX_FIXED);
+        REQUIRE(metadata.row_groups[0].pax_fixed_layout.has_value());
+        REQUIRE(metadata.row_groups[0].pax_fixed_layout->version == 1);
+        for (const auto& page : metadata.row_groups[0].pax_fixed_layout->pages) {
+            for (const auto& slice : page.slices) {
+                REQUIRE(slice.validity_kind == pax_fixed_validity_kind::ALL_VALID);
+                REQUIRE_FALSE(slice.validity_data_pointer.has_value());
+            }
+        }
+
+        metadata_reader_t reader(meta_mgr, legacy_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+
+        uint64_t scanned = 0;
+        loaded->scan_table_segment(0, NUM_ROWS, [&](data_chunk_t& chunk) {
+            for (auto& vector : chunk.data) {
+                vector.flatten(chunk.size());
+            }
+            auto* ids = chunk.data[0].data<int64_t>();
+            auto* scores = chunk.data[1].data<uint32_t>();
+            for (uint64_t i = 0; i < chunk.size(); i++) {
+                const auto row = scanned + i;
+                REQUIRE_FALSE(chunk.data[0].is_null(i));
+                REQUIRE_FALSE(chunk.data[1].is_null(i));
+                REQUIRE(ids[i] == static_cast<int64_t>(row * 9 + 1));
+                REQUIRE(scores[i] == static_cast<uint32_t>(row * 7 + 3));
+            }
+            scanned += chunk.size();
+        });
+        REQUIRE(scanned == NUM_ROWS);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: pax fixed v2 metadata restores nullable integer roots") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 260;
+    const auto table_path = test_db_path() + ".pax_fixed_v2_compat";
+    std::remove(table_path.c_str());
+
+    meta_block_pointer_t table_pointer;
+    meta_block_pointer_t legacy_pointer;
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("id", logical_type::BIGINT);
+        columns.emplace_back("score", logical_type::UINTEGER);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_fixed_v2");
+        append_nullable_fixed_integer_pair(
+            *table,
+            &env.resource,
+            NUM_ROWS,
+            [](uint64_t row) -> std::optional<int64_t> {
+                if (row % 9 == 0) {
+                    return std::nullopt;
+                }
+                return static_cast<int64_t>(row * 11 + 5);
+            },
+            [](uint64_t row) -> std::optional<uint32_t> {
+                if (row % 7 == 0) {
+                    return std::nullopt;
+                }
+                return static_cast<uint32_t>(row * 13 + 2);
+            });
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+        metadata_manager_t meta_mgr(bm);
+        legacy_pointer = rewrite_pax_fixed_layout_version(meta_mgr, table_pointer, 2);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        const auto metadata = read_persisted_table_metadata(meta_mgr, legacy_pointer);
+        REQUIRE(metadata.has_layout_metadata);
+        REQUIRE(metadata.row_groups.size() == 1);
+        REQUIRE(metadata.row_groups[0].layout_kind == row_group_layout_kind::PAX_FIXED);
+        REQUIRE(metadata.row_groups[0].pax_fixed_layout.has_value());
+        REQUIRE(metadata.row_groups[0].pax_fixed_layout->version == 2);
+        bool saw_legacy_validity_payload = false;
+        for (const auto& page : metadata.row_groups[0].pax_fixed_layout->pages) {
+            for (const auto& slice : page.slices) {
+                if (slice.validity_kind == pax_fixed_validity_kind::BITMASK) {
+                    REQUIRE(slice.validity_data_pointer.has_value());
+                    saw_legacy_validity_payload = true;
+                }
+            }
+        }
+        REQUIRE(saw_legacy_validity_payload);
+
+        metadata_reader_t reader(meta_mgr, legacy_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+
+        uint64_t scanned = 0;
+        loaded->scan_table_segment(0, NUM_ROWS, [&](data_chunk_t& chunk) {
+            for (auto& vector : chunk.data) {
+                vector.flatten(chunk.size());
+            }
+            auto* ids = chunk.data[0].data<int64_t>();
+            auto* scores = chunk.data[1].data<uint32_t>();
+            for (uint64_t i = 0; i < chunk.size(); i++) {
+                const auto row = scanned + i;
+                const bool id_is_null = (row % 9 == 0);
+                const bool score_is_null = (row % 7 == 0);
+                REQUIRE(chunk.data[0].is_null(i) == id_is_null);
+                REQUIRE(chunk.data[1].is_null(i) == score_is_null);
+                if (!id_is_null) {
+                    REQUIRE(ids[i] == static_cast<int64_t>(row * 11 + 5));
+                }
+                if (!score_is_null) {
+                    REQUIRE(scores[i] == static_cast<uint32_t>(row * 13 + 2));
+                }
+            }
+            scanned += chunk.size();
+        });
+        REQUIRE(scanned == NUM_ROWS);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: extended fixed-width scalar roots are written as pax fixed v4") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 260;
+    const auto table_path = test_db_path() + ".pax_fixed_extended";
+    std::remove(table_path.c_str());
+
+    meta_block_pointer_t table_pointer;
+    auto status_enum = make_status_enum_type(&env.resource);
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("flag", logical_type::BOOLEAN);
+        columns.emplace_back("signed_big", logical_type::HUGEINT);
+        columns.emplace_back("unsigned_big", logical_type::UHUGEINT);
+        columns.emplace_back("score_f", logical_type::FLOAT);
+        columns.emplace_back("score_d", logical_type::DOUBLE);
+        columns.emplace_back("ts_sec", logical_type::TIMESTAMP);
+        columns.emplace_back("ts_ms", logical_type::TIMESTAMP);
+        columns.emplace_back("ts_us", logical_type::TIMESTAMP);
+        columns.emplace_back("ts_ns", logical_type::TIMESTAMP);
+        columns.emplace_back("small_dec", complex_logical_type::create_decimal(4, 1, "small_dec"));
+        columns.emplace_back("medium_dec", complex_logical_type::create_decimal(9, 2, "medium_dec"));
+        columns.emplace_back("large_dec", complex_logical_type::create_decimal(18, 3, "large_dec"));
+        columns.emplace_back("huge_dec", complex_logical_type::create_decimal(30, 4, "huge_dec"));
+        columns.emplace_back("uuid_col", logical_type::UUID);
+        columns.emplace_back("status", status_enum);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_fixed_extended");
+
+        append_rows(*table, &env.resource, NUM_ROWS, [&](data_chunk_t& chunk, uint64_t row, uint64_t row_in_chunk) {
+            const bool is_null = row % 17 == 0;
+            chunk.data[0].data<bool>()[row_in_chunk] = (row % 2) == 0;
+            chunk.data[1].data<int128_t>()[row_in_chunk] = signed_huge_value(row);
+            chunk.data[2].data<uint128_t>()[row_in_chunk] = unsigned_huge_value(row);
+            chunk.data[3].data<float>()[row_in_chunk] = static_cast<float>(0.5f + static_cast<float>(row) * 0.25f);
+            chunk.data[4].data<double>()[row_in_chunk] = 1.25 + static_cast<double>(row) * 1.125;
+            chunk.data[5].data<int64_t>()[row_in_chunk] = static_cast<int64_t>(1000 + row * 3);
+            chunk.data[6].data<int64_t>()[row_in_chunk] = static_cast<int64_t>(100000 + row * 7);
+            chunk.data[7].data<int64_t>()[row_in_chunk] = static_cast<int64_t>(10000000 + row * 11);
+            chunk.data[8].data<int64_t>()[row_in_chunk] = static_cast<int64_t>(1000000000 + row * 13);
+            chunk.data[9].data<int16_t>()[row_in_chunk] = static_cast<int16_t>(100 + row);
+            chunk.data[10].data<int32_t>()[row_in_chunk] = static_cast<int32_t>(100000 + row * 17);
+            chunk.data[11].data<int64_t>()[row_in_chunk] = static_cast<int64_t>(1000000000000LL + row * 19);
+            chunk.data[12].data<int128_t>()[row_in_chunk] = (int128_t{1} << 85) + static_cast<int64_t>(row * 23);
+            chunk.data[13].data<int128_t>()[row_in_chunk] = uuid_like_value(row);
+            chunk.data[14].data<int32_t>()[row_in_chunk] = static_cast<int32_t>(row % 3);
+
+            if (is_null) {
+                for (auto& vector : chunk.data) {
+                    vector.validity().set(row_in_chunk, false);
+                }
+            }
+        });
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+
+        REQUIRE(reader.read_string() == "pax_fixed_extended");
+        auto column_count = reader.read<uint32_t>();
+        REQUIRE((column_count & TABLE_COLUMN_TYPES_METADATA_FLAG) != 0);
+        REQUIRE((column_count & ~TABLE_COLUMN_TYPES_METADATA_FLAG) == 15);
+        for (uint32_t i = 0; i < 15; i++) {
+            (void) reader.read_string();
+            (void) reader.read<uint8_t>();
+            (void) reader.read<uint8_t>();
+        }
+        REQUIRE(reader.read<uint32_t>() == COLUMN_TYPES_METADATA_MAGIC);
+        REQUIRE(reader.read<uint32_t>() == 15);
+        for (uint32_t i = 0; i < 15; i++) {
+            (void) reader.read_string();
+        }
+
+        auto row_group_count = reader.read<uint32_t>();
+        REQUIRE((row_group_count & TABLE_LAYOUT_METADATA_FLAG) != 0);
+        REQUIRE((row_group_count & ~TABLE_LAYOUT_METADATA_FLAG) == 1);
+
+        auto row_group = row_group_pointer_t::deserialize(reader);
+        REQUIRE(row_group.columnar_data_pointers.size() == 15);
+        for (const auto& pointers : row_group.columnar_data_pointers) {
+            REQUIRE(pointers.size() == 2);
+        }
+
+        REQUIRE(reader.read<uint32_t>() == ROW_GROUP_LAYOUTS_MAGIC);
+        REQUIRE(reader.read<uint32_t>() == 1);
+        REQUIRE(static_cast<row_group_layout_kind>(reader.read<uint8_t>()) == row_group_layout_kind::PAX_FIXED);
+        auto pax_layout = pax_fixed_row_group_layout_t::deserialize(reader);
+        REQUIRE(pax_layout.version == 4);
+        REQUIRE(pax_layout.rows_per_page == 256);
+        REQUIRE(pax_layout.pages.size() == 2);
+
+        const auto require_slice_type = [&](uint32_t column_index, pax_fixed_column_type expected_type) {
+            for (const auto& page : pax_layout.pages) {
+                const auto it =
+                    std::find_if(page.slices.begin(), page.slices.end(), [&](const pax_fixed_slice_t& slice) {
+                        return slice.column_index == column_index;
+                });
+                REQUIRE(it != page.slices.end());
+                REQUIRE(it->column_type == expected_type);
+                REQUIRE(it->statistics.has_value());
+            }
+        };
+
+        require_slice_type(0, pax_fixed_column_type::BOOL);
+        require_slice_type(1, pax_fixed_column_type::INT128);
+        require_slice_type(2, pax_fixed_column_type::UINT128);
+        require_slice_type(3, pax_fixed_column_type::FLOAT);
+        require_slice_type(4, pax_fixed_column_type::DOUBLE);
+        require_slice_type(5, pax_fixed_column_type::INT64);
+        require_slice_type(6, pax_fixed_column_type::INT64);
+        require_slice_type(7, pax_fixed_column_type::INT64);
+        require_slice_type(8, pax_fixed_column_type::INT64);
+        require_slice_type(9, pax_fixed_column_type::INT16);
+        require_slice_type(10, pax_fixed_column_type::INT32);
+        require_slice_type(11, pax_fixed_column_type::INT64);
+        require_slice_type(12, pax_fixed_column_type::INT128);
+        require_slice_type(13, pax_fixed_column_type::INT128);
+        require_slice_type(14, pax_fixed_column_type::INT32);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+
+        uint64_t scanned = 0;
+        loaded->scan_table_segment(0, NUM_ROWS, [&](data_chunk_t& chunk) {
+            for (auto& vector : chunk.data) {
+                vector.flatten(chunk.size());
+            }
+
+            auto* flag = chunk.data[0].data<bool>();
+            auto* signed_big = chunk.data[1].data<int128_t>();
+            auto* unsigned_big = chunk.data[2].data<uint128_t>();
+            auto* score_f = chunk.data[3].data<float>();
+            auto* score_d = chunk.data[4].data<double>();
+            auto* ts_sec = chunk.data[5].data<int64_t>();
+            auto* ts_ms = chunk.data[6].data<int64_t>();
+            auto* ts_us = chunk.data[7].data<int64_t>();
+            auto* ts_ns = chunk.data[8].data<int64_t>();
+            auto* small_dec = chunk.data[9].data<int16_t>();
+            auto* medium_dec = chunk.data[10].data<int32_t>();
+            auto* large_dec = chunk.data[11].data<int64_t>();
+            auto* huge_dec = chunk.data[12].data<int128_t>();
+            auto* uuid_col = chunk.data[13].data<int128_t>();
+            auto* status = chunk.data[14].data<int32_t>();
+
+            for (uint64_t i = 0; i < chunk.size(); i++) {
+                const auto row = scanned + i;
+                const bool is_null = row % 17 == 0;
+                for (const auto& vector : chunk.data) {
+                    REQUIRE(vector.is_null(i) == is_null);
+                }
+                if (is_null) {
+                    continue;
+                }
+
+                REQUIRE(flag[i] == ((row % 2) == 0));
+                REQUIRE(signed_big[i] == signed_huge_value(row));
+                REQUIRE(unsigned_big[i] == unsigned_huge_value(row));
+                REQUIRE(score_f[i] == Approx(static_cast<float>(0.5f + static_cast<float>(row) * 0.25f)));
+                REQUIRE(score_d[i] == Approx(1.25 + static_cast<double>(row) * 1.125));
+                REQUIRE(ts_sec[i] == static_cast<int64_t>(1000 + row * 3));
+                REQUIRE(ts_ms[i] == static_cast<int64_t>(100000 + row * 7));
+                REQUIRE(ts_us[i] == static_cast<int64_t>(10000000 + row * 11));
+                REQUIRE(ts_ns[i] == static_cast<int64_t>(1000000000 + row * 13));
+                REQUIRE(small_dec[i] == static_cast<int16_t>(100 + row));
+                REQUIRE(medium_dec[i] == static_cast<int32_t>(100000 + row * 17));
+                REQUIRE(large_dec[i] == static_cast<int64_t>(1000000000000LL + row * 19));
+                REQUIRE(huge_dec[i] == ((int128_t{1} << 85) + static_cast<int64_t>(row * 23)));
+                REQUIRE(uuid_col[i] == uuid_like_value(row));
+                REQUIRE(status[i] == static_cast<int32_t>(row % 3));
+            }
+            scanned += chunk.size();
+        });
+        REQUIRE(scanned == NUM_ROWS);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: string columns are written as pax generic") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 300;
+
+    meta_block_pointer_t table_pointer;
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("name", logical_type::STRING_LITERAL);
+        columns.emplace_back("id", logical_type::BIGINT);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_generic_table");
+
+        auto types = table->copy_types();
+        uint64_t offset = 0;
+        while (offset < NUM_ROWS) {
+            auto batch = std::min<uint64_t>(NUM_ROWS - offset, DEFAULT_VECTOR_CAPACITY);
+            data_chunk_t chunk(&env.resource, types, batch);
+            chunk.set_cardinality(batch);
+            for (uint64_t i = 0; i < batch; i++) {
+                const auto row = offset + i;
+                if (row % 7 == 0) {
+                    chunk.set_value(0, i, logical_value_t{&env.resource, nullptr});
+                } else {
+                    chunk.set_value(0, i, logical_value_t{&env.resource, std::string("name_") + std::to_string(row)});
+                }
+                chunk.set_value(1, i, logical_value_t{&env.resource, static_cast<int64_t>(row * 10)});
+            }
+            table_append_state state(&env.resource);
+            table->append_lock(state);
+            table->initialize_append(state);
+            table->append(chunk, state);
+            table->finalize_append(state, transaction_data{0, 0});
+            offset += batch;
+        }
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+
+        REQUIRE(reader.read_string() == "pax_generic_table");
+        REQUIRE(reader.read<uint32_t>() == 2);
+        for (uint32_t i = 0; i < 2; i++) {
+            (void) reader.read_string();
+            (void) reader.read<uint8_t>();
+            (void) reader.read<uint8_t>();
+        }
+
+        auto row_group_count = reader.read<uint32_t>();
+        REQUIRE((row_group_count & TABLE_LAYOUT_METADATA_FLAG) != 0);
+        REQUIRE((row_group_count & ~TABLE_LAYOUT_METADATA_FLAG) == 1);
+
+        auto row_group = row_group_pointer_t::deserialize(reader);
+        REQUIRE(row_group.columnar_data_pointers.size() == 2);
+        REQUIRE(row_group.columnar_data_pointers[0].size() == 2);
+        REQUIRE(row_group.columnar_data_pointers[1].empty());
+
+        REQUIRE(reader.read<uint32_t>() == ROW_GROUP_LAYOUTS_MAGIC);
+        REQUIRE(reader.read<uint32_t>() == 1);
+        auto layout_kind = static_cast<row_group_layout_kind>(reader.read<uint8_t>());
+        REQUIRE(layout_kind == row_group_layout_kind::PAX_GENERIC);
+
+        auto pax_layout = pax_generic_row_group_layout_t::deserialize(reader);
+        REQUIRE(pax_layout.version == 4);
+        REQUIRE(pax_layout.rows_per_page == 256);
+        REQUIRE(pax_layout.pages.size() == 2);
+        REQUIRE(pax_layout.pages[0].slices.size() == 4);
+        REQUIRE(pax_layout.pages[0].slices[0].slice_kind == pax_generic_slice_kind::STRING_VALUES);
+        REQUIRE(pax_layout.pages[0].slices[0].codec_kind == pax_generic_codec_kind::STRING_SEGMENT);
+        REQUIRE(pax_layout.pages[0].slices[0].statistics.has_value());
+        REQUIRE(pax_layout.pages[0].slices[1].slice_kind == pax_generic_slice_kind::VALIDITY);
+        REQUIRE(pax_layout.pages[0].slices[2].column_index == 1);
+        REQUIRE(pax_layout.pages[0].slices[2].slice_kind == pax_generic_slice_kind::FIXED_VALUES);
+        REQUIRE(pax_layout.pages[0].slices[2].codec_kind == pax_generic_codec_kind::FIXED_PLAIN);
+        REQUIRE(pax_layout.pages[0].slices[2].fixed_logical_type == logical_type::BIGINT);
+        REQUIRE(pax_layout.pages[0].slices[2].statistics.has_value());
+        REQUIRE(pax_layout.pages[0].slices[3].column_index == 1);
+        REQUIRE(pax_layout.pages[0].slices[3].slice_kind == pax_generic_slice_kind::VALIDITY);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+
+        uint64_t scanned = 0;
+        loaded->scan_table_segment(0, NUM_ROWS, [&](data_chunk_t& chunk) {
+            for (uint64_t i = 0; i < chunk.size(); i++) {
+                const auto row = scanned + i;
+                REQUIRE(chunk.data[0].is_null(i) == (row % 7 == 0));
+                if (row % 7 != 0) {
+                    REQUIRE(*chunk.data[0].value(i).value<std::string*>() == std::string("name_") + std::to_string(row));
+                }
+                REQUIRE(chunk.data[1].value(i).value<int64_t>() == static_cast<int64_t>(row * 10));
+            }
+            scanned += chunk.size();
+        });
+        REQUIRE(scanned == NUM_ROWS);
+    }
+
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: pax generic string scan preserves null validity across pages") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 300;
+    const auto table_path = test_db_path() + ".pax_generic_nulls";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+
+    auto value_fn = [](uint64_t row) -> std::optional<std::string> {
+        if (row < 128) {
+            return (row % 5 == 0) ? std::optional<std::string>{}
+                                  : std::optional<std::string>{std::string("left_") + std::to_string(row)};
+        }
+        if (row < 256) {
+            return std::nullopt;
+        }
+        return std::string("tail_") + std::to_string(row);
+    };
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("name", logical_type::STRING_LITERAL);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_generic_nulls");
+        append_nullable_string_data(*table, &env.resource, NUM_ROWS, value_fn);
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+
+        uint64_t scanned = 0;
+        loaded->scan_table_segment(0, NUM_ROWS, [&](data_chunk_t& chunk) {
+            for (uint64_t i = 0; i < chunk.size(); i++) {
+                const auto row = scanned + i;
+                const auto expected = value_fn(row);
+                REQUIRE(chunk.data[0].is_null(i) == !expected.has_value());
+                if (expected.has_value()) {
+                    REQUIRE(*chunk.data[0].value(i).value<std::string*>() == *expected);
+                }
+            }
+            scanned += chunk.size();
+        });
+        REQUIRE(scanned == NUM_ROWS);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+// Load many row groups under a small buffer pool, checkpoint, reopen in a fresh block
+// manager, and verify every row (value and null mask) comes back exactly. Small pool +
+// blocks make pool-pressure truncation reproduce at a few thousand rows.
+TEST_CASE("checkpoint_load: pax fixed round-trip preserves every row and null mask under buffer-pool pressure") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    // Independent small buffer pool (16 MB) + small blocks (256 KB).
+    std::pmr::synchronized_pool_resource resource;
+    core::filesystem::local_file_system_t fs;
+    buffer_pool_t pool(&resource, uint64_t(16) << 20, false, uint64_t(1) << 24);
+    standard_buffer_manager_t buffer_manager(&resource, fs, pool);
+    constexpr uint64_t BLOCK_ALLOC = uint64_t(256) << 10;
+
+    constexpr uint64_t NUM_ROWS = 40000;
+    const auto path = test_db_path();
+    std::remove(path.c_str());
+    meta_block_pointer_t table_pointer;
+
+    auto col0_fn = [](uint64_t row) -> std::optional<int64_t> {
+        return (row % 13 == 0) ? std::optional<int64_t>{} : std::optional<int64_t>{static_cast<int64_t>(row)};
+    };
+    auto col1_fn = [](uint64_t row) -> std::optional<uint32_t> {
+        return (row % 7 == 0) ? std::optional<uint32_t>{} : std::optional<uint32_t>{static_cast<uint32_t>(row * 3)};
+    };
+
+    {
+        single_file_block_manager_t bm(buffer_manager, fs, path, BLOCK_ALLOC);
+        bm.create_new_database();
+        bm.set_layout_policy(row_group_layout_policy::PAX_ONLY);
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("id", logical_type::BIGINT);
+        columns.emplace_back("payload", logical_type::UINTEGER);
+        auto table = std::make_unique<data_table_t>(&resource, bm, std::move(columns), "scale_nulls");
+        append_nullable_fixed_integer_pair(*table, &resource, NUM_ROWS, col0_fn, col1_fn);
+        REQUIRE(table->calculate_size() == NUM_ROWS);
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(buffer_manager, fs, path, BLOCK_ALLOC);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&resource, bm, reader);
+
+        uint64_t scanned = 0;
+        loaded->scan_table_segment(0, NUM_ROWS, [&](data_chunk_t& chunk) {
+            for (uint64_t i = 0; i < chunk.size(); i++) {
+                const auto row = scanned + i;
+                const auto e0 = col0_fn(row);
+                const auto e1 = col1_fn(row);
+                REQUIRE(chunk.data[0].is_null(i) == !e0.has_value());
+                if (e0.has_value()) {
+                    REQUIRE(chunk.data[0].value(i).value<int64_t>() == *e0);
+                }
+                REQUIRE(chunk.data[1].is_null(i) == !e1.has_value());
+                if (e1.has_value()) {
+                    REQUIRE(chunk.data[1].value(i).value<uint32_t>() == *e1);
+                }
+            }
+            scanned += chunk.size();
+        });
+        REQUIRE(scanned == NUM_ROWS); // the whole table survived — no silent truncation
+    }
+
+    std::remove(path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: clean restored row group checkpoint reuses persisted blocks") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 300;
+    const auto table_path = test_db_path() + ".clean_reuse";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+    uint64_t blocks_after_first_checkpoint = 0;
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("name", logical_type::STRING_LITERAL);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "clean_reuse");
+        append_nullable_string_data(*table, &env.resource, NUM_ROWS, [](uint64_t row) {
+            return std::string("name_") + std::to_string(row);
+        });
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+        blocks_after_first_checkpoint = bm.total_blocks();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+
+        loaded->compact(UINT64_MAX);
+
+        metadata_writer_t writer(meta_mgr);
+        loaded->checkpoint(writer);
+
+        REQUIRE(bm.total_blocks() <= blocks_after_first_checkpoint + 1);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: restored row group dirty append is persisted") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 129;
+    const auto table_path = test_db_path() + ".dirty_append";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("name", logical_type::STRING_LITERAL);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "dirty_append");
+        append_nullable_string_data(*table, &env.resource, NUM_ROWS, [](uint64_t row) {
+            return std::string("before_") + std::to_string(row);
+        });
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        append_nullable_string_data(*loaded, &env.resource, 1, [](uint64_t) {
+            return std::string("after_reload");
+        });
+
+        metadata_writer_t writer(meta_mgr);
+        loaded->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+
+        uint64_t scanned = 0;
+        loaded->scan_table_segment(0, NUM_ROWS + 1, [&](data_chunk_t& chunk) {
+            for (uint64_t i = 0; i < chunk.size(); i++) {
+                const auto row = scanned + i;
+                if (row < NUM_ROWS) {
+                    REQUIRE(*chunk.data[0].value(i).value<std::string*>() ==
+                            std::string("before_") + std::to_string(row));
+                } else {
+                    REQUIRE(*chunk.data[0].value(i).value<std::string*>() == "after_reload");
+                }
+            }
+            scanned += chunk.size();
+        });
+        REQUIRE(scanned == NUM_ROWS + 1);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: columnar-only policy rewrites restored pax row group") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 260;
+    const auto table_path = test_db_path() + ".policy_mismatch";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("name", logical_type::STRING_LITERAL);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "policy_mismatch");
+        append_nullable_string_data(*table, &env.resource, NUM_ROWS, [](uint64_t row) {
+            return std::string("name_") + std::to_string(row);
+        });
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.set_layout_policy(row_group_layout_policy::COLUMNAR_ONLY);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+
+        metadata_writer_t writer(meta_mgr);
+        loaded->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        auto metadata = read_persisted_table_metadata(meta_mgr, table_pointer);
+        REQUIRE(metadata.row_groups.size() == 1);
+        REQUIRE(metadata.row_groups[0].layout_kind == row_group_layout_kind::COLUMNAR);
+        REQUIRE_FALSE(metadata.row_groups[0].pax_generic_layout.has_value());
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: pax generic string scan restores overflow strings") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 130;
+    const auto table_path = test_db_path() + ".pax_generic_overflow";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+
+    auto value_fn = [](uint64_t row) -> std::optional<std::string> {
+        if (row % 9 == 0) {
+            return std::nullopt;
+        }
+        if (row % 3 == 0) {
+            return std::string(6000 + row, static_cast<char>('a' + (row % 26)));
+        }
+        return std::string("short_") + std::to_string(row);
+    };
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("payload", logical_type::STRING_LITERAL);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_generic_overflow");
+        append_nullable_string_data(*table, &env.resource, NUM_ROWS, value_fn);
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        REQUIRE(reader.read_string() == "pax_generic_overflow");
+        REQUIRE(reader.read<uint32_t>() == 1);
+        (void) reader.read_string();
+        (void) reader.read<uint8_t>();
+        (void) reader.read<uint8_t>();
+        auto row_group_count = reader.read<uint32_t>();
+        REQUIRE((row_group_count & ~TABLE_LAYOUT_METADATA_FLAG) == 1);
+        (void) row_group_pointer_t::deserialize(reader);
+        REQUIRE(reader.read<uint32_t>() == ROW_GROUP_LAYOUTS_MAGIC);
+        REQUIRE(reader.read<uint32_t>() == 1);
+        REQUIRE(static_cast<row_group_layout_kind>(reader.read<uint8_t>()) == row_group_layout_kind::PAX_GENERIC);
+        auto pax_layout = pax_generic_row_group_layout_t::deserialize(reader);
+        bool found_overflow = false;
+        for (const auto& page : pax_layout.pages) {
+            for (const auto& slice : page.slices) {
+                if (slice.slice_kind == pax_generic_slice_kind::STRING_VALUES && slice.payload.has_value() &&
+                    !slice.payload->extra_block_ids.empty()) {
+                    found_overflow = true;
+                }
+            }
+        }
+        REQUIRE(found_overflow);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+
+        uint64_t scanned = 0;
+        loaded->scan_table_segment(0, NUM_ROWS, [&](data_chunk_t& chunk) {
+            for (uint64_t i = 0; i < chunk.size(); i++) {
+                const auto row = scanned + i;
+                const auto expected = value_fn(row);
+                REQUIRE(chunk.data[0].is_null(i) == !expected.has_value());
+                if (expected.has_value()) {
+                    REQUIRE(*chunk.data[0].value(i).value<std::string*>() == *expected);
+                }
+            }
+            scanned += chunk.size();
+        });
+        REQUIRE(scanned == NUM_ROWS);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: columnar layout refuses to persist a nested column (fail-closed)") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    const auto table_path = test_db_path() + ".columnar_nested_reject";
+    std::remove(table_path.c_str());
+    auto struct_type = make_person_struct_type();
+
+    single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+    bm.create_new_database();
+    // COLUMNAR checkpoint can't persist struct child columns, so it must throw rather than drop them.
+    bm.set_layout_policy(row_group_layout_policy::COLUMNAR_ONLY);
+
+    std::vector<column_definition_t> columns;
+    columns.emplace_back("person", struct_type);
+    auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "cn");
+    auto value_fn = [&](uint64_t row) {
+        std::vector<logical_value_t> fields;
+        fields.emplace_back(&env.resource, row % 2 == 0);
+        fields.emplace_back(&env.resource, static_cast<int64_t>(row * 11));
+        fields.emplace_back(&env.resource, padded_name(row));
+        return logical_value_t::create_struct(&env.resource, struct_type, fields);
+    };
+    append_struct_data(*table, &env.resource, 64, value_fn);
+
+    metadata_manager_t meta_mgr(bm);
+    metadata_writer_t writer(meta_mgr);
+    REQUIRE_THROWS_AS(table->checkpoint(writer), std::logic_error);
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: pax generic struct column restores fixed and string children") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 180;
+    const auto table_path = test_db_path() + ".pax_generic_struct";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+    auto struct_type = make_person_struct_type();
+
+    auto value_fn = [&](uint64_t row) {
+        if (row % 7 == 0) {
+            return logical_value_t{&env.resource, nullptr};
+        }
+
+        std::vector<logical_value_t> fields;
+        fields.emplace_back(&env.resource, row % 2 == 0);
+        fields.emplace_back(&env.resource, static_cast<int64_t>(row * 11));
+        if (row % 5 == 0) {
+            fields.emplace_back(&env.resource, nullptr);
+        } else {
+            fields.emplace_back(&env.resource, padded_name(row));
+        }
+        return logical_value_t::create_struct(&env.resource, struct_type, fields);
+    };
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("person", struct_type);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_generic_struct");
+        append_struct_data(*table, &env.resource, NUM_ROWS, value_fn);
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        REQUIRE(reader.read_string() == "pax_generic_struct");
+        auto column_count = reader.read<uint32_t>();
+        REQUIRE((column_count & TABLE_COLUMN_TYPES_METADATA_FLAG) != 0);
+        REQUIRE((column_count & ~TABLE_COLUMN_TYPES_METADATA_FLAG) == 1);
+        (void) reader.read_string();
+        (void) reader.read<uint8_t>();
+        (void) reader.read<uint8_t>();
+        REQUIRE(reader.read<uint32_t>() == COLUMN_TYPES_METADATA_MAGIC);
+        REQUIRE(reader.read<uint32_t>() == 1);
+        {
+            auto type_spec = reader.read_string();
+            auto persisted_type = components::types::decode_type_spec(&env.resource, type_spec);
+            REQUIRE(persisted_type.type() == logical_type::STRUCT);
+            REQUIRE(persisted_type.child_types().size() == 3);
+            REQUIRE(persisted_type.child_types()[0].type() == logical_type::BOOLEAN);
+            REQUIRE(persisted_type.child_types()[1].type() == logical_type::BIGINT);
+            REQUIRE(persisted_type.child_types()[2].type() == logical_type::STRING_LITERAL);
+        }
+        auto row_group_count = reader.read<uint32_t>();
+        REQUIRE((row_group_count & ~TABLE_LAYOUT_METADATA_FLAG) == 1);
+        auto row_group = row_group_pointer_t::deserialize(reader);
+        REQUIRE(row_group.columnar_data_pointers.size() == 1);
+        REQUIRE(row_group.columnar_data_pointers[0].empty());
+
+        REQUIRE(reader.read<uint32_t>() == ROW_GROUP_LAYOUTS_MAGIC);
+        REQUIRE(reader.read<uint32_t>() == 1);
+        REQUIRE(static_cast<row_group_layout_kind>(reader.read<uint8_t>()) == row_group_layout_kind::PAX_GENERIC);
+        auto pax_layout = pax_generic_row_group_layout_t::deserialize(reader);
+        REQUIRE(pax_layout.version == 2);
+        bool found_root_validity = false;
+        bool found_flag_values = false;
+        bool found_id_values = false;
+        bool found_name_values = false;
+        for (const auto& page : pax_layout.pages) {
+            for (const auto& slice : page.slices) {
+                if (slice.slice_kind == pax_generic_slice_kind::VALIDITY && slice.field_path.empty()) {
+                    found_root_validity = true;
+                } else if (slice.slice_kind == pax_generic_slice_kind::FIXED_VALUES &&
+                           slice.field_path == std::vector<uint16_t>{0}) {
+                    found_flag_values = true;
+                } else if (slice.slice_kind == pax_generic_slice_kind::FIXED_VALUES &&
+                           slice.field_path == std::vector<uint16_t>{1}) {
+                    found_id_values = true;
+                } else if (slice.slice_kind == pax_generic_slice_kind::STRING_VALUES &&
+                           slice.field_path == std::vector<uint16_t>{2}) {
+                    found_name_values = true;
+                }
+            }
+        }
+        REQUIRE(found_root_validity);
+        REQUIRE(found_flag_values);
+        REQUIRE(found_id_values);
+        REQUIRE(found_name_values);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+
+        uint64_t scanned = 0;
+        loaded->scan_table_segment(0, NUM_ROWS, [&](data_chunk_t& chunk) {
+            for (uint64_t i = 0; i < chunk.size(); i++) {
+                const auto row = scanned + i;
+                auto expected = value_fn(row);
+                auto actual = chunk.data[0].value(i);
+                REQUIRE(actual.is_null() == expected.is_null());
+                if (expected.is_null()) {
+                    continue;
+                }
+                REQUIRE(actual.type().type() == logical_type::STRUCT);
+                REQUIRE(actual.children()[0].value<bool>() == expected.children()[0].value<bool>());
+                REQUIRE(actual.children()[1].value<int64_t>() == expected.children()[1].value<int64_t>());
+                REQUIRE(actual.children()[2].is_null() == expected.children()[2].is_null());
+                if (!expected.children()[2].is_null()) {
+                    REQUIRE(*actual.children()[2].value<std::string*>() == *expected.children()[2].value<std::string*>());
+                }
+            }
+            scanned += chunk.size();
+        });
+        REQUIRE(scanned == NUM_ROWS);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: pax generic nested struct column restores overflow strings") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 140;
+    const auto table_path = test_db_path() + ".pax_generic_nested_struct";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+    auto struct_type = make_nested_struct_type();
+    const auto& meta_type = struct_type.child_types()[1];
+
+    auto value_fn = [&](uint64_t row) {
+        if (row % 9 == 0) {
+            return logical_value_t{&env.resource, nullptr};
+        }
+
+        std::vector<logical_value_t> meta_fields;
+        if (row % 6 == 0) {
+            meta_fields.emplace_back(&env.resource, nullptr);
+        } else if (row % 4 == 0) {
+            meta_fields.emplace_back(&env.resource, std::string(6000 + row, static_cast<char>('a' + (row % 26))));
+        } else {
+            meta_fields.emplace_back(&env.resource, padded_name(row));
+        }
+        meta_fields.emplace_back(&env.resource, static_cast<int64_t>(row * 100));
+
+        std::vector<logical_value_t> fields;
+        fields.emplace_back(&env.resource, static_cast<int64_t>(row));
+        fields.emplace_back(logical_value_t::create_struct(&env.resource, meta_type, meta_fields));
+        return logical_value_t::create_struct(&env.resource, struct_type, fields);
+    };
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("entry", struct_type);
+        auto table =
+            std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_generic_nested_struct");
+        append_struct_data(*table, &env.resource, NUM_ROWS, value_fn);
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+
+        uint64_t scanned = 0;
+        loaded->scan_table_segment(0, NUM_ROWS, [&](data_chunk_t& chunk) {
+            for (uint64_t i = 0; i < chunk.size(); i++) {
+                const auto row = scanned + i;
+                auto expected = value_fn(row);
+                auto actual = chunk.data[0].value(i);
+                REQUIRE(actual.is_null() == expected.is_null());
+                if (expected.is_null()) {
+                    continue;
+                }
+
+                REQUIRE(actual.children()[0].value<int64_t>() == expected.children()[0].value<int64_t>());
+                const auto& actual_meta = actual.children()[1];
+                const auto& expected_meta = expected.children()[1];
+                REQUIRE(actual_meta.children()[0].is_null() == expected_meta.children()[0].is_null());
+                if (!expected_meta.children()[0].is_null()) {
+                    REQUIRE(*actual_meta.children()[0].value<std::string*>() ==
+                            *expected_meta.children()[0].value<std::string*>());
+                }
+                REQUIRE(actual_meta.children()[1].value<int64_t>() == expected_meta.children()[1].value<int64_t>());
+            }
+            scanned += chunk.size();
+        });
+        REQUIRE(scanned == NUM_ROWS);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: pax generic struct column restores extended fixed children") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 150;
+    const auto table_path = test_db_path() + ".pax_generic_extended_struct";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+    auto struct_type = make_extended_struct_type(&env.resource);
+    const auto& decimal_type = struct_type.child_types()[5];
+    const auto& enum_type = struct_type.child_types()[6];
+
+    auto value_fn = [&](uint64_t row) {
+        if (row % 11 == 0) {
+            return logical_value_t{&env.resource, nullptr};
+        }
+
+        std::vector<logical_value_t> fields;
+        fields.emplace_back(&env.resource, row % 2 == 0);
+        fields.emplace_back(&env.resource, signed_huge_value(row));
+        fields.emplace_back(&env.resource, 2.5 + static_cast<double>(row) * 0.75);
+        if (row % 5 == 0) {
+            fields.emplace_back(&env.resource, nullptr);
+        } else {
+            fields.emplace_back(&env.resource, padded_name(row));
+        }
+        fields.emplace_back(&env.resource,
+                            core::date::timestamp_t{core::date::microseconds{static_cast<int64_t>(5000 + row * 9)}});
+        fields.emplace_back(logical_value_t::create_decimal(&env.resource,
+                                                            decimal_type,
+                                                            (int128_t{1} << 80) + static_cast<int64_t>(row * 29)));
+        fields.emplace_back(logical_value_t::create_enum(&env.resource, enum_type, static_cast<int32_t>(row % 3)));
+        return logical_value_t::create_struct(&env.resource, struct_type, fields);
+    };
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("payload", struct_type);
+        auto table =
+            std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_generic_extended_struct");
+        append_struct_data(*table, &env.resource, NUM_ROWS, value_fn);
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        (void) reader.read_string();
+        auto column_count = reader.read<uint32_t>();
+        REQUIRE((column_count & TABLE_COLUMN_TYPES_METADATA_FLAG) != 0);
+        REQUIRE((column_count & ~TABLE_COLUMN_TYPES_METADATA_FLAG) == 1);
+        (void) reader.read_string();
+        (void) reader.read<uint8_t>();
+        (void) reader.read<uint8_t>();
+        REQUIRE(reader.read<uint32_t>() == COLUMN_TYPES_METADATA_MAGIC);
+        REQUIRE(reader.read<uint32_t>() == 1);
+        (void) reader.read_string();
+        auto row_group_count = reader.read<uint32_t>();
+        REQUIRE((row_group_count & TABLE_LAYOUT_METADATA_FLAG) != 0);
+        REQUIRE((row_group_count & ~TABLE_LAYOUT_METADATA_FLAG) == 1);
+        auto row_group = row_group_pointer_t::deserialize(reader);
+        REQUIRE(row_group.columnar_data_pointers.size() == 1);
+        REQUIRE(row_group.columnar_data_pointers[0].empty());
+
+        REQUIRE(reader.read<uint32_t>() == ROW_GROUP_LAYOUTS_MAGIC);
+        REQUIRE(reader.read<uint32_t>() == 1);
+        REQUIRE(static_cast<row_group_layout_kind>(reader.read<uint8_t>()) == row_group_layout_kind::PAX_GENERIC);
+        auto pax_layout = pax_generic_row_group_layout_t::deserialize(reader);
+        REQUIRE(pax_layout.version == 2);
+
+        bool found_flag = false;
+        bool found_huge = false;
+        bool found_ratio = false;
+        bool found_name = false;
+        bool found_timestamp = false;
+        bool found_decimal = false;
+        bool found_enum = false;
+        for (const auto& page : pax_layout.pages) {
+            for (const auto& slice : page.slices) {
+                if (slice.slice_kind == pax_generic_slice_kind::FIXED_VALUES &&
+                    slice.field_path == std::vector<uint16_t>{0} &&
+                    slice.fixed_logical_type == logical_type::BOOLEAN) {
+                    found_flag = true;
+                } else if (slice.slice_kind == pax_generic_slice_kind::FIXED_VALUES &&
+                           slice.field_path == std::vector<uint16_t>{1} &&
+                           slice.fixed_logical_type == logical_type::HUGEINT) {
+                    found_huge = true;
+                } else if (slice.slice_kind == pax_generic_slice_kind::FIXED_VALUES &&
+                           slice.field_path == std::vector<uint16_t>{2} &&
+                           slice.fixed_logical_type == logical_type::DOUBLE) {
+                    found_ratio = true;
+                } else if (slice.slice_kind == pax_generic_slice_kind::STRING_VALUES &&
+                           slice.field_path == std::vector<uint16_t>{3}) {
+                    found_name = true;
+                } else if (slice.slice_kind == pax_generic_slice_kind::FIXED_VALUES &&
+                           slice.field_path == std::vector<uint16_t>{4} &&
+                           slice.fixed_logical_type == logical_type::TIMESTAMP) {
+                    found_timestamp = true;
+                } else if (slice.slice_kind == pax_generic_slice_kind::FIXED_VALUES &&
+                           slice.field_path == std::vector<uint16_t>{5} &&
+                           slice.fixed_logical_type == logical_type::DECIMAL) {
+                    found_decimal = true;
+                } else if (slice.slice_kind == pax_generic_slice_kind::FIXED_VALUES &&
+                           slice.field_path == std::vector<uint16_t>{6} &&
+                           slice.fixed_logical_type == logical_type::ENUM) {
+                    found_enum = true;
+                }
+            }
+        }
+
+        REQUIRE(found_flag);
+        REQUIRE(found_huge);
+        REQUIRE(found_ratio);
+        REQUIRE(found_name);
+        REQUIRE(found_timestamp);
+        REQUIRE(found_decimal);
+        REQUIRE(found_enum);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+
+        uint64_t scanned = 0;
+        loaded->scan_table_segment(0, NUM_ROWS, [&](data_chunk_t& chunk) {
+            auto& payload = chunk.data[0];
+            auto& children = payload.entries();
+            for (auto& child : children) {
+                child->flatten(chunk.size());
+            }
+
+            for (uint64_t i = 0; i < chunk.size(); i++) {
+                const auto row = scanned + i;
+                auto expected = value_fn(row);
+                REQUIRE(payload.is_null(i) == expected.is_null());
+                if (expected.is_null()) {
+                    continue;
+                }
+
+                REQUIRE(children[0]->data<bool>()[i] == expected.children()[0].value<bool>());
+                REQUIRE(children[1]->data<int128_t>()[i] == expected.children()[1].value<int128_t>());
+                REQUIRE(children[2]->data<double>()[i] == Approx(expected.children()[2].value<double>()));
+                REQUIRE(children[3]->is_null(i) == expected.children()[3].is_null());
+                if (!expected.children()[3].is_null()) {
+                    REQUIRE(children[3]->data<std::string_view>()[i] == expected.children()[3].value<std::string_view>());
+                }
+                REQUIRE(children[4]->data<int64_t>()[i] ==
+                        expected.children()[4].value<core::date::timestamp_t>().value.count());
+                REQUIRE(children[5]->data<int128_t>()[i] == expected.children()[5].value<int128_t>());
+                REQUIRE(children[6]->data<int32_t>()[i] == expected.children()[6].value<int32_t>());
+            }
+            scanned += chunk.size();
+        });
+        REQUIRE(scanned == NUM_ROWS);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: pax generic union column restores active member") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 170;
+    const auto table_path = test_db_path() + ".pax_generic_union";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+    auto union_type = make_pax_union_type();
+    auto union_members = union_type.child_types();
+    union_members.erase(union_members.begin());
+
+    auto value_fn = [&](uint64_t row) {
+        if (row % 8 == 0) {
+            return logical_value_t{&env.resource, nullptr};
+        }
+
+        const auto tag = static_cast<uint8_t>(row % 3);
+        switch (tag) {
+            case 0:
+                return logical_value_t::create_union(&env.resource,
+                                                     union_members,
+                                                     tag,
+                                                     logical_value_t{&env.resource, row % 2 == 0});
+            case 1:
+                return logical_value_t::create_union(&env.resource,
+                                                     union_members,
+                                                     tag,
+                                                     logical_value_t{&env.resource, signed_huge_value(row)});
+            default:
+                return logical_value_t::create_union(
+                    &env.resource,
+                    union_members,
+                    tag,
+                    logical_value_t{&env.resource,
+                                    row % 5 == 0 ? std::string(5000 + row, static_cast<char>('a' + (row % 26)))
+                                                 : padded_name(row)});
+        }
+    };
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("payload", union_type);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_generic_union");
+        append_struct_data(*table, &env.resource, NUM_ROWS, value_fn);
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        (void) reader.read_string();
+        auto column_count = reader.read<uint32_t>();
+        REQUIRE((column_count & TABLE_COLUMN_TYPES_METADATA_FLAG) != 0);
+        REQUIRE((column_count & ~TABLE_COLUMN_TYPES_METADATA_FLAG) == 1);
+        (void) reader.read_string();
+        (void) reader.read<uint8_t>();
+        (void) reader.read<uint8_t>();
+        REQUIRE(reader.read<uint32_t>() == COLUMN_TYPES_METADATA_MAGIC);
+        REQUIRE(reader.read<uint32_t>() == 1);
+        (void) reader.read_string();
+        auto row_group_count = reader.read<uint32_t>();
+        REQUIRE((row_group_count & TABLE_LAYOUT_METADATA_FLAG) != 0);
+        REQUIRE((row_group_count & ~TABLE_LAYOUT_METADATA_FLAG) == 1);
+        auto row_group = row_group_pointer_t::deserialize(reader);
+        REQUIRE(row_group.columnar_data_pointers.size() == 1);
+        REQUIRE(row_group.columnar_data_pointers[0].empty());
+
+        REQUIRE(reader.read<uint32_t>() == ROW_GROUP_LAYOUTS_MAGIC);
+        REQUIRE(reader.read<uint32_t>() == 1);
+        REQUIRE(static_cast<row_group_layout_kind>(reader.read<uint8_t>()) == row_group_layout_kind::PAX_GENERIC);
+        auto pax_layout = pax_generic_row_group_layout_t::deserialize(reader);
+        REQUIRE(pax_layout.version == 2);
+
+        bool found_root_validity = false;
+        bool found_tag = false;
+        bool found_bool = false;
+        bool found_huge = false;
+        bool found_string = false;
+        for (const auto& page : pax_layout.pages) {
+            for (const auto& slice : page.slices) {
+                if (slice.slice_kind == pax_generic_slice_kind::VALIDITY && slice.field_path.empty()) {
+                    found_root_validity = true;
+                } else if (slice.slice_kind == pax_generic_slice_kind::FIXED_VALUES &&
+                           slice.field_path == std::vector<uint16_t>{0} &&
+                           slice.fixed_logical_type == logical_type::UTINYINT) {
+                    found_tag = true;
+                } else if (slice.slice_kind == pax_generic_slice_kind::FIXED_VALUES &&
+                           slice.field_path == std::vector<uint16_t>{1} &&
+                           slice.fixed_logical_type == logical_type::BOOLEAN) {
+                    found_bool = true;
+                } else if (slice.slice_kind == pax_generic_slice_kind::FIXED_VALUES &&
+                           slice.field_path == std::vector<uint16_t>{2} &&
+                           slice.fixed_logical_type == logical_type::HUGEINT) {
+                    found_huge = true;
+                } else if (slice.slice_kind == pax_generic_slice_kind::STRING_VALUES &&
+                           slice.field_path == std::vector<uint16_t>{3}) {
+                    found_string = true;
+                }
+            }
+        }
+
+        REQUIRE(found_root_validity);
+        REQUIRE(found_tag);
+        REQUIRE(found_bool);
+        REQUIRE(found_huge);
+        REQUIRE(found_string);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+
+        uint64_t scanned = 0;
+        loaded->scan_table_segment(0, NUM_ROWS, [&](data_chunk_t& chunk) {
+            for (uint64_t i = 0; i < chunk.size(); i++) {
+                const auto row = scanned + i;
+                auto expected = value_fn(row);
+                auto actual = chunk.data[0].value(i);
+                REQUIRE(actual.is_null() == expected.is_null());
+                if (expected.is_null()) {
+                    continue;
+                }
+
+                const auto tag = expected.children()[0].value<uint8_t>();
+                REQUIRE(actual.children()[0].value<uint8_t>() == tag);
+                switch (tag) {
+                    case 0:
+                        REQUIRE(actual.children()[1].value<bool>() == expected.children()[1].value<bool>());
+                        break;
+                    case 1:
+                        REQUIRE(actual.children()[2].value<int128_t>() == expected.children()[2].value<int128_t>());
+                        break;
+                    case 2:
+                        REQUIRE(actual.children()[3].value<std::string_view>() ==
+                                expected.children()[3].value<std::string_view>());
+                        break;
+                    default:
+                        FAIL("unexpected union tag");
+                }
+            }
+            scanned += chunk.size();
+        });
+        REQUIRE(scanned == NUM_ROWS);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: pax generic list column restores offsets and child strings") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 190;
+    const auto table_path = test_db_path() + ".pax_generic_list_strings";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+    const auto list_type = complex_logical_type::create_list(logical_type::STRING_LITERAL, "tags");
+
+    auto make_value = [&](uint64_t row) -> std::optional<std::vector<std::string>> {
+        if (row % 13 == 0) {
+            return std::nullopt;
+        }
+        std::vector<std::string> values;
+        const auto count = row % 5 == 0 ? 0U : static_cast<uint32_t>(1 + (row % 4));
+        values.reserve(count);
+        for (uint32_t i = 0; i < count; i++) {
+            if ((row + i) % 7 == 0) {
+                values.emplace_back(std::string(5000 + row + i, static_cast<char>('a' + (row % 26))));
+            } else {
+                values.emplace_back(padded_name(row) + "_" + std::to_string(i));
+            }
+        }
+        return values;
+    };
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("tags", list_type);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_generic_list_strings");
+
+        append_rows(*table, &env.resource, NUM_ROWS, [&](data_chunk_t& chunk, uint64_t row, uint64_t row_in_chunk) {
+            auto expected = make_value(row);
+            if (!expected.has_value()) {
+                chunk.data[0].set_null(row_in_chunk, true);
+                return;
+            }
+            std::vector<logical_value_t> items;
+            items.reserve(expected->size());
+            for (const auto& value : *expected) {
+                items.emplace_back(&env.resource, value);
+            }
+            chunk.set_value(0, row_in_chunk, logical_value_t::create_list(&env.resource, logical_type::STRING_LITERAL, items));
+        });
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        auto metadata = read_persisted_table_metadata(meta_mgr, table_pointer);
+        REQUIRE(metadata.row_groups.size() == 1);
+        REQUIRE(metadata.row_groups[0].layout_kind == row_group_layout_kind::PAX_GENERIC);
+        REQUIRE(metadata.row_groups[0].pax_generic_layout.has_value());
+        REQUIRE(metadata.row_groups[0].pax_generic_layout->version == 3);
+
+        bool found_offsets = false;
+        bool found_child_strings = false;
+        for (const auto& page : metadata.row_groups[0].pax_generic_layout->pages) {
+            for (const auto& slice : page.slices) {
+                if (slice.slice_kind == pax_generic_slice_kind::FIXED_VALUES && slice.field_path.empty() &&
+                    slice.fixed_logical_type == logical_type::UBIGINT) {
+                    found_offsets = true;
+                } else if (slice.slice_kind == pax_generic_slice_kind::STRING_VALUES &&
+                           slice.field_path == std::vector<uint16_t>{0}) {
+                    found_child_strings = true;
+                }
+            }
+        }
+        REQUIRE(found_offsets);
+        REQUIRE(found_child_strings);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+
+        uint64_t scanned = 0;
+        loaded->scan_table_segment(0, NUM_ROWS, [&](data_chunk_t& chunk) {
+            for (uint64_t i = 0; i < chunk.size(); i++) {
+                const auto row = scanned + i;
+                const auto expected = make_value(row);
+                REQUIRE(chunk.data[0].is_null(i) == !expected.has_value());
+                if (!expected.has_value()) {
+                    continue;
+                }
+
+                const auto actual = chunk.data[0].value(i);
+                REQUIRE(actual.children().size() == expected->size());
+                for (uint64_t child_index = 0; child_index < expected->size(); child_index++) {
+                    REQUIRE(actual.children()[child_index].value<std::string_view>() == (*expected)[child_index]);
+                }
+            }
+            scanned += chunk.size();
+        });
+        REQUIRE(scanned == NUM_ROWS);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: pax generic array of struct restores nested child streams") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 96;
+    constexpr uint64_t ARRAY_SIZE = 3;
+    const auto table_path = test_db_path() + ".pax_generic_array_struct";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+    const auto struct_type = make_list_struct_type();
+    const auto array_type = complex_logical_type::create_array(struct_type, ARRAY_SIZE, "entries");
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("entries", array_type);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_generic_array_struct");
+
+        append_rows(*table, &env.resource, NUM_ROWS, [&](data_chunk_t& chunk, uint64_t row, uint64_t row_in_chunk) {
+            std::vector<logical_value_t> entries;
+            entries.reserve(ARRAY_SIZE);
+            for (uint64_t child_index = 0; child_index < ARRAY_SIZE; child_index++) {
+                std::vector<logical_value_t> fields;
+                fields.emplace_back(&env.resource, static_cast<int64_t>(row * 10 + child_index));
+                fields.emplace_back(&env.resource, padded_name(row) + "_" + std::to_string(child_index));
+                entries.emplace_back(logical_value_t::create_struct(&env.resource, struct_type, fields));
+            }
+            chunk.set_value(0, row_in_chunk, logical_value_t::create_array(&env.resource, struct_type, entries));
+        });
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        auto metadata = read_persisted_table_metadata(meta_mgr, table_pointer);
+        REQUIRE(metadata.row_groups.size() == 1);
+        REQUIRE(metadata.row_groups[0].layout_kind == row_group_layout_kind::PAX_GENERIC);
+        REQUIRE(metadata.row_groups[0].pax_generic_layout.has_value());
+        REQUIRE(metadata.row_groups[0].pax_generic_layout->version == 3);
+
+        bool found_ids = false;
+        bool found_labels = false;
+        for (const auto& page : metadata.row_groups[0].pax_generic_layout->pages) {
+            for (const auto& slice : page.slices) {
+                if (slice.slice_kind == pax_generic_slice_kind::FIXED_VALUES &&
+                    slice.field_path == std::vector<uint16_t>{0, 0} &&
+                    slice.fixed_logical_type == logical_type::BIGINT) {
+                    found_ids = true;
+                } else if (slice.slice_kind == pax_generic_slice_kind::STRING_VALUES &&
+                           slice.field_path == std::vector<uint16_t>{0, 1}) {
+                    found_labels = true;
+                }
+            }
+        }
+        REQUIRE(found_ids);
+        REQUIRE(found_labels);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+
+        uint64_t scanned = 0;
+        loaded->scan_table_segment(0, NUM_ROWS, [&](data_chunk_t& chunk) {
+            for (uint64_t i = 0; i < chunk.size(); i++) {
+                const auto row = scanned + i;
+                const auto actual = chunk.data[0].value(i);
+                REQUIRE(actual.children().size() == ARRAY_SIZE);
+                for (uint64_t child_index = 0; child_index < ARRAY_SIZE; child_index++) {
+                    const auto& entry = actual.children()[child_index];
+                    REQUIRE(entry.children()[0].value<int64_t>() == static_cast<int64_t>(row * 10 + child_index));
+                    REQUIRE(entry.children()[1].value<std::string_view>() ==
+                            padded_name(row) + "_" + std::to_string(child_index));
+                }
+            }
+            scanned += chunk.size();
+        });
+        REQUIRE(scanned == NUM_ROWS);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: pax generic projected scan uses fast path") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 1300;
+    const auto table_path = test_db_path() + ".pax_generic_projected";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("name", logical_type::STRING_LITERAL);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_generic_projected");
+        append_nullable_string_data(*table,
+                                    &env.resource,
+                                    NUM_ROWS,
+                                    [](uint64_t row) -> std::optional<std::string> { return padded_name(row); });
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+
+        std::vector<storage_index_t> projected_indices{storage_index_t(0)};
+        std::vector<size_t> projected_cols{0};
+
+        table_scan_state helper_state(&env.resource);
+        loaded->initialize_scan(helper_state, projected_indices, nullptr);
+        auto* first_row_group = loaded->row_group()->row_group(0);
+        REQUIRE(first_row_group != nullptr);
+
+        data_chunk_t first_chunk(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+        REQUIRE(row_group_test_access_t::try_scan_pax_generic_projected(*first_row_group,
+                                                                        helper_state.table_state,
+                                                                        first_chunk));
+        REQUIRE(first_chunk.size() == DEFAULT_VECTOR_CAPACITY);
+        for (uint64_t i = 0; i < first_chunk.size(); i++) {
+            REQUIRE(*first_chunk.data[0].value(i).value<std::string*>() == padded_name(i));
+        }
+
+        row_group_test_access_t::reset_scan_path_counts(*first_row_group);
+
+        table_scan_state state(&env.resource);
+        loaded->initialize_scan(state, projected_indices, nullptr);
+        data_chunk_t result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+
+        uint64_t scanned = 0;
+        while (true) {
+            result.reset();
+            loaded->scan(result, state);
+            if (result.size() == 0) {
+                break;
+            }
+
+            for (uint64_t i = 0; i < result.size(); i++) {
+                REQUIRE(*result.data[0].value(i).value<std::string*>() == padded_name(scanned + i));
+            }
+            scanned += result.size();
+        }
+        REQUIRE(scanned == NUM_ROWS);
+        const auto counts = row_group_test_access_t::scan_path_counts(*first_row_group);
+        REQUIRE(counts.pax_generic_projected > 0);
+        REQUIRE(counts.pax_generic_pruned_pages == 0);
+        REQUIRE(counts.pax_generic_prefetched_blocks > 0);
+        REQUIRE(counts.pax_generic_skipped_payload_pages == 0);
+        REQUIRE(counts.pax_fixed_projected == 0);
+        REQUIRE(counts.regular == 0);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: pax generic projected scan skips committed deletes") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 512;
+    const auto table_path = test_db_path() + ".pax_generic_delete_overlay";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("name", logical_type::STRING_LITERAL);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_generic_delete");
+        append_nullable_string_data(*table,
+                                    &env.resource,
+                                    NUM_ROWS,
+                                    [](uint64_t row) -> std::optional<std::string> { return padded_name(row); });
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        auto* first_row_group = loaded->row_group()->row_group(0);
+        REQUIRE(first_row_group != nullptr);
+
+        const std::vector<uint64_t> deleted_rows{0, 5, 128, 255, 300, 511};
+        delete_committed_rows(*loaded, &env.resource, deleted_rows);
+
+        std::vector<uint64_t> expected_rows;
+        for (uint64_t row = 0; row < NUM_ROWS; row++) {
+            if (std::find(deleted_rows.begin(), deleted_rows.end(), row) == deleted_rows.end()) {
+                expected_rows.push_back(row);
+            }
+        }
+
+        std::vector<storage_index_t> projected_indices{storage_index_t(0)};
+        std::vector<size_t> projected_cols{0};
+
+        table_scan_state helper_state(&env.resource);
+        loaded->initialize_scan(helper_state, projected_indices, nullptr);
+        data_chunk_t helper_chunk(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+        REQUIRE(row_group_test_access_t::try_scan_pax_generic_projected(*first_row_group,
+                                                                        helper_state.table_state,
+                                                                        helper_chunk));
+        REQUIRE(helper_chunk.size() == expected_rows.size());
+
+        row_group_test_access_t::reset_scan_path_counts(*first_row_group);
+
+        table_scan_state state(&env.resource);
+        loaded->initialize_scan(state, projected_indices, nullptr);
+        data_chunk_t result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+
+        uint64_t scanned = 0;
+        while (true) {
+            result.reset();
+            loaded->scan(result, state);
+            if (result.size() == 0) {
+                break;
+            }
+
+            for (uint64_t i = 0; i < result.size(); i++) {
+                const auto row = expected_rows[scanned + i];
+                REQUIRE(*result.data[0].value(i).value<std::string*>() == padded_name(row));
+            }
+            scanned += result.size();
+        }
+        REQUIRE(scanned == expected_rows.size());
+        const auto counts = row_group_test_access_t::scan_path_counts(*first_row_group);
+        REQUIRE(counts.pax_generic_projected > 0);
+        REQUIRE(counts.pax_fixed_projected == 0);
+        REQUIRE(counts.regular == 0);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: pax generic projected scan applies active transaction delete visibility") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 512;
+    const auto table_path = test_db_path() + ".pax_generic_active_txn_delete_visibility";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("name", logical_type::STRING_LITERAL);
+        auto table =
+            std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_generic_active_txn_delete");
+        append_nullable_string_data(*table,
+                                    &env.resource,
+                                    NUM_ROWS,
+                                    [](uint64_t row) -> std::optional<std::string> { return padded_name(row); });
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        auto* first_row_group = loaded->row_group()->row_group(0);
+        REQUIRE(first_row_group != nullptr);
+
+        const std::vector<uint64_t> deleted_rows{0, 5, 128, 255, 300, 511};
+        vector_t row_ids(&env.resource, logical_type::BIGINT, deleted_rows.size());
+        for (uint64_t i = 0; i < deleted_rows.size(); i++) {
+            row_ids.set_value(i, logical_value_t{&env.resource, static_cast<int64_t>(deleted_rows[i])});
+        }
+
+        transaction_manager_t txn_manager(&env.resource);
+        auto writer_session = components::session::session_id_t::generate_uid();
+        auto& writer_txn = txn_manager.begin_transaction(writer_session);
+        auto delete_state = loaded->initialize_delete({});
+        REQUIRE(loaded->delete_rows(*delete_state,
+                                    row_ids,
+                                    deleted_rows.size(),
+                                    writer_txn.transaction_id()) == deleted_rows.size());
+
+        std::vector<uint64_t> all_rows;
+        all_rows.reserve(NUM_ROWS);
+        std::vector<uint64_t> committed_visible_rows;
+        committed_visible_rows.reserve(NUM_ROWS - deleted_rows.size());
+        for (uint64_t row = 0; row < NUM_ROWS; row++) {
+            all_rows.push_back(row);
+            if (std::find(deleted_rows.begin(), deleted_rows.end(), row) == deleted_rows.end()) {
+                committed_visible_rows.push_back(row);
+            }
+        }
+
+        std::vector<storage_index_t> projected_indices{storage_index_t(0)};
+        std::vector<size_t> projected_cols{0};
+
+        const auto scan_and_check = [&](transaction_data txn, const std::vector<uint64_t>& expected_rows) {
+            row_group_test_access_t::reset_scan_path_counts(*first_row_group);
+
+            table_scan_state state(&env.resource);
+            loaded->initialize_scan(state, projected_indices, nullptr);
+            state.table_state.txn = txn;
+            data_chunk_t result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+
+            uint64_t scanned = 0;
+            while (true) {
+                result.reset();
+                loaded->scan(result, state);
+                if (result.size() == 0) {
+                    break;
+                }
+
+                for (uint64_t i = 0; i < result.size(); i++) {
+                    const auto row = expected_rows[scanned + i];
+                    REQUIRE(*result.data[0].value(i).value<std::string*>() == padded_name(row));
+                }
+                scanned += result.size();
+            }
+            REQUIRE(scanned == expected_rows.size());
+
+            const auto counts = row_group_test_access_t::scan_path_counts(*first_row_group);
+            REQUIRE(counts.pax_generic_projected > 0);
+            REQUIRE(counts.pax_fixed_projected == 0);
+            REQUIRE(counts.regular == 0);
+        };
+
+        auto reader_session = components::session::session_id_t::generate_uid();
+        auto& reader_txn = txn_manager.begin_transaction(reader_session);
+        scan_and_check(reader_txn.data(), all_rows);
+        txn_manager.abort(reader_session);
+
+        const auto writer_txn_id = writer_txn.transaction_id();
+        const auto commit_id = txn_manager.commit(writer_session);
+        loaded->commit_all_deletes(writer_txn_id, commit_id);
+        txn_manager.publish(commit_id);
+
+        auto fresh_session = components::session::session_id_t::generate_uid();
+        auto& fresh_txn = txn_manager.begin_transaction(fresh_session);
+        scan_and_check(fresh_txn.data(), committed_visible_rows);
+        txn_manager.abort(fresh_session);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: pax generic projected scan persists committed deletes") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 512;
+    const auto table_path = test_db_path() + ".pax_generic_persisted_delete_overlay";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("name", logical_type::STRING_LITERAL);
+        auto table =
+            std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_generic_persisted_delete");
+        append_nullable_string_data(*table,
+                                    &env.resource,
+                                    NUM_ROWS,
+                                    [](uint64_t row) -> std::optional<std::string> { return padded_name(row); });
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    const std::vector<uint64_t> deleted_rows{0, 5, 128, 255, 300, 511};
+    std::vector<uint64_t> expected_rows;
+    for (uint64_t row = 0; row < NUM_ROWS; row++) {
+        if (std::find(deleted_rows.begin(), deleted_rows.end(), row) == deleted_rows.end()) {
+            expected_rows.push_back(row);
+        }
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        delete_committed_rows(*loaded, &env.resource, deleted_rows);
+
+        metadata_writer_t writer(meta_mgr);
+        loaded->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        auto* first_row_group = loaded->row_group()->row_group(0);
+        REQUIRE(first_row_group != nullptr);
+        REQUIRE(row_group_test_access_t::delete_pointer_count(*first_row_group) == 1);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        auto* first_row_group = loaded->row_group()->row_group(0);
+        REQUIRE(first_row_group != nullptr);
+        REQUIRE(row_group_test_access_t::delete_pointer_count(*first_row_group) == 1);
+        REQUIRE(loaded->calculate_size() == expected_rows.size());
+
+        std::vector<storage_index_t> projected_indices{storage_index_t(0)};
+        std::vector<size_t> projected_cols{0};
+
+        table_scan_state helper_state(&env.resource);
+        loaded->initialize_scan(helper_state, projected_indices, nullptr);
+        data_chunk_t helper_chunk(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+        REQUIRE(row_group_test_access_t::try_scan_pax_generic_projected(*first_row_group,
+                                                                        helper_state.table_state,
+                                                                        helper_chunk));
+        REQUIRE(helper_chunk.size() == expected_rows.size());
+
+        row_group_test_access_t::reset_scan_path_counts(*first_row_group);
+
+        table_scan_state state(&env.resource);
+        loaded->initialize_scan(state, projected_indices, nullptr);
+        data_chunk_t result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+
+        uint64_t scanned = 0;
+        while (true) {
+            result.reset();
+            loaded->scan(result, state);
+            if (result.size() == 0) {
+                break;
+            }
+
+            for (uint64_t i = 0; i < result.size(); i++) {
+                const auto row = expected_rows[scanned + i];
+                REQUIRE(*result.data[0].value(i).value<std::string*>() == padded_name(row));
+            }
+            scanned += result.size();
+        }
+        REQUIRE(scanned == expected_rows.size());
+
+        const auto counts = row_group_test_access_t::scan_path_counts(*first_row_group);
+        REQUIRE(counts.pax_generic_projected > 0);
+        REQUIRE(counts.pax_fixed_projected == 0);
+        REQUIRE(counts.regular == 0);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: pax generic projected scan applies update overlay") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 512;
+    const auto table_path = test_db_path() + ".pax_generic_update_overlay";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("name", logical_type::STRING_LITERAL);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_generic_update");
+        append_nullable_string_data(*table,
+                                    &env.resource,
+                                    NUM_ROWS,
+                                    [](uint64_t row) -> std::optional<std::string> { return padded_name(row); });
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        auto* first_row_group = loaded->row_group()->row_group(0);
+        REQUIRE(first_row_group != nullptr);
+
+        const std::vector<uint64_t> updated_rows{5, 128, 300};
+        const std::string updated_value = "zzzz_updated_hot";
+        update_string_column(*loaded,
+                             &env.resource,
+                             0,
+                             updated_rows,
+                             {updated_value, std::nullopt, updated_value});
+
+        std::vector<storage_index_t> projected_indices{storage_index_t(0)};
+        std::vector<size_t> projected_cols{0};
+
+        {
+            table_scan_state helper_state(&env.resource);
+            loaded->initialize_scan(helper_state, projected_indices, nullptr);
+            data_chunk_t helper_chunk(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+            REQUIRE(row_group_test_access_t::try_scan_pax_generic_projected(*first_row_group,
+                                                                            helper_state.table_state,
+                                                                            helper_chunk));
+            REQUIRE(helper_chunk.size() == NUM_ROWS);
+            REQUIRE(*helper_chunk.data[0].value(5).value<std::string*>() == updated_value);
+            REQUIRE(helper_chunk.data[0].is_null(128));
+            REQUIRE(*helper_chunk.data[0].value(300).value<std::string*>() == updated_value);
+        }
+
+        row_group_test_access_t::reset_scan_path_counts(*first_row_group);
+
+        std::pmr::vector<uint64_t> eq_filter_columns(&env.resource);
+        eq_filter_columns.push_back(0);
+        constant_filter_t eq_filter(components::expressions::compare_type::eq,
+                                    logical_value_t{&env.resource, updated_value},
+                                    std::move(eq_filter_columns));
+
+        table_scan_state eq_state(&env.resource);
+        loaded->initialize_scan(eq_state, projected_indices, &eq_filter);
+        data_chunk_t eq_result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+        loaded->scan(eq_result, eq_state);
+        REQUIRE(eq_result.size() == 2);
+        for (uint64_t i = 0; i < eq_result.size(); i++) {
+            REQUIRE(*eq_result.data[0].value(i).value<std::string*>() == updated_value);
+        }
+
+        std::pmr::vector<uint64_t> null_filter_columns(&env.resource);
+        null_filter_columns.push_back(0);
+        is_null_filter_t null_filter(components::expressions::compare_type::is_null, std::move(null_filter_columns));
+
+        table_scan_state null_state(&env.resource);
+        loaded->initialize_scan(null_state, projected_indices, &null_filter);
+        data_chunk_t null_result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+        loaded->scan(null_result, null_state);
+        REQUIRE(null_result.size() == 1);
+        REQUIRE(null_result.data[0].is_null(0));
+
+        const auto counts = row_group_test_access_t::scan_path_counts(*first_row_group);
+        REQUIRE(counts.pax_generic_projected > 0);
+        REQUIRE(counts.pax_fixed_projected == 0);
+        REQUIRE(counts.regular == 0);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: pax generic projected scan supports simple filters") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 300;
+    const auto table_path = test_db_path() + ".pax_generic_filters";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+
+    auto value_fn = [](uint64_t row) -> std::optional<std::string> {
+        if (row % 7 == 0) {
+            return std::nullopt;
+        }
+        return padded_name(row);
+    };
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("name", logical_type::STRING_LITERAL);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_generic_filters");
+        append_nullable_string_data(*table, &env.resource, NUM_ROWS, value_fn);
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+
+        std::vector<storage_index_t> projected_indices{storage_index_t(0)};
+        std::vector<size_t> projected_cols{0};
+
+        std::pmr::vector<uint64_t> eq_filter_columns(&env.resource);
+        eq_filter_columns.push_back(0);
+        constant_filter_t eq_filter(components::expressions::compare_type::eq,
+                                    logical_value_t{&env.resource, padded_name(111)},
+                                    std::move(eq_filter_columns));
+
+        table_scan_state eq_state(&env.resource);
+        loaded->initialize_scan(eq_state, projected_indices, &eq_filter);
+        auto* first_row_group = loaded->row_group()->row_group(0);
+        REQUIRE(first_row_group != nullptr);
+
+        data_chunk_t eq_chunk(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+        REQUIRE(row_group_test_access_t::try_scan_pax_generic_projected(*first_row_group,
+                                                                        eq_state.table_state,
+                                                                        eq_chunk));
+        REQUIRE(eq_chunk.size() == 1);
+        REQUIRE(*eq_chunk.data[0].value(0).value<std::string*>() == padded_name(111));
+
+        row_group_test_access_t::reset_scan_path_counts(*first_row_group);
+
+        std::pmr::vector<uint64_t> gt_filter_columns(&env.resource);
+        gt_filter_columns.push_back(0);
+        constant_filter_t gt_filter(components::expressions::compare_type::gt,
+                                    logical_value_t{&env.resource, padded_name(250)},
+                                    std::move(gt_filter_columns));
+
+        table_scan_state gt_state(&env.resource);
+        loaded->initialize_scan(gt_state, projected_indices, &gt_filter);
+        data_chunk_t gt_result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+        loaded->scan(gt_result, gt_state);
+
+        uint64_t expected_gt_count = 0;
+        for (uint64_t row = 0; row < NUM_ROWS; row++) {
+            auto expected = value_fn(row);
+            if (expected.has_value() && *expected > padded_name(250)) {
+                expected_gt_count++;
+            }
+        }
+        REQUIRE(gt_result.size() == expected_gt_count);
+        for (uint64_t i = 0; i < gt_result.size(); i++) {
+            REQUIRE(*gt_result.data[0].value(i).value<std::string*>() > padded_name(250));
+        }
+
+        std::pmr::vector<uint64_t> miss_filter_columns(&env.resource);
+        miss_filter_columns.push_back(0);
+        constant_filter_t miss_filter(components::expressions::compare_type::eq,
+                                      logical_value_t{&env.resource, padded_name(112)},
+                                      std::move(miss_filter_columns));
+
+        table_scan_state miss_state(&env.resource);
+        loaded->initialize_scan(miss_state, projected_indices, &miss_filter);
+        data_chunk_t miss_result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+        loaded->scan(miss_result, miss_state);
+        REQUIRE(miss_result.size() == 0);
+
+        const auto counts = row_group_test_access_t::scan_path_counts(*first_row_group);
+        REQUIRE(counts.pax_generic_projected > 0);
+        REQUIRE(counts.pax_generic_pruned_pages > 0);
+        REQUIRE(counts.pax_generic_prefetched_blocks > 0);
+        REQUIRE(counts.pax_generic_skipped_payload_pages > 0);
+        REQUIRE(counts.pax_fixed_projected == 0);
+        REQUIRE(counts.regular == 0);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: pax generic projected scan supports non-projected filters and null predicates") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 220;
+    const auto table_path = test_db_path() + ".pax_generic_filter_projection_split";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+
+    auto category_fn = [](uint64_t row) -> std::optional<std::string> {
+        if (row % 6 == 0) {
+            return std::nullopt;
+        }
+        return (row % 2 == 0) ? std::optional<std::string>{"alpha"} : std::optional<std::string>{"beta"};
+    };
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("name", logical_type::STRING_LITERAL);
+        columns.emplace_back("category", logical_type::STRING_LITERAL);
+        auto table =
+            std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_generic_filter_projection_split");
+
+        append_rows(*table, &env.resource, NUM_ROWS, [&](data_chunk_t& chunk, uint64_t row, uint64_t row_in_chunk) {
+            chunk.set_value(0, row_in_chunk, logical_value_t{&env.resource, padded_name(row)});
+            auto category = category_fn(row);
+            if (!category.has_value()) {
+                chunk.data[1].set_null(row_in_chunk, true);
+            } else {
+                chunk.set_value(1, row_in_chunk, logical_value_t{&env.resource, *category});
+            }
+        });
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        auto* first_row_group = loaded->row_group()->row_group(0);
+        REQUIRE(first_row_group != nullptr);
+
+        std::vector<storage_index_t> projected_indices{storage_index_t(0)};
+        std::vector<size_t> projected_cols{0};
+        std::vector<uint64_t> alpha_rows;
+        std::vector<uint64_t> null_rows;
+        for (uint64_t row = 0; row < NUM_ROWS; row++) {
+            auto category = category_fn(row);
+            if (!category.has_value()) {
+                null_rows.push_back(row);
+            } else if (*category == "alpha") {
+                alpha_rows.push_back(row);
+            }
+        }
+
+        {
+            std::pmr::vector<uint64_t> filter_columns(&env.resource);
+            filter_columns.push_back(1);
+            constant_filter_t filter(components::expressions::compare_type::eq,
+                                     logical_value_t{&env.resource, std::string("alpha")},
+                                     std::move(filter_columns));
+
+            table_scan_state helper_state(&env.resource);
+            loaded->initialize_scan(helper_state, projected_indices, &filter);
+            data_chunk_t helper_chunk(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+            REQUIRE(row_group_test_access_t::try_scan_pax_generic_projected(*first_row_group,
+                                                                            helper_state.table_state,
+                                                                            helper_chunk));
+
+            row_group_test_access_t::reset_scan_path_counts(*first_row_group);
+
+            table_scan_state state(&env.resource);
+            loaded->initialize_scan(state, projected_indices, &filter);
+            data_chunk_t result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+
+            uint64_t scanned = 0;
+            while (true) {
+                result.reset();
+                loaded->scan(result, state);
+                if (result.size() == 0) {
+                    break;
+                }
+                for (uint64_t i = 0; i < result.size(); i++) {
+                    REQUIRE(*result.data[0].value(i).value<std::string*>() == padded_name(alpha_rows[scanned + i]));
+                }
+                scanned += result.size();
+            }
+            REQUIRE(scanned == alpha_rows.size());
+
+            const auto counts = row_group_test_access_t::scan_path_counts(*first_row_group);
+            REQUIRE(counts.pax_generic_projected > 0);
+            REQUIRE(counts.pax_generic_prefetched_blocks > 0);
+            REQUIRE(counts.pax_fixed_projected == 0);
+            REQUIRE(counts.regular == 0);
+        }
+
+        {
+            std::pmr::vector<uint64_t> filter_columns(&env.resource);
+            filter_columns.push_back(1);
+            is_null_filter_t filter(components::expressions::compare_type::is_null, std::move(filter_columns));
+
+            table_scan_state state(&env.resource);
+            loaded->initialize_scan(state, projected_indices, &filter);
+            data_chunk_t result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+
+            uint64_t scanned = 0;
+            while (true) {
+                result.reset();
+                loaded->scan(result, state);
+                if (result.size() == 0) {
+                    break;
+                }
+                for (uint64_t i = 0; i < result.size(); i++) {
+                    REQUIRE(*result.data[0].value(i).value<std::string*>() == padded_name(null_rows[scanned + i]));
+                }
+                scanned += result.size();
+            }
+            REQUIRE(scanned == null_rows.size());
+        }
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: pax generic projected scan restores overflow strings") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 260;
+    const auto table_path = test_db_path() + ".pax_generic_projected_overflow";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+
+    auto value_fn = [](uint64_t row) -> std::optional<std::string> {
+        if (row % 9 == 0) {
+            return std::nullopt;
+        }
+        if (row % 5 == 0) {
+            return std::string(6000 + row, static_cast<char>('a' + (row % 26))) + "_" + padded_name(row);
+        }
+        return padded_name(row);
+    };
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("payload", logical_type::STRING_LITERAL);
+        auto table =
+            std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_generic_projected_overflow");
+        append_nullable_string_data(*table, &env.resource, NUM_ROWS, value_fn);
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+
+        std::vector<storage_index_t> projected_indices{storage_index_t(0)};
+        std::vector<size_t> projected_cols{0};
+
+        table_scan_state helper_state(&env.resource);
+        loaded->initialize_scan(helper_state, projected_indices, nullptr);
+        auto* first_row_group = loaded->row_group()->row_group(0);
+        REQUIRE(first_row_group != nullptr);
+
+        data_chunk_t first_chunk(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+        REQUIRE(row_group_test_access_t::try_scan_pax_generic_projected(*first_row_group,
+                                                                        helper_state.table_state,
+                                                                        first_chunk));
+        REQUIRE(first_chunk.size() == NUM_ROWS);
+        for (uint64_t i = 0; i < first_chunk.size(); i++) {
+            auto expected = value_fn(i);
+            REQUIRE(first_chunk.data[0].is_null(i) == !expected.has_value());
+            if (expected.has_value()) {
+                REQUIRE(*first_chunk.data[0].value(i).value<std::string*>() == *expected);
+            }
+        }
+
+        table_scan_state state(&env.resource);
+        loaded->initialize_scan(state, projected_indices, nullptr);
+        data_chunk_t result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+
+        uint64_t scanned = 0;
+        while (true) {
+            result.reset();
+            loaded->scan(result, state);
+            if (result.size() == 0) {
+                break;
+            }
+
+            for (uint64_t i = 0; i < result.size(); i++) {
+                auto expected = value_fn(scanned + i);
+                REQUIRE(result.data[0].is_null(i) == !expected.has_value());
+                if (expected.has_value()) {
+                    REQUIRE(*result.data[0].value(i).value<std::string*>() == *expected);
+                }
+            }
+            scanned += result.size();
+        }
+        REQUIRE(scanned == NUM_ROWS);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: pax generic projected scan supports mixed projection") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 200;
+    const auto table_path = test_db_path() + ".pax_generic_fallback";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("name", logical_type::STRING_LITERAL);
+        columns.emplace_back("id", logical_type::BIGINT);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_generic_fallback");
+
+        auto types = table->copy_types();
+        uint64_t offset = 0;
+        while (offset < NUM_ROWS) {
+            uint64_t batch = std::min(NUM_ROWS - offset, uint64_t(DEFAULT_VECTOR_CAPACITY));
+            data_chunk_t chunk(&env.resource, types, batch);
+            chunk.set_cardinality(batch);
+            for (uint64_t i = 0; i < batch; i++) {
+                const auto row = offset + i;
+                chunk.set_value(0, i, logical_value_t{&env.resource, padded_name(row)});
+                chunk.set_value(1, i, logical_value_t{&env.resource, static_cast<int64_t>(row * 2)});
+            }
+            table_append_state state(&env.resource);
+            table->append_lock(state);
+            table->initialize_append(state);
+            table->append(chunk, state);
+            table->finalize_append(state, transaction_data{0, 0});
+            offset += batch;
+        }
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+
+        std::vector<storage_index_t> projected_indices{storage_index_t(0), storage_index_t(1)};
+        std::vector<size_t> projected_cols{0, 1};
+
+        table_scan_state helper_state(&env.resource);
+        loaded->initialize_scan(helper_state, projected_indices, nullptr);
+        auto* first_row_group = loaded->row_group()->row_group(0);
+        REQUIRE(first_row_group != nullptr);
+
+        data_chunk_t helper_chunk(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+        REQUIRE(row_group_test_access_t::try_scan_pax_generic_projected(*first_row_group,
+                                                                        helper_state.table_state,
+                                                                        helper_chunk));
+        REQUIRE(helper_chunk.size() == NUM_ROWS);
+        for (uint64_t i = 0; i < helper_chunk.size(); i++) {
+            REQUIRE(*helper_chunk.data[0].value(i).value<std::string*>() == padded_name(i));
+            REQUIRE(helper_chunk.data[1].value(i).value<int64_t>() == static_cast<int64_t>(i * 2));
+        }
+
+        {
+            std::vector<storage_index_t> row_id_projection{storage_index_t(0), storage_index_t()};
+            std::pmr::vector<complex_logical_type> row_id_result_types(&env.resource);
+            row_id_result_types.emplace_back(logical_type::STRING_LITERAL);
+            row_id_result_types.emplace_back(logical_type::BIGINT);
+            table_scan_state row_id_state(&env.resource);
+            loaded->initialize_scan(row_id_state, row_id_projection, nullptr);
+            data_chunk_t row_id_result(&env.resource, row_id_result_types, DEFAULT_VECTOR_CAPACITY);
+            REQUIRE(row_group_test_access_t::try_scan_pax_generic_projected(*first_row_group,
+                                                                            row_id_state.table_state,
+                                                                            row_id_result));
+            REQUIRE(row_id_result.size() == NUM_ROWS);
+            for (uint64_t i = 0; i < row_id_result.size(); i++) {
+                REQUIRE(*row_id_result.data[0].value(i).value<std::string*>() == padded_name(i));
+                REQUIRE(row_id_result.data[1].value(i).value<int64_t>() == static_cast<int64_t>(i));
+            }
+        }
+
+        {
+            std::vector<storage_index_t> string_projection{storage_index_t(0)};
+            std::vector<size_t> string_projected_cols{0};
+            std::pmr::vector<uint64_t> filter_columns(&env.resource);
+            filter_columns.push_back(0);
+            constant_filter_t invalid_filter(components::expressions::compare_type::invalid,
+                                             logical_value_t{&env.resource, padded_name(10)},
+                                             std::move(filter_columns));
+            table_scan_state invalid_filter_state(&env.resource);
+            loaded->initialize_scan(invalid_filter_state, string_projection, &invalid_filter);
+            data_chunk_t invalid_filter_result(&env.resource,
+                                               loaded->copy_types(),
+                                               string_projected_cols,
+                                               DEFAULT_VECTOR_CAPACITY);
+            REQUIRE_FALSE(row_group_test_access_t::try_scan_pax_generic_projected(*first_row_group,
+                                                                                  invalid_filter_state.table_state,
+                                                                                  invalid_filter_result));
+        }
+
+        row_group_test_access_t::reset_scan_path_counts(*first_row_group);
+
+        table_scan_state state(&env.resource);
+        loaded->initialize_scan(state, projected_indices, nullptr);
+        data_chunk_t result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+
+        uint64_t scanned = 0;
+        while (true) {
+            result.reset();
+            loaded->scan(result, state);
+            if (result.size() == 0) {
+                break;
+            }
+            for (uint64_t i = 0; i < result.size(); i++) {
+                const auto row = scanned + i;
+                REQUIRE(*result.data[0].value(i).value<std::string*>() == padded_name(row));
+                REQUIRE(result.data[1].value(i).value<int64_t>() == static_cast<int64_t>(row * 2));
+            }
+            scanned += result.size();
+        }
+        REQUIRE(scanned == NUM_ROWS);
+
+        const auto counts = row_group_test_access_t::scan_path_counts(*first_row_group);
+        REQUIRE(counts.pax_generic_projected > 0);
+        REQUIRE(counts.pax_generic_pruned_pages == 0);
+        REQUIRE(counts.pax_generic_prefetched_blocks > 0);
+        REQUIRE(counts.pax_generic_skipped_payload_pages == 0);
+        REQUIRE(counts.pax_fixed_projected == 0);
+        REQUIRE(counts.regular == 0);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: pax fixed projected scan uses fast path") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 1300;
+    const auto table_path = test_db_path() + ".pax_scan";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("id", logical_type::BIGINT);
+        columns.emplace_back("value", logical_type::UINTEGER);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_scan");
+        append_fixed_integer_pair(*table,
+                                  &env.resource,
+                                  NUM_ROWS,
+                                  [](uint64_t row) { return static_cast<int64_t>(row); },
+                                  [](uint64_t row) { return static_cast<uint32_t>(row * 3); });
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+
+        std::vector<storage_index_t> projected_indices{storage_index_t(0), storage_index_t(1)};
+        std::vector<size_t> projected_cols{0, 1};
+
+        table_scan_state helper_state(&env.resource);
+        loaded->initialize_scan(helper_state, projected_indices, nullptr);
+        auto* first_row_group = loaded->row_group()->row_group(0);
+        REQUIRE(first_row_group != nullptr);
+
+        data_chunk_t first_chunk(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+        REQUIRE(row_group_test_access_t::try_scan_pax_fixed_projected(*first_row_group,
+                                                                      helper_state.table_state,
+                                                                      first_chunk));
+        REQUIRE(first_chunk.size() == DEFAULT_VECTOR_CAPACITY);
+        for (uint64_t i = 0; i < first_chunk.size(); i++) {
+            REQUIRE(first_chunk.data[0].value(i).value<int64_t>() == static_cast<int64_t>(i));
+            REQUIRE(first_chunk.data[1].value(i).value<uint32_t>() == static_cast<uint32_t>(i * 3));
+        }
+
+        row_group_test_access_t::reset_scan_path_counts(*first_row_group);
+
+        table_scan_state state(&env.resource);
+        loaded->initialize_scan(state, projected_indices, nullptr);
+        data_chunk_t result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+
+        uint64_t scanned = 0;
+        while (true) {
+            result.reset();
+            loaded->scan(result, state);
+            if (result.size() == 0) {
+                break;
+            }
+
+            for (uint64_t i = 0; i < result.size(); i++) {
+                const auto row = scanned + i;
+                REQUIRE(result.data[0].value(i).value<int64_t>() == static_cast<int64_t>(row));
+                REQUIRE(result.data[1].value(i).value<uint32_t>() == static_cast<uint32_t>(row * 3));
+            }
+            scanned += result.size();
+        }
+        REQUIRE(scanned == NUM_ROWS);
+        const auto counts = row_group_test_access_t::scan_path_counts(*first_row_group);
+        REQUIRE(counts.pax_generic_projected == 0);
+        REQUIRE(counts.pax_fixed_projected > 0);
+        REQUIRE(counts.pax_fixed_pruned_pages == 0);
+        REQUIRE(counts.pax_fixed_prefetched_blocks > 0);
+        REQUIRE(counts.pax_fixed_skipped_payload_pages == 0);
+        REQUIRE(counts.regular == 0);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: pax fixed projected scan skips committed deletes") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 512;
+    const auto table_path = test_db_path() + ".pax_fixed_delete_overlay";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("id", logical_type::BIGINT);
+        columns.emplace_back("value", logical_type::UINTEGER);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_fixed_delete");
+        append_fixed_integer_pair(*table,
+                                  &env.resource,
+                                  NUM_ROWS,
+                                  [](uint64_t row) { return static_cast<int64_t>(row); },
+                                  [](uint64_t row) { return static_cast<uint32_t>(row * 3); });
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        auto* first_row_group = loaded->row_group()->row_group(0);
+        REQUIRE(first_row_group != nullptr);
+
+        const std::vector<uint64_t> deleted_rows{0, 3, 128, 255, 256, 511};
+        delete_committed_rows(*loaded, &env.resource, deleted_rows);
+
+        std::vector<uint64_t> expected_rows;
+        for (uint64_t row = 0; row < NUM_ROWS; row++) {
+            if (std::find(deleted_rows.begin(), deleted_rows.end(), row) == deleted_rows.end()) {
+                expected_rows.push_back(row);
+            }
+        }
+
+        std::vector<storage_index_t> projected_indices{storage_index_t(0), storage_index_t(1)};
+        std::vector<size_t> projected_cols{0, 1};
+
+        table_scan_state helper_state(&env.resource);
+        loaded->initialize_scan(helper_state, projected_indices, nullptr);
+        data_chunk_t helper_chunk(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+        REQUIRE(row_group_test_access_t::try_scan_pax_fixed_projected(*first_row_group,
+                                                                      helper_state.table_state,
+                                                                      helper_chunk));
+        REQUIRE(helper_chunk.size() == expected_rows.size());
+
+        {
+            std::vector<storage_index_t> row_id_projection{storage_index_t(0), storage_index_t()};
+            std::pmr::vector<complex_logical_type> row_id_result_types(&env.resource);
+            row_id_result_types.emplace_back(logical_type::BIGINT);
+            row_id_result_types.emplace_back(logical_type::BIGINT);
+            table_scan_state row_id_state(&env.resource);
+            loaded->initialize_scan(row_id_state, row_id_projection, nullptr);
+            data_chunk_t row_id_result(&env.resource, row_id_result_types, DEFAULT_VECTOR_CAPACITY);
+            REQUIRE(row_group_test_access_t::try_scan_pax_fixed_projected(*first_row_group,
+                                                                          row_id_state.table_state,
+                                                                          row_id_result));
+            REQUIRE(row_id_result.size() == expected_rows.size());
+            for (uint64_t i = 0; i < row_id_result.size(); i++) {
+                const auto row = expected_rows[i];
+                REQUIRE(row_id_result.data[0].value(i).value<int64_t>() == static_cast<int64_t>(row));
+                REQUIRE(row_id_result.data[1].value(i).value<int64_t>() == static_cast<int64_t>(row));
+            }
+        }
+
+        row_group_test_access_t::reset_scan_path_counts(*first_row_group);
+
+        table_scan_state state(&env.resource);
+        loaded->initialize_scan(state, projected_indices, nullptr);
+        data_chunk_t result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+
+        uint64_t scanned = 0;
+        while (true) {
+            result.reset();
+            loaded->scan(result, state);
+            if (result.size() == 0) {
+                break;
+            }
+
+            for (uint64_t i = 0; i < result.size(); i++) {
+                const auto row = expected_rows[scanned + i];
+                REQUIRE(result.data[0].value(i).value<int64_t>() == static_cast<int64_t>(row));
+                REQUIRE(result.data[1].value(i).value<uint32_t>() == static_cast<uint32_t>(row * 3));
+            }
+            scanned += result.size();
+        }
+        REQUIRE(scanned == expected_rows.size());
+
+        auto counts = row_group_test_access_t::scan_path_counts(*first_row_group);
+        REQUIRE(counts.pax_fixed_projected > 0);
+        REQUIRE(counts.regular == 0);
+
+        row_group_test_access_t::reset_scan_path_counts(*first_row_group);
+
+        std::pmr::vector<uint64_t> filter_columns(&env.resource);
+        filter_columns.push_back(0);
+        constant_filter_t filter(components::expressions::compare_type::gte,
+                                 logical_value_t{&env.resource, int64_t(250)},
+                                 std::move(filter_columns));
+
+        std::vector<uint64_t> filtered_expected_rows;
+        for (auto row : expected_rows) {
+            if (row >= 250) {
+                filtered_expected_rows.push_back(row);
+            }
+        }
+
+        table_scan_state filtered_state(&env.resource);
+        loaded->initialize_scan(filtered_state, projected_indices, &filter);
+        data_chunk_t filtered_result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+
+        scanned = 0;
+        while (true) {
+            filtered_result.reset();
+            loaded->scan(filtered_result, filtered_state);
+            if (filtered_result.size() == 0) {
+                break;
+            }
+
+            for (uint64_t i = 0; i < filtered_result.size(); i++) {
+                const auto row = filtered_expected_rows[scanned + i];
+                REQUIRE(filtered_result.data[0].value(i).value<int64_t>() == static_cast<int64_t>(row));
+                REQUIRE(filtered_result.data[1].value(i).value<uint32_t>() == static_cast<uint32_t>(row * 3));
+            }
+            scanned += filtered_result.size();
+        }
+        REQUIRE(scanned == filtered_expected_rows.size());
+
+        counts = row_group_test_access_t::scan_path_counts(*first_row_group);
+        REQUIRE(counts.pax_fixed_projected > 0);
+        REQUIRE(counts.regular == 0);
+
+        row_group_test_access_t::reset_scan_path_counts(*first_row_group);
+
+        conjunction_and_filter_t range_filter;
+        std::pmr::vector<uint64_t> lower_filter_columns(&env.resource);
+        lower_filter_columns.push_back(0);
+        range_filter.child_filters.push_back(std::make_unique<constant_filter_t>(
+            components::expressions::compare_type::gte,
+            logical_value_t{&env.resource, int64_t(300)},
+            std::move(lower_filter_columns)));
+        std::pmr::vector<uint64_t> upper_filter_columns(&env.resource);
+        upper_filter_columns.push_back(0);
+        range_filter.child_filters.push_back(std::make_unique<constant_filter_t>(
+            components::expressions::compare_type::lt,
+            logical_value_t{&env.resource, int64_t(320)},
+            std::move(upper_filter_columns)));
+
+        std::vector<uint64_t> range_expected_rows;
+        for (auto row : expected_rows) {
+            if (row >= 300 && row < 320) {
+                range_expected_rows.push_back(row);
+            }
+        }
+
+        table_scan_state range_state(&env.resource);
+        loaded->initialize_scan(range_state, projected_indices, &range_filter);
+        data_chunk_t range_result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+
+        scanned = 0;
+        while (true) {
+            range_result.reset();
+            loaded->scan(range_result, range_state);
+            if (range_result.size() == 0) {
+                break;
+            }
+
+            for (uint64_t i = 0; i < range_result.size(); i++) {
+                const auto row = range_expected_rows[scanned + i];
+                REQUIRE(range_result.data[0].value(i).value<int64_t>() == static_cast<int64_t>(row));
+                REQUIRE(range_result.data[1].value(i).value<uint32_t>() == static_cast<uint32_t>(row * 3));
+            }
+            scanned += range_result.size();
+        }
+        REQUIRE(scanned == range_expected_rows.size());
+
+        counts = row_group_test_access_t::scan_path_counts(*first_row_group);
+        REQUIRE(counts.pax_fixed_projected > 0);
+        REQUIRE(counts.pax_fixed_pruned_pages > 0);
+        REQUIRE(counts.regular == 0);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: pax fixed projected scan applies active transaction delete visibility") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 512;
+    const auto table_path = test_db_path() + ".pax_fixed_active_txn_delete_visibility";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("id", logical_type::BIGINT);
+        columns.emplace_back("value", logical_type::UINTEGER);
+        auto table =
+            std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_fixed_active_txn_delete");
+        append_fixed_integer_pair(*table,
+                                  &env.resource,
+                                  NUM_ROWS,
+                                  [](uint64_t row) { return static_cast<int64_t>(row); },
+                                  [](uint64_t row) { return static_cast<uint32_t>(row * 5); });
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        auto* first_row_group = loaded->row_group()->row_group(0);
+        REQUIRE(first_row_group != nullptr);
+
+        const std::vector<uint64_t> deleted_rows{0, 3, 128, 255, 256, 511};
+        vector_t row_ids(&env.resource, logical_type::BIGINT, deleted_rows.size());
+        for (uint64_t i = 0; i < deleted_rows.size(); i++) {
+            row_ids.set_value(i, logical_value_t{&env.resource, static_cast<int64_t>(deleted_rows[i])});
+        }
+
+        transaction_manager_t txn_manager(&env.resource);
+        auto writer_session = components::session::session_id_t::generate_uid();
+        auto& writer_txn = txn_manager.begin_transaction(writer_session);
+        auto delete_state = loaded->initialize_delete({});
+        REQUIRE(loaded->delete_rows(*delete_state,
+                                    row_ids,
+                                    deleted_rows.size(),
+                                    writer_txn.transaction_id()) == deleted_rows.size());
+
+        std::vector<uint64_t> all_rows;
+        all_rows.reserve(NUM_ROWS);
+        std::vector<uint64_t> committed_visible_rows;
+        committed_visible_rows.reserve(NUM_ROWS - deleted_rows.size());
+        for (uint64_t row = 0; row < NUM_ROWS; row++) {
+            all_rows.push_back(row);
+            if (std::find(deleted_rows.begin(), deleted_rows.end(), row) == deleted_rows.end()) {
+                committed_visible_rows.push_back(row);
+            }
+        }
+
+        std::vector<storage_index_t> projected_indices{storage_index_t(0), storage_index_t(1)};
+        std::vector<size_t> projected_cols{0, 1};
+
+        const auto scan_and_check = [&](transaction_data txn, const std::vector<uint64_t>& expected_rows) {
+            row_group_test_access_t::reset_scan_path_counts(*first_row_group);
+
+            table_scan_state state(&env.resource);
+            loaded->initialize_scan(state, projected_indices, nullptr);
+            state.table_state.txn = txn;
+            data_chunk_t result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+
+            uint64_t scanned = 0;
+            while (true) {
+                result.reset();
+                loaded->scan(result, state);
+                if (result.size() == 0) {
+                    break;
+                }
+
+                for (uint64_t i = 0; i < result.size(); i++) {
+                    const auto row = expected_rows[scanned + i];
+                    REQUIRE(result.data[0].value(i).value<int64_t>() == static_cast<int64_t>(row));
+                    REQUIRE(result.data[1].value(i).value<uint32_t>() == static_cast<uint32_t>(row * 5));
+                }
+                scanned += result.size();
+            }
+            REQUIRE(scanned == expected_rows.size());
+
+            const auto counts = row_group_test_access_t::scan_path_counts(*first_row_group);
+            REQUIRE(counts.pax_fixed_projected > 0);
+            REQUIRE(counts.regular == 0);
+        };
+
+        auto reader_session = components::session::session_id_t::generate_uid();
+        auto& reader_txn = txn_manager.begin_transaction(reader_session);
+        scan_and_check(reader_txn.data(), all_rows);
+        txn_manager.abort(reader_session);
+
+        const auto writer_txn_id = writer_txn.transaction_id();
+        const auto commit_id = txn_manager.commit(writer_session);
+        loaded->commit_all_deletes(writer_txn_id, commit_id);
+        txn_manager.publish(commit_id);
+
+        auto fresh_session = components::session::session_id_t::generate_uid();
+        auto& fresh_txn = txn_manager.begin_transaction(fresh_session);
+        scan_and_check(fresh_txn.data(), committed_visible_rows);
+        txn_manager.abort(fresh_session);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: pax fixed projected scan persists committed deletes") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 512;
+    const auto table_path = test_db_path() + ".pax_fixed_persisted_delete_overlay";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("id", logical_type::BIGINT);
+        columns.emplace_back("value", logical_type::UINTEGER);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_fixed_persisted_delete");
+        append_fixed_integer_pair(*table,
+                                  &env.resource,
+                                  NUM_ROWS,
+                                  [](uint64_t row) { return static_cast<int64_t>(row); },
+                                  [](uint64_t row) { return static_cast<uint32_t>(row * 3); });
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    const std::vector<uint64_t> deleted_rows{0, 3, 128, 255, 256, 511};
+    std::vector<uint64_t> expected_rows;
+    for (uint64_t row = 0; row < NUM_ROWS; row++) {
+        if (std::find(deleted_rows.begin(), deleted_rows.end(), row) == deleted_rows.end()) {
+            expected_rows.push_back(row);
+        }
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        delete_committed_rows(*loaded, &env.resource, deleted_rows);
+
+        metadata_writer_t writer(meta_mgr);
+        loaded->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        auto* first_row_group = loaded->row_group()->row_group(0);
+        REQUIRE(first_row_group != nullptr);
+        REQUIRE(row_group_test_access_t::delete_pointer_count(*first_row_group) == 1);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        auto* first_row_group = loaded->row_group()->row_group(0);
+        REQUIRE(first_row_group != nullptr);
+        REQUIRE(row_group_test_access_t::delete_pointer_count(*first_row_group) == 1);
+        REQUIRE(loaded->calculate_size() == expected_rows.size());
+
+        std::vector<storage_index_t> projected_indices{storage_index_t(0), storage_index_t(1)};
+        std::vector<size_t> projected_cols{0, 1};
+
+        table_scan_state helper_state(&env.resource);
+        loaded->initialize_scan(helper_state, projected_indices, nullptr);
+        data_chunk_t helper_chunk(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+        REQUIRE(row_group_test_access_t::try_scan_pax_fixed_projected(*first_row_group,
+                                                                      helper_state.table_state,
+                                                                      helper_chunk));
+        REQUIRE(helper_chunk.size() == expected_rows.size());
+
+        row_group_test_access_t::reset_scan_path_counts(*first_row_group);
+
+        table_scan_state state(&env.resource);
+        loaded->initialize_scan(state, projected_indices, nullptr);
+        data_chunk_t result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+
+        uint64_t scanned = 0;
+        while (true) {
+            result.reset();
+            loaded->scan(result, state);
+            if (result.size() == 0) {
+                break;
+            }
+
+            for (uint64_t i = 0; i < result.size(); i++) {
+                const auto row = expected_rows[scanned + i];
+                REQUIRE(result.data[0].value(i).value<int64_t>() == static_cast<int64_t>(row));
+                REQUIRE(result.data[1].value(i).value<uint32_t>() == static_cast<uint32_t>(row * 3));
+            }
+            scanned += result.size();
+        }
+        REQUIRE(scanned == expected_rows.size());
+
+        const auto counts = row_group_test_access_t::scan_path_counts(*first_row_group);
+        REQUIRE(counts.pax_fixed_projected > 0);
+        REQUIRE(counts.regular == 0);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: pax fixed projected scan applies update overlay") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 512;
+    const auto table_path = test_db_path() + ".pax_fixed_update_overlay";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("id", logical_type::BIGINT);
+        columns.emplace_back("value", logical_type::UINTEGER);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_fixed_update");
+        append_fixed_integer_pair(*table,
+                                  &env.resource,
+                                  NUM_ROWS,
+                                  [](uint64_t row) { return static_cast<int64_t>(row); },
+                                  [](uint64_t row) { return static_cast<uint32_t>(row * 3); });
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        auto* first_row_group = loaded->row_group()->row_group(0);
+        REQUIRE(first_row_group != nullptr);
+
+        const std::vector<uint64_t> updated_rows{5, 128, 300};
+        update_fixed_column(*loaded,
+                            &env.resource,
+                            0,
+                            updated_rows,
+                            {logical_value_t{&env.resource, int64_t(100005)},
+                             logical_value_t{&env.resource, int64_t(100128)},
+                             logical_value_t{&env.resource, int64_t(100300)}},
+                            logical_type::BIGINT);
+        update_fixed_column(*loaded,
+                            &env.resource,
+                            1,
+                            updated_rows,
+                            {logical_value_t{&env.resource, uint32_t(9005)},
+                             logical_value_t{&env.resource, uint32_t(9128)},
+                             logical_value_t{&env.resource, uint32_t(9300)}},
+                            logical_type::UINTEGER);
+
+        std::vector<storage_index_t> projected_indices{storage_index_t(0), storage_index_t(1)};
+        std::vector<size_t> projected_cols{0, 1};
+
+        {
+            table_scan_state helper_state(&env.resource);
+            loaded->initialize_scan(helper_state, projected_indices, nullptr);
+            data_chunk_t helper_chunk(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+            REQUIRE(row_group_test_access_t::try_scan_pax_fixed_projected(*first_row_group,
+                                                                          helper_state.table_state,
+                                                                          helper_chunk));
+            REQUIRE(helper_chunk.size() == NUM_ROWS);
+            REQUIRE(helper_chunk.data[0].value(5).value<int64_t>() == int64_t(100005));
+            REQUIRE(helper_chunk.data[1].value(5).value<uint32_t>() == uint32_t(9005));
+            REQUIRE(helper_chunk.data[0].value(128).value<int64_t>() == int64_t(100128));
+            REQUIRE(helper_chunk.data[1].value(128).value<uint32_t>() == uint32_t(9128));
+            REQUIRE(helper_chunk.data[0].value(300).value<int64_t>() == int64_t(100300));
+            REQUIRE(helper_chunk.data[1].value(300).value<uint32_t>() == uint32_t(9300));
+        }
+
+        row_group_test_access_t::reset_scan_path_counts(*first_row_group);
+
+        std::pmr::vector<uint64_t> filter_columns(&env.resource);
+        filter_columns.push_back(0);
+        constant_filter_t filter(components::expressions::compare_type::gte,
+                                 logical_value_t{&env.resource, int64_t(100000)},
+                                 std::move(filter_columns));
+
+        table_scan_state state(&env.resource);
+        loaded->initialize_scan(state, projected_indices, &filter);
+        data_chunk_t result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+        loaded->scan(result, state);
+        REQUIRE(result.size() == updated_rows.size());
+        REQUIRE(result.data[0].value(0).value<int64_t>() == int64_t(100005));
+        REQUIRE(result.data[1].value(0).value<uint32_t>() == uint32_t(9005));
+        REQUIRE(result.data[0].value(1).value<int64_t>() == int64_t(100128));
+        REQUIRE(result.data[1].value(1).value<uint32_t>() == uint32_t(9128));
+        REQUIRE(result.data[0].value(2).value<int64_t>() == int64_t(100300));
+        REQUIRE(result.data[1].value(2).value<uint32_t>() == uint32_t(9300));
+
+        const auto counts = row_group_test_access_t::scan_path_counts(*first_row_group);
+        REQUIRE(counts.pax_generic_projected == 0);
+        REQUIRE(counts.pax_fixed_projected > 0);
+        REQUIRE(counts.regular == 0);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: pax fixed projected scan supports dml update predicate tree") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 768;
+    const auto table_path = test_db_path() + ".pax_fixed_update_predicate_tree";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("id", logical_type::BIGINT);
+        columns.emplace_back("flag", logical_type::UINTEGER);
+        columns.emplace_back("version", logical_type::UINTEGER);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_fixed_update_tree");
+
+        append_rows(*table, &env.resource, NUM_ROWS, [&](data_chunk_t& chunk, uint64_t row, uint64_t row_in_chunk) {
+            chunk.set_value(0, row_in_chunk, logical_value_t{&env.resource, static_cast<int64_t>(row)});
+            chunk.set_value(1, row_in_chunk, logical_value_t{&env.resource, uint32_t{0}});
+            chunk.set_value(2, row_in_chunk, logical_value_t{&env.resource, uint32_t{1}});
+        });
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        auto* first_row_group = loaded->row_group()->row_group(0);
+        REQUIRE(first_row_group != nullptr);
+
+        const std::vector<uint64_t> updated_rows{300, 305, 540, 600};
+        update_fixed_column(*loaded,
+                            &env.resource,
+                            1,
+                            updated_rows,
+                            {logical_value_t{&env.resource, uint32_t{0}},
+                             logical_value_t{&env.resource, uint32_t{1}},
+                             logical_value_t{&env.resource, uint32_t{1}},
+                             logical_value_t{&env.resource, uint32_t{1}}},
+                            logical_type::UINTEGER);
+        update_fixed_column(*loaded,
+                            &env.resource,
+                            2,
+                            updated_rows,
+                            {logical_value_t{&env.resource, uint32_t{2}},
+                             logical_value_t{&env.resource, uint32_t{1}},
+                             logical_value_t{&env.resource, uint32_t{2}},
+                             logical_value_t{&env.resource, uint32_t{2}}},
+                            logical_type::UINTEGER);
+
+        conjunction_and_filter_t filter;
+        std::pmr::vector<uint64_t> lower_filter_columns(&env.resource);
+        lower_filter_columns.push_back(0);
+        filter.child_filters.push_back(std::make_unique<constant_filter_t>(
+            components::expressions::compare_type::gte,
+            logical_value_t{&env.resource, int64_t{260}},
+            std::move(lower_filter_columns)));
+        std::pmr::vector<uint64_t> upper_filter_columns(&env.resource);
+        upper_filter_columns.push_back(0);
+        filter.child_filters.push_back(std::make_unique<constant_filter_t>(
+            components::expressions::compare_type::lt,
+            logical_value_t{&env.resource, int64_t{580}},
+            std::move(upper_filter_columns)));
+
+        auto changed_filter = std::make_unique<conjunction_or_filter_t>();
+        std::pmr::vector<uint64_t> flag_filter_columns(&env.resource);
+        flag_filter_columns.push_back(1);
+        changed_filter->child_filters.push_back(std::make_unique<constant_filter_t>(
+            components::expressions::compare_type::ne,
+            logical_value_t{&env.resource, uint32_t{0}},
+            std::move(flag_filter_columns)));
+        std::pmr::vector<uint64_t> version_filter_columns(&env.resource);
+        version_filter_columns.push_back(2);
+        changed_filter->child_filters.push_back(std::make_unique<constant_filter_t>(
+            components::expressions::compare_type::ne,
+            logical_value_t{&env.resource, uint32_t{1}},
+            std::move(version_filter_columns)));
+        filter.child_filters.push_back(std::move(changed_filter));
+
+        row_group_test_access_t::reset_scan_path_counts(*first_row_group);
+
+        std::vector<storage_index_t> projected_indices{storage_index_t(0), storage_index_t(1), storage_index_t(2)};
+        std::vector<size_t> projected_cols{0, 1, 2};
+        table_scan_state state(&env.resource);
+        loaded->initialize_scan(state, projected_indices, &filter);
+        data_chunk_t result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+
+        const std::vector<uint64_t> expected_rows{300, 305, 540};
+        uint64_t scanned = 0;
+        while (true) {
+            result.reset();
+            loaded->scan(result, state);
+            if (result.size() == 0) {
+                break;
+            }
+
+            for (uint64_t i = 0; i < result.size(); i++) {
+                const auto row = expected_rows[scanned + i];
+                REQUIRE(result.data[0].value(i).value<int64_t>() == static_cast<int64_t>(row));
+                REQUIRE(result.data[1].value(i).value<uint32_t>() == (row == 300 ? uint32_t{0} : uint32_t{1}));
+                REQUIRE(result.data[2].value(i).value<uint32_t>() == (row == 305 ? uint32_t{1} : uint32_t{2}));
+            }
+            scanned += result.size();
+        }
+        REQUIRE(scanned == expected_rows.size());
+
+        const auto counts = row_group_test_access_t::scan_path_counts(*first_row_group);
+        REQUIRE(counts.pax_generic_projected == 0);
+        REQUIRE(counts.pax_fixed_projected > 0);
+        REQUIRE(counts.pax_fixed_pruned_pages > 0);
+        REQUIRE(counts.regular == 0);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: pax fixed projected scan survives append after checkpoint") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t BASE_ROWS = DEFAULT_VECTOR_CAPACITY * 2 + 100;
+    constexpr uint64_t APPEND_ROWS = 50;
+    const auto table_path = test_db_path() + ".pax_fixed_append_after_checkpoint";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("id", logical_type::BIGINT);
+        columns.emplace_back("value", logical_type::UINTEGER);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_fixed_append");
+        append_fixed_integer_pair(*table,
+                                  &env.resource,
+                                  BASE_ROWS,
+                                  [](uint64_t row) { return static_cast<int64_t>(row); },
+                                  [](uint64_t row) { return static_cast<uint32_t>(row * 3); });
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+
+        append_fixed_integer_pair(*loaded,
+                                  &env.resource,
+                                  APPEND_ROWS,
+                                  [](uint64_t row) { return static_cast<int64_t>(BASE_ROWS + row); },
+                                  [](uint64_t row) { return static_cast<uint32_t>((BASE_ROWS + row) * 3); });
+
+        auto* first_row_group = loaded->row_group()->row_group(0);
+        auto* second_row_group = loaded->row_group()->row_group(1);
+        auto* partial_row_group = loaded->row_group()->row_group(2);
+        REQUIRE(first_row_group != nullptr);
+        REQUIRE(second_row_group != nullptr);
+        REQUIRE(partial_row_group != nullptr);
+        row_group_test_access_t::reset_scan_path_counts(*first_row_group);
+        row_group_test_access_t::reset_scan_path_counts(*second_row_group);
+        row_group_test_access_t::reset_scan_path_counts(*partial_row_group);
+
+        std::vector<storage_index_t> projected_indices{storage_index_t(0), storage_index_t(1)};
+        std::vector<size_t> projected_cols{0, 1};
+
+        table_scan_state state(&env.resource);
+        loaded->initialize_scan(state, projected_indices, nullptr);
+        data_chunk_t result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+
+        uint64_t scanned = 0;
+        while (true) {
+            result.reset();
+            loaded->scan(result, state);
+            if (result.size() == 0) {
+                break;
+            }
+            for (uint64_t i = 0; i < result.size(); i++) {
+                const auto row = scanned + i;
+                REQUIRE(result.data[0].value(i).value<int64_t>() == static_cast<int64_t>(row));
+                REQUIRE(result.data[1].validity().row_is_valid(i));
+                REQUIRE(result.data[1].value(i).value<uint32_t>() == static_cast<uint32_t>(row * 3));
+            }
+            scanned += result.size();
+        }
+        REQUIRE(scanned == BASE_ROWS + APPEND_ROWS);
+
+        const auto first_counts = row_group_test_access_t::scan_path_counts(*first_row_group);
+        const auto second_counts = row_group_test_access_t::scan_path_counts(*second_row_group);
+        const auto partial_counts = row_group_test_access_t::scan_path_counts(*partial_row_group);
+        REQUIRE(first_counts.pax_generic_projected == 0);
+        REQUIRE(second_counts.pax_generic_projected == 0);
+        REQUIRE(partial_counts.pax_generic_projected == 0);
+        REQUIRE(first_counts.pax_fixed_projected > 0);
+        REQUIRE(second_counts.pax_fixed_projected > 0);
+        REQUIRE(partial_counts.regular > 0);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+// A data block whose on-disk CRC32c no longer matches must be rejected on reopen, not scanned
+// (the prefetch/batch read path also has to verify, not just metadata blocks).
+TEST_CASE("checkpoint_load: torn/corrupt database header recovers from intact slot or throws") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    constexpr uint64_t ROWS = 1000;
+    const auto table_path = test_db_path() + ".hdr_fault";
+    std::remove(table_path.c_str());
+
+    // Phase 1: build + checkpoint. write_header stamps both header slots with valid checksums.
+    {
+        test_env_t env;
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("v", logical_type::BIGINT);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "hdr");
+        append_int64_data(*table, &env.resource, ROWS);
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        bm.set_meta_block(writer.get_block_pointer().block_pointer);
+        database_header_t header;
+        header.initialize();
+        header.meta_block = writer.get_block_pointer().block_pointer;
+        bm.write_header(header);
+        bm.file_sync();
+    }
+
+    // Flip a byte in the checksummed meta_block field of a header slot so its stored checksum no longer matches.
+    const auto corrupt_header_slot = [&](uint64_t slot_offset) {
+        std::fstream f(table_path, std::ios::in | std::ios::out | std::ios::binary);
+        REQUIRE(f.is_open());
+        const auto pos = static_cast<std::streamoff>(slot_offset + sizeof(uint64_t)); // meta_block field
+        f.seekg(pos);
+        char b = 0;
+        f.read(&b, 1);
+        REQUIRE(f.good());
+        b = static_cast<char>(static_cast<unsigned char>(b) ^ 0xFFu);
+        f.seekp(pos);
+        f.write(&b, 1);
+        f.flush();
+        REQUIRE(f.good());
+    };
+
+    // Phase 2: corrupt one slot. Reopen must reject it on checksum and recover from the intact slot.
+    corrupt_header_slot(SECTOR_SIZE);
+    {
+        test_env_t env;
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        REQUIRE_NOTHROW(bm.load_existing_database());
+        metadata_manager_t meta_mgr(bm);
+        meta_block_pointer_t mp;
+        mp.block_pointer = bm.meta_block();
+        metadata_reader_t reader(meta_mgr, mp);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        uint64_t scanned = 0;
+        loaded->scan_table_segment(0, ROWS, [&](data_chunk_t& chunk) {
+            for (uint64_t i = 0; i < chunk.size(); i++) {
+                REQUIRE(chunk.data[0].value(i).value<int64_t>() == static_cast<int64_t>(scanned + i));
+            }
+            scanned += chunk.size();
+        });
+        REQUIRE(scanned == ROWS);
+    }
+
+    // Phase 3: corrupt the other slot too. Both invalid, so load must throw.
+    corrupt_header_slot(2 * SECTOR_SIZE);
+    {
+        test_env_t env;
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        REQUIRE_THROWS_AS(bm.load_existing_database(), std::runtime_error);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: corrupted pax data block is detected on reopen scan") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    constexpr uint64_t ROWS = 4096; // several row groups, so real persisted PAX data blocks
+    const auto table_path = test_db_path() + ".pax_corrupt_detect";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+    uint64_t block_alloc_size = 0;
+
+    // Phase 1: build a PAX_ONLY table and checkpoint it to disk.
+    {
+        test_env_t env;
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+        bm.set_layout_policy(row_group_layout_policy::PAX_ONLY);
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("id", logical_type::BIGINT);
+        columns.emplace_back("value", logical_type::UINTEGER);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_corrupt");
+        append_fixed_integer_pair(*table,
+                                  &env.resource,
+                                  ROWS,
+                                  [](uint64_t row) { return static_cast<int64_t>(row); },
+                                  [](uint64_t row) { return static_cast<uint32_t>(row * 3); });
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+        block_alloc_size = bm.block_allocation_size();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    // Phase 2: introspect the persisted layout to find a value-column PAX data block id.
+    uint64_t corrupt_block_id = INVALID_INDEX;
+    {
+        test_env_t env;
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+
+        auto* rg0 = loaded->row_group()->row_group(0);
+        REQUIRE(rg0 != nullptr);
+        const auto& layout = row_group_test_access_t::pax_fixed_layout(*rg0);
+        REQUIRE(layout.has_value());
+        for (const auto& page : layout->pages) {
+            for (const auto& slice : page.slices) {
+                if (slice.column_index == 1) {
+                    corrupt_block_id = slice.data_pointer.block_pointer.block_id;
+                    break;
+                }
+            }
+            if (corrupt_block_id != INVALID_INDEX) {
+                break;
+            }
+        }
+        REQUIRE(corrupt_block_id != INVALID_INDEX);
+    }
+
+    // Phase 3: flip a payload byte inside that data block, invalidating its stored CRC32c.
+    {
+        const uint64_t payload_byte = BLOCK_START + corrupt_block_id * block_alloc_size + sizeof(uint64_t);
+        std::fstream f(table_path, std::ios::in | std::ios::out | std::ios::binary);
+        REQUIRE(f.is_open());
+        f.seekg(static_cast<std::streamoff>(payload_byte));
+        char b = 0;
+        f.read(&b, 1);
+        REQUIRE(f.good());
+        b = static_cast<char>(static_cast<unsigned char>(b) ^ 0xFFu);
+        f.seekp(static_cast<std::streamoff>(payload_byte));
+        f.write(&b, 1);
+        f.flush();
+        REQUIRE(f.good());
+    }
+
+    // Phase 4: reopen and scan. Metadata is intact so reopen succeeds; the corrupted data block
+    // must raise a checksum mismatch when the scan loads it.
+    {
+        test_env_t env;
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+
+        bool threw = false;
+        try {
+            auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+            std::vector<storage_index_t> projected_indices{storage_index_t(0), storage_index_t(1)};
+            std::vector<size_t> projected_cols{0, 1};
+            table_scan_state state(&env.resource);
+            loaded->initialize_scan(state, projected_indices, nullptr);
+            data_chunk_t result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+            while (true) {
+                result.reset();
+                loaded->scan(result, state);
+                if (result.size() == 0) {
+                    break;
+                }
+            }
+        } catch (const std::exception& e) {
+            threw = true;
+            REQUIRE(std::string(e.what()).find("checksum") != std::string::npos);
+        }
+        REQUIRE(threw);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+// A checkpoint interrupted before the header swap (new data/metadata blocks written and fsynced,
+// header never committed) must leave the prior committed state intact and reopenable. The header
+// swap is the atomic commit point; an un-swapped header still points at the prior meta_block.
+TEST_CASE("checkpoint_load: interrupted checkpoint before header swap preserves prior state") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    constexpr uint64_t V1_ROWS = 2000;       // committed state
+    constexpr uint64_t V2_EXTRA = 1500;      // appended but never committed
+    const auto table_path = test_db_path() + ".pax_durability";
+    std::remove(table_path.c_str());
+
+    // Commit: persist data/metadata, fsync, swap header, fsync.
+    const auto commit = [](single_file_block_manager_t& bm, data_table_t& table) {
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table.checkpoint(writer);
+        writer.flush();
+        bm.set_meta_block(writer.get_block_pointer().block_pointer);
+        auto free_list_ptr = bm.serialize_free_list();
+        bm.file_sync();
+        database_header_t header;
+        header.initialize();
+        header.free_list = free_list_ptr.block_pointer;
+        bm.write_header(header);
+        bm.file_sync();
+    };
+
+    // Reopen through the on-disk header's meta_block and scan, asserting `expected` rows with value == row*3.
+    const auto reopen_and_count = [](test_env_t& env, const std::string& path, uint64_t expected) {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, path);
+        bm.load_existing_database();
+        metadata_manager_t meta_mgr(bm);
+        meta_block_pointer_t meta_ptr;
+        meta_ptr.block_pointer = bm.meta_block();
+        metadata_reader_t reader(meta_mgr, meta_ptr);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+
+        std::vector<storage_index_t> projected_indices{storage_index_t(0), storage_index_t(1)};
+        std::vector<size_t> projected_cols{0, 1};
+        table_scan_state state(&env.resource);
+        loaded->initialize_scan(state, projected_indices, nullptr);
+        data_chunk_t result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+
+        uint64_t scanned = 0;
+        while (true) {
+            result.reset();
+            loaded->scan(result, state);
+            if (result.size() == 0) {
+                break;
+            }
+            for (uint64_t i = 0; i < result.size(); i++) {
+                const auto row = scanned + i;
+                REQUIRE(result.data[0].value(i).value<int64_t>() == static_cast<int64_t>(row));
+                REQUIRE(result.data[1].value(i).value<uint32_t>() == static_cast<uint32_t>(row * 3));
+            }
+            scanned += result.size();
+        }
+        REQUIRE(scanned == expected);
+    };
+
+    // Phase 1: build a PAX_ONLY table with V1_ROWS and commit it (header swapped).
+    {
+        test_env_t env;
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+        bm.set_layout_policy(row_group_layout_policy::PAX_ONLY);
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("id", logical_type::BIGINT);
+        columns.emplace_back("value", logical_type::UINTEGER);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_durability");
+        append_fixed_integer_pair(*table,
+                                  &env.resource,
+                                  V1_ROWS,
+                                  [](uint64_t row) { return static_cast<int64_t>(row); },
+                                  [](uint64_t row) { return static_cast<uint32_t>(row * 3); });
+        commit(bm, *table);
+    }
+
+    // Phase 2: reopen, append V2_EXTRA, persist+fsync the new data/metadata, but do not swap the
+    // header (the on-disk state after a crash between checkpoint's two fsyncs).
+    {
+        test_env_t env;
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+        metadata_manager_t meta_mgr(bm);
+        meta_block_pointer_t meta_ptr;
+        meta_ptr.block_pointer = bm.meta_block();
+        metadata_reader_t reader(meta_mgr, meta_ptr);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+
+        append_fixed_integer_pair(*loaded,
+                                  &env.resource,
+                                  V2_EXTRA,
+                                  [](uint64_t row) { return static_cast<int64_t>(V1_ROWS + row); },
+                                  [](uint64_t row) { return static_cast<uint32_t>((V1_ROWS + row) * 3); });
+
+        metadata_manager_t meta_mgr2(bm);
+        metadata_writer_t writer2(meta_mgr2);
+        loaded->checkpoint(writer2);
+        writer2.flush();
+        bm.set_meta_block(writer2.get_block_pointer().block_pointer);
+        (void) bm.serialize_free_list();
+        bm.file_sync();
+        // crash here: header is never written, so the on-disk header still points at V1's meta_block.
+    }
+
+    // Phase 3: reopen with a fresh pool via the header. Must observe exactly the committed V1.
+    {
+        test_env_t env;
+        reopen_and_count(env, table_path, V1_ROWS);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+// Single UINTEGER column, persisted via PAX, cold-reopened, then more rows appended into the same
+// sub-1024 row group, scanned via the regular path. Appending raw values into a reopened
+// dictionary-compressed segment used to decode back as garbage; the append must roll onto a fresh
+// uncompressed segment instead.
+TEST_CASE("checkpoint_load: minimal repro single-rg append-after-reopen value") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    const auto table_path = test_db_path() + ".pax_minrepro";
+
+    const auto commit = [](single_file_block_manager_t& bm, data_table_t& table) {
+        metadata_manager_t mm(bm);
+        metadata_writer_t w(mm);
+        table.checkpoint(w);
+        w.flush();
+        bm.set_meta_block(w.get_block_pointer().block_pointer);
+        auto fl = bm.serialize_free_list();
+        bm.file_sync();
+        database_header_t h;
+        h.initialize();
+        h.free_list = fl.block_pointer;
+        bm.write_header(h);
+        bm.file_sync();
+    };
+
+    const auto val = [](uint64_t row) { return static_cast<uint32_t>(row * 2654435761ull + 7ull); };
+
+    // Run without nulls first to isolate values from validity, then with nulls.
+    for (bool with_nulls : {false, true}) {
+        std::remove(table_path.c_str());
+        constexpr uint64_t R1 = 111;
+        constexpr uint64_t R2 = 205;
+
+        const auto append_batch = [&](data_table_t& table, std::pmr::memory_resource* res, uint64_t start, uint64_t n) {
+            auto types = table.copy_types();
+            uint64_t off = 0;
+            while (off < n) {
+                const uint64_t b = std::min(n - off, uint64_t(DEFAULT_VECTOR_CAPACITY));
+                data_chunk_t chunk(res, types, b);
+                chunk.set_cardinality(b);
+                for (uint64_t i = 0; i < b; i++) {
+                    const uint64_t row = start + off + i;
+                    if (with_nulls && (row % 3 == 2)) {
+                        chunk.set_value(0, i, logical_value_t{res, nullptr});
+                    } else {
+                        chunk.set_value(0, i, logical_value_t{res, val(row)});
+                    }
+                }
+                table_append_state st(res);
+                table.append_lock(st);
+                table.initialize_append(st);
+                table.append(chunk, st);
+                table.finalize_append(st, transaction_data{0, 0});
+                off += b;
+            }
+        };
+
+        {
+            test_env_t env;
+            single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+            bm.create_new_database();
+            bm.set_layout_policy(row_group_layout_policy::PAX_ONLY);
+            std::vector<column_definition_t> columns;
+            columns.emplace_back("v", logical_type::UINTEGER);
+            auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "minrepro");
+            append_batch(*table, &env.resource, 0, R1);
+            commit(bm, *table);
+        }
+        {
+            test_env_t env;
+            single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+            bm.load_existing_database();
+            metadata_manager_t mm(bm);
+            meta_block_pointer_t mp;
+            mp.block_pointer = bm.meta_block();
+            metadata_reader_t reader(mm, mp);
+            auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+            append_batch(*loaded, &env.resource, R1, R2);
+            commit(bm, *loaded);
+        }
+        {
+            test_env_t env;
+            single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+            bm.load_existing_database();
+            metadata_manager_t mm(bm);
+            meta_block_pointer_t mp;
+            mp.block_pointer = bm.meta_block();
+            metadata_reader_t reader(mm, mp);
+            auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+
+            std::vector<storage_index_t> idx{storage_index_t(0)};
+            std::vector<size_t> pcols{0};
+            table_scan_state state(&env.resource);
+            loaded->initialize_scan(state, idx, nullptr);
+            data_chunk_t result(&env.resource, loaded->copy_types(), pcols, DEFAULT_VECTOR_CAPACITY);
+            uint64_t scanned = 0;
+            while (true) {
+                result.reset();
+                loaded->scan(result, state);
+                if (result.size() == 0) {
+                    break;
+                }
+                for (uint64_t i = 0; i < result.size(); i++) {
+                    const uint64_t row = scanned + i;
+                    INFO("with_nulls=" << with_nulls << " row=" << row);
+                    const bool is_null = with_nulls && (row % 3 == 2);
+                    if (is_null) {
+                        REQUIRE_FALSE(result.data[0].validity().row_is_valid(i));
+                    } else {
+                        REQUIRE(result.data[0].validity().row_is_valid(i));
+                        REQUIRE(result.data[0].value(i).value<uint32_t>() == val(row));
+                    }
+                }
+                scanned += result.size();
+            }
+            REQUIRE(scanned == R1 + R2);
+        }
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+// Differential round-trip fuzzer (catalog mode). Catches silent corruption (wrong value or null
+// bit, no error). Runs seeded random trials (random schema, nulls, row counts across row-group/page
+// boundaries; append -> cold-reopen -> append-after-reopen -> cold-reopen -> scan, with random
+// DELETEs/UPDATEs mirrored into an oracle), collects a signature per mismatch instead of aborting on
+// the first, and asserts clean at the end. Each trial picks PAX_ONLY or COLUMNAR_ONLY; UPDATE is
+// gated to PAX because the columnar checkpoint drops the update_segment overlay on reopen (separate
+// open bug). Set FUZZ_TRIALS=N for more trials; FUZZ_ONLY_SEED=<seed> runs exactly that one trial.
+TEST_CASE("checkpoint_load: differential round-trip fuzzer catalog (pax cold-reopen == oracle)") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    const auto table_path = test_db_path() + ".pax_fuzz";
+
+    const auto commit = [](single_file_block_manager_t& bm, data_table_t& table) {
+        metadata_manager_t mm(bm);
+        metadata_writer_t w(mm);
+        table.checkpoint(w);
+        w.flush();
+        bm.set_meta_block(w.get_block_pointer().block_pointer);
+        auto fl = bm.serialize_free_list();
+        bm.file_sync();
+        database_header_t h;
+        h.initialize();
+        h.free_list = fl.block_pointer;
+        bm.write_header(h);
+        bm.file_sync();
+    };
+
+    struct cell_t {
+        bool isnull = false;
+        int64_t i64 = 0;  // all integer types (bit pattern)
+        double f64 = 0.0; // FLOAT/DOUBLE
+        std::string str;  // STRING_LITERAL
+    };
+
+    const std::array<logical_type, 12> TYPES{logical_type::BOOLEAN,
+                                             logical_type::TINYINT,
+                                             logical_type::UTINYINT,
+                                             logical_type::SMALLINT,
+                                             logical_type::USMALLINT,
+                                             logical_type::INTEGER,
+                                             logical_type::UINTEGER,
+                                             logical_type::BIGINT,
+                                             logical_type::UBIGINT,
+                                             logical_type::FLOAT,
+                                             logical_type::DOUBLE,
+                                             logical_type::STRING_LITERAL};
+    const auto type_name = [](logical_type t) -> const char* {
+        switch (t) {
+            case logical_type::BOOLEAN: return "BOOLEAN";
+            case logical_type::TINYINT: return "TINYINT";
+            case logical_type::UTINYINT: return "UTINYINT";
+            case logical_type::SMALLINT: return "SMALLINT";
+            case logical_type::USMALLINT: return "USMALLINT";
+            case logical_type::INTEGER: return "INTEGER";
+            case logical_type::UINTEGER: return "UINTEGER";
+            case logical_type::BIGINT: return "BIGINT";
+            case logical_type::UBIGINT: return "UBIGINT";
+            case logical_type::FLOAT: return "FLOAT";
+            case logical_type::DOUBLE: return "DOUBLE";
+            case logical_type::STRING_LITERAL: return "STRING";
+            default: return "?";
+        }
+    };
+
+    // Generate a value for `t`, write it into the chunk and return the oracle cell.
+    const auto gen = [](std::mt19937_64& rng, std::pmr::memory_resource* res, logical_type t, data_chunk_t& chunk,
+                        uint64_t col, uint64_t i) -> cell_t {
+        cell_t cell;
+        switch (t) {
+            case logical_type::BOOLEAN: {
+                const bool v = (rng() & 1u) != 0;
+                cell.i64 = v ? 1 : 0;
+                chunk.set_value(col, i, logical_value_t{res, v});
+                break;
+            }
+            case logical_type::TINYINT: {
+                const int8_t v = static_cast<int8_t>(rng());
+                cell.i64 = v;
+                chunk.set_value(col, i, logical_value_t{res, v});
+                break;
+            }
+            case logical_type::UTINYINT: {
+                const uint8_t v = static_cast<uint8_t>(rng());
+                cell.i64 = static_cast<int64_t>(v);
+                chunk.set_value(col, i, logical_value_t{res, v});
+                break;
+            }
+            case logical_type::SMALLINT: {
+                const int16_t v = static_cast<int16_t>(rng());
+                cell.i64 = v;
+                chunk.set_value(col, i, logical_value_t{res, v});
+                break;
+            }
+            case logical_type::USMALLINT: {
+                const uint16_t v = static_cast<uint16_t>(rng());
+                cell.i64 = static_cast<int64_t>(v);
+                chunk.set_value(col, i, logical_value_t{res, v});
+                break;
+            }
+            case logical_type::INTEGER: {
+                const int32_t v = static_cast<int32_t>(static_cast<uint32_t>(rng()));
+                cell.i64 = v;
+                chunk.set_value(col, i, logical_value_t{res, v});
+                break;
+            }
+            case logical_type::UINTEGER: {
+                const uint32_t v = static_cast<uint32_t>(rng());
+                cell.i64 = static_cast<int64_t>(v);
+                chunk.set_value(col, i, logical_value_t{res, v});
+                break;
+            }
+            case logical_type::BIGINT: {
+                const int64_t v = static_cast<int64_t>(rng());
+                cell.i64 = v;
+                chunk.set_value(col, i, logical_value_t{res, v});
+                break;
+            }
+            case logical_type::UBIGINT: {
+                const uint64_t v = rng();
+                cell.i64 = static_cast<int64_t>(v);
+                chunk.set_value(col, i, logical_value_t{res, v});
+                break;
+            }
+            case logical_type::FLOAT: {
+                const float v = static_cast<float>(static_cast<int64_t>(rng())) / 64.0f;
+                cell.f64 = static_cast<double>(v);
+                chunk.set_value(col, i, logical_value_t{res, v});
+                break;
+            }
+            case logical_type::DOUBLE: {
+                const double v = static_cast<double>(static_cast<int64_t>(rng())) / 1024.0;
+                cell.f64 = v;
+                chunk.set_value(col, i, logical_value_t{res, v});
+                break;
+            }
+            default: { // STRING_LITERAL
+                const uint64_t len = rng() % 25;
+                std::string s;
+                s.reserve(len);
+                for (uint64_t k = 0; k < len; k++) {
+                    s.push_back(static_cast<char>('a' + (rng() % 26)));
+                }
+                cell.str = s;
+                chunk.set_value(col, i, logical_value_t{res, s});
+                break;
+            }
+        }
+        return cell;
+    };
+
+    // Compare a scanned cell to its oracle. Returns "" on match, else a symptom string.
+    const auto check = [](logical_type t, const cell_t& cell, components::vector::vector_t& vec,
+                          uint64_t i) -> const char* {
+        const bool valid = vec.validity().row_is_valid(i);
+        if (cell.isnull) {
+            return valid ? "validity(expected-null,got-value)" : "";
+        }
+        if (!valid) {
+            return "validity(expected-value,got-null)";
+        }
+        const auto lv = vec.value(i);
+        switch (t) {
+            case logical_type::BOOLEAN:
+                return (lv.value<bool>() == (cell.i64 != 0)) ? "" : "value";
+            case logical_type::TINYINT:
+                return (lv.value<int8_t>() == static_cast<int8_t>(cell.i64)) ? "" : "value";
+            case logical_type::UTINYINT:
+                return (lv.value<uint8_t>() == static_cast<uint8_t>(cell.i64)) ? "" : "value";
+            case logical_type::SMALLINT:
+                return (lv.value<int16_t>() == static_cast<int16_t>(cell.i64)) ? "" : "value";
+            case logical_type::USMALLINT:
+                return (lv.value<uint16_t>() == static_cast<uint16_t>(cell.i64)) ? "" : "value";
+            case logical_type::INTEGER:
+                return (lv.value<int32_t>() == static_cast<int32_t>(cell.i64)) ? "" : "value";
+            case logical_type::UINTEGER:
+                return (lv.value<uint32_t>() == static_cast<uint32_t>(cell.i64)) ? "" : "value";
+            case logical_type::BIGINT:
+                return (lv.value<int64_t>() == cell.i64) ? "" : "value";
+            case logical_type::UBIGINT:
+                return (lv.value<uint64_t>() == static_cast<uint64_t>(cell.i64)) ? "" : "value";
+            case logical_type::FLOAT: {
+                const float got = lv.value<float>();
+                const float exp = static_cast<float>(cell.f64);
+                return (std::memcmp(&got, &exp, sizeof(float)) == 0) ? "" : "value";
+            }
+            case logical_type::DOUBLE: {
+                const double got = lv.value<double>();
+                return (std::memcmp(&got, &cell.f64, sizeof(double)) == 0) ? "" : "value";
+            }
+            default: {
+                const auto* got = lv.value<std::string*>();
+                return (got && *got == cell.str) ? "" : "value";
+            }
+        }
+    };
+
+    // Oracle for a constant_filter on an integer column: comparator(column_value, predicate), with a
+    // NULL column value always failing the filter. Integer-only so the comparison is exact.
+    const auto cmp_apply = [](components::expressions::compare_type c, auto x, auto y) -> bool {
+        using ct = components::expressions::compare_type;
+        switch (c) {
+            case ct::eq: return x == y;
+            case ct::ne: return x != y;
+            case ct::gt: return x > y;
+            case ct::gte: return x >= y;
+            case ct::lt: return x < y;
+            case ct::lte: return x <= y;
+            default: return false;
+        }
+    };
+    const auto cell_matches = [&cmp_apply](logical_type t, components::expressions::compare_type c, const cell_t& a,
+                                           const cell_t& b) -> bool {
+        if (a.isnull) {
+            return false;
+        }
+        switch (t) {
+            case logical_type::TINYINT: return cmp_apply(c, static_cast<int8_t>(a.i64), static_cast<int8_t>(b.i64));
+            case logical_type::UTINYINT: return cmp_apply(c, static_cast<uint8_t>(a.i64), static_cast<uint8_t>(b.i64));
+            case logical_type::SMALLINT: return cmp_apply(c, static_cast<int16_t>(a.i64), static_cast<int16_t>(b.i64));
+            case logical_type::USMALLINT:
+                return cmp_apply(c, static_cast<uint16_t>(a.i64), static_cast<uint16_t>(b.i64));
+            case logical_type::INTEGER: return cmp_apply(c, static_cast<int32_t>(a.i64), static_cast<int32_t>(b.i64));
+            case logical_type::UINTEGER: return cmp_apply(c, static_cast<uint32_t>(a.i64), static_cast<uint32_t>(b.i64));
+            case logical_type::BIGINT: return cmp_apply(c, static_cast<int64_t>(a.i64), static_cast<int64_t>(b.i64));
+            case logical_type::UBIGINT: return cmp_apply(c, static_cast<uint64_t>(a.i64), static_cast<uint64_t>(b.i64));
+            default: return false;
+        }
+    };
+    const auto is_filterable = [](logical_type t) {
+        switch (t) {
+            case logical_type::TINYINT:
+            case logical_type::UTINYINT:
+            case logical_type::SMALLINT:
+            case logical_type::USMALLINT:
+            case logical_type::INTEGER:
+            case logical_type::UINTEGER:
+            case logical_type::BIGINT:
+            case logical_type::UBIGINT: return true;
+            default: return false;
+        }
+    };
+
+    const int trials = std::getenv("FUZZ_TRIALS") ? std::atoi(std::getenv("FUZZ_TRIALS")) : 150;
+    std::map<std::string, std::pair<uint64_t, uint64_t>> catalog; // signature -> {count, example-seed}
+    const auto record = [&](const std::string& sig, uint64_t seed) {
+        auto& e = catalog[sig];
+        e.first++;
+        if (e.first == 1) {
+            e.second = seed;
+        }
+    };
+
+    const uint64_t seed_base = 12648430ull;
+    const uint64_t seed_mult = 2654435761ull;
+    // FUZZ_ONLY_SEED=<seed> runs exactly one trial with that seed (deterministic repro).
+    const char* only_seed_env = std::getenv("FUZZ_ONLY_SEED");
+    const bool single = only_seed_env != nullptr;
+    const uint64_t only_seed = single ? std::strtoull(only_seed_env, nullptr, 10) : 0;
+    const int loop_trials = single ? 1 : trials;
+    for (int trial = 0; trial < loop_trials; trial++) {
+        const uint64_t seed = single ? only_seed : seed_base + static_cast<uint64_t>(trial) * seed_mult;
+        std::mt19937_64 rng(seed);
+        std::remove(table_path.c_str());
+
+        const uint64_t ncols = 1 + (rng() % 4);
+        struct colspec_t {
+            logical_type type;
+            bool nullable;
+        };
+        std::vector<colspec_t> schema;
+        std::vector<column_definition_t> columns;
+        for (uint64_t c = 0; c < ncols; c++) {
+            const auto t = TYPES[rng() % TYPES.size()];
+            schema.push_back({t, (rng() % 3) != 0});
+            columns.emplace_back("c" + std::to_string(c), t);
+        }
+
+        std::vector<std::vector<cell_t>> oracle(ncols);
+        uint64_t total = 0;
+        std::set<uint64_t> deleted_rows; // rows removed via DELETE — excluded from the visible oracle
+        bool had_update = false;         // whether any UPDATE was applied this trial (signature tag)
+        const bool do_mid_reopen = (rng() & 1u) != 0; // distinguish reopen-append from plain append
+        // Exercise both on-disk layouts (PAX and COLUMNAR); both must round-trip values + null bits.
+        const bool use_columnar = (rng() % 3) == 0;
+        const auto layout_policy =
+            use_columnar ? row_group_layout_policy::COLUMNAR_ONLY : row_group_layout_policy::PAX_ONLY;
+        const char* layout_tag = use_columnar ? "columnar" : "pax";
+
+        const auto append_batch = [&](data_table_t& table, std::pmr::memory_resource* res, uint64_t n) {
+            auto types = table.copy_types();
+            uint64_t off = 0;
+            while (off < n) {
+                const uint64_t b = std::min(n - off, uint64_t(DEFAULT_VECTOR_CAPACITY));
+                data_chunk_t chunk(res, types, b);
+                chunk.set_cardinality(b);
+                for (uint64_t i = 0; i < b; i++) {
+                    for (uint64_t c = 0; c < ncols; c++) {
+                        if (schema[c].nullable && (rng() % 100) < 30) {
+                            cell_t nullcell;
+                            nullcell.isnull = true;
+                            oracle[c].push_back(nullcell);
+                            chunk.set_value(c, i, logical_value_t{res, nullptr});
+                        } else {
+                            oracle[c].push_back(gen(rng, res, schema[c].type, chunk, c, i));
+                        }
+                    }
+                }
+                table_append_state st(res);
+                table.append_lock(st);
+                table.initialize_append(st);
+                table.append(chunk, st);
+                table.finalize_append(st, transaction_data{0, 0});
+                off += b;
+                total += b;
+            }
+        };
+
+        // Apply random DELETEs and UPDATEs to the live table, mirroring each into the oracle.
+        // Called at every append/reopen point so mutations are verified across the reopen too.
+        const auto mutate = [&](data_table_t& table, std::pmr::memory_resource* res) {
+            if (total == 0) {
+                return;
+            }
+            const auto live_rows = [&]() {
+                std::vector<uint64_t> v;
+                for (uint64_t r = 0; r < total; r++) {
+                    if (deleted_rows.find(r) == deleted_rows.end()) {
+                        v.push_back(r);
+                    }
+                }
+                return v;
+            };
+            const auto pick_distinct = [&](const std::vector<uint64_t>& pool, uint64_t k) {
+                std::set<uint64_t> picks;
+                for (uint64_t t = 0; t < k * 4 && picks.size() < k; t++) {
+                    picks.insert(pool[rng() % pool.size()]);
+                }
+                return std::vector<uint64_t>(picks.begin(), picks.end());
+            };
+
+            // UPDATE a random column on a random subset of live rows. Gated to PAX: the columnar
+            // checkpoint drops the update_segment overlay on reopen (separate open bug). The coin is
+            // still drawn either way so the RNG stream stays stable across layouts.
+            const bool do_update = (rng() & 1u) != 0;
+            if (do_update && !use_columnar) {
+                auto live = live_rows();
+                if (!live.empty()) {
+                    const uint64_t c = rng() % ncols;
+                    const uint64_t k = 1 + rng() % std::min<uint64_t>(live.size(), 40);
+                    auto rows = pick_distinct(live, k);
+                    vector_t row_ids(res, logical_type::BIGINT, rows.size());
+                    data_chunk_t upd(res, {schema[c].type}, rows.size());
+                    upd.set_cardinality(rows.size());
+                    for (uint64_t i = 0; i < rows.size(); i++) {
+                        row_ids.set_value(i, logical_value_t{res, static_cast<int64_t>(rows[i])});
+                        if (schema[c].nullable && (rng() % 100) < 30) {
+                            cell_t nc;
+                            nc.isnull = true;
+                            oracle[c][rows[i]] = nc;
+                            upd.data[0].set_null(i, true);
+                        } else {
+                            // gen() writes the value straight into the update chunk and returns the cell.
+                            oracle[c][rows[i]] = gen(rng, res, schema[c].type, upd, 0, i);
+                        }
+                    }
+                    table.update_column(row_ids, {c}, upd);
+                    had_update = true;
+                }
+            }
+
+            // DELETE a random subset of live rows (~1/3 of the mutation points).
+            if ((rng() % 3) == 0) {
+                auto live = live_rows();
+                if (!live.empty()) {
+                    const uint64_t k = 1 + rng() % std::min<uint64_t>(live.size(), 30);
+                    auto rows = pick_distinct(live, k);
+                    vector_t row_ids(res, logical_type::BIGINT, rows.size());
+                    for (uint64_t i = 0; i < rows.size(); i++) {
+                        row_ids.set_value(i, logical_value_t{res, static_cast<int64_t>(rows[i])});
+                    }
+                    auto del_state = table.initialize_delete({});
+                    table.delete_rows(*del_state, row_ids, rows.size(), 0);
+                    for (auto r : rows) {
+                        deleted_rows.insert(r);
+                    }
+                }
+            }
+        };
+
+        const uint64_t r1 = (rng() % 3) * uint64_t(DEFAULT_VECTOR_CAPACITY) + (rng() % 400);
+        const uint64_t r2 = 1 + (rng() % 1200);
+
+        const auto reopen = [&](test_env_t& env, single_file_block_manager_t& bm) {
+            bm.load_existing_database();
+            metadata_manager_t mm(bm);
+            meta_block_pointer_t mp;
+            mp.block_pointer = bm.meta_block();
+            metadata_reader_t reader(mm, mp);
+            return data_table_t::load_from_disk(&env.resource, bm, reader); // metadata fully read here
+        };
+
+        bool trial_threw = false;
+        try {
+            if (do_mid_reopen) {
+                // append r1, commit, COLD-reopen, append r2 (append-after-reopen), commit.
+                {
+                    test_env_t env;
+                    single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+                    bm.create_new_database();
+                    bm.set_layout_policy(layout_policy);
+                    auto cols_copy = columns;
+                    auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(cols_copy), "pax_fuzz");
+                    append_batch(*table, &env.resource, r1);
+                    mutate(*table, &env.resource); // mutate in-memory r1 rows before commit #1
+                    commit(bm, *table);
+                }
+                {
+                    test_env_t env;
+                    single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+                    auto loaded = reopen(env, bm);
+                    mutate(*loaded, &env.resource); // mutate persisted/committed rows after reopen
+                    append_batch(*loaded, &env.resource, r2);
+                    mutate(*loaded, &env.resource); // mutate mixed committed+appended before commit #2
+                    commit(bm, *loaded);
+                }
+            } else {
+                // append r1+r2 in one process, single commit (no reopen between).
+                test_env_t env;
+                single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+                bm.create_new_database();
+                bm.set_layout_policy(layout_policy);
+                auto cols_copy = columns;
+                auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(cols_copy), "pax_fuzz");
+                append_batch(*table, &env.resource, r1);
+                append_batch(*table, &env.resource, r2);
+                mutate(*table, &env.resource); // mutate in-memory rows before the single commit
+                commit(bm, *table);
+            }
+        } catch (const std::exception& e) {
+            trial_threw = true;
+            record(std::string("THREW-on-build: ") + e.what(), seed);
+        }
+        if (trial_threw) {
+            continue;
+        }
+
+        // Verify: cold reopen, scan, diff against oracle, recording one signature per column.
+        try {
+            test_env_t env;
+            single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+            auto loaded = reopen(env, bm);
+
+            std::vector<storage_index_t> idx;
+            std::vector<size_t> pcols;
+            for (uint64_t c = 0; c < ncols; c++) {
+                idx.push_back(storage_index_t(c));
+                pcols.push_back(c);
+            }
+
+            // When an integer column exists, sometimes apply a random constant filter to exercise the
+            // filtered/projected scan and PAX zone-map pruning. The same predicate is applied to the oracle below.
+            std::optional<constant_filter_t> filter;
+            uint64_t filter_col = 0;
+            components::expressions::compare_type filter_cmp = components::expressions::compare_type::eq;
+            cell_t filter_threshold;
+            bool has_filter = false;
+            {
+                std::vector<uint64_t> filterable;
+                for (uint64_t c = 0; c < ncols; c++) {
+                    if (is_filterable(schema[c].type)) {
+                        filterable.push_back(c);
+                    }
+                }
+                // Gated to PAX: columnar filtered scans currently disagree with the oracle (separate bug).
+                if (!use_columnar && !filterable.empty() && (rng() & 1u) != 0) {
+                    filter_col = filterable[rng() % filterable.size()];
+                    static const components::expressions::compare_type cmps[] = {
+                        components::expressions::compare_type::eq,  components::expressions::compare_type::ne,
+                        components::expressions::compare_type::gt,  components::expressions::compare_type::gte,
+                        components::expressions::compare_type::lt,  components::expressions::compare_type::lte};
+                    filter_cmp = cmps[rng() % 6];
+                    data_chunk_t tchunk(&env.resource, {schema[filter_col].type}, 1);
+                    tchunk.set_cardinality(1);
+                    filter_threshold = gen(rng, &env.resource, schema[filter_col].type, tchunk, 0, 0);
+                    std::pmr::vector<uint64_t> fcols(&env.resource);
+                    fcols.push_back(filter_col);
+                    filter.emplace(filter_cmp, tchunk.data[0].value(0), std::move(fcols));
+                    has_filter = true;
+                }
+            }
+
+            table_scan_state state(&env.resource);
+            loaded->initialize_scan(state, idx, has_filter ? &*filter : nullptr);
+            data_chunk_t result(&env.resource, loaded->copy_types(), pcols, DEFAULT_VECTOR_CAPACITY);
+
+            // Scan returns surviving rows in ascending row-id order, so the k-th scanned row maps to
+            // the k-th non-deleted original row that also satisfies the filter.
+            std::vector<uint64_t> visible;
+            visible.reserve(total);
+            for (uint64_t r = 0; r < total; r++) {
+                if (deleted_rows.find(r) != deleted_rows.end()) {
+                    continue;
+                }
+                if (has_filter &&
+                    !cell_matches(schema[filter_col].type, filter_cmp, oracle[filter_col][r], filter_threshold)) {
+                    continue;
+                }
+                visible.push_back(r);
+            }
+            const char* del_tag = deleted_rows.empty() ? "0" : "1";
+            const char* upd_tag = had_update ? "1" : "0";
+            const char* filt_tag = has_filter ? "1" : "0";
+
+            std::set<uint64_t> recorded_cols;
+            uint64_t scanned = 0;
+            bool overflow = false;
+            while (true) {
+                result.reset();
+                loaded->scan(result, state);
+                if (result.size() == 0) {
+                    break;
+                }
+                for (uint64_t i = 0; i < result.size(); i++) {
+                    const uint64_t scan_idx = scanned + i;
+                    if (scan_idx >= visible.size()) {
+                        overflow = true; // a deleted/extra row surfaced — flagged by the count check below
+                        continue;
+                    }
+                    const uint64_t row = visible[scan_idx];
+                    for (uint64_t c = 0; c < ncols; c++) {
+                        if (recorded_cols.count(c) || row >= oracle[c].size()) {
+                            continue;
+                        }
+                        const char* sym = check(schema[c].type, oracle[c][row], result.data[c], i);
+                        if (sym[0] != '\0') {
+                            const char* region = (do_mid_reopen && row >= r1) ? "appended" : "committed";
+                            std::string sig = std::string("layout=") + layout_tag + " type=" +
+                                              type_name(schema[c].type) +
+                                              " nullcol=" + (schema[c].nullable ? "1" : "0") + " region=" + region +
+                                              " reopen_append=" + (do_mid_reopen ? "1" : "0") + " del=" + del_tag +
+                                              " upd=" + upd_tag + " filt=" + filt_tag + " symptom=" + sym;
+                            record(sig, seed);
+                            recorded_cols.insert(c);
+                        }
+                    }
+                }
+                scanned += result.size();
+            }
+            if (overflow || scanned != visible.size()) {
+                record("layout=" + std::string(layout_tag) + " row-count-mismatch reopen_append=" +
+                           std::string(do_mid_reopen ? "1" : "0") + " del=" + del_tag + " upd=" + upd_tag +
+                           " filt=" + filt_tag,
+                       seed);
+            }
+        } catch (const std::exception& e) {
+            record(std::string("THREW-on-scan: ") + e.what(), seed);
+        }
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+
+    if (!catalog.empty()) {
+        std::fprintf(stderr, "\n==== PAX fuzzer bug catalog (%d trials) — %zu distinct classes ====\n",
+                     trials, catalog.size());
+        for (const auto& [sig, info] : catalog) {
+            std::fprintf(stderr, "  [%4llu x] %s  (example seed=%llu)\n",
+                         static_cast<unsigned long long>(info.first), sig.c_str(),
+                         static_cast<unsigned long long>(info.second));
+        }
+        std::fprintf(stderr, "====================================================================\n\n");
+    }
+    INFO("PAX fuzzer found " << catalog.size() << " distinct bug classes (see stderr catalog above)");
+    REQUIRE(catalog.empty());
+}
+
+TEST_CASE("checkpoint_load: pax fixed projected scan decodes value encodings") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 512;
+    const auto table_path = test_db_path() + ".pax_fixed_encodings";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("constant_value", logical_type::BIGINT);
+        columns.emplace_back("run_value", logical_type::BIGINT);
+        columns.emplace_back("dict_value", logical_type::BIGINT);
+        columns.emplace_back("plain_value", logical_type::BIGINT);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_fixed_encodings");
+
+        append_rows(*table, &env.resource, NUM_ROWS, [&](data_chunk_t& chunk, uint64_t row, uint64_t row_in_chunk) {
+            chunk.set_value(0, row_in_chunk, logical_value_t{&env.resource, int64_t(42)});
+            chunk.set_value(1, row_in_chunk, logical_value_t{&env.resource, static_cast<int64_t>(row / 64)});
+            chunk.set_value(2, row_in_chunk, logical_value_t{&env.resource, static_cast<int64_t>(row % 5)});
+            chunk.set_value(3, row_in_chunk, logical_value_t{&env.resource, static_cast<int64_t>(row * 1000003)});
+        });
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        auto* first_row_group = loaded->row_group()->row_group(0);
+        REQUIRE(first_row_group != nullptr);
+
+        const auto& layout = row_group_test_access_t::pax_fixed_layout(*first_row_group);
+        REQUIRE(layout.has_value());
+
+        bool saw_constant = false;
+        bool saw_rle = false;
+        bool saw_dictionary = false;
+        bool saw_uncompressed = false;
+        for (const auto& page : layout->pages) {
+            for (const auto& slice : page.slices) {
+                const auto compression = slice.data_pointer.compression;
+                const auto raw_size = static_cast<uint64_t>(slice.data_pointer.tuple_count) * sizeof(int64_t);
+                switch (slice.column_index) {
+                    case 0:
+                        saw_constant = saw_constant ||
+                                       compression == components::table::compression::compression_type::CONSTANT;
+                        break;
+                    case 1:
+                        saw_rle = saw_rle || compression == components::table::compression::compression_type::RLE;
+                        break;
+                    case 2:
+                        saw_dictionary =
+                            saw_dictionary ||
+                            compression == components::table::compression::compression_type::DICTIONARY;
+                        break;
+                    case 3:
+                        saw_uncompressed =
+                            saw_uncompressed ||
+                            compression == components::table::compression::compression_type::UNCOMPRESSED;
+                        break;
+                    default:
+                        break;
+                }
+                if (compression != components::table::compression::compression_type::UNCOMPRESSED) {
+                    REQUIRE(slice.data_pointer.segment_size < raw_size);
+                }
+            }
+        }
+        REQUIRE(saw_constant);
+        REQUIRE(saw_rle);
+        REQUIRE(saw_dictionary);
+        REQUIRE(saw_uncompressed);
+
+        row_group_test_access_t::reset_scan_path_counts(*first_row_group);
+
+        std::vector<storage_index_t> projected_indices{
+            storage_index_t(0), storage_index_t(1), storage_index_t(2), storage_index_t(3)};
+        std::vector<size_t> projected_cols{0, 1, 2, 3};
+        table_scan_state state(&env.resource);
+        loaded->initialize_scan(state, projected_indices, nullptr);
+        data_chunk_t result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+
+        uint64_t scanned = 0;
+        while (true) {
+            result.reset();
+            loaded->scan(result, state);
+            if (result.size() == 0) {
+                break;
+            }
+            for (uint64_t i = 0; i < result.size(); i++) {
+                const auto row = scanned + i;
+                REQUIRE(result.data[0].value(i).value<int64_t>() == 42);
+                REQUIRE(result.data[1].value(i).value<int64_t>() == static_cast<int64_t>(row / 64));
+                REQUIRE(result.data[2].value(i).value<int64_t>() == static_cast<int64_t>(row % 5));
+                REQUIRE(result.data[3].value(i).value<int64_t>() == static_cast<int64_t>(row * 1000003));
+            }
+            scanned += result.size();
+        }
+        REQUIRE(scanned == NUM_ROWS);
+
+        const auto counts = row_group_test_access_t::scan_path_counts(*first_row_group);
+        REQUIRE(counts.pax_fixed_projected > 0);
+        REQUIRE(counts.pax_fixed_prefetched_blocks > 0);
+        REQUIRE(counts.regular == 0);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+// rows_per_page (100) does not divide DEFAULT_VECTOR_CAPACITY, so a batch boundary cuts through a
+// page and the next batch decodes it from a non-zero in-page offset. Exercises the windowed
+// (offset>0) decode path for CONSTANT/RLE/DICTIONARY/UNCOMPRESSED columns.
+TEST_CASE("checkpoint_load: pax fixed projected scan decodes value encodings across page-split windows") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 2500;
+    constexpr uint16_t ROWS_PER_PAGE = 100;
+    static_assert(DEFAULT_VECTOR_CAPACITY % ROWS_PER_PAGE != 0,
+                  "rows_per_page must not divide the vector capacity, otherwise batches stay page-aligned");
+    const auto table_path = test_db_path() + ".pax_fixed_encodings_windowed";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+        bm.set_pax_rows_per_page(ROWS_PER_PAGE);
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("constant_value", logical_type::BIGINT);
+        columns.emplace_back("run_value", logical_type::BIGINT);
+        columns.emplace_back("dict_value", logical_type::BIGINT);
+        columns.emplace_back("plain_value", logical_type::BIGINT);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_fixed_encodings_windowed");
+
+        append_rows(*table, &env.resource, NUM_ROWS, [&](data_chunk_t& chunk, uint64_t row, uint64_t row_in_chunk) {
+            chunk.set_value(0, row_in_chunk, logical_value_t{&env.resource, int64_t(42)});
+            chunk.set_value(1, row_in_chunk, logical_value_t{&env.resource, static_cast<int64_t>(row / 64)});
+            chunk.set_value(2, row_in_chunk, logical_value_t{&env.resource, static_cast<int64_t>(row % 5)});
+            chunk.set_value(3, row_in_chunk, logical_value_t{&env.resource, static_cast<int64_t>(row * 1000003)});
+        });
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        auto* first_row_group = loaded->row_group()->row_group(0);
+        REQUIRE(first_row_group != nullptr);
+        REQUIRE(row_group_test_access_t::pax_fixed_layout(*first_row_group).has_value());
+
+        std::vector<storage_index_t> projected_indices{
+            storage_index_t(0), storage_index_t(1), storage_index_t(2), storage_index_t(3)};
+        std::vector<size_t> projected_cols{0, 1, 2, 3};
+        table_scan_state state(&env.resource);
+        loaded->initialize_scan(state, projected_indices, nullptr);
+        data_chunk_t result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+
+        uint64_t scanned = 0;
+        while (true) {
+            result.reset();
+            loaded->scan(result, state);
+            if (result.size() == 0) {
+                break;
+            }
+            for (uint64_t i = 0; i < result.size(); i++) {
+                const auto row = scanned + i;
+                REQUIRE(result.data[0].value(i).value<int64_t>() == 42);
+                REQUIRE(result.data[1].value(i).value<int64_t>() == static_cast<int64_t>(row / 64));
+                REQUIRE(result.data[2].value(i).value<int64_t>() == static_cast<int64_t>(row % 5));
+                REQUIRE(result.data[3].value(i).value<int64_t>() == static_cast<int64_t>(row * 1000003));
+            }
+            scanned += result.size();
+        }
+        REQUIRE(scanned == NUM_ROWS);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: pax fixed projected scan supports simple filters") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 1300;
+    const auto table_path = test_db_path() + ".pax_filter";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("id", logical_type::BIGINT);
+        columns.emplace_back("value", logical_type::UINTEGER);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_filter");
+        append_fixed_integer_pair(*table,
+                                  &env.resource,
+                                  NUM_ROWS,
+                                  [](uint64_t row) { return static_cast<int64_t>(row); },
+                                  [](uint64_t row) { return static_cast<uint32_t>(row + 100); });
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        auto* first_row_group = loaded->row_group()->row_group(0);
+        REQUIRE(first_row_group != nullptr);
+        row_group_test_access_t::reset_scan_path_counts(*first_row_group);
+
+        std::vector<storage_index_t> projected_indices{storage_index_t(0), storage_index_t(1)};
+        std::vector<size_t> projected_cols{0, 1};
+
+        std::pmr::vector<uint64_t> filter_columns(&env.resource);
+        filter_columns.push_back(0);
+        constant_filter_t eq_filter(components::expressions::compare_type::eq,
+                                    logical_value_t{&env.resource, int64_t(777)},
+                                    std::move(filter_columns));
+
+        table_scan_state eq_state(&env.resource);
+        loaded->initialize_scan(eq_state, projected_indices, &eq_filter);
+        data_chunk_t eq_result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+        loaded->scan(eq_result, eq_state);
+        REQUIRE(eq_result.size() == 1);
+        REQUIRE(eq_result.data[0].value(0).value<int64_t>() == 777);
+        REQUIRE(eq_result.data[1].value(0).value<uint32_t>() == 877);
+
+        std::pmr::vector<uint64_t> gt_filter_columns(&env.resource);
+        gt_filter_columns.push_back(0);
+        constant_filter_t gt_filter(components::expressions::compare_type::gt,
+                                    logical_value_t{&env.resource, int64_t(1200)},
+                                    std::move(gt_filter_columns));
+
+        table_scan_state gt_state(&env.resource);
+        loaded->initialize_scan(gt_state, projected_indices, &gt_filter);
+        data_chunk_t gt_result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+        loaded->scan(gt_result, gt_state);
+        REQUIRE(gt_result.size() == NUM_ROWS - 1201);
+        for (uint64_t i = 0; i < gt_result.size(); i++) {
+            const auto row = 1201 + i;
+            REQUIRE(gt_result.data[0].value(i).value<int64_t>() == static_cast<int64_t>(row));
+            REQUIRE(gt_result.data[1].value(i).value<uint32_t>() == static_cast<uint32_t>(row + 100));
+        }
+
+        {
+            const auto counts = row_group_test_access_t::scan_path_counts(*first_row_group);
+            REQUIRE(counts.pax_generic_projected == 0);
+            REQUIRE(counts.pax_fixed_projected > 0);
+            REQUIRE(counts.pax_fixed_prefetched_blocks > 0);
+            REQUIRE(counts.regular == 0);
+        }
+
+        row_group_test_access_t::reset_scan_path_counts(*first_row_group);
+
+        std::pmr::vector<uint64_t> miss_filter_columns(&env.resource);
+        miss_filter_columns.push_back(0);
+        constant_filter_t miss_filter(components::expressions::compare_type::gte,
+                                      logical_value_t{&env.resource, int64_t(5000)},
+                                      std::move(miss_filter_columns));
+
+        table_scan_state miss_state(&env.resource);
+        loaded->initialize_scan(miss_state, projected_indices, &miss_filter);
+        data_chunk_t miss_result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+        loaded->scan(miss_result, miss_state);
+        REQUIRE(miss_result.size() == 0);
+
+        const auto counts = row_group_test_access_t::scan_path_counts(*first_row_group);
+        REQUIRE(counts.pax_generic_projected == 0);
+        REQUIRE(counts.pax_fixed_projected > 0);
+        REQUIRE(counts.pax_fixed_pruned_pages > 0);
+        REQUIRE(counts.pax_fixed_prefetched_blocks == 0);
+        REQUIRE(counts.pax_fixed_skipped_payload_pages > 0);
+        REQUIRE(counts.regular == 0);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: pax fixed projected scan filters fixed-width scalar types") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 300;
+    constexpr uint64_t TARGET_ROW = 37;
+    const auto table_path = test_db_path() + ".pax_fixed_filter_types";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+    auto status_enum = make_status_enum_type(&env.resource);
+    const auto decimal_i64_type = complex_logical_type::create_decimal(18, 3, "decimal_i64");
+    const auto decimal_i128_type = complex_logical_type::create_decimal(30, 4, "decimal_i128");
+
+    const auto tiny_value = [](uint64_t row) { return static_cast<int8_t>((row % 101) - 50); };
+    const auto utiny_value = [](uint64_t row) { return static_cast<uint8_t>((row * 3) % 251); };
+    const auto small_value = [](uint64_t row) { return static_cast<int16_t>(-1000 + static_cast<int64_t>(row * 5)); };
+    const auto usmall_value = [](uint64_t row) { return static_cast<uint16_t>(1000 + row * 7); };
+    const auto int_value = [](uint64_t row) { return static_cast<int32_t>(-50000 + static_cast<int64_t>(row * 11)); };
+    const auto uint_value = [](uint64_t row) { return static_cast<uint32_t>(50000 + row * 13); };
+    const auto ubig_value = [](uint64_t row) { return static_cast<uint64_t>(1000000000ULL + row * 17); };
+    const auto float_value = [](uint64_t row) { return static_cast<float>(0.25f + static_cast<float>(row) * 0.5f); };
+    const auto double_value = [](uint64_t row) { return 0.125 + static_cast<double>(row) * 0.25; };
+    const auto ts_value = [](uint64_t row) {
+        return core::date::timestamp_t{core::date::microseconds{static_cast<int64_t>(5000 + row * 19)}};
+    };
+    const auto tstz_value = [](uint64_t row) {
+        return core::date::timestamptz_t{core::date::microseconds{static_cast<int64_t>(7000 + row * 23)}};
+    };
+    const auto decimal_i64_value = [](uint64_t row) {
+        return static_cast<int64_t>(1000000000000LL + row * 29);
+    };
+    const auto decimal_i128_value = [](uint64_t row) {
+        return (int128_t{1} << 85) + static_cast<int64_t>(row * 31);
+    };
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("flag", logical_type::BOOLEAN);
+        columns.emplace_back("tiny_col", logical_type::TINYINT);
+        columns.emplace_back("utiny_col", logical_type::UTINYINT);
+        columns.emplace_back("small_col", logical_type::SMALLINT);
+        columns.emplace_back("usmall_col", logical_type::USMALLINT);
+        columns.emplace_back("int_col", logical_type::INTEGER);
+        columns.emplace_back("uint_col", logical_type::UINTEGER);
+        columns.emplace_back("ubig_col", logical_type::UBIGINT);
+        columns.emplace_back("huge_col", logical_type::HUGEINT);
+        columns.emplace_back("uhuge_col", logical_type::UHUGEINT);
+        columns.emplace_back("float_col", logical_type::FLOAT);
+        columns.emplace_back("ts_col", logical_type::TIMESTAMP);
+        columns.emplace_back("tstz_col", logical_type::TIMESTAMP_TZ);
+        columns.emplace_back("decimal_i64_col", decimal_i64_type);
+        columns.emplace_back("decimal_i128_col", decimal_i128_type);
+        columns.emplace_back("uuid_col", logical_type::UUID);
+        columns.emplace_back("double_col", logical_type::DOUBLE);
+        columns.emplace_back("status", status_enum);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_fixed_filter_types");
+
+        append_rows(*table, &env.resource, NUM_ROWS, [&](data_chunk_t& chunk, uint64_t row, uint64_t row_in_chunk) {
+            chunk.data[0].data<bool>()[row_in_chunk] = (row % 2) == 0;
+            chunk.data[1].data<int8_t>()[row_in_chunk] = tiny_value(row);
+            chunk.data[2].data<uint8_t>()[row_in_chunk] = utiny_value(row);
+            chunk.data[3].data<int16_t>()[row_in_chunk] = small_value(row);
+            chunk.data[4].data<uint16_t>()[row_in_chunk] = usmall_value(row);
+            chunk.data[5].data<int32_t>()[row_in_chunk] = int_value(row);
+            chunk.data[6].data<uint32_t>()[row_in_chunk] = uint_value(row);
+            chunk.data[7].data<uint64_t>()[row_in_chunk] = ubig_value(row);
+            chunk.data[8].data<int128_t>()[row_in_chunk] = signed_huge_value(row);
+            chunk.data[9].data<uint128_t>()[row_in_chunk] = unsigned_huge_value(row);
+            chunk.data[10].data<float>()[row_in_chunk] = float_value(row);
+            chunk.data[11].data<int64_t>()[row_in_chunk] = ts_value(row).value.count();
+            chunk.data[12].data<int64_t>()[row_in_chunk] = tstz_value(row).value.count();
+            chunk.data[13].data<int64_t>()[row_in_chunk] = decimal_i64_value(row);
+            chunk.data[14].data<int128_t>()[row_in_chunk] = decimal_i128_value(row);
+            chunk.data[15].data<int128_t>()[row_in_chunk] = uuid_like_value(row);
+            chunk.data[16].data<double>()[row_in_chunk] = double_value(row);
+            chunk.data[17].data<int32_t>()[row_in_chunk] = static_cast<int32_t>(row % 3);
+
+            if (row >= 256 && row % 29 == 0) {
+                for (auto& vector : chunk.data) {
+                    vector.validity().set(row_in_chunk, false);
+                }
+            }
+        });
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        auto* first_row_group = loaded->row_group()->row_group(0);
+        REQUIRE(first_row_group != nullptr);
+        row_group_test_access_t::reset_scan_path_counts(*first_row_group);
+
+        using compare_type = components::expressions::compare_type;
+
+        const auto scan_constant_filter = [&](uint64_t column_index,
+                                              compare_type filter_type,
+                                              logical_value_t constant,
+                                              auto&& check_value) {
+            std::vector<storage_index_t> projected_indices{storage_index_t(column_index)};
+            std::vector<size_t> projected_cols{static_cast<size_t>(column_index)};
+            std::pmr::vector<uint64_t> filter_columns(&env.resource);
+            filter_columns.push_back(column_index);
+            constant_filter_t filter(filter_type, std::move(constant), std::move(filter_columns));
+
+            table_scan_state state(&env.resource);
+            loaded->initialize_scan(state, projected_indices, &filter);
+            data_chunk_t result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+
+            uint64_t matched = 0;
+            while (true) {
+                result.reset();
+                loaded->scan(result, state);
+                if (result.size() == 0) {
+                    break;
+                }
+                for (uint64_t i = 0; i < result.size(); i++) {
+                    REQUIRE_FALSE(result.data[column_index].is_null(i));
+                    check_value(result.data[column_index], i);
+                }
+                matched += result.size();
+            }
+            INFO("column_index=" << column_index << " filter_type=" << static_cast<int>(filter_type));
+            REQUIRE(matched > 0);
+        };
+
+        const auto scan_eq = [&](uint64_t column_index, logical_value_t constant, auto&& check_value) {
+            scan_constant_filter(column_index, compare_type::eq, std::move(constant), check_value);
+        };
+
+        const auto exercise_non_eq_filters =
+            [&]<typename MakeConstant, typename ReadValue, typename CompareValue>(
+                uint64_t column_index, MakeConstant make_constant, ReadValue read_value, CompareValue constant_value) {
+                scan_constant_filter(column_index, compare_type::ne, make_constant(), [&](const vector_t& values, uint64_t i) {
+                    REQUIRE(read_value(values, i) != constant_value);
+                });
+                scan_constant_filter(column_index, compare_type::gt, make_constant(), [&](const vector_t& values, uint64_t i) {
+                    REQUIRE(read_value(values, i) > constant_value);
+                });
+                scan_constant_filter(column_index, compare_type::gte, make_constant(), [&](const vector_t& values, uint64_t i) {
+                    REQUIRE(read_value(values, i) >= constant_value);
+                });
+                scan_constant_filter(column_index, compare_type::lt, make_constant(), [&](const vector_t& values, uint64_t i) {
+                    REQUIRE(read_value(values, i) < constant_value);
+                });
+                scan_constant_filter(column_index, compare_type::lte, make_constant(), [&](const vector_t& values, uint64_t i) {
+                    REQUIRE(read_value(values, i) <= constant_value);
+                });
+            };
+
+        scan_eq(0, logical_value_t{&env.resource, false}, [](const vector_t& values, uint64_t i) {
+            REQUIRE_FALSE(values.data<bool>()[i]);
+        });
+        scan_eq(1, logical_value_t{&env.resource, tiny_value(TARGET_ROW)}, [&](const vector_t& values, uint64_t i) {
+            REQUIRE(values.data<int8_t>()[i] == tiny_value(TARGET_ROW));
+        });
+        scan_eq(2, logical_value_t{&env.resource, utiny_value(TARGET_ROW)}, [&](const vector_t& values, uint64_t i) {
+            REQUIRE(values.data<uint8_t>()[i] == utiny_value(TARGET_ROW));
+        });
+        scan_eq(3, logical_value_t{&env.resource, small_value(TARGET_ROW)}, [&](const vector_t& values, uint64_t i) {
+            REQUIRE(values.data<int16_t>()[i] == small_value(TARGET_ROW));
+        });
+        scan_eq(4, logical_value_t{&env.resource, usmall_value(TARGET_ROW)}, [&](const vector_t& values, uint64_t i) {
+            REQUIRE(values.data<uint16_t>()[i] == usmall_value(TARGET_ROW));
+        });
+        scan_eq(5, logical_value_t{&env.resource, int_value(TARGET_ROW)}, [&](const vector_t& values, uint64_t i) {
+            REQUIRE(values.data<int32_t>()[i] == int_value(TARGET_ROW));
+        });
+        scan_eq(6, logical_value_t{&env.resource, uint_value(TARGET_ROW)}, [&](const vector_t& values, uint64_t i) {
+            REQUIRE(values.data<uint32_t>()[i] == uint_value(TARGET_ROW));
+        });
+        scan_eq(7, logical_value_t{&env.resource, ubig_value(TARGET_ROW)}, [&](const vector_t& values, uint64_t i) {
+            REQUIRE(values.data<uint64_t>()[i] == ubig_value(TARGET_ROW));
+        });
+        scan_eq(8, logical_value_t{&env.resource, signed_huge_value(TARGET_ROW)}, [&](const vector_t& values, uint64_t i) {
+            REQUIRE(values.data<int128_t>()[i] == signed_huge_value(TARGET_ROW));
+        });
+        scan_eq(9,
+                logical_value_t{&env.resource, unsigned_huge_value(TARGET_ROW)},
+                [&](const vector_t& values, uint64_t i) {
+                    REQUIRE(values.data<uint128_t>()[i] == unsigned_huge_value(TARGET_ROW));
+                });
+        scan_eq(10, logical_value_t{&env.resource, float_value(TARGET_ROW)}, [&](const vector_t& values, uint64_t i) {
+            REQUIRE(values.data<float>()[i] == Approx(float_value(TARGET_ROW)));
+        });
+        scan_eq(11, logical_value_t{&env.resource, ts_value(TARGET_ROW)}, [&](const vector_t& values, uint64_t i) {
+            REQUIRE(values.data<int64_t>()[i] == ts_value(TARGET_ROW).value.count());
+        });
+        scan_eq(12, logical_value_t{&env.resource, tstz_value(TARGET_ROW)}, [&](const vector_t& values, uint64_t i) {
+            REQUIRE(values.data<int64_t>()[i] == tstz_value(TARGET_ROW).value.count());
+        });
+        scan_eq(13,
+                logical_value_t::create_decimal(&env.resource, decimal_i64_type, decimal_i64_value(TARGET_ROW)),
+                [&](const vector_t& values, uint64_t i) {
+                    REQUIRE(values.data<int64_t>()[i] == decimal_i64_value(TARGET_ROW));
+                });
+        scan_eq(14,
+                logical_value_t::create_decimal(&env.resource, decimal_i128_type, decimal_i128_value(TARGET_ROW)),
+                [&](const vector_t& values, uint64_t i) {
+                    REQUIRE(values.data<int128_t>()[i] == decimal_i128_value(TARGET_ROW));
+                });
+        scan_eq(15, logical_value_t{&env.resource, uuid_like_value(TARGET_ROW)}, [&](const vector_t& values, uint64_t i) {
+            REQUIRE(values.data<int128_t>()[i] == uuid_like_value(TARGET_ROW));
+        });
+        scan_eq(16, logical_value_t{&env.resource, double_value(TARGET_ROW)}, [&](const vector_t& values, uint64_t i) {
+            REQUIRE(values.data<double>()[i] == Approx(double_value(TARGET_ROW)));
+        });
+        scan_eq(17,
+                logical_value_t::create_enum(&env.resource, status_enum, static_cast<int32_t>(TARGET_ROW % 3)),
+                [&](const vector_t& values, uint64_t i) {
+                    REQUIRE(values.data<int32_t>()[i] == static_cast<int32_t>(TARGET_ROW % 3));
+                });
+
+        scan_constant_filter(0, compare_type::ne, logical_value_t{&env.resource, false}, [](const vector_t& values, uint64_t i) {
+            REQUIRE(values.data<bool>()[i]);
+        });
+        scan_constant_filter(0, compare_type::gt, logical_value_t{&env.resource, false}, [](const vector_t& values, uint64_t i) {
+            REQUIRE(values.data<bool>()[i]);
+        });
+        scan_constant_filter(0, compare_type::gte, logical_value_t{&env.resource, true}, [](const vector_t& values, uint64_t i) {
+            REQUIRE(values.data<bool>()[i]);
+        });
+        scan_constant_filter(0, compare_type::lt, logical_value_t{&env.resource, true}, [](const vector_t& values, uint64_t i) {
+            REQUIRE_FALSE(values.data<bool>()[i]);
+        });
+        scan_constant_filter(0, compare_type::lte, logical_value_t{&env.resource, false}, [](const vector_t& values, uint64_t i) {
+            REQUIRE_FALSE(values.data<bool>()[i]);
+        });
+        exercise_non_eq_filters(
+            1,
+            [&] { return logical_value_t{&env.resource, tiny_value(TARGET_ROW)}; },
+            [](const vector_t& values, uint64_t i) { return values.data<int8_t>()[i]; },
+            tiny_value(TARGET_ROW));
+        exercise_non_eq_filters(
+            2,
+            [&] { return logical_value_t{&env.resource, utiny_value(TARGET_ROW)}; },
+            [](const vector_t& values, uint64_t i) { return values.data<uint8_t>()[i]; },
+            utiny_value(TARGET_ROW));
+        exercise_non_eq_filters(
+            3,
+            [&] { return logical_value_t{&env.resource, small_value(TARGET_ROW)}; },
+            [](const vector_t& values, uint64_t i) { return values.data<int16_t>()[i]; },
+            small_value(TARGET_ROW));
+        exercise_non_eq_filters(
+            4,
+            [&] { return logical_value_t{&env.resource, usmall_value(TARGET_ROW)}; },
+            [](const vector_t& values, uint64_t i) { return values.data<uint16_t>()[i]; },
+            usmall_value(TARGET_ROW));
+        exercise_non_eq_filters(
+            5,
+            [&] { return logical_value_t{&env.resource, int_value(TARGET_ROW)}; },
+            [](const vector_t& values, uint64_t i) { return values.data<int32_t>()[i]; },
+            int_value(TARGET_ROW));
+        exercise_non_eq_filters(
+            6,
+            [&] { return logical_value_t{&env.resource, uint_value(TARGET_ROW)}; },
+            [](const vector_t& values, uint64_t i) { return values.data<uint32_t>()[i]; },
+            uint_value(TARGET_ROW));
+        exercise_non_eq_filters(
+            7,
+            [&] { return logical_value_t{&env.resource, ubig_value(TARGET_ROW)}; },
+            [](const vector_t& values, uint64_t i) { return values.data<uint64_t>()[i]; },
+            ubig_value(TARGET_ROW));
+        exercise_non_eq_filters(
+            8,
+            [&] { return logical_value_t{&env.resource, signed_huge_value(TARGET_ROW)}; },
+            [](const vector_t& values, uint64_t i) { return values.data<int128_t>()[i]; },
+            signed_huge_value(TARGET_ROW));
+        exercise_non_eq_filters(
+            9,
+            [&] { return logical_value_t{&env.resource, unsigned_huge_value(TARGET_ROW)}; },
+            [](const vector_t& values, uint64_t i) { return values.data<uint128_t>()[i]; },
+            unsigned_huge_value(TARGET_ROW));
+        scan_constant_filter(10,
+                             compare_type::ne,
+                             logical_value_t{&env.resource, float_value(TARGET_ROW)},
+                             [&](const vector_t& values, uint64_t i) {
+                                 REQUIRE_FALSE(values.data<float>()[i] == Approx(float_value(TARGET_ROW)));
+                             });
+        scan_constant_filter(10,
+                             compare_type::gt,
+                             logical_value_t{&env.resource, float_value(TARGET_ROW)},
+                             [&](const vector_t& values, uint64_t i) {
+                                 REQUIRE(values.data<float>()[i] > float_value(TARGET_ROW));
+                             });
+        scan_constant_filter(10,
+                             compare_type::gte,
+                             logical_value_t{&env.resource, float_value(TARGET_ROW)},
+                             [&](const vector_t& values, uint64_t i) {
+                                 REQUIRE(values.data<float>()[i] >= float_value(TARGET_ROW));
+                             });
+        scan_constant_filter(10,
+                             compare_type::lt,
+                             logical_value_t{&env.resource, float_value(TARGET_ROW)},
+                             [&](const vector_t& values, uint64_t i) {
+                                 REQUIRE(values.data<float>()[i] < float_value(TARGET_ROW));
+                             });
+        scan_constant_filter(10,
+                             compare_type::lte,
+                             logical_value_t{&env.resource, float_value(TARGET_ROW)},
+                             [&](const vector_t& values, uint64_t i) {
+                                 REQUIRE(values.data<float>()[i] <= float_value(TARGET_ROW));
+                             });
+        exercise_non_eq_filters(
+            11,
+            [&] { return logical_value_t{&env.resource, ts_value(TARGET_ROW)}; },
+            [](const vector_t& values, uint64_t i) { return values.data<int64_t>()[i]; },
+            ts_value(TARGET_ROW).value.count());
+        exercise_non_eq_filters(
+            12,
+            [&] { return logical_value_t{&env.resource, tstz_value(TARGET_ROW)}; },
+            [](const vector_t& values, uint64_t i) { return values.data<int64_t>()[i]; },
+            tstz_value(TARGET_ROW).value.count());
+        exercise_non_eq_filters(
+            13,
+            [&] { return logical_value_t::create_decimal(&env.resource, decimal_i64_type, decimal_i64_value(TARGET_ROW)); },
+            [](const vector_t& values, uint64_t i) { return values.data<int64_t>()[i]; },
+            decimal_i64_value(TARGET_ROW));
+        exercise_non_eq_filters(
+            14,
+            [&] { return logical_value_t::create_decimal(&env.resource, decimal_i128_type, decimal_i128_value(TARGET_ROW)); },
+            [](const vector_t& values, uint64_t i) { return values.data<int128_t>()[i]; },
+            decimal_i128_value(TARGET_ROW));
+        exercise_non_eq_filters(
+            15,
+            [&] { return logical_value_t{&env.resource, uuid_like_value(TARGET_ROW)}; },
+            [](const vector_t& values, uint64_t i) { return values.data<int128_t>()[i]; },
+            uuid_like_value(TARGET_ROW));
+        scan_constant_filter(16,
+                             compare_type::ne,
+                             logical_value_t{&env.resource, double_value(TARGET_ROW)},
+                             [&](const vector_t& values, uint64_t i) {
+                                 REQUIRE_FALSE(values.data<double>()[i] == Approx(double_value(TARGET_ROW)));
+                             });
+        scan_constant_filter(16,
+                             compare_type::gt,
+                             logical_value_t{&env.resource, double_value(TARGET_ROW)},
+                             [&](const vector_t& values, uint64_t i) {
+                                 REQUIRE(values.data<double>()[i] > double_value(TARGET_ROW));
+                             });
+        scan_constant_filter(16,
+                             compare_type::gte,
+                             logical_value_t{&env.resource, double_value(TARGET_ROW)},
+                             [&](const vector_t& values, uint64_t i) {
+                                 REQUIRE(values.data<double>()[i] >= double_value(TARGET_ROW));
+                             });
+        scan_constant_filter(16,
+                             compare_type::lt,
+                             logical_value_t{&env.resource, double_value(TARGET_ROW)},
+                             [&](const vector_t& values, uint64_t i) {
+                                 REQUIRE(values.data<double>()[i] < double_value(TARGET_ROW));
+                             });
+        scan_constant_filter(16,
+                             compare_type::lte,
+                             logical_value_t{&env.resource, double_value(TARGET_ROW)},
+                             [&](const vector_t& values, uint64_t i) {
+                                 REQUIRE(values.data<double>()[i] <= double_value(TARGET_ROW));
+                             });
+        exercise_non_eq_filters(
+            17,
+            [&] { return logical_value_t::create_enum(&env.resource, status_enum, static_cast<int32_t>(TARGET_ROW % 3)); },
+            [](const vector_t& values, uint64_t i) { return values.data<int32_t>()[i]; },
+            static_cast<int32_t>(TARGET_ROW % 3));
+
+        const auto counts = row_group_test_access_t::scan_path_counts(*first_row_group);
+        REQUIRE(counts.pax_generic_projected == 0);
+        REQUIRE(counts.pax_fixed_projected > 0);
+        REQUIRE(counts.pax_fixed_prefetched_blocks > 0);
+        REQUIRE(counts.regular == 0);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: pax fixed projected scan supports extended projections and non-projected filters") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 320;
+    const auto table_path = test_db_path() + ".pax_fixed_extended_projection";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("flag", logical_type::BOOLEAN);
+        columns.emplace_back("score", logical_type::DOUBLE);
+        columns.emplace_back("event_ts", logical_type::TIMESTAMP);
+        columns.emplace_back("uuid_col", logical_type::UUID);
+        auto table =
+            std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_fixed_extended_projection");
+
+        append_rows(*table, &env.resource, NUM_ROWS, [&](data_chunk_t& chunk, uint64_t row, uint64_t row_in_chunk) {
+            chunk.set_value(0, row_in_chunk, logical_value_t{&env.resource, row % 2 == 0});
+            chunk.set_value(1, row_in_chunk, logical_value_t{&env.resource, 10.0 + static_cast<double>(row) / 4.0});
+            chunk.set_value(2,
+                            row_in_chunk,
+                            logical_value_t{&env.resource,
+                                            core::date::timestamp_t{core::date::microseconds{
+                                                static_cast<int64_t>(1000 + row * 15)}}});
+            chunk.data[3].data<int128_t>()[row_in_chunk] = uuid_like_value(row);
+        });
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        auto* first_row_group = loaded->row_group()->row_group(0);
+        REQUIRE(first_row_group != nullptr);
+
+        std::vector<storage_index_t> projected_indices{storage_index_t(0), storage_index_t(2), storage_index_t(3)};
+        std::vector<size_t> projected_cols{0, 2, 3};
+        std::pmr::vector<uint64_t> filter_columns(&env.resource);
+        filter_columns.push_back(1);
+        constant_filter_t filter(components::expressions::compare_type::gt,
+                                 logical_value_t{&env.resource, 60.0},
+                                 std::move(filter_columns));
+
+        table_scan_state helper_state(&env.resource);
+        loaded->initialize_scan(helper_state, projected_indices, &filter);
+        data_chunk_t helper_chunk(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+        REQUIRE(row_group_test_access_t::try_scan_pax_fixed_projected(*first_row_group,
+                                                                      helper_state.table_state,
+                                                                      helper_chunk));
+
+        row_group_test_access_t::reset_scan_path_counts(*first_row_group);
+
+        std::vector<uint64_t> expected_rows;
+        for (uint64_t row = 0; row < NUM_ROWS; row++) {
+            if (10.0 + static_cast<double>(row) / 4.0 > 60.0) {
+                expected_rows.push_back(row);
+            }
+        }
+
+        table_scan_state state(&env.resource);
+        loaded->initialize_scan(state, projected_indices, &filter);
+        data_chunk_t result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+
+        uint64_t scanned = 0;
+        while (true) {
+            result.reset();
+            loaded->scan(result, state);
+            if (result.size() == 0) {
+                break;
+            }
+            for (uint64_t i = 0; i < result.size(); i++) {
+                const auto row = expected_rows[scanned + i];
+                REQUIRE(result.data[0].data<bool>()[i] == (row % 2 == 0));
+                REQUIRE(result.data[2].data<int64_t>()[i] == static_cast<int64_t>(1000 + row * 15));
+                REQUIRE(result.data[3].data<int128_t>()[i] == uuid_like_value(row));
+            }
+            scanned += result.size();
+        }
+        REQUIRE(scanned == expected_rows.size());
+
+        const auto counts = row_group_test_access_t::scan_path_counts(*first_row_group);
+        REQUIRE(counts.pax_generic_projected == 0);
+        REQUIRE(counts.pax_fixed_projected > 0);
+        REQUIRE(counts.pax_fixed_prefetched_blocks > 0);
+        REQUIRE(counts.regular == 0);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: pax fixed projected scan supports null predicates") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 260;
+    const auto table_path = test_db_path() + ".pax_fixed_null_predicates";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("id", logical_type::BIGINT);
+        columns.emplace_back("score", logical_type::DOUBLE);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_fixed_null_predicates");
+
+        append_rows(*table, &env.resource, NUM_ROWS, [&](data_chunk_t& chunk, uint64_t row, uint64_t row_in_chunk) {
+            chunk.set_value(0, row_in_chunk, logical_value_t{&env.resource, static_cast<int64_t>(row)});
+            if (row % 7 == 0) {
+                chunk.data[1].set_null(row_in_chunk, true);
+            } else {
+                chunk.set_value(1, row_in_chunk, logical_value_t{&env.resource, static_cast<double>(row) * 1.5});
+            }
+        });
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        auto* first_row_group = loaded->row_group()->row_group(0);
+        REQUIRE(first_row_group != nullptr);
+
+        std::vector<storage_index_t> projected_indices{storage_index_t(0)};
+        std::vector<size_t> projected_cols{0};
+        std::pmr::vector<uint64_t> filter_columns(&env.resource);
+        filter_columns.push_back(1);
+        is_null_filter_t filter(components::expressions::compare_type::is_null, std::move(filter_columns));
+
+        table_scan_state helper_state(&env.resource);
+        loaded->initialize_scan(helper_state, projected_indices, &filter);
+        data_chunk_t helper_chunk(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+        REQUIRE(row_group_test_access_t::try_scan_pax_fixed_projected(*first_row_group,
+                                                                      helper_state.table_state,
+                                                                      helper_chunk));
+
+        std::vector<uint64_t> expected_rows;
+        for (uint64_t row = 0; row < NUM_ROWS; row++) {
+            if (row % 7 == 0) {
+                expected_rows.push_back(row);
+            }
+        }
+
+        table_scan_state state(&env.resource);
+        loaded->initialize_scan(state, projected_indices, &filter);
+        data_chunk_t result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+
+        uint64_t scanned = 0;
+        while (true) {
+            result.reset();
+            loaded->scan(result, state);
+            if (result.size() == 0) {
+                break;
+            }
+            for (uint64_t i = 0; i < result.size(); i++) {
+                REQUIRE(result.data[0].value(i).value<int64_t>() == static_cast<int64_t>(expected_rows[scanned + i]));
+            }
+            scanned += result.size();
+        }
+        REQUIRE(scanned == expected_rows.size());
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: pax fixed projected scan preserves null validity") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 1300;
+    const auto table_path = test_db_path() + ".pax_nulls";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+
+    auto left_value_fn = [](uint64_t row) -> std::optional<int64_t> {
+        if (row < 128) {
+            return (row % 5 == 0) ? std::optional<int64_t>{} : std::optional<int64_t>{static_cast<int64_t>(row)};
+        }
+        if (row < 256) {
+            return std::nullopt;
+        }
+        if (row < 384) {
+            return static_cast<int64_t>(row);
+        }
+        return (row % 11 == 0) ? std::optional<int64_t>{} : std::optional<int64_t>{static_cast<int64_t>(row)};
+    };
+
+    auto right_value_fn = [](uint64_t row) -> std::optional<uint32_t> {
+        if (row < 128) {
+            return static_cast<uint32_t>(row * 7);
+        }
+        if (row < 256) {
+            return (row % 2 == 0) ? std::optional<uint32_t>{} : std::optional<uint32_t>{static_cast<uint32_t>(row * 7)};
+        }
+        if (row < 384) {
+            return std::nullopt;
+        }
+        return static_cast<uint32_t>(row * 7);
+    };
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("id", logical_type::BIGINT);
+        columns.emplace_back("value", logical_type::UINTEGER);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_nulls");
+        append_nullable_fixed_integer_pair(*table, &env.resource, NUM_ROWS, left_value_fn, right_value_fn);
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        auto* first_row_group = loaded->row_group()->row_group(0);
+        REQUIRE(first_row_group != nullptr);
+
+        std::vector<storage_index_t> projected_indices{storage_index_t(0), storage_index_t(1)};
+        std::vector<size_t> projected_cols{0, 1};
+
+        table_scan_state helper_state(&env.resource);
+        loaded->initialize_scan(helper_state, projected_indices, nullptr);
+        data_chunk_t helper_chunk(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+        REQUIRE(row_group_test_access_t::try_scan_pax_fixed_projected(*first_row_group,
+                                                                      helper_state.table_state,
+                                                                      helper_chunk));
+        REQUIRE(helper_chunk.size() == DEFAULT_VECTOR_CAPACITY);
+
+        table_scan_state state(&env.resource);
+        loaded->initialize_scan(state, projected_indices, nullptr);
+        data_chunk_t result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+
+        uint64_t scanned = 0;
+        while (true) {
+            result.reset();
+            loaded->scan(result, state);
+            if (result.size() == 0) {
+                break;
+            }
+
+            for (uint64_t i = 0; i < result.size(); i++) {
+                const auto row = scanned + i;
+                const auto expected_left = left_value_fn(row);
+                const auto expected_right = right_value_fn(row);
+
+                REQUIRE(result.data[0].is_null(i) == !expected_left.has_value());
+                if (expected_left.has_value()) {
+                    REQUIRE(result.data[0].value(i).value<int64_t>() == *expected_left);
+                }
+
+                REQUIRE(result.data[1].is_null(i) == !expected_right.has_value());
+                if (expected_right.has_value()) {
+                    REQUIRE(result.data[1].value(i).value<uint32_t>() == *expected_right);
+                }
+            }
+            scanned += result.size();
+        }
+        REQUIRE(scanned == NUM_ROWS);
+
+        std::pmr::vector<uint64_t> match_columns(&env.resource);
+        match_columns.push_back(0);
+        constant_filter_t match_filter(components::expressions::compare_type::eq,
+                                       logical_value_t{&env.resource, int64_t(400)},
+                                       std::move(match_columns));
+        table_scan_state match_state(&env.resource);
+        loaded->initialize_scan(match_state, projected_indices, &match_filter);
+        data_chunk_t match_result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+        loaded->scan(match_result, match_state);
+        REQUIRE(match_result.size() == 1);
+        REQUIRE_FALSE(match_result.data[0].is_null(0));
+        REQUIRE(match_result.data[0].value(0).value<int64_t>() == 400);
+        REQUIRE_FALSE(match_result.data[1].is_null(0));
+        REQUIRE(match_result.data[1].value(0).value<uint32_t>() == 2800);
+
+        std::pmr::vector<uint64_t> null_columns(&env.resource);
+        null_columns.push_back(0);
+        constant_filter_t null_filter(components::expressions::compare_type::eq,
+                                      logical_value_t{&env.resource, int64_t(130)},
+                                      std::move(null_columns));
+        table_scan_state null_state(&env.resource);
+        loaded->initialize_scan(null_state, projected_indices, &null_filter);
+        data_chunk_t null_result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+        loaded->scan(null_result, null_state);
+        REQUIRE(null_result.size() == 0);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+// A column buffer is reused across pages within a filtered batch, so a page with cleared validity
+// bits must not leak nulls into a later all-valid page. 4 pages in one batch with the nullable
+// column ALL_INVALID/ALL_VALID/BITMASK/ALL_VALID; a filter (id >= 0) selects every row to force the
+// per-page path. The buffer's validity has to be reset on hand-out or pages 1/3 read as null.
+TEST_CASE("checkpoint_load: pax fixed projected scan resets reused buffer validity across pages") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 256;
+    constexpr uint16_t ROWS_PER_PAGE = 64;
+    const auto table_path = test_db_path() + ".pax_fixed_buffer_reuse_validity";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+
+    auto payload_is_null = [](uint64_t row) {
+        if (row < 64) {
+            return true; // page 0: ALL_INVALID
+        }
+        if (row >= 128 && row < 192) {
+            return row % 2 == 0; // page 2: BITMASK
+        }
+        return false; // pages 1 and 3: ALL_VALID
+    };
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+        bm.set_pax_rows_per_page(ROWS_PER_PAGE);
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("id", logical_type::BIGINT);
+        columns.emplace_back("payload", logical_type::BIGINT);
+        auto table =
+            std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_fixed_buffer_reuse_validity");
+
+        append_rows(*table, &env.resource, NUM_ROWS, [&](data_chunk_t& chunk, uint64_t row, uint64_t row_in_chunk) {
+            chunk.set_value(0, row_in_chunk, logical_value_t{&env.resource, static_cast<int64_t>(row)});
+            if (payload_is_null(row)) {
+                chunk.data[1].set_null(row_in_chunk, true);
+            } else {
+                chunk.set_value(1, row_in_chunk, logical_value_t{&env.resource, static_cast<int64_t>(row) * 10});
+            }
+        });
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+
+        // Project both the filter column and the nullable payload column to exercise both reuse paths.
+        std::vector<storage_index_t> projected_indices{storage_index_t(0), storage_index_t(1)};
+        std::vector<size_t> projected_cols{0, 1};
+
+        std::pmr::vector<uint64_t> filter_columns(&env.resource);
+        filter_columns.push_back(0);
+        constant_filter_t filter(components::expressions::compare_type::gte,
+                                 logical_value_t{&env.resource, int64_t(0)},
+                                 std::move(filter_columns));
+
+        table_scan_state state(&env.resource);
+        loaded->initialize_scan(state, projected_indices, &filter);
+        data_chunk_t result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+
+        uint64_t scanned = 0;
+        while (true) {
+            result.reset();
+            loaded->scan(result, state);
+            if (result.size() == 0) {
+                break;
+            }
+            for (uint64_t i = 0; i < result.size(); i++) {
+                const auto row = scanned + i;
+                REQUIRE_FALSE(result.data[0].is_null(i));
+                REQUIRE(result.data[0].value(i).value<int64_t>() == static_cast<int64_t>(row));
+                REQUIRE(result.data[1].is_null(i) == payload_is_null(row));
+                if (!payload_is_null(row)) {
+                    REQUIRE(result.data[1].value(i).value<int64_t>() == static_cast<int64_t>(row) * 10);
+                }
+            }
+            scanned += result.size();
+        }
+        REQUIRE(scanned == NUM_ROWS);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+// Multi-column AND page pruning: a two-column conjunction (a >= 200 AND b < 1000000) where column
+// `a`'s per-page min/max excludes whole pages. Two distinct filter columns take the filter-tree
+// statistics path rather than the single-column fast branch. 4 pages; pages 0..2 prune, page 3 scans.
+TEST_CASE("checkpoint_load: pax fixed projected scan prunes pages on multi-column AND filter") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 256;
+    constexpr uint16_t ROWS_PER_PAGE = 64;
+    const auto table_path = test_db_path() + ".pax_fixed_multicol_prune";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+        bm.set_pax_rows_per_page(ROWS_PER_PAGE);
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("a", logical_type::BIGINT);
+        columns.emplace_back("b", logical_type::BIGINT);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_fixed_multicol_prune");
+
+        append_rows(*table, &env.resource, NUM_ROWS, [&](data_chunk_t& chunk, uint64_t row, uint64_t row_in_chunk) {
+            chunk.set_value(0, row_in_chunk, logical_value_t{&env.resource, static_cast<int64_t>(row)});
+            chunk.set_value(1, row_in_chunk, logical_value_t{&env.resource, static_cast<int64_t>(row) * 3});
+        });
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        auto* first_row_group = loaded->row_group()->row_group(0);
+        REQUIRE(first_row_group != nullptr);
+
+        std::vector<storage_index_t> projected_indices{storage_index_t(0), storage_index_t(1)};
+        std::vector<size_t> projected_cols{0, 1};
+
+        conjunction_and_filter_t filter;
+        std::pmr::vector<uint64_t> a_columns(&env.resource);
+        a_columns.push_back(0);
+        filter.child_filters.push_back(std::make_unique<constant_filter_t>(
+            components::expressions::compare_type::gte, logical_value_t{&env.resource, int64_t(200)}, std::move(a_columns)));
+        std::pmr::vector<uint64_t> b_columns(&env.resource);
+        b_columns.push_back(1);
+        filter.child_filters.push_back(std::make_unique<constant_filter_t>(
+            components::expressions::compare_type::lt, logical_value_t{&env.resource, int64_t(1000000)}, std::move(b_columns)));
+
+        row_group_test_access_t::reset_scan_path_counts(*first_row_group);
+
+        table_scan_state state(&env.resource);
+        loaded->initialize_scan(state, projected_indices, &filter);
+        data_chunk_t result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+
+        uint64_t scanned = 0;
+        while (true) {
+            result.reset();
+            loaded->scan(result, state);
+            if (result.size() == 0) {
+                break;
+            }
+            for (uint64_t i = 0; i < result.size(); i++) {
+                const auto row = 200 + scanned + i;
+                REQUIRE(result.data[0].value(i).value<int64_t>() == static_cast<int64_t>(row));
+                REQUIRE(result.data[1].value(i).value<int64_t>() == static_cast<int64_t>(row) * 3);
+            }
+            scanned += result.size();
+        }
+        REQUIRE(scanned == NUM_ROWS - 200);
+
+        const auto counts = row_group_test_access_t::scan_path_counts(*first_row_group);
+        REQUIRE(counts.pax_fixed_projected > 0);
+        REQUIRE(counts.regular == 0);
+        REQUIRE(counts.pax_fixed_pruned_pages == 3);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: pax fixed projected scan falls back for unsupported cases") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    const auto table_path = test_db_path() + ".pax_fallback";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("id", logical_type::BIGINT);
+        columns.emplace_back("value", logical_type::UINTEGER);
+        columns.emplace_back("name", logical_type::STRING_LITERAL);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_fallback");
+
+        auto types = table->copy_types();
+        for (uint64_t offset = 0; offset < 64; offset += DEFAULT_VECTOR_CAPACITY) {
+            const auto batch = std::min<uint64_t>(64 - offset, DEFAULT_VECTOR_CAPACITY);
+            data_chunk_t chunk(&env.resource, types, batch);
+            chunk.set_cardinality(batch);
+            for (uint64_t i = 0; i < batch; i++) {
+                const auto row = offset + i;
+                chunk.set_value(0, i, logical_value_t{&env.resource, static_cast<int64_t>(row)});
+                chunk.set_value(1, i, logical_value_t{&env.resource, static_cast<uint32_t>(row * 5)});
+                chunk.set_value(2, i, logical_value_t{&env.resource, std::string("name_") + std::to_string(row)});
+            }
+            table_append_state state(&env.resource);
+            table->append_lock(state);
+            table->initialize_append(state);
+            table->append(chunk, state);
+            table->finalize_append(state, transaction_data{0, 0});
+        }
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        auto* first_row_group = loaded->row_group()->row_group(0);
+        REQUIRE(first_row_group != nullptr);
+
+        {
+            std::vector<storage_index_t> projected_indices{storage_index_t(0), storage_index_t(2)};
+            std::vector<size_t> projected_cols{0, 2};
+            table_scan_state state(&env.resource);
+            loaded->initialize_scan(state, projected_indices, nullptr);
+            data_chunk_t result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+            REQUIRE_FALSE(row_group_test_access_t::try_scan_pax_fixed_projected(*first_row_group,
+                                                                                state.table_state,
+                                                                                result));
+        }
+
+        {
+            std::vector<storage_index_t> row_id_projection{storage_index_t(0), storage_index_t()};
+            std::vector<size_t> row_id_projected_cols{0, 1};
+            table_scan_state state(&env.resource);
+            loaded->initialize_scan(state, row_id_projection, nullptr);
+            data_chunk_t result(&env.resource, loaded->copy_types(), row_id_projected_cols, DEFAULT_VECTOR_CAPACITY);
+            REQUIRE_FALSE(row_group_test_access_t::try_scan_pax_fixed_projected(*first_row_group,
+                                                                                state.table_state,
+                                                                                result));
+        }
+
+        {
+            std::vector<storage_index_t> projected_indices{storage_index_t(0)};
+            std::vector<size_t> projected_cols{0};
+            std::pmr::vector<uint64_t> filter_columns(&env.resource);
+            filter_columns.push_back(0);
+            constant_filter_t invalid_filter(components::expressions::compare_type::invalid,
+                                             logical_value_t{&env.resource, int64_t{10}},
+                                             std::move(filter_columns));
+            table_scan_state state(&env.resource);
+            loaded->initialize_scan(state, projected_indices, &invalid_filter);
+            data_chunk_t result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+            REQUIRE_FALSE(row_group_test_access_t::try_scan_pax_fixed_projected(*first_row_group,
+                                                                                state.table_state,
+                                                                                result));
+        }
+
+        {
+            std::vector<storage_index_t> projected_indices{storage_index_t(0)};
+            std::vector<size_t> projected_cols{0};
+            std::pmr::vector<uint64_t> filter_columns(&env.resource);
+            filter_columns.push_back(1);
+            constant_filter_t filter(components::expressions::compare_type::gt,
+                                     logical_value_t{&env.resource, uint32_t(100)},
+                                     std::move(filter_columns));
+            table_scan_state state(&env.resource);
+            loaded->initialize_scan(state, projected_indices, &filter);
+            data_chunk_t result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+            REQUIRE_FALSE(row_group_test_access_t::try_scan_pax_fixed_projected(*first_row_group,
+                                                                                state.table_state,
+                                                                                result));
+        }
+    }
+
+    std::remove(table_path.c_str());
     cleanup_test_file();
 }
 
@@ -773,5 +8064,459 @@ TEST_CASE("checkpoint_load: small segment — 2 rows edge case") {
         REQUIRE(scanned == NUM_ROWS);
     }
 
+    cleanup_test_file();
+}
+
+// ---------------------------------------------------------------------------------------------
+// Commit-path fault injection. The two tests below inject EIO via the POSIX fsync/pwrite hooks: a
+// checkpoint that can't be made durable must throw, and the prior committed state must survive
+// (header never swapped).
+#if defined(DEV_MODE) && defined(PLATFORM_POSIX)
+namespace {
+    // Hooks are capture-less function pointers, so the state lives at TU scope. The RAII guard
+    // clears it on scope exit (including on a REQUIRE/throw unwind) so a fault can't leak into a later test.
+    bool g_fault_fsync_fail = false;                          // every fsync fails with EIO
+    uint64_t g_fault_pwrite_fail_at_or_above = UINT64_MAX;    // fail pwrites whose offset >= this
+
+    int fault_fsync_hook(int fd) {
+        if (g_fault_fsync_fail) {
+            errno = EIO;
+            return -1;
+        }
+        return ::fsync(fd);
+    }
+    int64_t fault_pwrite_hook(int fd, const void* buffer, size_t nr_bytes, uint64_t location) {
+        if (location >= g_fault_pwrite_fail_at_or_above) {
+            errno = EIO;
+            return -1;
+        }
+        return ::pwrite(fd, buffer, nr_bytes, static_cast<off_t>(location));
+    }
+    struct fault_injection_guard_t {
+        fault_injection_guard_t() {
+            g_fault_fsync_fail = false;
+            g_fault_pwrite_fail_at_or_above = UINT64_MAX;
+        }
+        ~fault_injection_guard_t() {
+            core::filesystem::testing::reset_posix_positioned_io_hooks();
+            g_fault_fsync_fail = false;
+            g_fault_pwrite_fail_at_or_above = UINT64_MAX;
+        }
+    };
+} // namespace
+
+TEST_CASE("checkpoint_load: fsync failure during checkpoint aborts commit and preserves prior state") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    constexpr uint64_t V1_ROWS = 1500;  // durably committed
+    constexpr uint64_t V2_EXTRA = 800;  // appended, commit aborted by fsync EIO
+    const auto table_path = test_db_path() + ".fsync_fault";
+    std::remove(table_path.c_str());
+
+    fault_injection_guard_t guard;
+
+    // Commit: persist data/metadata, fsync, swap header, fsync.
+    const auto commit = [](single_file_block_manager_t& bm, data_table_t& table) {
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table.checkpoint(writer);
+        writer.flush();
+        bm.set_meta_block(writer.get_block_pointer().block_pointer);
+        auto free_list_ptr = bm.serialize_free_list();
+        bm.file_sync();
+        database_header_t header;
+        header.initialize();
+        header.free_list = free_list_ptr.block_pointer;
+        bm.write_header(header);
+        bm.file_sync();
+    };
+
+    const auto reopen_and_count = [](test_env_t& env, const std::string& path, uint64_t expected) {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, path);
+        bm.load_existing_database();
+        metadata_manager_t meta_mgr(bm);
+        meta_block_pointer_t meta_ptr;
+        meta_ptr.block_pointer = bm.meta_block();
+        metadata_reader_t reader(meta_mgr, meta_ptr);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        std::vector<storage_index_t> projected_indices{storage_index_t(0), storage_index_t(1)};
+        std::vector<size_t> projected_cols{0, 1};
+        table_scan_state state(&env.resource);
+        loaded->initialize_scan(state, projected_indices, nullptr);
+        data_chunk_t result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+        uint64_t scanned = 0;
+        while (true) {
+            result.reset();
+            loaded->scan(result, state);
+            if (result.size() == 0) {
+                break;
+            }
+            for (uint64_t i = 0; i < result.size(); i++) {
+                const auto row = scanned + i;
+                REQUIRE(result.data[0].value(i).value<int64_t>() == static_cast<int64_t>(row));
+                REQUIRE(result.data[1].value(i).value<uint32_t>() == static_cast<uint32_t>(row * 3));
+            }
+            scanned += result.size();
+        }
+        REQUIRE(scanned == expected);
+    };
+
+    // Phase 1: build V1 and commit it durably (hooks inactive).
+    {
+        test_env_t env;
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+        bm.set_layout_policy(row_group_layout_policy::PAX_ONLY);
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("id", logical_type::BIGINT);
+        columns.emplace_back("value", logical_type::UINTEGER);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "fsync_fault");
+        append_fixed_integer_pair(*table,
+                                  &env.resource,
+                                  V1_ROWS,
+                                  [](uint64_t row) { return static_cast<int64_t>(row); },
+                                  [](uint64_t row) { return static_cast<uint32_t>(row * 3); });
+        commit(bm, *table);
+    }
+
+    // Phase 2: reopen, append V2, attempt commit with fsync forced to fail. file_sync() must throw
+    // (checkpoint not durable); the header is never swapped.
+    {
+        test_env_t env;
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+        metadata_manager_t meta_mgr(bm);
+        meta_block_pointer_t meta_ptr;
+        meta_ptr.block_pointer = bm.meta_block();
+        metadata_reader_t reader(meta_mgr, meta_ptr);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        append_fixed_integer_pair(*loaded,
+                                  &env.resource,
+                                  V2_EXTRA,
+                                  [](uint64_t row) { return static_cast<int64_t>(V1_ROWS + row); },
+                                  [](uint64_t row) { return static_cast<uint32_t>((V1_ROWS + row) * 3); });
+
+        core::filesystem::testing::set_posix_fsync_hook(&fault_fsync_hook);
+        g_fault_fsync_fail = true;
+        REQUIRE_THROWS_AS(commit(bm, *loaded), std::runtime_error);
+        g_fault_fsync_fail = false;
+        core::filesystem::testing::set_posix_fsync_hook(nullptr);
+    }
+
+    // Phase 3: reopen via the on-disk header. Must observe exactly the committed V1.
+    {
+        test_env_t env;
+        reopen_and_count(env, table_path, V1_ROWS);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+TEST_CASE("checkpoint_load: block-write failure during checkpoint aborts commit and preserves prior state") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    constexpr uint64_t V1_ROWS = 1500;  // durably committed
+    constexpr uint64_t V2_EXTRA = 800;  // appended, commit aborted by block-write EIO
+    const auto table_path = test_db_path() + ".write_fault";
+    std::remove(table_path.c_str());
+
+    fault_injection_guard_t guard;
+
+    const auto commit = [](single_file_block_manager_t& bm, data_table_t& table) {
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table.checkpoint(writer);
+        writer.flush();
+        bm.set_meta_block(writer.get_block_pointer().block_pointer);
+        auto free_list_ptr = bm.serialize_free_list();
+        bm.file_sync();
+        database_header_t header;
+        header.initialize();
+        header.free_list = free_list_ptr.block_pointer;
+        bm.write_header(header);
+        bm.file_sync();
+    };
+
+    const auto reopen_and_count = [](test_env_t& env, const std::string& path, uint64_t expected) {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, path);
+        bm.load_existing_database();
+        metadata_manager_t meta_mgr(bm);
+        meta_block_pointer_t meta_ptr;
+        meta_ptr.block_pointer = bm.meta_block();
+        metadata_reader_t reader(meta_mgr, meta_ptr);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        std::vector<storage_index_t> projected_indices{storage_index_t(0), storage_index_t(1)};
+        std::vector<size_t> projected_cols{0, 1};
+        table_scan_state state(&env.resource);
+        loaded->initialize_scan(state, projected_indices, nullptr);
+        data_chunk_t result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+        uint64_t scanned = 0;
+        while (true) {
+            result.reset();
+            loaded->scan(result, state);
+            if (result.size() == 0) {
+                break;
+            }
+            for (uint64_t i = 0; i < result.size(); i++) {
+                const auto row = scanned + i;
+                REQUIRE(result.data[0].value(i).value<int64_t>() == static_cast<int64_t>(row));
+                REQUIRE(result.data[1].value(i).value<uint32_t>() == static_cast<uint32_t>(row * 3));
+            }
+            scanned += result.size();
+        }
+        REQUIRE(scanned == expected);
+    };
+
+    // Phase 1: build V1 and commit it durably (hooks inactive).
+    {
+        test_env_t env;
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+        bm.set_layout_policy(row_group_layout_policy::PAX_ONLY);
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("id", logical_type::BIGINT);
+        columns.emplace_back("value", logical_type::UINTEGER);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "write_fault");
+        append_fixed_integer_pair(*table,
+                                  &env.resource,
+                                  V1_ROWS,
+                                  [](uint64_t row) { return static_cast<int64_t>(row); },
+                                  [](uint64_t row) { return static_cast<uint32_t>(row * 3); });
+        commit(bm, *table);
+    }
+
+    // Phase 2: reopen, append V2, attempt commit while every data/metadata block write (offset >=
+    // BLOCK_START, header slots still writable) fails with EIO. checksum_and_write must throw rather
+    // than swallow the failed write; the header is never swapped.
+    {
+        test_env_t env;
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+        metadata_manager_t meta_mgr(bm);
+        meta_block_pointer_t meta_ptr;
+        meta_ptr.block_pointer = bm.meta_block();
+        metadata_reader_t reader(meta_mgr, meta_ptr);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        append_fixed_integer_pair(*loaded,
+                                  &env.resource,
+                                  V2_EXTRA,
+                                  [](uint64_t row) { return static_cast<int64_t>(V1_ROWS + row); },
+                                  [](uint64_t row) { return static_cast<uint32_t>((V1_ROWS + row) * 3); });
+
+        core::filesystem::testing::set_posix_pwrite_hook(&fault_pwrite_hook);
+        g_fault_pwrite_fail_at_or_above = BLOCK_START;
+        REQUIRE_THROWS_AS(commit(bm, *loaded), std::runtime_error);
+        g_fault_pwrite_fail_at_or_above = UINT64_MAX;
+        core::filesystem::testing::set_posix_pwrite_hook(nullptr);
+    }
+
+    // Phase 3: reopen via the on-disk header. Must observe exactly the committed V1.
+    {
+        test_env_t env;
+        reopen_and_count(env, table_path, V1_ROWS);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+#endif // DEV_MODE && PLATFORM_POSIX
+
+// Corrupt the metadata block (the row-group-pointer tree). A flipped payload byte invalidates its
+// CRC32c, so reopening and rebuilding the table must raise a checksum mismatch rather than walk a
+// corrupt pointer tree.
+TEST_CASE("checkpoint_load: corrupted metadata block is detected on reopen") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    constexpr uint64_t ROWS = 2048;
+    const auto table_path = test_db_path() + ".meta_corrupt";
+    std::remove(table_path.c_str());
+
+    meta_block_pointer_t meta_ptr;
+    uint64_t block_alloc_size = 0;
+
+    // Phase 1: build a PAX_ONLY table and commit it; capture the metadata block pointer.
+    {
+        test_env_t env;
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+        bm.set_layout_policy(row_group_layout_policy::PAX_ONLY);
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("id", logical_type::BIGINT);
+        columns.emplace_back("value", logical_type::UINTEGER);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "meta_corrupt");
+        append_fixed_integer_pair(*table,
+                                  &env.resource,
+                                  ROWS,
+                                  [](uint64_t row) { return static_cast<int64_t>(row); },
+                                  [](uint64_t row) { return static_cast<uint32_t>(row * 3); });
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        writer.flush();
+        meta_ptr = writer.get_block_pointer();
+        bm.set_meta_block(meta_ptr.block_pointer);
+        block_alloc_size = bm.block_allocation_size();
+        bm.file_sync();
+        database_header_t header;
+        header.initialize();
+        header.meta_block = meta_ptr.block_pointer;
+        bm.write_header(header);
+        bm.file_sync();
+    }
+
+    // Phase 2: flip a payload byte inside the metadata block, invalidating its stored CRC32c.
+    {
+        const uint64_t meta_block_id = meta_ptr.block_id();
+        const uint64_t payload_byte = BLOCK_START + meta_block_id * block_alloc_size + sizeof(uint64_t);
+        std::fstream f(table_path, std::ios::in | std::ios::out | std::ios::binary);
+        REQUIRE(f.is_open());
+        f.seekg(static_cast<std::streamoff>(payload_byte));
+        char b = 0;
+        f.read(&b, 1);
+        REQUIRE(f.good());
+        b = static_cast<char>(static_cast<unsigned char>(b) ^ 0xFFu);
+        f.seekp(static_cast<std::streamoff>(payload_byte));
+        f.write(&b, 1);
+        f.flush();
+        REQUIRE(f.good());
+    }
+
+    // Phase 3: reopen. The header is intact so load succeeds, but rebuilding the table walks the
+    // corrupted metadata block, which must raise a checksum mismatch.
+    {
+        test_env_t env;
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database(); // header intact, so this succeeds
+        metadata_manager_t meta_mgr(bm);
+
+        bool threw = false;
+        try {
+            // The reader ctor CRC-verifies the first metadata block, so the mismatch may surface here
+            // rather than in load_from_disk; keep both inside the try.
+            metadata_reader_t reader(meta_mgr, meta_ptr);
+            auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+            // If the metadata block were read lazily, force it by scanning.
+            std::vector<storage_index_t> projected_indices{storage_index_t(0), storage_index_t(1)};
+            std::vector<size_t> projected_cols{0, 1};
+            table_scan_state state(&env.resource);
+            loaded->initialize_scan(state, projected_indices, nullptr);
+            data_chunk_t result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+            while (true) {
+                result.reset();
+                loaded->scan(result, state);
+                if (result.size() == 0) {
+                    break;
+                }
+            }
+        } catch (const std::exception& e) {
+            threw = true;
+            REQUIRE(std::string(e.what()).find("checksum") != std::string::npos);
+        }
+        REQUIRE(threw);
+    }
+
+    std::remove(table_path.c_str());
+    cleanup_test_file();
+}
+
+// The per-block CRC32c proves bytes are intact, not that a decoded block_pointer offset is in range.
+// A bug or hostile file could leave a CRC-valid metadata pointer whose data offset points past the
+// block; the PAX scan decode path must throw on it, not read OOB. Simulate by corrupting the loaded
+// in-memory layout's data offset (bypassing the metadata CRC) and then scanning.
+TEST_CASE("checkpoint_load: out-of-bounds pax data offset fails closed on scan") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    constexpr uint64_t NUM_ROWS = 1300;
+    const auto table_path = test_db_path() + ".pax_oob_offset";
+    std::remove(table_path.c_str());
+    meta_block_pointer_t table_pointer;
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.create_new_database();
+        bm.set_layout_policy(row_group_layout_policy::PAX_ONLY);
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("id", logical_type::BIGINT);
+        columns.emplace_back("value", logical_type::UINTEGER);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "pax_oob");
+        append_fixed_integer_pair(*table,
+                                  &env.resource,
+                                  NUM_ROWS,
+                                  [](uint64_t row) { return static_cast<int64_t>(row); },
+                                  [](uint64_t row) { return static_cast<uint32_t>(row * 3); });
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        table->checkpoint(writer);
+        table_pointer = writer.get_block_pointer();
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, table_path);
+        bm.load_existing_database();
+        const uint64_t block_size = bm.block_size();
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+
+        std::vector<storage_index_t> projected_indices{storage_index_t(0), storage_index_t(1)};
+        std::vector<size_t> projected_cols{0, 1};
+
+        // Baseline: an unmodified projected scan succeeds.
+        {
+            table_scan_state state(&env.resource);
+            loaded->initialize_scan(state, projected_indices, nullptr);
+            auto* rg0 = loaded->row_group()->row_group(0);
+            REQUIRE(rg0 != nullptr);
+            data_chunk_t chunk(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+            REQUIRE(row_group_test_access_t::try_scan_pax_fixed_projected(*rg0, state.table_state, chunk));
+            REQUIRE(chunk.size() == DEFAULT_VECTOR_CAPACITY);
+        }
+
+        // Corrupt the value column's data offset in the loaded layout to point past the block, then scan.
+        auto* rg0 = loaded->row_group()->row_group(0);
+        REQUIRE(rg0 != nullptr);
+        auto& layout = row_group_test_access_t::pax_fixed_layout_mutable(*rg0);
+        REQUIRE(layout.has_value());
+        bool corrupted = false;
+        for (auto& page : layout->pages) {
+            for (auto& slice : page.slices) {
+                if (slice.column_index == 1) {
+                    slice.data_pointer.block_pointer.offset = static_cast<uint32_t>(block_size + 64);
+                    corrupted = true;
+                }
+            }
+        }
+        REQUIRE(corrupted);
+
+        table_scan_state state(&env.resource);
+        loaded->initialize_scan(state, projected_indices, nullptr);
+        data_chunk_t result(&env.resource, loaded->copy_types(), projected_cols, DEFAULT_VECTOR_CAPACITY);
+        // The decode path bounds-checks the disk-derived offset and throws rather than reading OOB.
+        REQUIRE_THROWS_AS(row_group_test_access_t::try_scan_pax_fixed_projected(*rg0, state.table_state, result),
+                          std::logic_error);
+    }
+
+    std::remove(table_path.c_str());
     cleanup_test_file();
 }

--- a/components/table/test/test_checkpoint_load.cpp
+++ b/components/table/test/test_checkpoint_load.cpp
@@ -1169,7 +1169,7 @@ TEST_CASE("checkpoint_load: explicit columnar-only root support matrix excludes 
     REQUIRE_FALSE(components::table::detail::is_explicit_pax_columnar_only_root_type(make_pax_union_type()));
     REQUIRE(to_physical_type(logical_type::BLOB) == physical_type::INVALID);
     REQUIRE(to_physical_type(logical_type::INTERVAL) == physical_type::STRUCT);
-    REQUIRE(to_physical_type(logical_type::MAP) == physical_type::INVALID);
+    REQUIRE(to_physical_type(logical_type::MAP) == physical_type::LIST);
 
     const auto variant_type = complex_logical_type::create_variant(std::pmr::get_default_resource(), "payload");
     REQUIRE(variant_type.child_types().size() == 4);

--- a/components/table/test/test_checkpoint_load.cpp
+++ b/components/table/test/test_checkpoint_load.cpp
@@ -1234,7 +1234,8 @@ TEST_CASE("checkpoint_load: explicit pax support matrix accepts mixed and reject
         REQUIRE(error_message.find("not supported by USING PAX") != std::string::npos);
     };
 
-    require_unsupported_complex(complex_logical_type::create_map(logical_type::INTEGER,
+    require_unsupported_complex(complex_logical_type::create_map(std::pmr::get_default_resource(),
+                                                                 logical_type::INTEGER,
                                                                  logical_type::STRING_LITERAL,
                                                                  "map_payload"));
     require_unsupported_complex(complex_logical_type::create_variant(std::pmr::get_default_resource(), "variant_payload"));

--- a/components/table/test/test_logical_storage_stats.cpp
+++ b/components/table/test/test_logical_storage_stats.cpp
@@ -1,0 +1,135 @@
+#include <catch2/catch.hpp>
+
+#include <components/table/data_table.hpp>
+#include <components/table/storage/buffer_pool.hpp>
+#include <components/table/storage/in_memory_block_manager.hpp>
+#include <components/table/storage/standard_buffer_manager.hpp>
+#include <core/file/local_file_system.hpp>
+
+namespace {
+
+struct table_test_env_t {
+    std::pmr::synchronized_pool_resource resource;
+    core::filesystem::local_file_system_t fs;
+    components::table::storage::buffer_pool_t buffer_pool;
+    components::table::storage::standard_buffer_manager_t buffer_manager;
+    components::table::storage::in_memory_block_manager_t block_manager;
+
+    table_test_env_t()
+        : buffer_pool(&resource, uint64_t(1) << 32, false, uint64_t(1) << 24)
+        , buffer_manager(&resource, fs, buffer_pool)
+        , block_manager(buffer_manager, components::table::storage::DEFAULT_BLOCK_ALLOC_SIZE) {}
+};
+
+void append_chunk(components::table::data_table_t& table, components::vector::data_chunk_t& chunk) {
+    components::table::table_append_state state(chunk.resource());
+    table.append_lock(state);
+    table.initialize_append(state);
+    table.append(chunk, state);
+    table.finalize_append(state, components::table::transaction_data{0, 0});
+}
+
+} // namespace
+
+TEST_CASE("components::table::logical_storage_stats scalar columns count fixed, varlen, and validity bytes") {
+    using namespace components::table;
+    using namespace components::types;
+    using namespace components::vector;
+
+    table_test_env_t env;
+
+    std::vector<column_definition_t> columns;
+    columns.emplace_back("id", logical_type::BIGINT);
+    columns.emplace_back("note", logical_type::STRING_LITERAL);
+
+    data_table_t table(&env.resource, env.block_manager, std::move(columns), "logical_stats_scalar");
+
+    const std::string overflow_value(40, 'x');
+    data_chunk_t chunk(&env.resource, table.copy_types(), 3);
+    chunk.set_cardinality(3);
+    chunk.set_value(0, 0, logical_value_t{&env.resource, int64_t{10}});
+    chunk.set_value(1, 0, logical_value_t{&env.resource, std::string("abc")});
+    chunk.set_value(0, 1, logical_value_t{&env.resource, int64_t{20}});
+    chunk.set_value(1, 1, logical_value_t{&env.resource, nullptr});
+    chunk.set_value(0, 2, logical_value_t{&env.resource, int64_t{30}});
+    chunk.set_value(1, 2, logical_value_t{&env.resource, overflow_value});
+    append_chunk(table, chunk);
+
+    const auto stats = table.logical_storage_stats();
+    const auto types = table.copy_types();
+    const auto validity_bytes = validity_mask_t::validity_mask_size(3);
+    const auto expected_fixed_bytes = 3 * types[0].size();
+    const auto expected_varlen_bytes = uint64_t{3 + overflow_value.size()};
+    const auto expected_validity_bytes = 2 * validity_bytes;
+
+    REQUIRE(stats.rows == 3);
+    REQUIRE(stats.fixed_value_bytes == expected_fixed_bytes);
+    REQUIRE(stats.varlen_value_bytes == expected_varlen_bytes);
+    REQUIRE(stats.validity_bytes == expected_validity_bytes);
+    REQUIRE(stats.logical_input_bytes() == expected_fixed_bytes + expected_varlen_bytes + expected_validity_bytes);
+}
+
+TEST_CASE("components::table::logical_storage_stats nested columns include child values and child validity") {
+    using namespace components::table;
+    using namespace components::types;
+    using namespace components::vector;
+
+    table_test_env_t env;
+
+    const auto list_type = complex_logical_type::create_list(logical_type::STRING_LITERAL, "tags");
+    const auto array_type = complex_logical_type::create_array(logical_type::BIGINT, 2, "metrics");
+
+    std::vector<column_definition_t> columns;
+    columns.emplace_back("tags", list_type);
+    columns.emplace_back("metrics", array_type);
+
+    data_table_t table(&env.resource, env.block_manager, std::move(columns), "logical_stats_nested");
+
+    data_chunk_t chunk(&env.resource, table.copy_types(), 2);
+    chunk.set_cardinality(2);
+    chunk.set_value(0,
+                    0,
+                    logical_value_t::create_list(
+                        &env.resource,
+                        logical_type::STRING_LITERAL,
+                        std::vector<logical_value_t>{
+                            logical_value_t{&env.resource, std::string("ab")},
+                            logical_value_t{&env.resource, std::string("cdef")},
+                        }));
+    chunk.set_value(1,
+                    0,
+                    logical_value_t::create_array(
+                        &env.resource,
+                        logical_type::BIGINT,
+                        std::vector<logical_value_t>{
+                            logical_value_t{&env.resource, int64_t{1}},
+                            logical_value_t{&env.resource, int64_t{2}},
+                        }));
+    chunk.set_value(0, 1, logical_value_t{&env.resource, nullptr});
+    chunk.set_value(1,
+                    1,
+                    logical_value_t::create_array(
+                        &env.resource,
+                        logical_type::BIGINT,
+                        std::vector<logical_value_t>{
+                            logical_value_t{&env.resource, int64_t{3}},
+                            logical_value_t{&env.resource, int64_t{4}},
+                        }));
+    append_chunk(table, chunk);
+
+    const auto stats = table.logical_storage_stats();
+    const auto types = table.copy_types();
+    const auto top_level_validity_bytes = validity_mask_t::validity_mask_size(2);
+    const auto child_list_validity_bytes = validity_mask_t::validity_mask_size(2);
+    const auto child_array_validity_bytes = validity_mask_t::validity_mask_size(4);
+    const auto expected_fixed_bytes = 2 * types[0].size() + 4 * types[1].child_type().size();
+    const auto expected_varlen_bytes = uint64_t{2 + 4};
+    const auto expected_validity_bytes =
+        top_level_validity_bytes + child_list_validity_bytes + top_level_validity_bytes + child_array_validity_bytes;
+
+    REQUIRE(stats.rows == 2);
+    REQUIRE(stats.fixed_value_bytes == expected_fixed_bytes);
+    REQUIRE(stats.varlen_value_bytes == expected_varlen_bytes);
+    REQUIRE(stats.validity_bytes == expected_validity_bytes);
+    REQUIRE(stats.logical_input_bytes() == expected_fixed_bytes + expected_varlen_bytes + expected_validity_bytes);
+}

--- a/components/table/test/test_metadata.cpp
+++ b/components/table/test/test_metadata.cpp
@@ -1,11 +1,13 @@
 #include <catch2/catch.hpp>
 #include <components/table/storage/buffer_pool.hpp>
+#include <components/table/storage/data_pointer.hpp>
 #include <components/table/storage/in_memory_block_manager.hpp>
 #include <components/table/storage/metadata_manager.hpp>
 #include <components/table/storage/metadata_reader.hpp>
 #include <components/table/storage/metadata_writer.hpp>
 #include <components/table/storage/single_file_block_manager.hpp>
 #include <components/table/storage/standard_buffer_manager.hpp>
+#include <components/vector/validation.hpp>
 #include <core/file/local_file_system.hpp>
 
 #include <cstring>
@@ -59,6 +61,48 @@ TEST_CASE("metadata: write and read small data") {
     {
         metadata_reader_t reader(manager, pointer);
         std::vector<std::byte> read_data(100);
+        reader.read_data(read_data.data(), read_data.size());
+        REQUIRE(std::memcmp(test_data.data(), read_data.data(), test_data.size()) == 0);
+    }
+
+    cleanup_test_file();
+}
+
+TEST_CASE("metadata: long chain stays within persisted block payload") {
+    using namespace components::table::storage;
+    cleanup_test_file();
+
+    test_env_t env;
+    meta_block_pointer_t pointer;
+    std::vector<std::byte> test_data;
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+        bm.create_new_database();
+
+        metadata_manager_t manager(bm);
+        constexpr uint64_t sub_block_header_size = sizeof(uint64_t) + sizeof(uint32_t);
+        REQUIRE(manager.sub_block_size() * META_SUB_BLOCKS_PER_BLOCK <= bm.block_size());
+
+        const auto payload_per_sub_block = manager.sub_block_size() - sub_block_header_size;
+        test_data.resize(payload_per_sub_block * (META_SUB_BLOCKS_PER_BLOCK + 6) + 31);
+        for (size_t i = 0; i < test_data.size(); i++) {
+            test_data[i] = static_cast<std::byte>((i * 131U + 17U) & 0xFFU);
+        }
+
+        metadata_writer_t writer(manager);
+        writer.write_data(test_data.data(), test_data.size());
+        pointer = writer.get_block_pointer();
+        writer.flush();
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+        bm.load_existing_database();
+
+        metadata_manager_t manager(bm);
+        std::vector<std::byte> read_data(test_data.size());
+        metadata_reader_t reader(manager, pointer);
         reader.read_data(read_data.data(), read_data.size());
         REQUIRE(std::memcmp(test_data.data(), read_data.data(), test_data.size()) == 0);
     }
@@ -140,6 +184,385 @@ TEST_CASE("metadata: multiple independent chains") {
 
         metadata_reader_t reader3(manager, ptr3);
         REQUIRE(reader3.read<uint64_t>() == 333);
+    }
+
+    cleanup_test_file();
+}
+
+TEST_CASE("metadata: row_group_pointer reads older columnar format") {
+    using namespace components::table::storage;
+    cleanup_test_file();
+
+    test_env_t env;
+    single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+    bm.create_new_database();
+
+    metadata_manager_t manager(bm);
+    meta_block_pointer_t pointer;
+    {
+        metadata_writer_t writer(manager);
+
+        data_pointer_t first;
+        first.row_start = 0;
+        first.tuple_count = 128;
+        first.block_pointer = block_pointer_t(11, 32);
+        first.compression = components::table::compression::compression_type::UNCOMPRESSED;
+        first.segment_size = 1024;
+
+        data_pointer_t second;
+        second.row_start = 128;
+        second.tuple_count = 128;
+        second.block_pointer = block_pointer_t(12, 64);
+        second.compression = components::table::compression::compression_type::RLE;
+        second.segment_size = 256;
+
+        writer.write<uint64_t>(0);
+        writer.write<uint64_t>(256);
+        writer.write<uint32_t>(2);
+        writer.write<uint32_t>(1);
+        first.serialize(writer);
+        writer.write<uint32_t>(1);
+        second.serialize(writer);
+        writer.write<uint32_t>(0);
+
+        pointer = writer.get_block_pointer();
+        writer.flush();
+    }
+
+    {
+        metadata_reader_t reader(manager, pointer);
+        auto row_group = row_group_pointer_t::deserialize(reader);
+        REQUIRE(row_group.row_start == 0);
+        REQUIRE(row_group.tuple_count == 256);
+        REQUIRE(row_group.columnar_data_pointers.size() == 2);
+        REQUIRE(row_group.columnar_data_pointers[0].size() == 1);
+        REQUIRE(row_group.columnar_data_pointers[1].size() == 1);
+        REQUIRE(row_group.columnar_data_pointers[0][0].block_pointer.block_id == 11);
+        REQUIRE(row_group.columnar_data_pointers[1][0].block_pointer.block_id == 12);
+        REQUIRE(row_group.layout_kind == row_group_layout_kind::COLUMNAR);
+        REQUIRE_FALSE(row_group.pax_fixed_layout.has_value());
+        REQUIRE_FALSE(row_group.pax_generic_layout.has_value());
+    }
+
+    cleanup_test_file();
+}
+
+TEST_CASE("metadata: pax_fixed layout round trip") {
+    using namespace components::table::storage;
+    cleanup_test_file();
+
+    test_env_t env;
+    single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+    bm.create_new_database();
+
+    metadata_manager_t manager(bm);
+
+    pax_fixed_row_group_layout_t layout;
+    layout.version = 2;
+    layout.rows_per_page = 256;
+
+    pax_fixed_page_t first_page;
+    first_page.row_offset_in_group = 0;
+    first_page.tuple_count = 128;
+
+    pax_fixed_slice_t first_slice;
+    first_slice.column_index = 0;
+    first_slice.column_type = pax_fixed_column_type::INT64;
+    first_slice.data_pointer.row_start = 0;
+    first_slice.data_pointer.tuple_count = 128;
+    first_slice.data_pointer.block_pointer = block_pointer_t(101, 0);
+    first_slice.data_pointer.segment_size = 1024;
+    first_slice.validity_kind = pax_fixed_validity_kind::BITMASK;
+    first_slice.validity_data_pointer = data_pointer_t{};
+    first_slice.validity_data_pointer->row_start = 0;
+    first_slice.validity_data_pointer->tuple_count = 128;
+    first_slice.validity_data_pointer->block_pointer = block_pointer_t(101, 1536);
+    first_slice.validity_data_pointer->compression =
+        components::table::compression::compression_type::VALIDITY_UNCOMPRESSED;
+    first_slice.validity_data_pointer->segment_size = components::vector::validity_mask_t::validity_mask_size(128);
+
+    pax_fixed_slice_t second_slice;
+    second_slice.column_index = 1;
+    second_slice.column_type = pax_fixed_column_type::UINT32;
+    second_slice.data_pointer.row_start = 0;
+    second_slice.data_pointer.tuple_count = 128;
+    second_slice.data_pointer.block_pointer = block_pointer_t(101, 1024);
+    second_slice.data_pointer.segment_size = 512;
+    second_slice.validity_kind = pax_fixed_validity_kind::ALL_VALID;
+
+    first_page.slices.push_back(first_slice);
+    first_page.slices.push_back(second_slice);
+    layout.pages.push_back(first_page);
+
+    meta_block_pointer_t pointer;
+    {
+        metadata_writer_t writer(manager);
+        layout.serialize(writer);
+        pointer = writer.get_block_pointer();
+        writer.flush();
+    }
+
+    {
+        metadata_reader_t reader(manager, pointer);
+        auto restored = pax_fixed_row_group_layout_t::deserialize(reader);
+        REQUIRE(restored.version == 2);
+        REQUIRE(restored.rows_per_page == 256);
+        REQUIRE(restored.pages.size() == 1);
+        REQUIRE(restored.pages[0].tuple_count == 128);
+        REQUIRE(restored.pages[0].slices.size() == 2);
+        REQUIRE(restored.pages[0].slices[0].column_index == 0);
+        REQUIRE(restored.pages[0].slices[0].column_type == pax_fixed_column_type::INT64);
+        REQUIRE(restored.pages[0].slices[0].validity_kind == pax_fixed_validity_kind::BITMASK);
+        REQUIRE(restored.pages[0].slices[0].validity_data_pointer.has_value());
+        REQUIRE(restored.pages[0].slices[0].validity_data_pointer->block_pointer.offset == 1536);
+        REQUIRE(restored.pages[0].slices[1].column_index == 1);
+        REQUIRE(restored.pages[0].slices[1].data_pointer.block_pointer.offset == 1024);
+        REQUIRE(restored.pages[0].slices[1].validity_kind == pax_fixed_validity_kind::ALL_VALID);
+        REQUIRE_FALSE(restored.pages[0].slices[1].validity_data_pointer.has_value());
+    }
+
+    cleanup_test_file();
+}
+
+TEST_CASE("metadata: pax_fixed v1 layout defaults to all valid validity") {
+    using namespace components::table::storage;
+    cleanup_test_file();
+
+    test_env_t env;
+    single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+    bm.create_new_database();
+
+    metadata_manager_t manager(bm);
+
+    pax_fixed_row_group_layout_t layout;
+    layout.version = 1;
+    layout.rows_per_page = 256;
+
+    pax_fixed_page_t page;
+    page.row_offset_in_group = 0;
+    page.tuple_count = 64;
+
+    pax_fixed_slice_t slice;
+    slice.column_index = 0;
+    slice.column_type = pax_fixed_column_type::INT32;
+    slice.data_pointer.row_start = 0;
+    slice.data_pointer.tuple_count = 64;
+    slice.data_pointer.block_pointer = block_pointer_t(7, 0);
+    slice.data_pointer.segment_size = 256;
+    page.slices.push_back(slice);
+    layout.pages.push_back(page);
+
+    meta_block_pointer_t pointer;
+    {
+        metadata_writer_t writer(manager);
+        layout.serialize(writer);
+        pointer = writer.get_block_pointer();
+        writer.flush();
+    }
+
+    {
+        metadata_reader_t reader(manager, pointer);
+        auto restored = pax_fixed_row_group_layout_t::deserialize(reader);
+        REQUIRE(restored.version == 1);
+        REQUIRE(restored.pages.size() == 1);
+        REQUIRE(restored.pages[0].slices.size() == 1);
+        REQUIRE(restored.pages[0].slices[0].validity_kind == pax_fixed_validity_kind::ALL_VALID);
+        REQUIRE_FALSE(restored.pages[0].slices[0].validity_data_pointer.has_value());
+    }
+
+    cleanup_test_file();
+}
+
+TEST_CASE("metadata: pax_generic layout round trip") {
+    using namespace components::table::storage;
+    cleanup_test_file();
+
+    test_env_t env;
+    single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+    bm.create_new_database();
+
+    metadata_manager_t manager(bm);
+
+    pax_generic_row_group_layout_t layout;
+    layout.version = 1;
+    layout.rows_per_page = 256;
+
+    pax_generic_page_t first_page;
+    first_page.row_offset_in_group = 0;
+    first_page.tuple_count = 128;
+
+    pax_generic_slice_t string_slice;
+    string_slice.column_index = 0;
+    string_slice.slice_kind = pax_generic_slice_kind::STRING_VALUES;
+    string_slice.codec_kind = pax_generic_codec_kind::STRING_SEGMENT;
+    string_slice.payload = pax_block_payload_t{};
+    string_slice.payload->main_pointer.row_start = 0;
+    string_slice.payload->main_pointer.tuple_count = 128;
+    string_slice.payload->main_pointer.block_pointer = block_pointer_t(200, 0);
+    string_slice.payload->main_pointer.segment_size = 4096;
+    string_slice.payload->extra_block_ids = {300, 301};
+
+    pax_generic_slice_t validity_slice;
+    validity_slice.column_index = 0;
+    validity_slice.slice_kind = pax_generic_slice_kind::VALIDITY;
+    validity_slice.codec_kind = pax_generic_codec_kind::VALIDITY_BITMASK;
+    validity_slice.payload = pax_block_payload_t{};
+    validity_slice.payload->main_pointer.row_start = 0;
+    validity_slice.payload->main_pointer.tuple_count = 128;
+    validity_slice.payload->main_pointer.block_pointer = block_pointer_t(200, 4096);
+    validity_slice.payload->main_pointer.compression =
+        components::table::compression::compression_type::VALIDITY_UNCOMPRESSED;
+    validity_slice.payload->main_pointer.segment_size = components::vector::validity_mask_t::validity_mask_size(128);
+
+    first_page.slices.push_back(string_slice);
+    first_page.slices.push_back(validity_slice);
+
+    pax_generic_page_t second_page;
+    second_page.row_offset_in_group = 128;
+    second_page.tuple_count = 16;
+
+    pax_generic_slice_t second_string_slice;
+    second_string_slice.column_index = 0;
+    second_string_slice.slice_kind = pax_generic_slice_kind::STRING_VALUES;
+    second_string_slice.codec_kind = pax_generic_codec_kind::STRING_SEGMENT;
+    second_string_slice.payload = pax_block_payload_t{};
+    second_string_slice.payload->main_pointer.row_start = 128;
+    second_string_slice.payload->main_pointer.tuple_count = 16;
+    second_string_slice.payload->main_pointer.block_pointer = block_pointer_t(201, 0);
+    second_string_slice.payload->main_pointer.segment_size = 256;
+
+    pax_generic_slice_t second_validity_slice;
+    second_validity_slice.column_index = 0;
+    second_validity_slice.slice_kind = pax_generic_slice_kind::VALIDITY;
+    second_validity_slice.codec_kind = pax_generic_codec_kind::VALIDITY_ALL_INVALID;
+
+    second_page.slices.push_back(second_string_slice);
+    second_page.slices.push_back(second_validity_slice);
+
+    layout.pages.push_back(first_page);
+    layout.pages.push_back(second_page);
+
+    meta_block_pointer_t pointer;
+    {
+        metadata_writer_t writer(manager);
+        layout.serialize(writer);
+        pointer = writer.get_block_pointer();
+        writer.flush();
+    }
+
+    {
+        metadata_reader_t reader(manager, pointer);
+        auto restored = pax_generic_row_group_layout_t::deserialize(reader);
+        REQUIRE(restored.version == 1);
+        REQUIRE(restored.rows_per_page == 256);
+        REQUIRE(restored.pages.size() == 2);
+        REQUIRE(restored.pages[0].slices.size() == 2);
+        REQUIRE(restored.pages[0].slices[0].slice_kind == pax_generic_slice_kind::STRING_VALUES);
+        REQUIRE(restored.pages[0].slices[0].codec_kind == pax_generic_codec_kind::STRING_SEGMENT);
+        REQUIRE(restored.pages[0].slices[0].payload.has_value());
+        REQUIRE(restored.pages[0].slices[0].payload->main_pointer.block_pointer.block_id == 200);
+        REQUIRE(restored.pages[0].slices[0].payload->extra_block_ids == std::vector<uint32_t>{300, 301});
+        REQUIRE(restored.pages[0].slices[1].slice_kind == pax_generic_slice_kind::VALIDITY);
+        REQUIRE(restored.pages[0].slices[1].codec_kind == pax_generic_codec_kind::VALIDITY_BITMASK);
+        REQUIRE(restored.pages[0].slices[1].payload.has_value());
+        REQUIRE(restored.pages[0].slices[1].payload->main_pointer.segment_size ==
+                components::vector::validity_mask_t::validity_mask_size(128));
+        REQUIRE(restored.pages[1].slices[1].codec_kind == pax_generic_codec_kind::VALIDITY_ALL_INVALID);
+        REQUIRE_FALSE(restored.pages[1].slices[1].payload.has_value());
+    }
+
+    cleanup_test_file();
+}
+
+TEST_CASE("metadata: pax_generic v2 struct layout round trip") {
+    using namespace components::table::storage;
+    using namespace components::types;
+    cleanup_test_file();
+
+    test_env_t env;
+    single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+    bm.create_new_database();
+
+    metadata_manager_t manager(bm);
+
+    pax_generic_row_group_layout_t layout;
+    layout.version = 2;
+    layout.rows_per_page = 256;
+
+    pax_generic_page_t page;
+    page.row_offset_in_group = 0;
+    page.tuple_count = 64;
+
+    pax_generic_slice_t root_validity;
+    root_validity.column_index = 2;
+    root_validity.slice_kind = pax_generic_slice_kind::VALIDITY;
+    root_validity.codec_kind = pax_generic_codec_kind::VALIDITY_BITMASK;
+    root_validity.payload = pax_block_payload_t{};
+    root_validity.payload->main_pointer.row_start = 0;
+    root_validity.payload->main_pointer.tuple_count = 64;
+    root_validity.payload->main_pointer.block_pointer = block_pointer_t(500, 0);
+    root_validity.payload->main_pointer.compression =
+        components::table::compression::compression_type::VALIDITY_UNCOMPRESSED;
+    root_validity.payload->main_pointer.segment_size = components::vector::validity_mask_t::validity_mask_size(64);
+
+    pax_generic_slice_t fixed_child;
+    fixed_child.column_index = 2;
+    fixed_child.slice_kind = pax_generic_slice_kind::FIXED_VALUES;
+    fixed_child.codec_kind = pax_generic_codec_kind::FIXED_PLAIN;
+    fixed_child.field_path = {0};
+    fixed_child.fixed_logical_type = logical_type::BIGINT;
+    fixed_child.payload = pax_block_payload_t{};
+    fixed_child.payload->main_pointer.row_start = 0;
+    fixed_child.payload->main_pointer.tuple_count = 64;
+    fixed_child.payload->main_pointer.block_pointer = block_pointer_t(501, 0);
+    fixed_child.payload->main_pointer.segment_size = 64 * sizeof(int64_t);
+
+    pax_generic_slice_t string_child;
+    string_child.column_index = 2;
+    string_child.slice_kind = pax_generic_slice_kind::STRING_VALUES;
+    string_child.codec_kind = pax_generic_codec_kind::STRING_SEGMENT;
+    string_child.field_path = {1};
+    string_child.payload = pax_block_payload_t{};
+    string_child.payload->main_pointer.row_start = 0;
+    string_child.payload->main_pointer.tuple_count = 64;
+    string_child.payload->main_pointer.block_pointer = block_pointer_t(502, 0);
+    string_child.payload->main_pointer.segment_size = 2048;
+    string_child.payload->extra_block_ids = {700};
+
+    pax_generic_slice_t string_validity;
+    string_validity.column_index = 2;
+    string_validity.slice_kind = pax_generic_slice_kind::VALIDITY;
+    string_validity.codec_kind = pax_generic_codec_kind::VALIDITY_ALL_INVALID;
+    string_validity.field_path = {1};
+
+    page.slices.push_back(root_validity);
+    page.slices.push_back(fixed_child);
+    page.slices.push_back(string_child);
+    page.slices.push_back(string_validity);
+    layout.pages.push_back(page);
+
+    meta_block_pointer_t pointer;
+    {
+        metadata_writer_t writer(manager);
+        layout.serialize(writer);
+        pointer = writer.get_block_pointer();
+        writer.flush();
+    }
+
+    {
+        metadata_reader_t reader(manager, pointer);
+        auto restored = pax_generic_row_group_layout_t::deserialize(reader);
+        REQUIRE(restored.version == 2);
+        REQUIRE(restored.pages.size() == 1);
+        REQUIRE(restored.pages[0].slices.size() == 4);
+        REQUIRE(restored.pages[0].slices[1].slice_kind == pax_generic_slice_kind::FIXED_VALUES);
+        REQUIRE(restored.pages[0].slices[1].codec_kind == pax_generic_codec_kind::FIXED_PLAIN);
+        REQUIRE(restored.pages[0].slices[1].field_path == std::vector<uint16_t>{0});
+        REQUIRE(restored.pages[0].slices[1].fixed_logical_type == logical_type::BIGINT);
+        REQUIRE(restored.pages[0].slices[2].field_path == std::vector<uint16_t>{1});
+        REQUIRE(restored.pages[0].slices[2].payload.has_value());
+        REQUIRE(restored.pages[0].slices[2].payload->extra_block_ids == std::vector<uint32_t>{700});
+        REQUIRE(restored.pages[0].slices[3].codec_kind == pax_generic_codec_kind::VALIDITY_ALL_INVALID);
     }
 
     cleanup_test_file();

--- a/components/table/test/test_mvcc_operations.cpp
+++ b/components/table/test/test_mvcc_operations.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch.hpp>
+#include <components/storage/table_storage_adapter.hpp>
 #include <components/table/data_table.hpp>
 #include <components/table/storage/buffer_pool.hpp>
 #include <components/table/storage/in_memory_block_manager.hpp>
@@ -6,6 +7,7 @@
 #include <components/table/transaction_manager.hpp>
 #include <core/file/local_file_system.hpp>
 
+#include <algorithm>
 #include <set>
 
 using namespace components::types;
@@ -92,6 +94,32 @@ namespace {
         table.scan(result, scan_state);
         total += result.size();
         return total;
+    }
+
+    std::vector<int64_t> scan_values_txn(data_table_t& table, test_env& env, transaction_data txn) {
+        std::vector<storage_index_t> column_ids;
+        column_ids.emplace_back(0);
+
+        table_scan_state scan_state(&env.resource);
+        table.initialize_scan(scan_state, column_ids);
+        scan_state.table_state.txn = txn;
+
+        auto types = table.copy_types();
+        auto result = data_chunk_t(&env.resource, types, DEFAULT_VECTOR_CAPACITY);
+        table.scan(result, scan_state);
+        result.flatten();
+
+        std::vector<int64_t> values;
+        values.reserve(result.size());
+        auto* data = result.data[0].data<int64_t>();
+        for (uint64_t i = 0; i < result.size(); i++) {
+            values.push_back(data[i]);
+        }
+        return values;
+    }
+
+    bool contains_value(const std::vector<int64_t>& values, int64_t expected) {
+        return std::find(values.begin(), values.end(), expected) != values.end();
     }
 
 } // anonymous namespace
@@ -480,11 +508,133 @@ TEST_CASE("components::table::mvcc::txn_sees_own_writes") {
     mgr.abort(s2);
 }
 
+TEST_CASE("components::table::mvcc::snapshot_does_not_see_later_insert_commit") {
+    test_env env;
+    auto table = make_int_table(env);
+
+    append_rows(*table, env, 0, 5);
+    REQUIRE(scan_count(*table, env) == 5);
+
+    transaction_manager_t mgr(&env.resource);
+
+    auto reader_session = components::session::session_id_t::generate_uid();
+    auto& reader_txn = mgr.begin_transaction(reader_session);
+    auto reader_snapshot = reader_txn.data();
+
+    auto writer_session = components::session::session_id_t::generate_uid();
+    auto& writer_txn = mgr.begin_transaction(writer_session);
+    append_rows_txn(*table, env, 100, 3, writer_txn.data());
+    auto writer_commit_id = mgr.commit(writer_session);
+    table->commit_append(writer_commit_id, 5, 3);
+    mgr.publish(writer_commit_id);
+
+    REQUIRE(scan_count_txn(*table, env, reader_snapshot) == 5);
+
+    auto fresh_session = components::session::session_id_t::generate_uid();
+    auto& fresh_txn = mgr.begin_transaction(fresh_session);
+    REQUIRE(scan_count_txn(*table, env, fresh_txn.data()) == 8);
+
+    mgr.abort(reader_session);
+    mgr.abort(fresh_session);
+}
+
+TEST_CASE("components::table::mvcc::snapshot_keeps_rows_deleted_after_start") {
+    test_env env;
+    auto table = make_int_table(env);
+
+    append_rows(*table, env, 0, 10);
+    REQUIRE(scan_count(*table, env) == 10);
+
+    transaction_manager_t mgr(&env.resource);
+
+    auto reader_session = components::session::session_id_t::generate_uid();
+    auto& reader_txn = mgr.begin_transaction(reader_session);
+    auto reader_snapshot = reader_txn.data();
+
+    auto writer_session = components::session::session_id_t::generate_uid();
+    auto& writer_txn = mgr.begin_transaction(writer_session);
+
+    std::pmr::vector<complex_logical_type> id_type(&env.resource);
+    id_type.emplace_back(logical_type::BIGINT);
+    auto row_ids_chunk = data_chunk_t(&env.resource, id_type, 5);
+    for (uint64_t i = 0; i < 5; i++) {
+        row_ids_chunk.data[0].set_value(i, logical_value_t(&env.resource, static_cast<int64_t>(i)));
+    }
+    row_ids_chunk.set_cardinality(5);
+
+    table_delete_state del_state(&env.resource);
+    auto writer_txn_id = writer_txn.data().transaction_id;
+    table->delete_rows(del_state, row_ids_chunk.data[0], 5, writer_txn_id);
+    auto writer_commit_id = mgr.commit(writer_session);
+    table->commit_all_deletes(writer_txn_id, writer_commit_id);
+    mgr.publish(writer_commit_id);
+
+    REQUIRE(scan_count_txn(*table, env, reader_snapshot) == 10);
+
+    auto fresh_session = components::session::session_id_t::generate_uid();
+    auto& fresh_txn = mgr.begin_transaction(fresh_session);
+    REQUIRE(scan_count_txn(*table, env, fresh_txn.data()) == 5);
+
+    mgr.abort(reader_session);
+    mgr.abort(fresh_session);
+}
+
+TEST_CASE("components::table::mvcc::snapshot_keeps_old_row_for_later_update_commit") {
+    test_env env;
+    auto table = make_int_table(env);
+
+    append_rows(*table, env, 0, 5);
+    REQUIRE(scan_count(*table, env) == 5);
+
+    transaction_manager_t mgr(&env.resource);
+
+    auto reader_session = components::session::session_id_t::generate_uid();
+    auto& reader_txn = mgr.begin_transaction(reader_session);
+    auto reader_snapshot = reader_txn.data();
+
+    auto writer_session = components::session::session_id_t::generate_uid();
+    auto& writer_txn = mgr.begin_transaction(writer_session);
+
+    vector_t row_ids(&env.resource, logical_type::BIGINT, 1);
+    row_ids.set_value(0, logical_value_t(&env.resource, int64_t{2}));
+
+    auto update_chunk = data_chunk_t(&env.resource, table->copy_types(), 1);
+    update_chunk.data[0].set_value(0, logical_value_t(&env.resource, int64_t{200}));
+    update_chunk.set_cardinality(1);
+
+    components::storage::table_storage_adapter_t storage(*table, &env.resource);
+    auto [append_start, append_count] = storage.update(row_ids, update_chunk, writer_txn.data());
+    REQUIRE(append_count == 1);
+
+    auto writer_txn_id = writer_txn.data().transaction_id;
+    auto writer_commit_id = mgr.commit(writer_session);
+    table->commit_all_deletes(writer_txn_id, writer_commit_id);
+    table->commit_append(writer_commit_id, append_start, append_count);
+    mgr.publish(writer_commit_id);
+
+    auto reader_values = scan_values_txn(*table, env, reader_snapshot);
+    REQUIRE(reader_values.size() == 5);
+    REQUIRE(contains_value(reader_values, 2));
+    REQUIRE_FALSE(contains_value(reader_values, 200));
+
+    auto fresh_session = components::session::session_id_t::generate_uid();
+    auto& fresh_txn = mgr.begin_transaction(fresh_session);
+    auto fresh_values = scan_values_txn(*table, env, fresh_txn.data());
+    REQUIRE(fresh_values.size() == 5);
+    REQUIRE_FALSE(contains_value(fresh_values, 2));
+    REQUIRE(contains_value(fresh_values, 200));
+
+    mgr.abort(reader_session);
+    mgr.abort(fresh_session);
+}
+
 namespace {
 
     // Distinct row VALUES (not just counts): compact() rebuilds the collection, so a
     // dropped old version and a leaked new version can cancel out in a bare count.
-    std::set<int64_t> scan_values_txn(data_table_t& table, test_env& env, transaction_data txn) {
+    // NOTE: renamed from scan_values_txn to avoid colliding with the vector-returning
+    // scan_values_txn helper defined at the top of this file (feature branch).
+    std::set<int64_t> scan_value_set_txn(data_table_t& table, test_env& env, transaction_data txn) {
         std::vector<storage_index_t> column_ids;
         column_ids.emplace_back(0);
 
@@ -548,7 +698,7 @@ TEST_CASE("components::table::mvcc::compact_preserves_old_snapshot_view") {
     // txn2: snapshot BEFORE the update — must keep seeing {0..9} forever.
     auto s2 = components::session::session_id_t::generate_uid();
     auto& txn2 = mgr.begin_transaction(s2);
-    REQUIRE(scan_values_txn(*table, env, txn2.data()) == make_range(0, 9));
+    REQUIRE(scan_value_set_txn(*table, env, txn2.data()) == make_range(0, 9));
 
     // txn3: "update" row 0 — delete it and append replacement value 100;
     // commit, storage-stamp BOTH sides, publish. Fully published: only txn2's
@@ -568,16 +718,16 @@ TEST_CASE("components::table::mvcc::compact_preserves_old_snapshot_view") {
     auto& txn4 = mgr.begin_transaction(s4);
     auto expected_new = make_range(1, 9);
     expected_new.insert(100);
-    REQUIRE(scan_values_txn(*table, env, txn4.data()) == expected_new);
+    REQUIRE(scan_value_set_txn(*table, env, txn4.data()) == expected_new);
 
     // Compact while txn2's older snapshot is still active: the watermark sits
     // below c3, so the rebuild must be refused.
     REQUIRE_FALSE(table->compact(mgr.compact_watermark()));
 
     // MVCC promise: txn2 still sees the pre-update view — row 0 alive, no 100.
-    REQUIRE(scan_values_txn(*table, env, txn2.data()) == make_range(0, 9));
+    REQUIRE(scan_value_set_txn(*table, env, txn2.data()) == make_range(0, 9));
     // And the fresh snapshot keeps the post-update view.
-    REQUIRE(scan_values_txn(*table, env, txn4.data()) == expected_new);
+    REQUIRE(scan_value_set_txn(*table, env, txn4.data()) == expected_new);
 
     mgr.abort(s2);
     mgr.abort(s4);
@@ -588,7 +738,7 @@ TEST_CASE("components::table::mvcc::compact_preserves_old_snapshot_view") {
     REQUIRE(table->row_group()->total_rows() == 10);
     auto s6 = components::session::session_id_t::generate_uid();
     auto& txn6 = mgr.begin_transaction(s6);
-    REQUIRE(scan_values_txn(*table, env, txn6.data()) == expected_new);
+    REQUIRE(scan_value_set_txn(*table, env, txn6.data()) == expected_new);
     mgr.abort(s6);
 }
 
@@ -627,14 +777,14 @@ TEST_CASE("components::table::mvcc::compact_in_flight_commit_window") {
     // see the OLD version of row 0 and must not see the replacement.
     auto s4 = components::session::session_id_t::generate_uid();
     auto& txn4 = mgr.begin_transaction(s4);
-    REQUIRE(scan_values_txn(*table, env, txn4.data()) == make_range(0, 9));
+    REQUIRE(scan_value_set_txn(*table, env, txn4.data()) == make_range(0, 9));
 
     // Checkpoint-path compact fires inside the window: c3 is in flight, so the
     // watermark sits below it and the rebuild must be refused.
     REQUIRE_FALSE(table->compact(mgr.compact_watermark()));
 
     // The row must NOT vanish: txn4 still sees the pre-update version.
-    REQUIRE(scan_values_txn(*table, env, txn4.data()) == make_range(0, 9));
+    REQUIRE(scan_value_set_txn(*table, env, txn4.data()) == make_range(0, 9));
 
     // Finish the commit pipeline: stamp the replacement, publish.
     table->commit_append(c3, 10, 1);
@@ -645,7 +795,7 @@ TEST_CASE("components::table::mvcc::compact_in_flight_commit_window") {
     auto& txn5 = mgr.begin_transaction(s5);
     auto expected_new = make_range(1, 9);
     expected_new.insert(100);
-    REQUIRE(scan_values_txn(*table, env, txn5.data()) == expected_new);
+    REQUIRE(scan_value_set_txn(*table, env, txn5.data()) == expected_new);
 
     mgr.abort(s4);
     mgr.abort(s5);
@@ -655,6 +805,6 @@ TEST_CASE("components::table::mvcc::compact_in_flight_commit_window") {
     REQUIRE(table->row_group()->total_rows() == 10);
     auto s6 = components::session::session_id_t::generate_uid();
     auto& txn6 = mgr.begin_transaction(s6);
-    REQUIRE(scan_values_txn(*table, env, txn6.data()) == expected_new);
+    REQUIRE(scan_value_set_txn(*table, env, txn6.data()) == expected_new);
     mgr.abort(s6);
 }

--- a/components/table/test/test_parallel_scan.cpp
+++ b/components/table/test/test_parallel_scan.cpp
@@ -6,6 +6,8 @@
 #include <components/table/storage/standard_buffer_manager.hpp>
 #include <core/file/local_file_system.hpp>
 #include <set>
+#include <thread>
+#include <vector>
 
 using namespace components::types;
 using namespace components::vector;
@@ -20,8 +22,8 @@ namespace {
         storage::standard_buffer_manager_t buffer_manager;
         storage::in_memory_block_manager_t block_manager;
 
-        test_env()
-            : buffer_pool(&resource, uint64_t(1) << 32, false, uint64_t(1) << 24)
+        explicit test_env(uint64_t max_memory = uint64_t(1) << 32)
+            : buffer_pool(&resource, max_memory, false, uint64_t(1) << 24)
             , buffer_manager(&resource, fs, buffer_pool)
             , block_manager(buffer_manager, storage::DEFAULT_BLOCK_ALLOC_SIZE) {}
     };
@@ -243,4 +245,77 @@ TEST_CASE("parallel scan: copy_segments provides snapshot") {
         REQUIRE(segments[i] != nullptr);
         REQUIRE(segments[i]->count == rows_per_rg);
     }
+}
+
+namespace {
+    // Drive next_parallel_chunk from nthreads threads sharing one parallel_state; each thread keeps
+    // its own scan_state and result chunk. Returns all scanned values.
+    std::vector<int64_t> parallel_scan_all(data_table_t& table, test_env& env, unsigned nthreads) {
+        std::vector<storage_index_t> column_ids;
+        column_ids.emplace_back(0);
+        auto parallel_state = table.create_parallel_scan_state(column_ids);
+        auto types = table.copy_types();
+
+        std::vector<std::vector<int64_t>> per_thread(nthreads);
+        std::vector<std::thread> threads;
+        threads.reserve(nthreads);
+        for (unsigned t = 0; t < nthreads; t++) {
+            threads.emplace_back([&, t]() {
+                table_scan_state local_state(&env.resource);
+                data_chunk_t result(&env.resource, types, DEFAULT_VECTOR_CAPACITY);
+                while (table.next_parallel_chunk(*parallel_state, local_state, result)) {
+                    for (uint64_t i = 0; i < result.size(); i++) {
+                        per_thread[t].push_back(result.data[0].value(i).value<int64_t>());
+                    }
+                }
+            });
+        }
+        for (auto& th : threads) {
+            th.join();
+        }
+        std::vector<int64_t> all;
+        for (auto& v : per_thread) {
+            all.insert(all.end(), v.begin(), v.end());
+        }
+        return all;
+    }
+
+    void require_exact_cover(std::vector<int64_t> values, uint64_t total) {
+        REQUIRE(values.size() == total);
+        std::set<int64_t> distinct(values.begin(), values.end());
+        REQUIRE(distinct.size() == total);
+        REQUIRE(*distinct.begin() == 0);
+        REQUIRE(*distinct.rbegin() == static_cast<int64_t>(total) - 1);
+    }
+} // namespace
+
+TEST_CASE("parallel scan: concurrent threads cover all rows exactly once [tsan]") {
+    test_env env;
+    auto table = make_int_table(env);
+
+    constexpr uint64_t rows_per_rg = DEFAULT_VECTOR_CAPACITY;
+    constexpr int num_row_groups = 32;
+    for (int i = 0; i < num_row_groups; i++) {
+        append_rows(*table, env, static_cast<int64_t>(static_cast<uint64_t>(i) * rows_per_rg), rows_per_rg);
+    }
+    const uint64_t total = static_cast<uint64_t>(num_row_groups) * rows_per_rg;
+    REQUIRE(table->row_group()->total_rows() == total);
+
+    require_exact_cover(parallel_scan_all(*table, env, 8), total);
+}
+
+TEST_CASE("parallel scan: concurrent threads under buffer-pool eviction pressure [tsan]") {
+    // Small pool forces blocks to be evicted and re-pinned while other threads scan.
+    test_env env(uint64_t(1) << 21);
+
+    auto table = make_int_table(env);
+    constexpr uint64_t rows_per_rg = DEFAULT_VECTOR_CAPACITY;
+    constexpr int num_row_groups = 64;
+    for (int i = 0; i < num_row_groups; i++) {
+        append_rows(*table, env, static_cast<int64_t>(static_cast<uint64_t>(i) * rows_per_rg), rows_per_rg);
+    }
+    const uint64_t total = static_cast<uint64_t>(num_row_groups) * rows_per_rg;
+    REQUIRE(table->row_group()->total_rows() == total);
+
+    require_exact_cover(parallel_scan_all(*table, env, 8), total);
 }

--- a/components/table/test/test_statistics.cpp
+++ b/components/table/test/test_statistics.cpp
@@ -197,8 +197,11 @@ TEST_CASE("per-segment statistics: check_segment_zonemap") {
 
     // Simulate two segments with non-overlapping ranges
     // Segment 1: [1..50], Segment 2: [51..100]
-    auto seg1 =
-        column_segment_t::create_segment(buffer_manager, complex_logical_type{logical_type::BIGINT}, 0, 262144, 262144);
+    auto seg1 = column_segment_t::create_segment(buffer_manager,
+                                                 complex_logical_type{logical_type::BIGINT},
+                                                 0,
+                                                 block_manager.block_size(),
+                                                 block_manager.block_size());
     {
         base_statistics_t s1(&resource, logical_type::BIGINT);
         s1.set_min(logical_value_t{&resource, int64_t(1)});
@@ -209,8 +212,8 @@ TEST_CASE("per-segment statistics: check_segment_zonemap") {
     auto seg2 = column_segment_t::create_segment(buffer_manager,
                                                  complex_logical_type{logical_type::BIGINT},
                                                  50,
-                                                 262144,
-                                                 262144);
+                                                 block_manager.block_size(),
+                                                 block_manager.block_size());
     {
         base_statistics_t s2(&resource, logical_type::BIGINT);
         s2.set_min(logical_value_t{&resource, int64_t(51)});

--- a/components/table/test/test_table.cpp
+++ b/components/table/test/test_table.cpp
@@ -967,3 +967,189 @@ TEST_CASE("components::table::data_table") {
         }
     }
 }
+
+TEST_CASE("components::table::data_table row id projection covers indexed scan paths") {
+    using namespace components::types;
+    using namespace components::vector;
+    using namespace components::table;
+
+    std::pmr::synchronized_pool_resource resource;
+    core::filesystem::local_file_system_t fs;
+    auto buffer_pool = storage::buffer_pool_t(&resource, uint64_t(1) << 32, false, uint64_t(1) << 24);
+    auto buffer_manager = storage::standard_buffer_manager_t(&resource, fs, buffer_pool);
+    auto block_manager = storage::in_memory_block_manager_t(buffer_manager, storage::DEFAULT_BLOCK_ALLOC_SIZE);
+
+    std::vector<column_definition_t> columns;
+    columns.emplace_back("value", logical_type::BIGINT);
+    auto table = std::make_unique<data_table_t>(&resource, block_manager, std::move(columns), "row_id_projection");
+
+    constexpr uint64_t row_count = 32;
+    {
+        auto types = table->copy_types();
+        data_chunk_t chunk(&resource, types, row_count);
+        for (uint64_t i = 0; i < row_count; i++) {
+            chunk.set_value(0, i, logical_value_t(&resource, static_cast<int64_t>(100 + i)));
+        }
+        chunk.set_cardinality(row_count);
+
+        table_append_state state(&resource);
+        table->append_lock(state);
+        table->initialize_append(state);
+        table->append(chunk, state);
+        table->finalize_append(state, transaction_data{0, 0});
+    }
+
+    auto make_result_types = [&]() {
+        std::pmr::vector<complex_logical_type> types(&resource);
+        types.emplace_back(logical_type::BIGINT, "value");
+        types.emplace_back(logical_type::BIGINT, "row_id");
+        return types;
+    };
+    std::vector<storage_index_t> projection{storage_index_t(0), storage_index_t()};
+
+    {
+        table_scan_state state(&resource);
+        table->initialize_scan(state, projection);
+        auto result_types = make_result_types();
+        data_chunk_t result(&resource, result_types, row_count);
+        table->scan(result, state);
+
+        REQUIRE(result.size() == row_count);
+        result.flatten();
+        const auto* values = result.data[0].data<int64_t>();
+        const auto* row_ids = result.data[1].data<int64_t>();
+        for (uint64_t i = 0; i < row_count; i++) {
+            REQUIRE(values[i] == static_cast<int64_t>(100 + i));
+            REQUIRE(row_ids[i] == static_cast<int64_t>(i));
+        }
+    }
+
+    {
+        auto filter = constant_filter_t(components::expressions::compare_type::gte,
+                                        logical_value_t(&resource, int64_t{116}),
+                                        std::pmr::vector<uint64_t>{{uint64_t{0}}, &resource});
+        table_scan_state state(&resource);
+        table->initialize_scan(state, projection, &filter);
+        auto result_types = make_result_types();
+        data_chunk_t result(&resource, result_types, row_count);
+        table->scan(result, state);
+
+        REQUIRE(result.size() == 16);
+        result.flatten();
+        const auto* values = result.data[0].data<int64_t>();
+        const auto* row_ids = result.data[1].data<int64_t>();
+        for (uint64_t i = 0; i < result.size(); i++) {
+            REQUIRE(values[i] == static_cast<int64_t>(116 + i));
+            REQUIRE(row_ids[i] == static_cast<int64_t>(16 + i));
+        }
+    }
+
+    {
+        auto filter = constant_filter_t(components::expressions::compare_type::lt,
+                                        logical_value_t(&resource, int64_t{0}),
+                                        std::pmr::vector<uint64_t>{{uint64_t{0}}, &resource});
+        table_scan_state state(&resource);
+        table->initialize_scan(state, projection, &filter);
+        auto result_types = make_result_types();
+        data_chunk_t result(&resource, result_types, row_count);
+        table->scan(result, state);
+
+        REQUIRE(result.size() == 0);
+    }
+
+    {
+        vector_t deleted_row_ids(&resource, logical_type::BIGINT, row_count / 2);
+        for (uint64_t i = 0; i < row_count; i += 2) {
+            deleted_row_ids.set_value(i / 2, logical_value_t(&resource, static_cast<int64_t>(i)));
+        }
+        auto delete_state = table->initialize_delete({});
+        REQUIRE(table->delete_rows(*delete_state, deleted_row_ids, row_count / 2, 0) == row_count / 2);
+
+        table_scan_state state(&resource);
+        table->initialize_scan(state, projection);
+        auto result_types = make_result_types();
+        data_chunk_t result(&resource, result_types, row_count);
+        table->scan(result, state);
+
+        REQUIRE(result.size() == row_count / 2);
+        result.flatten();
+        const auto* values = result.data[0].data<int64_t>();
+        const auto* row_ids = result.data[1].data<int64_t>();
+        for (uint64_t i = 0; i < result.size(); i++) {
+            const auto original_row = static_cast<int64_t>(i * 2 + 1);
+            REQUIRE(values[i] == 100 + original_row);
+            REQUIRE(row_ids[i] == original_row);
+        }
+    }
+}
+
+TEST_CASE("components::table::data_table string column update owns long strings") {
+    using namespace components::types;
+    using namespace components::vector;
+    using namespace components::table;
+
+    std::pmr::synchronized_pool_resource resource;
+    core::filesystem::local_file_system_t fs;
+    auto buffer_pool = storage::buffer_pool_t(&resource, uint64_t(1) << 32, false, uint64_t(1) << 24);
+    auto buffer_manager = storage::standard_buffer_manager_t(&resource, fs, buffer_pool);
+    auto block_manager = storage::in_memory_block_manager_t(buffer_manager, storage::DEFAULT_BLOCK_ALLOC_SIZE);
+
+    std::vector<column_definition_t> columns;
+    columns.emplace_back("id", logical_type::BIGINT);
+    columns.emplace_back("name", logical_type::STRING_LITERAL);
+    auto table = std::make_unique<data_table_t>(&resource, block_manager, std::move(columns), "string_update");
+
+    constexpr uint64_t row_count = DEFAULT_VECTOR_CAPACITY + 64;
+    {
+        auto types = table->copy_types();
+        data_chunk_t chunk(&resource, types, row_count);
+        for (uint64_t i = 0; i < row_count; i++) {
+            chunk.set_value(0, i, logical_value_t(&resource, static_cast<int64_t>(i)));
+            chunk.set_value(1, i, logical_value_t(&resource, std::string{"name_" + std::to_string(i)}));
+        }
+        chunk.set_cardinality(row_count);
+
+        table_append_state state(&resource);
+        table->append_lock(state);
+        table->initialize_append(state);
+        table->append(chunk, state);
+        table->finalize_append(state, transaction_data{0, 0});
+    }
+
+    const std::string updated = "updated_name_with_a_much_longer_materialized_value";
+    constexpr uint64_t update_count = 16;
+    constexpr uint64_t update_start = DEFAULT_VECTOR_CAPACITY + 8;
+    {
+        vector_t row_ids(&resource, logical_type::BIGINT, update_count);
+        data_chunk_t updates(&resource, {logical_type::STRING_LITERAL}, update_count);
+        for (uint64_t i = 0; i < update_count; i++) {
+            row_ids.set_value(i, logical_value_t(&resource, static_cast<int64_t>(update_start + i)));
+            updates.set_value(0, i, logical_value_t(&resource, updated));
+            const auto update_value = updates.data[0].value(i);
+            REQUIRE(update_value.value<std::string_view>() == updated);
+        }
+        updates.set_cardinality(update_count);
+        table->update_column(row_ids, {1}, updates);
+    }
+
+    {
+        std::vector<storage_index_t> projection{storage_index_t(0), storage_index_t(1)};
+        table_scan_state state(&resource);
+        table->initialize_scan(state, projection);
+        auto result_types = table->copy_types();
+        data_chunk_t result(&resource, result_types, row_count);
+        table->scan(result, state);
+        result.flatten();
+
+        REQUIRE(result.size() == row_count);
+        for (uint64_t i = 0; i < row_count; i++) {
+            const auto logical_value = result.data[1].value(i);
+            const auto value = std::string(logical_value.value<std::string_view>());
+            if (i >= update_start && i < update_start + update_count) {
+                REQUIRE(value == updated);
+            } else {
+                REQUIRE(value == std::string{"name_" + std::to_string(i)});
+            }
+        }
+    }
+}

--- a/components/table/update_segment.cpp
+++ b/components/table/update_segment.cpp
@@ -202,6 +202,23 @@ namespace components::table {
 
     bool update_segment_t::has_updates() const { return root_.get() != nullptr; }
 
+    bool update_segment_t::has_uncommitted_updates() const {
+        auto read_lock = std::shared_lock(m_);
+        if (!root_) {
+            return false;
+        }
+        for (const auto& entry : root_->info) {
+            if (!entry.is_set()) {
+                continue;
+            }
+            auto pin = entry.pin();
+            if (pin.update_info().has_next()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     bool update_segment_t::has_uncommitted_updates(uint64_t vector_index) {
         auto read_lock = std::shared_lock(m_);
         auto entry = update_node(vector_index);
@@ -260,7 +277,15 @@ namespace components::table {
     }
 
     void update_segment_t::fetch_committed_range(int64_t start_row, uint64_t count, vector::vector_t& result) {
+        fetch_committed_range(start_row, count, uint64_t(0), result);
+    }
+
+    void update_segment_t::fetch_committed_range(int64_t start_row,
+                                                 uint64_t count,
+                                                 uint64_t result_offset,
+                                                 vector::vector_t& result) {
         assert(count > 0);
+        auto lock_handle = std::shared_lock(m_);
         if (!root_) {
             return;
         }
@@ -284,9 +309,13 @@ namespace components::table {
                                                               : vector::DEFAULT_VECTOR_CAPACITY;
             assert(start_in_vector < end_in_vector);
             assert(end_in_vector > 0 && end_in_vector <= vector::DEFAULT_VECTOR_CAPACITY);
-            uint64_t result_offset =
+            uint64_t vector_result_offset =
                 vector_idx * vector::DEFAULT_VECTOR_CAPACITY + start_in_vector - static_cast<uint64_t>(start_row);
-            fetch_committed_range(pin.update_info(), start_in_vector, end_in_vector, result_offset, result);
+            fetch_committed_range(pin.update_info(),
+                                  start_in_vector,
+                                  end_in_vector,
+                                  result_offset + vector_result_offset,
+                                  result);
         }
     }
 

--- a/components/table/update_segment.hpp
+++ b/components/table/update_segment.hpp
@@ -11,6 +11,7 @@
 #include <cstring>
 #include <shared_mutex>
 #include <stdexcept>
+#include <type_traits>
 
 #include "storage/buffer_handle.hpp"
 
@@ -178,6 +179,7 @@ namespace components::table {
         explicit update_segment_t(column_data_t& column);
 
         bool has_updates() const;
+        bool has_uncommitted_updates() const;
         bool has_uncommitted_updates(uint64_t vector_index);
         bool has_updates(uint64_t vector_index);
         bool has_updates(int64_t start_row_idx, int64_t end_row_idx);
@@ -185,6 +187,10 @@ namespace components::table {
         void fetch_updates(uint64_t vector_index, uint64_t result_offset, vector::vector_t& result);
         void fetch_committed(uint64_t vector_index, uint64_t result_offset, vector::vector_t& result);
         void fetch_committed_range(int64_t start_row, uint64_t count, vector::vector_t& result);
+        void fetch_committed_range(int64_t start_row,
+                                   uint64_t count,
+                                   uint64_t result_offset,
+                                   vector::vector_t& result);
         void update(uint64_t column_index,
                     vector::vector_t& update,
                     int64_t* ids,
@@ -281,7 +287,6 @@ namespace components::table {
                                                uint64_t count,
                                                const vector::indexing_vector_t& indexing,
                                                T (*extractor)(const V* data, uint64_t index));
-
         template<typename T>
         static void templated_fetch_committed_range(update_info_t& info,
                                                     uint64_t start,
@@ -304,7 +309,7 @@ namespace components::table {
         uint64_t type_size_;
         core::string_heap_t heap_;
         column_data_t* column_data_;
-        std::shared_mutex m_;
+        mutable std::shared_mutex m_;
     };
 
     struct update_select_element_t {
@@ -312,11 +317,25 @@ namespace components::table {
         static T operation(update_segment_t*, T element) {
             return element;
         }
+
+        template<typename T>
+        static T persisted_operation(update_segment_t* segment, T element) {
+            if constexpr (std::is_same_v<T, std::string_view>) {
+                return {static_cast<char*>(segment->heap().insert(element.data(), element.size())), element.size()};
+            } else {
+                return element;
+            }
+        }
     };
 
-    template<>
-    inline std::string_view update_select_element_t::operation(update_segment_t* segment, std::string_view element) {
-        return {static_cast<char*>(segment->heap().insert(element)), element.size()};
+    inline std::string_view copy_update_string_to_result(vector::vector_t& result, std::string_view value) {
+        auto auxiliary = result.auxiliary();
+        if (!auxiliary || auxiliary->type() != vector::vector_buffer_type::STRING) {
+            result.set_auxiliary(std::make_shared<vector::string_vector_buffer_t>(result.resource()));
+            auxiliary = result.auxiliary();
+        }
+        auto* string_buffer = static_cast<vector::string_vector_buffer_t*>(auxiliary.get());
+        return {static_cast<char*>(string_buffer->insert(value.data(), value.size())), value.size()};
     }
 
     template<typename... Args>
@@ -617,8 +636,9 @@ namespace components::table {
             case types::physical_type::FLOAT:
                 return templated_check_row<float>(std::forward<Args>(args)...);
             case types::physical_type::DOUBLE:
-                // case types::physical_type::INTERVAL:
-                // return templated_check_row<interval_t>(std::forward<Args>(args)...);
+                return templated_check_row<double>(std::forward<Args>(args)...);
+            // case types::physical_type::INTERVAL:
+            // return templated_check_row<interval_t>(std::forward<Args>(args)...);
             case types::physical_type::STRING:
                 return templated_check_row<std::string_view>(std::forward<Args>(args)...);
             default:
@@ -690,8 +710,8 @@ namespace components::table {
         auto tuple_data = update_info.data<T>();
 
         for (uint64_t i = 0; i < update_info.N; i++) {
-            auto idx = indexing.get_index(i) + base_info.vector_index * vector::DEFAULT_VECTOR_CAPACITY;
-            tuple_data[i] = update_select_element_t::operation<T>(update_info.segment, update_data[idx]);
+            auto idx = indexing.get_index(i);
+            tuple_data[i] = update_select_element_t::persisted_operation<T>(update_info.segment, update_data[idx]);
         }
 
         auto base_array_data = base_data.data<T>();
@@ -703,7 +723,8 @@ namespace components::table {
             if (!base_validity.row_is_valid(base_idx)) {
                 continue;
             }
-            base_tuple_data[i] = update_select_element_t::operation<T>(base_info.segment, base_array_data[base_idx]);
+            base_tuple_data[i] =
+                update_select_element_t::persisted_operation<T>(base_info.segment, base_array_data[base_idx]);
         }
     }
 
@@ -821,7 +842,8 @@ namespace components::table {
                 result_values[result_offset] = base_info_data[base_info_offset];
             } else {
                 result_values[result_offset] =
-                    update_select_element_t::operation<T>(base_info.segment, extractor(base_table_data, update_id));
+                    update_select_element_t::persisted_operation<T>(base_info.segment,
+                                                                    extractor(base_table_data, update_id));
             }
             result_ids[result_offset++] = static_cast<uint32_t>(update_id);
         }
@@ -836,7 +858,9 @@ namespace components::table {
 
         result_offset = 0;
         auto pick_new = [&](uint64_t id, uint64_t aidx, uint64_t) {
-            result_values[result_offset] = extractor(update_vector_data, aidx);
+            result_values[result_offset] =
+                update_select_element_t::persisted_operation<T>(base_info.segment,
+                                                                extractor(update_vector_data, aidx));
             result_ids[result_offset] = static_cast<uint32_t>(id);
             result_offset++;
         };
@@ -846,9 +870,10 @@ namespace components::table {
             result_offset++;
         };
         auto merge = [&](uint64_t id, uint64_t aidx, uint64_t, uint64_t count) { pick_new(id, aidx, count); };
+        const auto update_count = count;
         uint64_t aidx = 0, bidx = 0;
         uint64_t counter = 0;
-        while (aidx < count && bidx < base_info.N) {
+        while (aidx < update_count && bidx < base_info.N) {
             auto a_index = indexing.get_index(aidx);
             auto a_id = static_cast<uint64_t>(ids[a_index]) - base_id;
             auto b_id = base_info.tuples()[bidx];
@@ -867,14 +892,14 @@ namespace components::table {
                 counter++;
             }
         }
-        for (; aidx < count; aidx++) {
+        for (; aidx < update_count; aidx++) {
             auto a_index = indexing.get_index(aidx);
-            pick_new(static_cast<uint64_t>(ids[a_index]) - base_id, a_index, count);
-            count++;
+            pick_new(static_cast<uint64_t>(ids[a_index]) - base_id, a_index, counter);
+            counter++;
         }
         for (; bidx < base_info.N; bidx++) {
-            pick_old(base_info.tuples()[bidx], bidx, count);
-            count++;
+            pick_old(base_info.tuples()[bidx], bidx, counter);
+            counter++;
         }
 
         base_info.N = static_cast<uint32_t>(result_offset);
@@ -920,6 +945,81 @@ namespace components::table {
             }
         });
         return result;
+    }
+
+    template<>
+    inline void update_segment_t::templated_fetch_committed<std::string_view>(update_info_t& info,
+                                                                              uint64_t result_offset,
+                                                                              vector::vector_t& result) {
+        auto result_data = result.data<std::string_view>();
+        auto tuples = info.tuples();
+        auto info_data = info.data<std::string_view>();
+        if (info.N == vector::DEFAULT_VECTOR_CAPACITY) {
+            for (uint64_t i = 0; i < info.N; i++) {
+                result_data[result_offset + i] = copy_update_string_to_result(result, info_data[i]);
+            }
+            return;
+        }
+        for (uint64_t i = 0; i < info.N; i++) {
+            result_data[result_offset + tuples[i]] = copy_update_string_to_result(result, info_data[i]);
+        }
+    }
+
+    template<>
+    inline void update_segment_t::update_merge_fetch<std::string_view>(update_info_t& info,
+                                                                       uint64_t result_offset,
+                                                                       vector::vector_t& result) {
+        auto result_data = result.data<std::string_view>();
+        update_info_t::update_for_transaction(info, [&](update_info_t* current) {
+            auto tuples = current->tuples();
+            auto info_data = current->data<std::string_view>();
+            if (current->N == vector::DEFAULT_VECTOR_CAPACITY) {
+                for (uint64_t i = 0; i < current->N; i++) {
+                    result_data[result_offset + i] = copy_update_string_to_result(result, info_data[i]);
+                }
+                return;
+            }
+            for (uint64_t i = 0; i < current->N; i++) {
+                result_data[result_offset + tuples[i]] = copy_update_string_to_result(result, info_data[i]);
+            }
+        });
+    }
+
+    template<>
+    inline void update_segment_t::templated_fetch_committed_range<std::string_view>(update_info_t& info,
+                                                                                   uint64_t start,
+                                                                                   uint64_t end,
+                                                                                   uint64_t result_offset,
+                                                                                   vector::vector_t& result) {
+        auto result_data = result.data<std::string_view>();
+        auto tuples = info.tuples();
+        auto info_data = info.data<std::string_view>();
+        for (uint64_t i = 0; i < info.N; i++) {
+            auto tuple_idx = tuples[i];
+            if (tuple_idx < start) {
+                continue;
+            } else if (tuple_idx >= end) {
+                break;
+            }
+            auto result_idx = result_offset + tuple_idx - start;
+            result_data[result_idx] = copy_update_string_to_result(result, info_data[i]);
+        }
+    }
+
+    template<>
+    inline void update_segment_t::templated_fetch_row<std::string_view>(update_info_t& info,
+                                                                        uint64_t row_index,
+                                                                        vector::vector_t& result,
+                                                                        uint64_t result_index) {
+        auto result_data = result.data<std::string_view>();
+        update_info_t::update_for_transaction(info, [&](update_info_t* current) {
+            auto info_data = current->data<std::string_view>();
+            auto tuples = current->tuples();
+            auto it = std::lower_bound(tuples, tuples + current->N, row_index);
+            if (it != tuples + current->N && *it == row_index) {
+                result_data[result_index] = copy_update_string_to_result(result, info_data[it - tuples]);
+            }
+        });
     }
 
 } // namespace components::table

--- a/components/types/CMakeLists.txt
+++ b/components/types/CMakeLists.txt
@@ -2,6 +2,7 @@ project(types CXX)
 
 set(SOURCE_${PROJECT_NAME}
         types.cpp
+        type_spec.cpp
         physical_value.cpp
         logical_value.cpp
         operations_helper.cpp

--- a/components/types/tests/CMakeLists.txt
+++ b/components/types/tests/CMakeLists.txt
@@ -23,4 +23,4 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 
 include(CTest)
 include(Catch)
-catch_discover_tests(${PROJECT_NAME})
+otterbrix_discover_tests(${PROJECT_NAME})

--- a/components/types/type_spec.cpp
+++ b/components/types/type_spec.cpp
@@ -1,0 +1,475 @@
+#include "type_spec.hpp"
+
+#include "logical_value.hpp"
+
+#include <charconv>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace components::types {
+    namespace {
+
+        std::string_view scalar_type_to_name(logical_type type) {
+            switch (type) {
+                case logical_type::BOOLEAN:
+                    return "bool";
+                case logical_type::TINYINT:
+                    return "int1";
+                case logical_type::UTINYINT:
+                    return "uint1";
+                case logical_type::SMALLINT:
+                    return "int2";
+                case logical_type::USMALLINT:
+                    return "uint2";
+                case logical_type::INTEGER:
+                    return "int4";
+                case logical_type::UINTEGER:
+                    return "uint4";
+                case logical_type::BIGINT:
+                    return "int8";
+                case logical_type::UBIGINT:
+                    return "uint8";
+                case logical_type::HUGEINT:
+                    return "hugeint";
+                case logical_type::UHUGEINT:
+                    return "uhugeint";
+                case logical_type::FLOAT:
+                    return "float4";
+                case logical_type::DOUBLE:
+                    return "float8";
+                case logical_type::STRING_LITERAL:
+                    return "text";
+                case logical_type::TIMESTAMP:
+                    return "timestamp";
+                case logical_type::TIMESTAMP_TZ:
+                    return "timestamp with time zone";
+                case logical_type::DATE:
+                    return "date";
+                case logical_type::TIME:
+                    return "time";
+                case logical_type::TIME_TZ:
+                    return "time with time zone";
+                case logical_type::INTERVAL:
+                    return "interval";
+                case logical_type::BLOB:
+                    return "bytea";
+                case logical_type::UUID:
+                    return "uuid";
+                default:
+                    return "";
+            }
+        }
+
+        logical_type scalar_name_to_type(std::string_view name) {
+            if (name == "bool")
+                return logical_type::BOOLEAN;
+            if (name == "int1")
+                return logical_type::TINYINT;
+            if (name == "uint1")
+                return logical_type::UTINYINT;
+            if (name == "int2")
+                return logical_type::SMALLINT;
+            if (name == "uint2")
+                return logical_type::USMALLINT;
+            if (name == "int4")
+                return logical_type::INTEGER;
+            if (name == "uint4")
+                return logical_type::UINTEGER;
+            if (name == "int8")
+                return logical_type::BIGINT;
+            if (name == "uint8")
+                return logical_type::UBIGINT;
+            if (name == "hugeint")
+                return logical_type::HUGEINT;
+            if (name == "uhugeint")
+                return logical_type::UHUGEINT;
+            if (name == "float4")
+                return logical_type::FLOAT;
+            if (name == "float8")
+                return logical_type::DOUBLE;
+            if (name == "text")
+                return logical_type::STRING_LITERAL;
+            if (name == "timestamp")
+                return logical_type::TIMESTAMP;
+            if (name == "timestamp with time zone")
+                return logical_type::TIMESTAMP_TZ;
+            if (name == "date")
+                return logical_type::DATE;
+            if (name == "time")
+                return logical_type::TIME;
+            if (name == "time with time zone")
+                return logical_type::TIME_TZ;
+            if (name == "interval")
+                return logical_type::INTERVAL;
+            if (name == "bytea")
+                return logical_type::BLOB;
+            if (name == "uuid")
+                return logical_type::UUID;
+
+            if (name == "int16")
+                return logical_type::SMALLINT;
+            if (name == "int32")
+                return logical_type::INTEGER;
+            if (name == "int64")
+                return logical_type::BIGINT;
+            if (name == "float32")
+                return logical_type::FLOAT;
+            if (name == "float64")
+                return logical_type::DOUBLE;
+            if (name == "string")
+                return logical_type::STRING_LITERAL;
+            if (name == "blob")
+                return logical_type::BLOB;
+            if (name == "boolean")
+                return logical_type::BOOLEAN;
+            if (name == "integer")
+                return logical_type::INTEGER;
+            if (name == "bigint")
+                return logical_type::BIGINT;
+
+            if (name == "double")
+                return logical_type::DOUBLE;
+            if (name == "float")
+                return logical_type::FLOAT;
+            if (name == "smallint")
+                return logical_type::SMALLINT;
+            if (name == "tinyint")
+                return logical_type::TINYINT;
+            if (name == "varchar")
+                return logical_type::STRING_LITERAL;
+            if (name == "int8_t")
+                return logical_type::BIGINT;
+            return logical_type::UNKNOWN;
+        }
+
+        std::string encode_type_nested(const complex_logical_type& type) {
+            auto scalar_name = scalar_type_to_name(type.type());
+            if (!scalar_name.empty()) {
+                return std::string(scalar_name);
+            }
+
+            if (type.type() == logical_type::DECIMAL) {
+                const auto* ext = static_cast<const decimal_logical_type_extension*>(type.extension());
+                return "numeric(" + std::to_string(static_cast<unsigned>(ext->width())) + "," +
+                       std::to_string(static_cast<unsigned>(ext->scale())) + ")";
+            }
+            if (type.type() == logical_type::ENUM) {
+                std::string out = "ENUM(";
+                out += type.type_name();
+                const auto* ext = type.extension();
+                if (ext != nullptr) {
+                    const auto* enum_ext = static_cast<const enum_logical_type_extension*>(ext);
+                    for (const auto& entry : enum_ext->entries()) {
+                        out += ',';
+                        const auto& entry_type = entry.type();
+                        out += entry_type.has_alias() ? entry_type.alias() : std::string{};
+                        out += '=';
+                        out += std::to_string(entry.value<std::int32_t>());
+                    }
+                }
+                out += ')';
+                return out;
+            }
+            if (type.type() == logical_type::UNKNOWN) {
+                return "UNKNOWN(" + type.type_name() + ")";
+            }
+            if (type.type() == logical_type::LIST) {
+                return "LIST(" + encode_type_nested(type.child_type()) + ")";
+            }
+            if (type.type() == logical_type::ARRAY) {
+                const auto* ext = static_cast<const array_logical_type_extension*>(type.extension());
+                return "ARRAY(" + encode_type_nested(ext->internal_type()) + "," + std::to_string(ext->size()) + ")";
+            }
+            if (type.type() == logical_type::MAP) {
+                const auto* ext = static_cast<const map_logical_type_extension*>(type.extension());
+                return "MAP(" + encode_type_nested(ext->key()) + "," + encode_type_nested(ext->value()) + ")";
+            }
+            if (type.type() == logical_type::STRUCT) {
+                const auto* ext = static_cast<const struct_logical_type_extension*>(type.extension());
+                std::string out = "STRUCT(" + ext->type_name();
+                for (const auto& field : ext->child_types()) {
+                    out += ',';
+                    out += field.alias();
+                    out += ':';
+                    out += encode_type_nested(field);
+                }
+                out += ')';
+                return out;
+            }
+            if (type.type() == logical_type::UNION) {
+                const auto& children = type.child_types();
+                std::string out = "UNION(";
+                bool first = true;
+                for (size_t i = 1; i < children.size(); ++i) {
+                    if (!first) {
+                        out += ',';
+                    }
+                    first = false;
+                    out += children[i].alias();
+                    out += ':';
+                    out += encode_type_nested(children[i]);
+                }
+                out += ')';
+                return out;
+            }
+            if (type.type() == logical_type::VARIANT) {
+                return "VARIANT";
+            }
+            return "UNKNOWN(" + std::to_string(static_cast<int>(type.type())) + ")";
+        }
+
+        complex_logical_type parse_flat_type(std::pmr::memory_resource* resource, std::string_view spec, size_t& pos);
+
+        std::string read_token(std::string_view spec, size_t& pos) {
+            const size_t start = pos;
+            while (pos < spec.size() && spec[pos] != '(' && spec[pos] != ')' && spec[pos] != ',' &&
+                   spec[pos] != ':') {
+                ++pos;
+            }
+            return std::string{spec.substr(start, pos - start)};
+        }
+
+        complex_logical_type parse_flat_type(std::pmr::memory_resource* resource, std::string_view spec, size_t& pos) {
+            std::string name = read_token(spec, pos);
+
+            if (pos >= spec.size() || spec[pos] != '(') {
+                if (name == "VARIANT") {
+                    return complex_logical_type::create_variant(resource);
+                }
+                auto type = scalar_name_to_type(name);
+                if (type != logical_type::UNKNOWN) {
+                    return complex_logical_type{type};
+                }
+                return complex_logical_type::create_unknown(name);
+            }
+            ++pos;
+
+            if (name == "numeric" || name == "DECIMAL") {
+                std::string width = read_token(spec, pos);
+                ++pos;
+                std::string scale = read_token(spec, pos);
+                ++pos;
+                int parsed_width{};
+                int parsed_scale{};
+                auto width_result = std::from_chars(width.data(), width.data() + width.size(), parsed_width);
+                auto scale_result = std::from_chars(scale.data(), scale.data() + scale.size(), parsed_scale);
+                if (width_result.ec != std::errc{} || scale_result.ec != std::errc{}) {
+                    return complex_logical_type{logical_type::UNKNOWN};
+                }
+                return complex_logical_type::create_decimal(static_cast<uint8_t>(parsed_width),
+                                                            static_cast<uint8_t>(parsed_scale));
+            }
+            if (name == "ENUM") {
+                std::string enum_name = read_token(spec, pos);
+                std::vector<logical_value_t> entries;
+                while (pos < spec.size() && spec[pos] == ',') {
+                    ++pos;
+                    std::string token = read_token(spec, pos);
+                    auto eq = token.find('=');
+                    if (eq != std::string::npos) {
+                        std::string label = token.substr(0, eq);
+                        auto value_spec = token.substr(eq + 1);
+                        int value{};
+                        auto value_result =
+                            std::from_chars(value_spec.data(), value_spec.data() + value_spec.size(), value);
+                        if (value_result.ec != std::errc{}) {
+                            return complex_logical_type{logical_type::UNKNOWN};
+                        }
+                        logical_value_t logical_value(resource, value);
+                        logical_value.set_alias(label);
+                        entries.push_back(std::move(logical_value));
+                    }
+                }
+                if (pos < spec.size() && spec[pos] == ')') {
+                    ++pos;
+                }
+                return complex_logical_type::create_enum(enum_name, std::move(entries));
+            }
+            if (name == "UNKNOWN") {
+                std::string type_name = read_token(spec, pos);
+                ++pos;
+                return complex_logical_type::create_unknown(type_name);
+            }
+            if (name == "LIST") {
+                auto inner = parse_flat_type(resource, spec, pos);
+                ++pos;
+                return complex_logical_type::create_list(inner);
+            }
+            if (name == "ARRAY") {
+                auto inner = parse_flat_type(resource, spec, pos);
+                ++pos;
+                std::string size = read_token(spec, pos);
+                ++pos;
+                unsigned long long parsed_size{};
+                auto size_result = std::from_chars(size.data(), size.data() + size.size(), parsed_size);
+                if (size_result.ec != std::errc{}) {
+                    return complex_logical_type{logical_type::UNKNOWN};
+                }
+                return complex_logical_type::create_array(inner, parsed_size);
+            }
+            if (name == "MAP") {
+                auto key = parse_flat_type(resource, spec, pos);
+                ++pos;
+                auto value = parse_flat_type(resource, spec, pos);
+                ++pos;
+                return complex_logical_type::create_map(key, value);
+            }
+            if (name == "STRUCT") {
+                std::string struct_name = read_token(spec, pos);
+                std::pmr::vector<complex_logical_type> fields(resource);
+                while (pos < spec.size() && spec[pos] == ',') {
+                    ++pos;
+                    std::string field_name = read_token(spec, pos);
+                    ++pos;
+                    auto field_type = parse_flat_type(resource, spec, pos);
+                    field_type.set_alias(field_name);
+                    fields.push_back(std::move(field_type));
+                }
+                if (pos < spec.size() && spec[pos] == ')') {
+                    ++pos;
+                }
+                auto struct_type = complex_logical_type::create_struct(struct_name, fields);
+                struct_type.set_alias(struct_name);
+                return struct_type;
+            }
+            if (name == "UNION") {
+                std::pmr::vector<complex_logical_type> fields(resource);
+                if (pos < spec.size() && spec[pos] != ')') {
+                    std::string field_name = read_token(spec, pos);
+                    ++pos;
+                    auto field_type = parse_flat_type(resource, spec, pos);
+                    field_type.set_alias(field_name);
+                    fields.push_back(std::move(field_type));
+                }
+                while (pos < spec.size() && spec[pos] == ',') {
+                    ++pos;
+                    std::string field_name = read_token(spec, pos);
+                    ++pos;
+                    auto field_type = parse_flat_type(resource, spec, pos);
+                    field_type.set_alias(field_name);
+                    fields.push_back(std::move(field_type));
+                }
+                if (pos < spec.size() && spec[pos] == ')') {
+                    ++pos;
+                }
+                return complex_logical_type::create_union(std::move(fields));
+            }
+
+            int depth = 1;
+            while (pos < spec.size() && depth > 0) {
+                if (spec[pos] == '(') {
+                    ++depth;
+                } else if (spec[pos] == ')') {
+                    --depth;
+                }
+                ++pos;
+            }
+            return complex_logical_type::create_unknown(name);
+        }
+
+    } // namespace
+
+    std::string encode_type_spec(const complex_logical_type& type) {
+        switch (type.type()) {
+            case logical_type::BOOLEAN:
+            case logical_type::TINYINT:
+            case logical_type::UTINYINT:
+            case logical_type::SMALLINT:
+            case logical_type::USMALLINT:
+            case logical_type::INTEGER:
+            case logical_type::UINTEGER:
+            case logical_type::BIGINT:
+            case logical_type::UBIGINT:
+            case logical_type::FLOAT:
+            case logical_type::DOUBLE:
+            case logical_type::STRING_LITERAL:
+            case logical_type::TIMESTAMP:
+            case logical_type::TIMESTAMP_TZ:
+            case logical_type::DATE:
+            case logical_type::TIME:
+            case logical_type::TIME_TZ:
+            case logical_type::INTERVAL:
+            case logical_type::BLOB:
+            case logical_type::UUID:
+                return "";
+            default:
+                break;
+        }
+
+        if (type.type() == logical_type::ENUM) {
+            std::string out = "ENUM:";
+            out += type.type_name();
+            out += ':';
+            const auto* ext = type.extension();
+            if (ext != nullptr) {
+                const auto* enum_ext = static_cast<const enum_logical_type_extension*>(ext);
+                bool first = true;
+                for (const auto& entry : enum_ext->entries()) {
+                    if (!first) {
+                        out += ',';
+                    }
+                    first = false;
+                    const auto& entry_type = entry.type();
+                    out += entry_type.has_alias() ? entry_type.alias() : std::string{};
+                    out += '=';
+                    out += std::to_string(entry.value<std::int32_t>());
+                }
+            }
+            return out;
+        }
+
+        return encode_type_nested(type);
+    }
+
+    complex_logical_type decode_type_spec(std::pmr::memory_resource* resource, std::string_view spec) {
+        if (spec.empty()) {
+            return complex_logical_type{logical_type::UNKNOWN};
+        }
+
+        if (spec.size() >= 5 && spec.compare(0, 5, "ENUM:") == 0) {
+            auto rest = spec.substr(5);
+            auto colon = rest.find(':');
+            std::string name =
+                (colon == std::string_view::npos) ? std::string{rest} : std::string{rest.substr(0, colon)};
+            std::vector<logical_value_t> entries;
+            if (colon != std::string_view::npos) {
+                auto entries_spec = rest.substr(colon + 1);
+                std::size_t i = 0;
+                while (i < entries_spec.size()) {
+                    std::size_t comma = entries_spec.find(',', i);
+                    std::string token{
+                        entries_spec.substr(i,
+                                            comma == std::string_view::npos ? std::string_view::npos : comma - i)};
+                    std::size_t eq = token.find('=');
+                    if (eq != std::string::npos) {
+                        std::string label = token.substr(0, eq);
+                        const auto value_spec = token.substr(eq + 1);
+                        int value{};
+                        auto value_result =
+                            std::from_chars(value_spec.data(), value_spec.data() + value_spec.size(), value);
+                        if (value_result.ec != std::errc{}) {
+                            return complex_logical_type{logical_type::UNKNOWN};
+                        }
+                        logical_value_t logical_value(resource, value);
+                        logical_value.set_alias(label);
+                        entries.push_back(std::move(logical_value));
+                    }
+                    if (comma == std::string_view::npos) {
+                        break;
+                    }
+                    i = comma + 1;
+                }
+            }
+            return complex_logical_type::create_enum(name, std::move(entries));
+        }
+
+        try {
+            size_t pos = 0;
+            return parse_flat_type(resource, spec, pos);
+        } catch (...) {
+            return complex_logical_type{logical_type::UNKNOWN};
+        }
+    }
+
+} // namespace components::types

--- a/components/types/type_spec.cpp
+++ b/components/types/type_spec.cpp
@@ -313,7 +313,7 @@ namespace components::types {
                 ++pos;
                 auto value = parse_flat_type(resource, spec, pos);
                 ++pos;
-                return complex_logical_type::create_map(key, value);
+                return complex_logical_type::create_map(resource, key, value);
             }
             if (name == "STRUCT") {
                 std::string struct_name = read_token(spec, pos);

--- a/components/types/type_spec.hpp
+++ b/components/types/type_spec.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "types.hpp"
+
+#include <memory_resource>
+#include <string>
+#include <string_view>
+
+namespace components::types {
+
+    std::string encode_type_spec(const complex_logical_type& type);
+    complex_logical_type decode_type_spec(std::pmr::memory_resource* resource, std::string_view spec);
+
+} // namespace components::types

--- a/components/types/types.cpp
+++ b/components/types/types.cpp
@@ -224,6 +224,10 @@ namespace components::types {
                 return sizeof(int32_t);
             case physical_type::INT64:
                 return sizeof(int64_t);
+            case physical_type::UINT128:
+                return sizeof(uint128_t);
+            case physical_type::INT128:
+                return sizeof(int128_t);
             case physical_type::FLOAT:
                 return sizeof(float);
             case physical_type::DOUBLE:
@@ -265,6 +269,10 @@ namespace components::types {
                 return alignof(int32_t);
             case physical_type::INT64:
                 return alignof(int64_t);
+            case physical_type::UINT128:
+                return alignof(uint128_t);
+            case physical_type::INT128:
+                return alignof(int128_t);
             case physical_type::FLOAT:
                 return alignof(float);
             case physical_type::DOUBLE:
@@ -432,6 +440,9 @@ namespace components::types {
 
     bool complex_logical_type::is_convertable_to(const complex_logical_type& other) const {
         if (*this == other) {
+            return true;
+        }
+        if (type_ == logical_type::NA) {
             return true;
         }
 

--- a/components/vector/data_chunk.cpp
+++ b/components/vector/data_chunk.cpp
@@ -64,6 +64,11 @@ namespace components::vector {
             return;
         }
         capacity_ = DEFAULT_VECTOR_CAPACITY;
+        // Scans only set invalid bits, never clear them, so a reused chunk must reset
+        // validity to all-valid or it keeps stale NULLs from a prior fill.
+        for (auto& column : data) {
+            column.validity().reset(capacity_);
+        }
         set_cardinality(0);
     }
 
@@ -439,13 +444,31 @@ namespace components::vector {
     }
 
     core::result_wrapper_t<types::logical_value_t> compact_to_array_value(const data_chunk_t& data) {
-        if (!data.empty() && data.column_count() == 1) {
+        // A single-column result compacts to an array (used to materialise the
+        // right-hand side of `x IN (subquery)` / ANY / ALL). Zero rows is a
+        // valid, common case — an empty IN-list — and must yield an EMPTY array
+        // (so `x IN ()` evaluates to false), NOT an error. The column type is
+        // still available on an empty chunk (empty() means zero rows, not zero
+        // columns), so the element type is preserved. Mirrors
+        // compact_to_single_value, which yields NULL rather than erroring on an
+        // empty scalar sub-query. Only a genuine shape violation (more than one
+        // column) is an error.
+        if (data.column_count() == 1) {
             std::vector<types::logical_value_t> array;
             array.reserve(data.size());
             for (size_t i = 0; i < data.size(); ++i) {
                 array.emplace_back(data.value(0, i));
             }
             return types::logical_value_t::create_array(data.resource(), data.data[0].type(), array);
+        } else if (data.column_count() == 0 && data.size() == 0) {
+            // An empty sub-query result whose single projected column was a
+            // placeholder gets stripped at the cursor boundary, leaving zero
+            // columns. An IN-list with no values is always false regardless of
+            // element type, so yield an empty array (NA element type) rather
+            // than erroring — mirrors the empty single-column case above.
+            std::vector<types::logical_value_t> empty_array;
+            return types::logical_value_t::create_array(
+                data.resource(), types::complex_logical_type{types::logical_type::NA}, empty_array);
         } else {
             return core::error_t(core::error_code_t::conversion_failure,
                                  std::pmr::string{"could not convert data_chunk_t to a array value", data.resource()});

--- a/components/vector/data_chunk_binary.cpp
+++ b/components/vector/data_chunk_binary.cpp
@@ -2,9 +2,12 @@
 
 #include <cassert>
 #include <cstring>
+#include <limits>
 #include <stdexcept>
 #include <string_view>
+#include <utility>
 
+#include <core/date/date_types.hpp>
 #include <components/types/types.hpp>
 #include <components/vector/vector.hpp>
 #include <components/vector/vector_buffer.hpp>
@@ -18,6 +21,7 @@ namespace components::vector {
 
         inline void write_le16(char* destination, uint16_t value) { std::memcpy(destination, &value, 2); }
         inline void write_le32(char* destination, uint32_t value) { std::memcpy(destination, &value, 4); }
+        inline void write_le64(char* destination, uint64_t value) { std::memcpy(destination, &value, 8); }
 
         inline uint16_t read_le16(const char* source) {
             uint16_t value;
@@ -29,6 +33,16 @@ namespace components::vector {
             std::memcpy(&value, source, 4);
             return value;
         }
+        inline uint64_t read_le64(const char* source) {
+            uint64_t value;
+            std::memcpy(&value, source, 8);
+            return value;
+        }
+
+        constexpr uint16_t kExtendedFormatMagic = 0xFFFF;
+        constexpr uint16_t kExtendedFormatVersion = 2;
+
+        data_chunk_t make_empty_error_chunk(std::pmr::memory_resource* resource);
 
         // Return the byte-size of one element for a fixed-width physical type.
         // Returns 0 for STRING (variable-width) and for composite types (ARRAY, etc.).
@@ -60,6 +74,866 @@ namespace components::vector {
 
         bool is_variable_type(types::physical_type physical_type) {
             return physical_type == types::physical_type::STRING;
+        }
+
+        bool uses_legacy_binary_format(const data_chunk_t& chunk) {
+            if (chunk.column_count() > std::numeric_limits<uint16_t>::max()) {
+                return false;
+            }
+
+            for (const auto& column : chunk.data) {
+                const auto& type = column.type();
+                auto physical_type = type.to_physical_type();
+
+                if (type.type() == types::logical_type::ENUM) {
+                    return false;
+                }
+                if (is_variable_type(physical_type)) {
+                    if (type.type() != types::logical_type::STRING_LITERAL) {
+                        return false;
+                    }
+                    continue;
+                }
+                if (fixed_type_size(physical_type) == 0) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        void append_raw(services::wal::buffer_t& buffer, const void* data, size_t size) {
+            buffer.append(reinterpret_cast<const char*>(data), size);
+        }
+
+        void append_u8(services::wal::buffer_t& buffer, uint8_t value) {
+            buffer.push_back(static_cast<char>(value));
+        }
+
+        void append_le16(services::wal::buffer_t& buffer, uint16_t value) {
+            char data[2];
+            write_le16(data, value);
+            append_raw(buffer, data, sizeof(data));
+        }
+
+        void append_le32(services::wal::buffer_t& buffer, uint32_t value) {
+            char data[4];
+            write_le32(data, value);
+            append_raw(buffer, data, sizeof(data));
+        }
+
+        void append_le64(services::wal::buffer_t& buffer, uint64_t value) {
+            char data[8];
+            write_le64(data, value);
+            append_raw(buffer, data, sizeof(data));
+        }
+
+        template<typename T>
+        void append_trivial(services::wal::buffer_t& buffer, const T& value) {
+            append_raw(buffer, &value, sizeof(T));
+        }
+
+        void patch_le32(services::wal::buffer_t& buffer, size_t offset, uint32_t value) {
+            assert(offset + sizeof(uint32_t) <= buffer.size());
+            write_le32(buffer.data() + offset, value);
+        }
+
+        void append_string(services::wal::buffer_t& buffer, std::string_view value) {
+            if (value.size() > std::numeric_limits<uint32_t>::max()) {
+                throw std::runtime_error("data_chunk_binary: string is too large to serialize");
+            }
+            append_le32(buffer, static_cast<uint32_t>(value.size()));
+            if (!value.empty()) {
+                append_raw(buffer, value.data(), value.size());
+            }
+        }
+
+        class binary_reader_t {
+        public:
+            binary_reader_t(const char* data, size_t len)
+                : pointer_(data)
+                , end_(data + len) {}
+
+            bool read_u8(uint8_t& value) {
+                if (remaining() < 1) {
+                    return false;
+                }
+                value = static_cast<uint8_t>(*pointer_++);
+                return true;
+            }
+
+            bool read_le16(uint16_t& value) {
+                if (remaining() < 2) {
+                    return false;
+                }
+                std::memcpy(&value, pointer_, 2);
+                pointer_ += 2;
+                return true;
+            }
+
+            bool read_le32(uint32_t& value) {
+                if (remaining() < 4) {
+                    return false;
+                }
+                std::memcpy(&value, pointer_, 4);
+                pointer_ += 4;
+                return true;
+            }
+
+            bool read_le64(uint64_t& value) {
+                if (remaining() < 8) {
+                    return false;
+                }
+                std::memcpy(&value, pointer_, 8);
+                pointer_ += 8;
+                return true;
+            }
+
+            bool read_raw(void* out, size_t size) {
+                if (remaining() < size) {
+                    return false;
+                }
+                std::memcpy(out, pointer_, size);
+                pointer_ += size;
+                return true;
+            }
+
+            bool skip(size_t size) {
+                if (remaining() < size) {
+                    return false;
+                }
+                pointer_ += size;
+                return true;
+            }
+
+            bool read_string(std::string& value) {
+                uint32_t size = 0;
+                if (!read_le32(size) || remaining() < size) {
+                    return false;
+                }
+                value.assign(pointer_, size);
+                pointer_ += size;
+                return true;
+            }
+
+            const char* current() const { return pointer_; }
+            size_t remaining() const { return static_cast<size_t>(end_ - pointer_); }
+            bool done() const { return pointer_ == end_; }
+
+        private:
+            const char* pointer_;
+            const char* end_;
+        };
+
+        void write_full_type(services::wal::buffer_t& buffer, const types::complex_logical_type& type) {
+            append_u8(buffer, static_cast<uint8_t>(type.type()));
+            append_string(buffer, type.has_alias() ? std::string_view(type.alias()) : std::string_view());
+
+            switch (type.type()) {
+                case types::logical_type::DECIMAL: {
+                    const auto* decimal_extension =
+                        static_cast<const types::decimal_logical_type_extension*>(type.extension());
+                    append_u8(buffer, decimal_extension->width());
+                    append_u8(buffer, decimal_extension->scale());
+                    break;
+                }
+                case types::logical_type::ENUM: {
+                    append_string(buffer, type.type_name());
+                    const auto* enum_extension =
+                        static_cast<const types::enum_logical_type_extension*>(type.extension());
+                    const auto& entries = enum_extension->entries();
+                    append_le32(buffer, static_cast<uint32_t>(entries.size()));
+                    for (const auto& entry : entries) {
+                        append_string(buffer,
+                                      entry.type().has_alias() ? std::string_view(entry.type().alias())
+                                                               : std::string_view());
+                        append_trivial(buffer, entry.value<int32_t>());
+                    }
+                    break;
+                }
+                case types::logical_type::UNKNOWN:
+                    append_string(buffer, type.type_name());
+                    break;
+                case types::logical_type::LIST:
+                    write_full_type(buffer, type.child_type());
+                    break;
+                case types::logical_type::ARRAY: {
+                    const auto* array_extension =
+                        static_cast<const types::array_logical_type_extension*>(type.extension());
+                    append_le64(buffer, static_cast<uint64_t>(array_extension->size()));
+                    write_full_type(buffer, array_extension->internal_type());
+                    break;
+                }
+                case types::logical_type::MAP: {
+                    const auto* map_extension = static_cast<const types::map_logical_type_extension*>(type.extension());
+                    write_full_type(buffer, map_extension->key());
+                    write_full_type(buffer, map_extension->value());
+                    break;
+                }
+                case types::logical_type::STRUCT: {
+                    append_string(buffer, type.type_name());
+                    const auto& children = type.child_types();
+                    append_le32(buffer, static_cast<uint32_t>(children.size()));
+                    for (const auto& child : children) {
+                        write_full_type(buffer, child);
+                    }
+                    break;
+                }
+                case types::logical_type::UNION: {
+                    const auto& children = type.child_types();
+                    const auto member_count = children.empty() ? 0 : children.size() - 1;
+                    append_le32(buffer, static_cast<uint32_t>(member_count));
+                    for (size_t i = 1; i < children.size(); ++i) {
+                        write_full_type(buffer, children[i]);
+                    }
+                    break;
+                }
+                default:
+                    break;
+            }
+        }
+
+        types::complex_logical_type
+        read_full_type(binary_reader_t& reader, std::pmr::memory_resource* resource, bool& ok) {
+            uint8_t type_byte = 0;
+            std::string alias;
+            if (!reader.read_u8(type_byte) || !reader.read_string(alias)) {
+                ok = false;
+                return types::complex_logical_type{types::logical_type::INVALID};
+            }
+
+            auto logical_type_value = static_cast<types::logical_type>(type_byte);
+            auto finish_with_alias = [&alias](types::complex_logical_type type) {
+                if (!alias.empty()) {
+                    type.set_alias(alias);
+                }
+                return type;
+            };
+
+            switch (logical_type_value) {
+                case types::logical_type::DECIMAL: {
+                    uint8_t width = 0;
+                    uint8_t scale = 0;
+                    if (!reader.read_u8(width) || !reader.read_u8(scale)) {
+                        ok = false;
+                        return types::complex_logical_type{types::logical_type::INVALID};
+                    }
+                    return types::complex_logical_type::create_decimal(width, scale, std::move(alias));
+                }
+                case types::logical_type::ENUM: {
+                    std::string type_name;
+                    uint32_t entry_count = 0;
+                    if (!reader.read_string(type_name) || !reader.read_le32(entry_count)) {
+                        ok = false;
+                        return types::complex_logical_type{types::logical_type::INVALID};
+                    }
+                    std::vector<types::logical_value_t> entries;
+                    entries.reserve(entry_count);
+                    for (uint32_t i = 0; i < entry_count; ++i) {
+                        std::string entry_alias;
+                        int32_t entry_value = 0;
+                        if (!reader.read_string(entry_alias) || !reader.read_raw(&entry_value, sizeof(entry_value))) {
+                            ok = false;
+                            return types::complex_logical_type{types::logical_type::INVALID};
+                        }
+                        types::logical_value_t value(resource, entry_value);
+                        if (!entry_alias.empty()) {
+                            value.set_alias(entry_alias);
+                        }
+                        entries.emplace_back(std::move(value));
+                    }
+                    return types::complex_logical_type::create_enum(type_name, std::move(entries), std::move(alias));
+                }
+                case types::logical_type::UNKNOWN: {
+                    std::string type_name;
+                    if (!reader.read_string(type_name)) {
+                        ok = false;
+                        return types::complex_logical_type{types::logical_type::INVALID};
+                    }
+                    return types::complex_logical_type::create_unknown(type_name, std::move(alias));
+                }
+                case types::logical_type::LIST: {
+                    auto child = read_full_type(reader, resource, ok);
+                    if (!ok) {
+                        return types::complex_logical_type{types::logical_type::INVALID};
+                    }
+                    return types::complex_logical_type::create_list(child, std::move(alias));
+                }
+                case types::logical_type::ARRAY: {
+                    uint64_t array_size = 0;
+                    if (!reader.read_le64(array_size)) {
+                        ok = false;
+                        return types::complex_logical_type{types::logical_type::INVALID};
+                    }
+                    auto child = read_full_type(reader, resource, ok);
+                    if (!ok) {
+                        return types::complex_logical_type{types::logical_type::INVALID};
+                    }
+                    return types::complex_logical_type::create_array(child,
+                                                                     static_cast<size_t>(array_size),
+                                                                     std::move(alias));
+                }
+                case types::logical_type::MAP: {
+                    auto key = read_full_type(reader, resource, ok);
+                    auto value = read_full_type(reader, resource, ok);
+                    if (!ok) {
+                        return types::complex_logical_type{types::logical_type::INVALID};
+                    }
+                    return types::complex_logical_type::create_map(key, value, std::move(alias));
+                }
+                case types::logical_type::STRUCT: {
+                    std::string type_name;
+                    uint32_t child_count = 0;
+                    if (!reader.read_string(type_name) || !reader.read_le32(child_count)) {
+                        ok = false;
+                        return types::complex_logical_type{types::logical_type::INVALID};
+                    }
+                    std::pmr::vector<types::complex_logical_type> children(resource);
+                    children.reserve(child_count);
+                    for (uint32_t i = 0; i < child_count; ++i) {
+                        children.emplace_back(read_full_type(reader, resource, ok));
+                        if (!ok) {
+                            return types::complex_logical_type{types::logical_type::INVALID};
+                        }
+                    }
+                    return types::complex_logical_type::create_struct(type_name, children, std::move(alias));
+                }
+                case types::logical_type::UNION: {
+                    uint32_t child_count = 0;
+                    if (!reader.read_le32(child_count)) {
+                        ok = false;
+                        return types::complex_logical_type{types::logical_type::INVALID};
+                    }
+                    std::pmr::vector<types::complex_logical_type> children(resource);
+                    children.reserve(child_count);
+                    for (uint32_t i = 0; i < child_count; ++i) {
+                        children.emplace_back(read_full_type(reader, resource, ok));
+                        if (!ok) {
+                            return types::complex_logical_type{types::logical_type::INVALID};
+                        }
+                    }
+                    return types::complex_logical_type::create_union(std::move(children), std::move(alias));
+                }
+                case types::logical_type::VARIANT:
+                    return types::complex_logical_type::create_variant(resource, std::move(alias));
+                default:
+                    return finish_with_alias(types::complex_logical_type{logical_type_value});
+            }
+        }
+
+        void write_nullable_value(services::wal::buffer_t& buffer,
+                                  const types::complex_logical_type& type,
+                                  const types::logical_value_t& value);
+
+        types::logical_value_t read_nullable_value(binary_reader_t& reader,
+                                                   std::pmr::memory_resource* resource,
+                                                   const types::complex_logical_type& type,
+                                                   bool& ok);
+
+        void write_value_payload(services::wal::buffer_t& buffer,
+                                 const types::complex_logical_type& type,
+                                 const types::logical_value_t& value) {
+            switch (type.type()) {
+                case types::logical_type::BOOLEAN:
+                    append_u8(buffer, value.value<bool>() ? 1 : 0);
+                    break;
+                case types::logical_type::TINYINT:
+                    append_trivial(buffer, value.value<int8_t>());
+                    break;
+                case types::logical_type::UTINYINT:
+                    append_trivial(buffer, value.value<uint8_t>());
+                    break;
+                case types::logical_type::SMALLINT:
+                    append_trivial(buffer, value.value<int16_t>());
+                    break;
+                case types::logical_type::USMALLINT:
+                    append_trivial(buffer, value.value<uint16_t>());
+                    break;
+                case types::logical_type::INTEGER:
+                    append_trivial(buffer, value.value<int32_t>());
+                    break;
+                case types::logical_type::UINTEGER:
+                    append_trivial(buffer, value.value<uint32_t>());
+                    break;
+                case types::logical_type::BIGINT:
+                    append_trivial(buffer, value.value<int64_t>());
+                    break;
+                case types::logical_type::UBIGINT:
+                    append_trivial(buffer, value.value<uint64_t>());
+                    break;
+                case types::logical_type::HUGEINT:
+                    append_trivial(buffer, value.value<types::int128_t>());
+                    break;
+                case types::logical_type::UHUGEINT:
+                    append_trivial(buffer, value.value<types::uint128_t>());
+                    break;
+                case types::logical_type::FLOAT:
+                    append_trivial(buffer, value.value<float>());
+                    break;
+                case types::logical_type::DOUBLE:
+                    append_trivial(buffer, value.value<double>());
+                    break;
+                case types::logical_type::STRING_LITERAL:
+                    append_string(buffer, value.value<std::string_view>());
+                    break;
+                case types::logical_type::DATE:
+                    append_trivial(buffer, value.value<core::date::date_t>().value.count());
+                    break;
+                case types::logical_type::TIME:
+                    append_trivial(buffer, value.value<core::date::time_t>().value.count());
+                    break;
+                case types::logical_type::TIMESTAMP:
+                    append_trivial(buffer, value.value<core::date::timestamp_t>().value.count());
+                    break;
+                case types::logical_type::TIMESTAMP_TZ:
+                    append_trivial(buffer, value.value<core::date::timestamptz_t>().value.count());
+                    break;
+                case types::logical_type::TIME_TZ: {
+                    auto timetz = value.value<core::date::timetz_t>();
+                    append_trivial(buffer, timetz.time.count());
+                    append_trivial(buffer, timetz.zone.count());
+                    break;
+                }
+                case types::logical_type::INTERVAL: {
+                    auto interval = value.value<core::date::interval_t>();
+                    append_trivial(buffer, interval.time.count());
+                    append_trivial(buffer, interval.day.count());
+                    append_trivial(buffer, interval.month.count());
+                    break;
+                }
+                case types::logical_type::DECIMAL:
+                    switch (type.to_physical_type()) {
+                        case types::physical_type::INT16:
+                            append_trivial(buffer, value.value<int16_t>());
+                            break;
+                        case types::physical_type::INT32:
+                            append_trivial(buffer, value.value<int32_t>());
+                            break;
+                        case types::physical_type::INT64:
+                            append_trivial(buffer, value.value<int64_t>());
+                            break;
+                        case types::physical_type::INT128:
+                            append_trivial(buffer, value.value<types::int128_t>());
+                            break;
+                        default:
+                            throw std::runtime_error("data_chunk_binary: unsupported DECIMAL physical type");
+                    }
+                    break;
+                case types::logical_type::ENUM:
+                    append_trivial(buffer, value.value<int32_t>());
+                    break;
+                case types::logical_type::LIST: {
+                    const auto& children = value.children();
+                    append_le32(buffer, static_cast<uint32_t>(children.size()));
+                    for (const auto& child : children) {
+                        write_nullable_value(buffer, type.child_type(), child);
+                    }
+                    break;
+                }
+                case types::logical_type::ARRAY: {
+                    const auto& children = value.children();
+                    append_le32(buffer, static_cast<uint32_t>(children.size()));
+                    for (const auto& child : children) {
+                        write_nullable_value(buffer, type.child_type(), child);
+                    }
+                    break;
+                }
+                case types::logical_type::STRUCT: {
+                    const auto& children = value.children();
+                    const auto& child_types = type.child_types();
+                    if (children.size() != child_types.size()) {
+                        throw std::runtime_error("data_chunk_binary: STRUCT value does not match type");
+                    }
+                    for (size_t i = 0; i < children.size(); ++i) {
+                        write_nullable_value(buffer, child_types[i], children[i]);
+                    }
+                    break;
+                }
+                case types::logical_type::UNION: {
+                    const auto& children = value.children();
+                    if (children.empty()) {
+                        throw std::runtime_error("data_chunk_binary: UNION value without tag");
+                    }
+                    const auto tag = children[0].value<uint8_t>();
+                    const auto& child_types = type.child_types();
+                    if (static_cast<size_t>(tag) + 1 >= child_types.size() ||
+                        static_cast<size_t>(tag) + 1 >= children.size()) {
+                        throw std::runtime_error("data_chunk_binary: UNION tag out of range");
+                    }
+                    append_u8(buffer, tag);
+                    write_nullable_value(buffer, child_types[static_cast<size_t>(tag) + 1],
+                                         children[static_cast<size_t>(tag) + 1]);
+                    break;
+                }
+                default:
+                    throw std::runtime_error("data_chunk_binary: unsupported logical type in extended WAL chunk");
+            }
+        }
+
+        void write_nullable_value(services::wal::buffer_t& buffer,
+                                  const types::complex_logical_type& type,
+                                  const types::logical_value_t& value) {
+            append_u8(buffer, value.is_null() ? 0 : 1);
+            if (!value.is_null()) {
+                write_value_payload(buffer, type, value);
+            }
+        }
+
+        template<typename T>
+        bool read_trivial(binary_reader_t& reader, T& value) {
+            return reader.read_raw(&value, sizeof(T));
+        }
+
+        types::logical_value_t read_value_payload(binary_reader_t& reader,
+                                                  std::pmr::memory_resource* resource,
+                                                  const types::complex_logical_type& type,
+                                                  bool& ok) {
+            switch (type.type()) {
+                case types::logical_type::BOOLEAN: {
+                    uint8_t value = 0;
+                    ok = reader.read_u8(value);
+                    return ok ? types::logical_value_t(resource, value != 0)
+                              : types::logical_value_t(resource, types::logical_type::NA);
+                }
+                case types::logical_type::TINYINT: {
+                    int8_t value = 0;
+                    ok = read_trivial(reader, value);
+                    return ok ? types::logical_value_t(resource, value)
+                              : types::logical_value_t(resource, types::logical_type::NA);
+                }
+                case types::logical_type::UTINYINT: {
+                    uint8_t value = 0;
+                    ok = read_trivial(reader, value);
+                    return ok ? types::logical_value_t(resource, value)
+                              : types::logical_value_t(resource, types::logical_type::NA);
+                }
+                case types::logical_type::SMALLINT: {
+                    int16_t value = 0;
+                    ok = read_trivial(reader, value);
+                    return ok ? types::logical_value_t(resource, value)
+                              : types::logical_value_t(resource, types::logical_type::NA);
+                }
+                case types::logical_type::USMALLINT: {
+                    uint16_t value = 0;
+                    ok = read_trivial(reader, value);
+                    return ok ? types::logical_value_t(resource, value)
+                              : types::logical_value_t(resource, types::logical_type::NA);
+                }
+                case types::logical_type::INTEGER: {
+                    int32_t value = 0;
+                    ok = read_trivial(reader, value);
+                    return ok ? types::logical_value_t(resource, value)
+                              : types::logical_value_t(resource, types::logical_type::NA);
+                }
+                case types::logical_type::UINTEGER: {
+                    uint32_t value = 0;
+                    ok = read_trivial(reader, value);
+                    return ok ? types::logical_value_t(resource, value)
+                              : types::logical_value_t(resource, types::logical_type::NA);
+                }
+                case types::logical_type::BIGINT: {
+                    int64_t value = 0;
+                    ok = read_trivial(reader, value);
+                    return ok ? types::logical_value_t(resource, value)
+                              : types::logical_value_t(resource, types::logical_type::NA);
+                }
+                case types::logical_type::UBIGINT: {
+                    uint64_t value = 0;
+                    ok = read_trivial(reader, value);
+                    return ok ? types::logical_value_t(resource, value)
+                              : types::logical_value_t(resource, types::logical_type::NA);
+                }
+                case types::logical_type::HUGEINT: {
+                    types::int128_t value = 0;
+                    ok = read_trivial(reader, value);
+                    return ok ? types::logical_value_t(resource, value)
+                              : types::logical_value_t(resource, types::logical_type::NA);
+                }
+                case types::logical_type::UHUGEINT: {
+                    types::uint128_t value = 0;
+                    ok = read_trivial(reader, value);
+                    return ok ? types::logical_value_t(resource, value)
+                              : types::logical_value_t(resource, types::logical_type::NA);
+                }
+                case types::logical_type::FLOAT: {
+                    float value = 0;
+                    ok = read_trivial(reader, value);
+                    return ok ? types::logical_value_t(resource, value)
+                              : types::logical_value_t(resource, types::logical_type::NA);
+                }
+                case types::logical_type::DOUBLE: {
+                    double value = 0;
+                    ok = read_trivial(reader, value);
+                    return ok ? types::logical_value_t(resource, value)
+                              : types::logical_value_t(resource, types::logical_type::NA);
+                }
+                case types::logical_type::STRING_LITERAL: {
+                    std::string value;
+                    ok = reader.read_string(value);
+                    return ok ? types::logical_value_t(resource, std::move(value))
+                              : types::logical_value_t(resource, types::logical_type::NA);
+                }
+                case types::logical_type::DATE: {
+                    int32_t days = 0;
+                    ok = read_trivial(reader, days);
+                    return ok ? types::logical_value_t(resource, core::date::date_t{core::date::days{days}})
+                              : types::logical_value_t(resource, types::logical_type::NA);
+                }
+                case types::logical_type::TIME: {
+                    int64_t micros = 0;
+                    ok = read_trivial(reader, micros);
+                    return ok ? types::logical_value_t(resource, core::date::time_t{core::date::microseconds{micros}})
+                              : types::logical_value_t(resource, types::logical_type::NA);
+                }
+                case types::logical_type::TIMESTAMP: {
+                    int64_t micros = 0;
+                    ok = read_trivial(reader, micros);
+                    return ok ? types::logical_value_t(resource,
+                                                       core::date::timestamp_t{core::date::microseconds{micros}})
+                              : types::logical_value_t(resource, types::logical_type::NA);
+                }
+                case types::logical_type::TIMESTAMP_TZ: {
+                    int64_t micros = 0;
+                    ok = read_trivial(reader, micros);
+                    return ok ? types::logical_value_t(resource,
+                                                       core::date::timestamptz_t{core::date::microseconds{micros}})
+                              : types::logical_value_t(resource, types::logical_type::NA);
+                }
+                case types::logical_type::TIME_TZ: {
+                    int64_t micros = 0;
+                    int32_t zone = 0;
+                    ok = read_trivial(reader, micros) && read_trivial(reader, zone);
+                    return ok ? types::logical_value_t(
+                                    resource,
+                                    core::date::timetz_t{core::date::microseconds{micros},
+                                                         core::date::seconds_i32{zone}})
+                              : types::logical_value_t(resource, types::logical_type::NA);
+                }
+                case types::logical_type::INTERVAL: {
+                    int64_t micros = 0;
+                    int32_t days = 0;
+                    int32_t months = 0;
+                    ok = read_trivial(reader, micros) && read_trivial(reader, days) && read_trivial(reader, months);
+                    return ok ? types::logical_value_t(
+                                    resource,
+                                    core::date::interval_t{core::date::microseconds{micros},
+                                                           core::date::days{days},
+                                                           core::date::months{months}})
+                              : types::logical_value_t(resource, types::logical_type::NA);
+                }
+                case types::logical_type::DECIMAL:
+                    switch (type.to_physical_type()) {
+                        case types::physical_type::INT16: {
+                            int16_t value = 0;
+                            ok = read_trivial(reader, value);
+                            return ok ? types::logical_value_t::create_decimal(resource,
+                                                                               type,
+                                                                               static_cast<int64_t>(value))
+                                      : types::logical_value_t(resource, types::logical_type::NA);
+                        }
+                        case types::physical_type::INT32: {
+                            int32_t value = 0;
+                            ok = read_trivial(reader, value);
+                            return ok ? types::logical_value_t::create_decimal(resource,
+                                                                               type,
+                                                                               static_cast<int64_t>(value))
+                                      : types::logical_value_t(resource, types::logical_type::NA);
+                        }
+                        case types::physical_type::INT64: {
+                            int64_t value = 0;
+                            ok = read_trivial(reader, value);
+                            return ok ? types::logical_value_t::create_decimal(resource, type, value)
+                                      : types::logical_value_t(resource, types::logical_type::NA);
+                        }
+                        case types::physical_type::INT128: {
+                            types::int128_t value = 0;
+                            ok = read_trivial(reader, value);
+                            return ok ? types::logical_value_t::create_decimal(resource, type, value)
+                                      : types::logical_value_t(resource, types::logical_type::NA);
+                        }
+                        default:
+                            ok = false;
+                            return types::logical_value_t(resource, types::logical_type::NA);
+                    }
+                case types::logical_type::ENUM: {
+                    int32_t value = 0;
+                    ok = read_trivial(reader, value);
+                    return ok ? types::logical_value_t::create_enum(resource, type, value)
+                              : types::logical_value_t(resource, types::logical_type::NA);
+                }
+                case types::logical_type::LIST: {
+                    uint32_t child_count = 0;
+                    if (!reader.read_le32(child_count)) {
+                        ok = false;
+                        return types::logical_value_t(resource, types::logical_type::NA);
+                    }
+                    std::vector<types::logical_value_t> children;
+                    children.reserve(child_count);
+                    for (uint32_t i = 0; i < child_count; ++i) {
+                        children.emplace_back(read_nullable_value(reader, resource, type.child_type(), ok));
+                        if (!ok) {
+                            return types::logical_value_t(resource, types::logical_type::NA);
+                        }
+                    }
+                    return types::logical_value_t::create_list(resource, type.child_type(), children);
+                }
+                case types::logical_type::ARRAY: {
+                    uint32_t child_count = 0;
+                    if (!reader.read_le32(child_count)) {
+                        ok = false;
+                        return types::logical_value_t(resource, types::logical_type::NA);
+                    }
+                    std::vector<types::logical_value_t> children;
+                    children.reserve(child_count);
+                    for (uint32_t i = 0; i < child_count; ++i) {
+                        children.emplace_back(read_nullable_value(reader, resource, type.child_type(), ok));
+                        if (!ok) {
+                            return types::logical_value_t(resource, types::logical_type::NA);
+                        }
+                    }
+                    return types::logical_value_t::create_array(resource, type.child_type(), children);
+                }
+                case types::logical_type::STRUCT: {
+                    const auto& child_types = type.child_types();
+                    std::vector<types::logical_value_t> children;
+                    children.reserve(child_types.size());
+                    for (const auto& child_type : child_types) {
+                        children.emplace_back(read_nullable_value(reader, resource, child_type, ok));
+                        if (!ok) {
+                            return types::logical_value_t(resource, types::logical_type::NA);
+                        }
+                    }
+                    return types::logical_value_t::create_struct(resource, type, children);
+                }
+                case types::logical_type::UNION: {
+                    uint8_t tag = 0;
+                    if (!reader.read_u8(tag)) {
+                        ok = false;
+                        return types::logical_value_t(resource, types::logical_type::NA);
+                    }
+                    const auto& encoded_children = type.child_types();
+                    if (static_cast<size_t>(tag) + 1 >= encoded_children.size()) {
+                        ok = false;
+                        return types::logical_value_t(resource, types::logical_type::NA);
+                    }
+                    auto child_value =
+                        read_nullable_value(reader, resource, encoded_children[static_cast<size_t>(tag) + 1], ok);
+                    if (!ok) {
+                        return types::logical_value_t(resource, types::logical_type::NA);
+                    }
+                    std::pmr::vector<types::complex_logical_type> members(resource);
+                    members.reserve(encoded_children.size() - 1);
+                    for (size_t i = 1; i < encoded_children.size(); ++i) {
+                        members.emplace_back(encoded_children[i]);
+                    }
+                    return types::logical_value_t::create_union(resource,
+                                                                std::move(members),
+                                                                tag,
+                                                                std::move(child_value));
+                }
+                default:
+                    ok = false;
+                    return types::logical_value_t(resource, types::logical_type::NA);
+            }
+        }
+
+        types::logical_value_t read_nullable_value(binary_reader_t& reader,
+                                                   std::pmr::memory_resource* resource,
+                                                   const types::complex_logical_type& type,
+                                                   bool& ok) {
+            uint8_t valid = 0;
+            if (!reader.read_u8(valid)) {
+                ok = false;
+                return types::logical_value_t(resource, types::logical_type::NA);
+            }
+            if (valid == 0) {
+                return types::logical_value_t(resource, types::logical_type::NA);
+            }
+            return read_value_payload(reader, resource, type, ok);
+        }
+
+        void serialize_binary_extended(const data_chunk_t& chunk, services::wal::buffer_t& buffer) {
+            if (chunk.column_count() > std::numeric_limits<uint32_t>::max() ||
+                chunk.size() > std::numeric_limits<uint32_t>::max()) {
+                throw std::runtime_error("data_chunk_binary: data chunk is too large to serialize");
+            }
+
+            append_le16(buffer, kExtendedFormatMagic);
+            append_le16(buffer, kExtendedFormatVersion);
+            append_le32(buffer, static_cast<uint32_t>(chunk.column_count()));
+            append_le32(buffer, static_cast<uint32_t>(chunk.size()));
+
+            for (uint64_t column_index = 0; column_index < chunk.column_count(); ++column_index) {
+                const auto& column = chunk.data[column_index];
+                write_full_type(buffer, column.type());
+
+                const auto size_offset = buffer.size();
+                append_le32(buffer, 0);
+                const auto payload_offset = buffer.size();
+                for (uint64_t row_index = 0; row_index < chunk.size(); ++row_index) {
+                    write_nullable_value(buffer, column.type(), column.value(row_index));
+                }
+                const auto payload_size = buffer.size() - payload_offset;
+                if (payload_size > std::numeric_limits<uint32_t>::max()) {
+                    throw std::runtime_error("data_chunk_binary: column payload is too large to serialize");
+                }
+                patch_le32(buffer, size_offset, static_cast<uint32_t>(payload_size));
+            }
+        }
+
+        data_chunk_t
+        deserialize_binary_extended(const char* data, size_t len, std::pmr::memory_resource* resource, bool& ok) {
+            binary_reader_t reader(data, len);
+            uint16_t magic = 0;
+            uint16_t version = 0;
+            uint32_t num_columns = 0;
+            uint32_t num_rows = 0;
+            if (!reader.read_le16(magic) || !reader.read_le16(version) || magic != kExtendedFormatMagic ||
+                version != kExtendedFormatVersion || !reader.read_le32(num_columns) || !reader.read_le32(num_rows)) {
+                ok = false;
+                return make_empty_error_chunk(resource);
+            }
+
+            std::pmr::vector<types::complex_logical_type> column_types(resource);
+            column_types.reserve(num_columns);
+            std::vector<std::pair<const char*, uint32_t>> payloads;
+            payloads.reserve(num_columns);
+
+            for (uint32_t column_index = 0; column_index < num_columns; ++column_index) {
+                column_types.emplace_back(read_full_type(reader, resource, ok));
+                if (!ok) {
+                    return make_empty_error_chunk(resource);
+                }
+                uint32_t payload_size = 0;
+                if (!reader.read_le32(payload_size) || reader.remaining() < payload_size) {
+                    ok = false;
+                    return make_empty_error_chunk(resource);
+                }
+                payloads.emplace_back(reader.current(), payload_size);
+                if (!reader.skip(payload_size)) {
+                    ok = false;
+                    return make_empty_error_chunk(resource);
+                }
+            }
+
+            data_chunk_t chunk(resource, column_types, num_rows);
+            chunk.set_cardinality(num_rows);
+
+            for (uint32_t column_index = 0; column_index < num_columns; ++column_index) {
+                binary_reader_t payload_reader(payloads[column_index].first, payloads[column_index].second);
+                for (uint32_t row_index = 0; row_index < num_rows; ++row_index) {
+                    auto value = read_nullable_value(payload_reader, resource, column_types[column_index], ok);
+                    if (!ok) {
+                        return make_empty_error_chunk(resource);
+                    }
+                    chunk.set_value(column_index, row_index, value);
+                }
+                if (!payload_reader.done()) {
+                    ok = false;
+                    return make_empty_error_chunk(resource);
+                }
+            }
+
+            return chunk;
         }
 
         // Compute the size of the type header for a single column.
@@ -219,6 +1093,11 @@ namespace components::vector {
     // serialize_binary
     // -----------------------------------------------------------------------
     void serialize_binary(const data_chunk_t& chunk, services::wal::buffer_t& buffer) {
+        if (!uses_legacy_binary_format(chunk)) {
+            serialize_binary_extended(chunk, buffer);
+            return;
+        }
+
         const auto num_columns = static_cast<uint16_t>(chunk.column_count());
         const auto num_rows = static_cast<uint32_t>(chunk.size());
 
@@ -337,6 +1216,10 @@ namespace components::vector {
         if (len < 10) {
             ok = false;
             return make_empty_error_chunk(resource);
+        }
+
+        if (read_le16(data) == kExtendedFormatMagic) {
+            return deserialize_binary_extended(data, len, resource, ok);
         }
 
         const char* pointer = data;

--- a/components/vector/data_chunk_binary.cpp
+++ b/components/vector/data_chunk_binary.cpp
@@ -378,7 +378,7 @@ namespace components::vector {
                     if (!ok) {
                         return types::complex_logical_type{types::logical_type::INVALID};
                     }
-                    return types::complex_logical_type::create_map(key, value, std::move(alias));
+                    return types::complex_logical_type::create_map(resource, key, value, std::move(alias));
                 }
                 case types::logical_type::STRUCT: {
                     std::string type_name;

--- a/components/vector/tests/CMakeLists.txt
+++ b/components/vector/tests/CMakeLists.txt
@@ -23,4 +23,4 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 
 include(CTest)
 include(Catch)
-catch_discover_tests(${PROJECT_NAME})
+otterbrix_discover_tests(${PROJECT_NAME})

--- a/components/vector/validation.cpp
+++ b/components/vector/validation.cpp
@@ -135,7 +135,8 @@ namespace components::vector {
                 uint64_t idx_in_entry;
                 entry_index(count, entry_idx, idx_in_entry);
                 for (uint64_t i = 0; i < idx_in_entry; ++i) {
-                    valid += uint64_t(entry & uint64_t(1) << uint64_t(i));
+                    // Shift then mask: `entry & (1 << i)` yields 0 or 2^i, which over-counts here.
+                    valid += (entry >> uint64_t(i)) & uint64_t(1);
                 }
                 break;
             }

--- a/components/vector/vector.cpp
+++ b/components/vector/vector.cpp
@@ -480,10 +480,12 @@ namespace components::vector {
                         auxiliary_ = std::make_unique<string_vector_buffer_t>(resource());
                     }
                     assert(auxiliary_->type() == vector_buffer_type::STRING);
+                    const auto* string_value = val.value<std::string*>();
                     reinterpret_cast<std::string_view*>(data_)[index] =
                         std::string_view(reinterpret_cast<char*>(static_cast<string_vector_buffer_t*>(auxiliary_.get())
-                                                                     ->insert(*(val.value<std::string*>()))),
-                                         val.value<std::string*>()->size());
+                                                                     ->insert(string_value->data(),
+                                                                              string_value->size())),
+                                         string_value->size());
                 }
                 break;
             }
@@ -724,9 +726,7 @@ namespace components::vector {
                         children.back().set_alias(vector->type_.child_name(child_idx));
                     }
                 }
-                return types::logical_value_t::create_struct(vector->resource(),
-                                                             vector->type_.type_name(),
-                                                             std::move(children));
+                return types::logical_value_t::create_struct(vector->resource(), vector->type_, std::move(children));
             }
             case types::logical_type::LIST: {
                 auto offlen = reinterpret_cast<types::list_entry_t*>(vector->data_)[index];
@@ -1266,11 +1266,27 @@ namespace components::vector {
     }
 
     void vector_t::set_vector_type(vector_type vector_type) {
-        this->vector_type_ = vector_type;
+        const auto previous_type = vector_type_;
+
         if (types::complex_logical_type::type_is_constant_size(type_.type()) &&
-            (vector_type_ == vector_type::CONSTANT || vector_type_ == vector_type::FLAT)) {
+            (vector_type == vector_type::CONSTANT || vector_type == vector_type::FLAT)) {
+            if (previous_type == vector_type::DICTIONARY && auxiliary_) {
+                auto& child_vector = child();
+                buffer_ = child_vector.buffer_;
+                data_ = child_vector.data_;
+                validity_ = child_vector.validity_;
+            } else if (previous_type == vector_type::CONSTANT || previous_type == vector_type::SEQUENCE || !buffer_ ||
+                       buffer_->type() != vector_buffer_type::STANDARD) {
+                const auto capacity = validity_.count() == 0 ? uint64_t(1) : validity_.count();
+                buffer_ = std::make_shared<vector_buffer_t>(resource(), type_, capacity);
+                data_ = buffer_->data();
+            } else {
+                data_ = buffer_->data();
+            }
             auxiliary_.reset();
         }
+
+        this->vector_type_ = vector_type;
         if (vector_type_ == vector_type::CONSTANT && type_.to_physical_type() == types::physical_type::STRUCT) {
             for (auto& entry : entries()) {
                 entry->set_vector_type(vector_type_);

--- a/components/vector/vector_buffer.cpp
+++ b/components/vector/vector_buffer.cpp
@@ -33,6 +33,8 @@ namespace components::vector {
 
     void* string_vector_buffer_t::insert(void* data, size_t size) { return string_heap_.insert(data, size); }
 
+    void* string_vector_buffer_t::insert(const void* data, size_t size) { return string_heap_.insert(data, size); }
+
     void* string_vector_buffer_t::empty_string(size_t size) { return string_heap_.empty_string(size); }
 
     void string_vector_buffer_t::add_heap_reference(std::unique_ptr<vector_buffer_t> heap) {

--- a/components/vector/vector_buffer.hpp
+++ b/components/vector/vector_buffer.hpp
@@ -111,6 +111,7 @@ namespace components::vector {
     public:
         explicit string_vector_buffer_t(std::pmr::memory_resource* resource);
         void* insert(void* data, size_t size);
+        void* insert(const void* data, size_t size);
         template<typename T>
         void* insert(T&& str_like);
         void* empty_string(size_t size);

--- a/components/vector/vector_operations.cpp
+++ b/components/vector/vector_operations.cpp
@@ -728,10 +728,11 @@ namespace components::vector::vector_ops {
                     }
                     auto target_idx = target_offset + i;
                     if (tmask.row_is_valid(target_idx)) {
+                        auto source_value = ldata[source_idx];
                         tdata[target_idx] = std::string_view(
                             reinterpret_cast<char*>(static_cast<string_vector_buffer_t*>(target.auxiliary().get())
-                                                        ->insert(ldata[source_idx])),
-                            ldata[source_idx].size());
+                                                        ->insert(source_value.data(), source_value.size())),
+                            source_value.size());
                     }
                 }
                 break;

--- a/core/assert/tests/CMakeLists.txt
+++ b/core/assert/tests/CMakeLists.txt
@@ -18,4 +18,4 @@ target_link_libraries(
 
 include(CTest)
 include(Catch)
-catch_discover_tests(${PROJECT_NAME})
+otterbrix_discover_tests(${PROJECT_NAME})

--- a/core/b_plus_tree/tests/CMakeLists.txt
+++ b/core/b_plus_tree/tests/CMakeLists.txt
@@ -23,4 +23,4 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 
 include(CTest)
 include(Catch)
-catch_discover_tests(${PROJECT_NAME})
+otterbrix_discover_tests(${PROJECT_NAME})

--- a/core/file/local_file_system.cpp
+++ b/core/file/local_file_system.cpp
@@ -44,6 +44,26 @@ extern "C" WINBASEAPI BOOL WINAPI GetPhysicallyInstalledSystemMemory(PULONGLONG)
 
 namespace core::filesystem {
 
+#if defined(DEV_MODE) && defined(PLATFORM_POSIX)
+    namespace testing {
+        static posix_pread_hook_t g_posix_pread_hook = nullptr;
+        static posix_pwrite_hook_t g_posix_pwrite_hook = nullptr;
+        static posix_fsync_hook_t g_posix_fsync_hook = nullptr;
+
+        void set_posix_pread_hook(posix_pread_hook_t hook) { g_posix_pread_hook = hook; }
+
+        void set_posix_pwrite_hook(posix_pwrite_hook_t hook) { g_posix_pwrite_hook = hook; }
+
+        void set_posix_fsync_hook(posix_fsync_hook_t hook) { g_posix_fsync_hook = hook; }
+
+        void reset_posix_positioned_io_hooks() {
+            g_posix_pread_hook = nullptr;
+            g_posix_pwrite_hook = nullptr;
+            g_posix_fsync_hook = nullptr;
+        }
+    } // namespace testing
+#endif
+
     static constexpr uint64_t INVALID_INDEX = uint64_t(-1);
 
 #ifndef PLATFORM_WINDOWS
@@ -394,11 +414,20 @@ namespace core::filesystem {
         int fd = reinterpret_cast<unix_file_handle_t&>(handle).fd;
         auto read_buffer = reinterpret_cast<char*>(buffer);
         while (nr_bytes > 0) {
-            int64_t bytes_read = pread(fd, read_buffer, static_cast<size_t>(nr_bytes), static_cast<off_t>(location));
+            int64_t bytes_read;
+#if defined(DEV_MODE)
+            if (testing::g_posix_pread_hook) {
+                bytes_read = testing::g_posix_pread_hook(fd, read_buffer, static_cast<size_t>(nr_bytes), location);
+            } else
+#endif
+            {
+                bytes_read = pread(fd, read_buffer, static_cast<size_t>(nr_bytes), static_cast<off_t>(location));
+            }
             if (bytes_read == -1 || bytes_read == 0) {
                 return false;
             }
             read_buffer += bytes_read;
+            location += static_cast<uint64_t>(bytes_read);
             nr_bytes -= bytes_read;
         }
         return true;
@@ -414,12 +443,20 @@ namespace core::filesystem {
         int fd = reinterpret_cast<unix_file_handle_t&>(handle).fd;
         auto write_buffer = reinterpret_cast<char*>(buffer);
         while (nr_bytes > 0) {
-            int64_t bytes_written =
-                pwrite(fd, write_buffer, static_cast<size_t>(nr_bytes), static_cast<off_t>(location));
+            int64_t bytes_written;
+#if defined(DEV_MODE)
+            if (testing::g_posix_pwrite_hook) {
+                bytes_written = testing::g_posix_pwrite_hook(fd, write_buffer, static_cast<size_t>(nr_bytes), location);
+            } else
+#endif
+            {
+                bytes_written = pwrite(fd, write_buffer, static_cast<size_t>(nr_bytes), static_cast<off_t>(location));
+            }
             if (bytes_written <= 0) {
                 return false;
             }
             write_buffer += bytes_written;
+            location += static_cast<uint64_t>(bytes_written);
             nr_bytes -= bytes_written;
         }
         return true;
@@ -602,7 +639,17 @@ namespace core::filesystem {
 
     bool file_sync(local_file_system_t&, file_handle_t& handle) {
         int fd = reinterpret_cast<unix_file_handle_t&>(handle).fd;
-        if (fsync(fd) != 0) {
+        int rc;
+#if defined(DEV_MODE) && defined(PLATFORM_POSIX)
+        if (testing::g_posix_fsync_hook) {
+            rc = testing::g_posix_fsync_hook(fd);
+        } else {
+            rc = fsync(fd);
+        }
+#else
+        rc = fsync(fd);
+#endif
+        if (rc != 0) {
             return false;
         }
         return true;

--- a/core/file/local_file_system.hpp
+++ b/core/file/local_file_system.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "file_handle.hpp"
+#include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <vector>
 
@@ -76,6 +78,19 @@ namespace core::filesystem {
 
 #ifdef PLATFORM_WINDOWS
     std::string last_error_as_string(local_file_system_t&);
+#endif
+
+#if defined(DEV_MODE) && defined(PLATFORM_POSIX)
+    namespace testing {
+        using posix_pread_hook_t = int64_t (*)(int fd, void* buffer, size_t nr_bytes, uint64_t location);
+        using posix_pwrite_hook_t = int64_t (*)(int fd, const void* buffer, size_t nr_bytes, uint64_t location);
+        using posix_fsync_hook_t = int (*)(int fd);
+
+        void set_posix_pread_hook(posix_pread_hook_t hook);
+        void set_posix_pwrite_hook(posix_pwrite_hook_t hook);
+        void set_posix_fsync_hook(posix_fsync_hook_t hook);
+        void reset_posix_positioned_io_hooks();
+    } // namespace testing
 #endif
 
 } // namespace core::filesystem

--- a/core/file/tests/CMakeLists.txt
+++ b/core/file/tests/CMakeLists.txt
@@ -22,4 +22,4 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 
 include(CTest)
 include(Catch)
-catch_discover_tests(${PROJECT_NAME})
+otterbrix_discover_tests(${PROJECT_NAME})

--- a/core/file/tests/test_file_system.cpp
+++ b/core/file/tests/test_file_system.cpp
@@ -1,9 +1,12 @@
 #include <catch2/catch.hpp>
 
 #include "file_system.hpp"
+#include <algorithm>
 #include <components/log/log.hpp>
+#include <cstring>
 #include <fstream>
 #include <string>
+#include <vector>
 
 #if defined(__linux__)
 #include <unistd.h>
@@ -164,3 +167,82 @@ TEST_CASE("core::file::filesystem") {
         }
     }
 }
+
+#if defined(DEV_MODE) && defined(PLATFORM_POSIX)
+namespace {
+    struct posix_io_hook_guard_t {
+        ~posix_io_hook_guard_t() { testing::reset_posix_positioned_io_hooks(); }
+    };
+
+    std::string g_test_pread_source;
+    std::vector<uint64_t> g_test_pread_offsets;
+    std::string g_test_pwrite_sink;
+    std::vector<uint64_t> g_test_pwrite_offsets;
+
+    int64_t test_partial_pread(int, void* buffer, size_t nr_bytes, uint64_t location) {
+        g_test_pread_offsets.push_back(location);
+        if (location >= g_test_pread_source.size()) {
+            return 0;
+        }
+        const auto available = g_test_pread_source.size() - static_cast<size_t>(location);
+        const auto chunk = std::min<size_t>({size_t{3}, nr_bytes, available});
+        std::memcpy(buffer, g_test_pread_source.data() + static_cast<size_t>(location), chunk);
+        return static_cast<int64_t>(chunk);
+    }
+
+    int64_t test_partial_pwrite(int, const void* buffer, size_t nr_bytes, uint64_t location) {
+        g_test_pwrite_offsets.push_back(location);
+        const auto chunk = std::min<size_t>(size_t{2}, nr_bytes);
+        const auto required = static_cast<size_t>(location) + chunk;
+        if (g_test_pwrite_sink.size() < required) {
+            g_test_pwrite_sink.resize(required, '\0');
+        }
+        std::memcpy(g_test_pwrite_sink.data() + static_cast<size_t>(location), buffer, chunk);
+        return static_cast<int64_t>(chunk);
+    }
+} // namespace
+
+TEST_CASE("core::file::filesystem_posix_positioned_io_advances_offset_on_partial_io") {
+    local_file_system_t fs;
+    if (!directory_exists(fs, testing_directory)) {
+        create_directory(fs, testing_directory);
+    }
+
+    auto fname = testing_directory;
+    fname /= "positioned_partial_io";
+    posix_io_hook_guard_t hook_guard;
+
+    auto handle =
+        open_file(fs, fname, file_flags::READ | file_flags::WRITE | file_flags::FILE_CREATE, file_lock_type::NO_LOCK);
+    REQUIRE(handle);
+
+    SECTION("pread retries from the advanced location") {
+        g_test_pread_source = "abcdefgh";
+        g_test_pread_offsets.clear();
+        std::vector<char> buffer(g_test_pread_source.size(), '\0');
+
+        testing::set_posix_pread_hook(&test_partial_pread);
+        REQUIRE(handle->read(buffer.data(), buffer.size(), 0));
+
+        REQUIRE(std::string(buffer.data(), buffer.size()) == g_test_pread_source);
+        REQUIRE(g_test_pread_offsets == std::vector<uint64_t>{0, 3, 6});
+        testing::set_posix_pread_hook(nullptr);
+    }
+
+    SECTION("pwrite retries from the advanced location") {
+        const std::string payload = "uvwxyz";
+        g_test_pwrite_sink.clear();
+        g_test_pwrite_offsets.clear();
+
+        testing::set_posix_pwrite_hook(&test_partial_pwrite);
+        REQUIRE(handle->write(const_cast<char*>(payload.data()), payload.size(), 0));
+
+        REQUIRE(g_test_pwrite_sink == payload);
+        REQUIRE(g_test_pwrite_offsets == std::vector<uint64_t>{0, 2, 4});
+        testing::set_posix_pwrite_hook(nullptr);
+    }
+
+    handle.reset();
+    remove_file(fs, fname);
+}
+#endif

--- a/core/string_heap/string_heap.cpp
+++ b/core/string_heap/string_heap.cpp
@@ -10,7 +10,9 @@ namespace core {
 
     void* string_heap_t::insert(const void* data, size_t size) {
         void* ptr = arena_allocator_.allocate(size);
-        std::memcpy(ptr, data, size);
+        if (size > 0) {
+            std::memcpy(ptr, data, size);
+        }
         return ptr;
     }
 

--- a/core/tests/CMakeLists.txt
+++ b/core/tests/CMakeLists.txt
@@ -21,4 +21,4 @@ target_link_libraries(
 
 include(CTest)
 include(Catch)
-catch_discover_tests(${PROJECT_NAME})
+otterbrix_discover_tests(${PROJECT_NAME})

--- a/integration/c/test/CMakeLists.txt
+++ b/integration/c/test/CMakeLists.txt
@@ -39,4 +39,4 @@ target_link_libraries(
 
 include(CTest)
 include(Catch)
-catch_discover_tests(${PROJECT_NAME})
+otterbrix_discover_tests(${PROJECT_NAME})

--- a/integration/cpp/base_spaces.cpp
+++ b/integration/cpp/base_spaces.cpp
@@ -114,8 +114,9 @@ namespace otterbrix {
         trace(log_, "spaces::manager_index finish");
 
         trace(log_, "spaces::manager_dispatcher start");
-        manager_dispatcher_ =
-            actor_zeta::spawn<services::dispatcher::manager_dispatcher_t>(&resource, scheduler_dispatcher_.get(), log_);
+        manager_dispatcher_ = actor_zeta::spawn<services::dispatcher::manager_dispatcher_t>(&resource,
+                                                                                            scheduler_dispatcher_.get(),
+                                                                                            log_);
         trace(log_, "spaces::manager_dispatcher finish");
 
         wrapper_dispatcher_ = actor_zeta::spawn<wrapper_dispatcher_t>(&resource,
@@ -239,7 +240,13 @@ namespace otterbrix {
                             }
                             break;
                         case services::wal::wal_record_type::PHYSICAL_DELETE: {
-                            disk_ptr->direct_delete_sync(table_oid, r->physical_row_ids, r->physical_row_count);
+                            if (r->transaction_id != 0) {
+                                disk_ptr->direct_delete_sync(table_oid,
+                                                             r->physical_row_ids,
+                                                             r->physical_row_count);
+                            } else {
+                                disk_ptr->direct_delete_sync(table_oid, r->physical_row_ids, r->physical_row_count);
+                            }
                             break;
                         }
                         case services::wal::wal_record_type::PHYSICAL_UPDATE:
@@ -409,10 +416,23 @@ namespace otterbrix {
 
     wrapper_dispatcher_t* base_otterbrix_t::dispatcher() { return wrapper_dispatcher_.get(); }
 
+    components::table::row_group_scan_path_counts_t base_otterbrix_t::user_table_scan_path_counts() const noexcept {
+        if (!manager_disk_) {
+            return {};
+        }
+        return manager_disk_->user_table_scan_path_counts_sync();
+    }
+
+    void base_otterbrix_t::reset_user_table_scan_path_counts() noexcept {
+        if (manager_disk_) {
+            manager_disk_->reset_user_table_scan_path_counts_sync();
+        }
+    }
+
     base_otterbrix_t::~base_otterbrix_t() {
         trace(log_, "delete spaces");
         // Checkpoint all disk tables before shutdown
-        if (wrapper_dispatcher_) {
+        if (checkpoint_on_shutdown_ && wrapper_dispatcher_) {
             try {
                 auto session = components::session::session_id_t();
                 auto checkpoint_node = components::logical_plan::make_node_checkpoint(&resource);

--- a/integration/cpp/base_spaces.hpp
+++ b/integration/cpp/base_spaces.hpp
@@ -4,6 +4,7 @@
 #include <actor-zeta/detail/memory.hpp>
 #include <components/configuration/configuration.hpp>
 #include <components/log/log.hpp>
+#include <components/table/row_group.hpp>
 #include <core/executor.hpp>
 
 #include <core/config.hpp>
@@ -47,6 +48,11 @@ namespace otterbrix {
 
         log_t& get_log();
         otterbrix::wrapper_dispatcher_t* dispatcher();
+        components::table::row_group_scan_path_counts_t user_table_scan_path_counts() const noexcept;
+        void reset_user_table_scan_path_counts() noexcept;
+#if defined(DEV_MODE)
+        void disable_shutdown_checkpoint_for_tests() noexcept { checkpoint_on_shutdown_ = false; }
+#endif
         ~base_otterbrix_t();
 
     protected:
@@ -78,6 +84,7 @@ namespace otterbrix {
         services::index::manager_index_ptr manager_index_;
         std::unique_ptr<otterbrix::wrapper_dispatcher_t, actor_zeta::pmr::deleter_t> wrapper_dispatcher_;
         actor_zeta::scheduler_ptr scheduler_disk_;
+        bool checkpoint_on_shutdown_{true};
 
         // Catalog-driven index bootstrap. Called once during construction, after
         // WAL replay and before scheduler.start, while single-threaded. Scans

--- a/integration/cpp/test/CMakeLists.txt
+++ b/integration/cpp/test/CMakeLists.txt
@@ -67,7 +67,7 @@ target_link_libraries(
 
 include(CTest)
 include(Catch)
-catch_discover_tests(${PROJECT_NAME} PROPERTIES TIMEOUT 1800)
+otterbrix_discover_tests(${PROJECT_NAME} PROPERTIES TIMEOUT 1800)
 
 # Profiling binary for arithmetic
 add_executable(profile_arithmetic profile_arithmetic.cpp)

--- a/integration/cpp/test/test_batch_execution.cpp
+++ b/integration/cpp/test/test_batch_execution.cpp
@@ -805,14 +805,13 @@ TEST_CASE("integration::cpp::test_batch_boundaries") {
         }
     }
 
-    INFO("DELETE across chunk boundaries removes every matching row") {
-        auto session = otterbrix::session_id_t();
-        auto del = dispatcher->execute_sql(session, "DELETE FROM TestDatabase.TestCollection WHERE count >= 1000;");
-        REQUIRE(del->is_success());
-        auto expected_removed = row_count > 1000 ? row_count - 1000 : 0u;
-        auto cur = dispatcher->execute_sql(session, "SELECT COUNT(name) AS cnt FROM TestDatabase.TestCollection;");
-        REQUIRE(cur->is_success());
-        REQUIRE(cur->size() == 1);
-        REQUIRE(cur->chunk_data().value(0, 0).value<uint64_t>() == row_count - expected_removed);
-    }
+    INFO("DELETE across chunk boundaries removes every matching row");
+    auto session = otterbrix::session_id_t();
+    auto del = dispatcher->execute_sql(session, "DELETE FROM TestDatabase.TestCollection WHERE count >= 1000;");
+    REQUIRE(del->is_success());
+    auto expected_removed = row_count > 1000 ? row_count - 1000 : 0u;
+    auto cur = dispatcher->execute_sql(session, "SELECT COUNT(name) AS cnt FROM TestDatabase.TestCollection;");
+    REQUIRE(cur->is_success());
+    REQUIRE(cur->size() == 1);
+    REQUIRE(cur->chunk_data().value(0, 0).value<uint64_t>() == row_count - expected_removed);
 }

--- a/integration/cpp/test/test_clean_break_startup.cpp
+++ b/integration/cpp/test/test_clean_break_startup.cpp
@@ -40,7 +40,7 @@ namespace {
 
     // The manager actors self-drive on internal threads; futures become ready
     // asynchronously. Pump the (thread-safe) child scheduler with a bounded poll
-    // until the future is ready before extracting its value with take_ready().
+    // until the future is ready before extracting its value with std::move(fut).get().
     template<typename Fut>
     void poll_ready(core::non_thread_scheduler::scheduler_test_t* scheduler, Fut& fut) {
         for (int i = 0; i < 100000 && !fut.is_ready(); ++i) {
@@ -78,7 +78,7 @@ namespace {
         auto invoke(Fn fn, Args&&... args) {
             auto [_, future] = actor_zeta::otterbrix::send(manager->address(), fn, std::forward<Args>(args)...);
             poll_ready(scheduler, future);
-            return std::move(future).take_ready();
+            return std::move(future).get();
         }
     };
 } // namespace
@@ -146,7 +146,7 @@ TEST_CASE("integration::clean_break_startup::oid_generator_seeded_max_plus_1") {
                                                    services::wal::id_t{0},
                                                    std::numeric_limits<uint64_t>::max());
         poll_ready(fd.scheduler, cf);
-        (void) std::move(cf).take_ready();
+        (void) std::move(cf).get();
     }
     {
         fresh_disk fd2(dir);
@@ -174,7 +174,7 @@ TEST_CASE("integration::clean_break_startup::namespace_round_trip") {
                                                    services::wal::id_t{0},
                                                    std::numeric_limits<uint64_t>::max());
         poll_ready(fd.scheduler, cf);
-        (void) std::move(cf).take_ready();
+        (void) std::move(cf).get();
     }
     {
         fresh_disk fd2(dir);
@@ -189,7 +189,7 @@ TEST_CASE("integration::clean_break_startup::namespace_round_trip") {
                                                     std::string("durable_ns"),
                                                     std::uint64_t{0});
         poll_ready(fd2.scheduler, fut);
-        auto rr = std::move(fut).take_ready();
+        auto rr = std::move(fut).get();
         REQUIRE(rr.found);
         REQUIRE(rr.oid == ns_oid);
     }
@@ -216,7 +216,7 @@ TEST_CASE("integration::clean_break_startup::table_round_trip_with_columns") {
                                                    services::wal::id_t{0},
                                                    std::numeric_limits<uint64_t>::max());
         poll_ready(fd.scheduler, cf);
-        (void) std::move(cf).take_ready();
+        (void) std::move(cf).get();
     }
     {
         fresh_disk fd2(dir);
@@ -231,7 +231,7 @@ TEST_CASE("integration::clean_break_startup::table_round_trip_with_columns") {
                                                      std::string("ns"),
                                                      std::uint64_t{0});
         poll_ready(fd2.scheduler, nfut);
-        auto rns = std::move(nfut).take_ready();
+        auto rns = std::move(nfut).get();
         REQUIRE(rns.found);
 
         auto rt = test_probe::probe_table(fd2, ctx, rns.oid, std::string("tbl"));
@@ -266,7 +266,7 @@ TEST_CASE("integration::clean_break_startup::index_round_trip") {
                                                     services::wal::id_t{0},
                                                     std::numeric_limits<uint64_t>::max());
         poll_ready(fd.scheduler, cf);
-        (void) std::move(cf).take_ready();
+        (void) std::move(cf).get();
     }
     {
         fresh_disk fd2(dir);
@@ -302,7 +302,7 @@ TEST_CASE("integration::clean_break_startup::resolve_after_restart") {
                                                    services::wal::id_t{0},
                                                    std::numeric_limits<uint64_t>::max());
         poll_ready(fd.scheduler, cf);
-        (void) std::move(cf).take_ready();
+        (void) std::move(cf).get();
     }
     {
         fresh_disk fd2(dir);
@@ -317,7 +317,7 @@ TEST_CASE("integration::clean_break_startup::resolve_after_restart") {
                                                     std::string("post_restart"),
                                                     std::uint64_t{0});
         poll_ready(fd2.scheduler, fut);
-        auto rns = std::move(fut).take_ready();
+        auto rns = std::move(fut).get();
         REQUIRE(rns.found);
     }
     std::filesystem::remove_all(dir);
@@ -345,7 +345,7 @@ TEST_CASE("integration::clean_break_startup::sequence_view_macro_via_pg_class") 
                                                    services::wal::id_t{0},
                                                    std::numeric_limits<uint64_t>::max());
         poll_ready(fd.scheduler, cf);
-        (void) std::move(cf).take_ready();
+        (void) std::move(cf).get();
     }
     {
         fresh_disk fd2(dir);

--- a/integration/cpp/test/test_clean_break_startup.cpp
+++ b/integration/cpp/test/test_clean_break_startup.cpp
@@ -40,7 +40,7 @@ namespace {
 
     // The manager actors self-drive on internal threads; futures become ready
     // asynchronously. Pump the (thread-safe) child scheduler with a bounded poll
-    // until the future is ready before extracting its value with std::move(fut).get().
+    // until the future is ready before extracting its value with std::move(fut).take_ready().
     template<typename Fut>
     void poll_ready(core::non_thread_scheduler::scheduler_test_t* scheduler, Fut& fut) {
         for (int i = 0; i < 100000 && !fut.is_ready(); ++i) {
@@ -78,7 +78,7 @@ namespace {
         auto invoke(Fn fn, Args&&... args) {
             auto [_, future] = actor_zeta::otterbrix::send(manager->address(), fn, std::forward<Args>(args)...);
             poll_ready(scheduler, future);
-            return std::move(future).get();
+            return std::move(future).take_ready();
         }
     };
 } // namespace
@@ -146,7 +146,7 @@ TEST_CASE("integration::clean_break_startup::oid_generator_seeded_max_plus_1") {
                                                    services::wal::id_t{0},
                                                    std::numeric_limits<uint64_t>::max());
         poll_ready(fd.scheduler, cf);
-        (void) std::move(cf).get();
+        (void) std::move(cf).take_ready();
     }
     {
         fresh_disk fd2(dir);
@@ -174,7 +174,7 @@ TEST_CASE("integration::clean_break_startup::namespace_round_trip") {
                                                    services::wal::id_t{0},
                                                    std::numeric_limits<uint64_t>::max());
         poll_ready(fd.scheduler, cf);
-        (void) std::move(cf).get();
+        (void) std::move(cf).take_ready();
     }
     {
         fresh_disk fd2(dir);
@@ -189,7 +189,7 @@ TEST_CASE("integration::clean_break_startup::namespace_round_trip") {
                                                     std::string("durable_ns"),
                                                     std::uint64_t{0});
         poll_ready(fd2.scheduler, fut);
-        auto rr = std::move(fut).get();
+        auto rr = std::move(fut).take_ready();
         REQUIRE(rr.found);
         REQUIRE(rr.oid == ns_oid);
     }
@@ -216,7 +216,7 @@ TEST_CASE("integration::clean_break_startup::table_round_trip_with_columns") {
                                                    services::wal::id_t{0},
                                                    std::numeric_limits<uint64_t>::max());
         poll_ready(fd.scheduler, cf);
-        (void) std::move(cf).get();
+        (void) std::move(cf).take_ready();
     }
     {
         fresh_disk fd2(dir);
@@ -231,7 +231,7 @@ TEST_CASE("integration::clean_break_startup::table_round_trip_with_columns") {
                                                      std::string("ns"),
                                                      std::uint64_t{0});
         poll_ready(fd2.scheduler, nfut);
-        auto rns = std::move(nfut).get();
+        auto rns = std::move(nfut).take_ready();
         REQUIRE(rns.found);
 
         auto rt = test_probe::probe_table(fd2, ctx, rns.oid, std::string("tbl"));
@@ -266,7 +266,7 @@ TEST_CASE("integration::clean_break_startup::index_round_trip") {
                                                     services::wal::id_t{0},
                                                     std::numeric_limits<uint64_t>::max());
         poll_ready(fd.scheduler, cf);
-        (void) std::move(cf).get();
+        (void) std::move(cf).take_ready();
     }
     {
         fresh_disk fd2(dir);
@@ -302,7 +302,7 @@ TEST_CASE("integration::clean_break_startup::resolve_after_restart") {
                                                    services::wal::id_t{0},
                                                    std::numeric_limits<uint64_t>::max());
         poll_ready(fd.scheduler, cf);
-        (void) std::move(cf).get();
+        (void) std::move(cf).take_ready();
     }
     {
         fresh_disk fd2(dir);
@@ -317,7 +317,7 @@ TEST_CASE("integration::clean_break_startup::resolve_after_restart") {
                                                     std::string("post_restart"),
                                                     std::uint64_t{0});
         poll_ready(fd2.scheduler, fut);
-        auto rns = std::move(fut).get();
+        auto rns = std::move(fut).take_ready();
         REQUIRE(rns.found);
     }
     std::filesystem::remove_all(dir);
@@ -345,7 +345,7 @@ TEST_CASE("integration::clean_break_startup::sequence_view_macro_via_pg_class") 
                                                    services::wal::id_t{0},
                                                    std::numeric_limits<uint64_t>::max());
         poll_ready(fd.scheduler, cf);
-        (void) std::move(cf).get();
+        (void) std::move(cf).take_ready();
     }
     {
         fresh_disk fd2(dir);

--- a/integration/cpp/test/test_config.hpp
+++ b/integration/cpp/test/test_config.hpp
@@ -69,10 +69,10 @@ public:
     auto disk_invoke(Fn fn, Args&&... args) {
         auto [_, future] =
             actor_zeta::otterbrix::send(manager_disk_->address(), fn, std::forward<Args>(args)...);
-        while (!future.available()) {
+        while (!future.is_ready()) {
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
-        return std::move(future).get();
+        return std::move(future).take_ready();
     }
 
     // Alias so test_probe::probe_* (services/disk/tests/catalog_probe.hpp) can drive
@@ -86,20 +86,20 @@ public:
     auto wal_invoke(Fn fn, Args&&... args) {
         auto [_, future] =
             actor_zeta::otterbrix::send(manager_wal_->address(), fn, std::forward<Args>(args)...);
-        while (!future.available()) {
+        while (!future.is_ready()) {
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
-        return std::move(future).get();
+        return std::move(future).take_ready();
     }
 
     template<typename Fn, typename... Args>
     auto dispatcher_invoke(Fn fn, Args&&... args) {
         auto [_, future] =
             actor_zeta::otterbrix::send(manager_dispatcher_->address(), fn, std::forward<Args>(args)...);
-        while (!future.available()) {
+        while (!future.is_ready()) {
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
-        return std::move(future).get();
+        return std::move(future).take_ready();
     }
 
 #if defined(DEV_MODE)

--- a/integration/cpp/test/test_config.hpp
+++ b/integration/cpp/test/test_config.hpp
@@ -4,6 +4,18 @@
 #include <components/logical_plan/node_create_collection.hpp>
 #include <components/sql/transformer/utils.hpp>
 #include <integration/cpp/base_spaces.hpp>
+#include <services/dispatcher/dispatcher.hpp>
+#include <services/disk/manager_disk.hpp>
+#include <services/wal/manager_wal_replicate.hpp>
+#include <services/wal/wal_sync_mode.hpp>
+
+#include <actor-zeta/send.hpp>
+
+#include <components/catalog/catalog_oids.hpp>
+
+#include <chrono>
+#include <thread>
+#include <utility>
 
 inline configuration::config test_create_config(const std::filesystem::path& path = std::filesystem::current_path()) {
     return configuration::config::create_config(path);
@@ -52,4 +64,81 @@ public:
         // null function at plan-gen).
         components::compute::function_registry_t::reset_default();
     }
+
+    template<typename Fn, typename... Args>
+    auto disk_invoke(Fn fn, Args&&... args) {
+        auto [_, future] =
+            actor_zeta::otterbrix::send(manager_disk_->address(), fn, std::forward<Args>(args)...);
+        while (!future.available()) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        return std::move(future).get();
+    }
+
+    // Alias so test_probe::probe_* (services/disk/tests/catalog_probe.hpp) can drive
+    // this integration fixture: probe_read() calls fx.invoke(&manager_disk_t::...).
+    template<typename Fn, typename... Args>
+    auto invoke(Fn fn, Args&&... args) {
+        return disk_invoke(fn, std::forward<Args>(args)...);
+    }
+
+    template<typename Fn, typename... Args>
+    auto wal_invoke(Fn fn, Args&&... args) {
+        auto [_, future] =
+            actor_zeta::otterbrix::send(manager_wal_->address(), fn, std::forward<Args>(args)...);
+        while (!future.available()) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        return std::move(future).get();
+    }
+
+    template<typename Fn, typename... Args>
+    auto dispatcher_invoke(Fn fn, Args&&... args) {
+        auto [_, future] =
+            actor_zeta::otterbrix::send(manager_dispatcher_->address(), fn, std::forward<Args>(args)...);
+        while (!future.available()) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        return std::move(future).get();
+    }
+
+#if defined(DEV_MODE)
+    void debug_write_committed_physical_update(components::catalog::oid_t table_oid,
+                                               std::pmr::vector<int64_t> row_ids,
+                                               components::vector::data_chunk_t& data) {
+        auto wal_data =
+            std::make_unique<components::vector::data_chunk_t>(&resource, data.types(), data.size());
+        data.copy(*wal_data, 0);
+
+        manager_disk_->direct_update_sync(table_oid, row_ids, data);
+        wal_invoke(&services::wal::manager_wal_replicate_t::write_physical_update,
+                   otterbrix::session_id_t(),
+                   table_oid,
+                   std::move(row_ids),
+                   std::move(wal_data),
+                   data.size(),
+                   std::uint64_t{0},
+                   components::catalog::well_known_oid::main_database);
+        wal_invoke(&services::wal::manager_wal_replicate_t::commit_txn,
+                   otterbrix::session_id_t(),
+                   std::uint64_t{0},
+                   services::wal::wal_sync_mode::NORMAL,
+                   components::catalog::well_known_oid::main_database,
+                   std::uint64_t{0});
+    }
+
+    components::table::storage::row_group_layout_kind
+    debug_first_row_group_layout_kind(components::catalog::oid_t table_oid) const noexcept {
+        return manager_disk_->debug_first_row_group_layout_kind_sync(table_oid);
+    }
+
+    void debug_reset_first_row_group_scan_path_counts(components::catalog::oid_t table_oid) noexcept {
+        manager_disk_->debug_reset_first_row_group_scan_path_counts_sync(table_oid);
+    }
+
+    components::table::row_group_scan_path_counts_t
+    debug_first_row_group_scan_path_counts(components::catalog::oid_t table_oid) const noexcept {
+        return manager_disk_->debug_first_row_group_scan_path_counts_sync(table_oid);
+    }
+#endif
 };

--- a/integration/cpp/test/test_persistence.cpp
+++ b/integration/cpp/test/test_persistence.cpp
@@ -1582,6 +1582,622 @@ TEST_CASE("integration::cpp::test_persistence::disk_add_column_survives_restart"
     }
 }
 
+TEST_CASE("integration::cpp::test_persistence::disk_pax_fixed_full_cycle") {
+    auto config = test_create_config("/tmp/otterbrix/integration/test_persistence/disk_pax_fixed_full_cycle");
+    test_clear_directory(config);
+
+    INFO("phase 1: create pure fixed-width DISK table, insert 100 rows, checkpoint") {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+
+        {
+            auto session = otterbrix::session_id_t();
+            dispatcher->execute_sql(session, "CREATE DATABASE " + database_name + ";");
+        }
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(session,
+                                               "CREATE TABLE TestDatabase.TestCollection (id bigint, value bigint) "
+                                               "WITH (storage = 'disk');");
+            REQUIRE(cur->is_success());
+        }
+
+        {
+            auto session = otterbrix::session_id_t();
+            std::stringstream query;
+            query << "INSERT INTO TestDatabase.TestCollection (id, value) VALUES ";
+            for (int i = 0; i < 100; ++i) {
+                query << "(" << i << ", " << (i * 10) << ")" << (i == 99 ? ";" : ", ");
+            }
+            auto cur = dispatcher->execute_sql(session, query.str());
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 100);
+        }
+
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection;", 100);
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(session, "CHECKPOINT;");
+            REQUIRE(cur->is_success());
+        }
+    }
+
+    INFO("phase 2: restart, apply DML on PAX_FIXED-backed rows, checkpoint again") {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection;", 100);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE id = 50 AND value = 500;", 1);
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(session, "DELETE FROM TestDatabase.TestCollection WHERE id >= 90;");
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 10);
+        }
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(session,
+                                               "UPDATE TestDatabase.TestCollection SET value = 9999 WHERE id = 50;");
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 1);
+        }
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(session,
+                                               "INSERT INTO TestDatabase.TestCollection (id, value) VALUES "
+                                               "(100, 1000), (101, 1010), (102, 1020);");
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 3);
+        }
+
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection;", 93);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE id = 50 AND value = 9999;", 1);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE id = 95;", 0);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE id = 102 AND value = 1020;", 1);
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(session, "CHECKPOINT;");
+            REQUIRE(cur->is_success());
+        }
+    }
+
+    INFO("phase 3: second restart keeps final pure PAX_FIXED table state") {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection;", 93);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE id = 50 AND value = 9999;", 1);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE value = 500;", 0);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE id = 95;", 0);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE id = 100 AND value = 1000;", 1);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE id = 101 AND value = 1010;", 1);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE id = 102 AND value = 1020;", 1);
+    }
+}
+
+TEST_CASE("integration::cpp::test_persistence::disk_pax_fixed_wal_tail_recovery") {
+    auto config = test_create_config("/tmp/otterbrix/integration/test_persistence/disk_pax_fixed_wal_tail_recovery");
+    test_clear_directory(config);
+
+    INFO("phase 1: create pure fixed-width DISK table, insert rows, checkpoint into PAX_FIXED") {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+
+        {
+            auto session = otterbrix::session_id_t();
+            dispatcher->execute_sql(session, "CREATE DATABASE " + database_name + ";");
+        }
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(session,
+                                               "CREATE TABLE TestDatabase.TestCollection (id bigint, value bigint) "
+                                               "WITH (storage = 'disk');");
+            REQUIRE(cur->is_success());
+        }
+
+        {
+            auto session = otterbrix::session_id_t();
+            std::stringstream query;
+            query << "INSERT INTO TestDatabase.TestCollection (id, value) VALUES ";
+            for (int i = 0; i < 100; ++i) {
+                query << "(" << i << ", " << (i * 10) << ")" << (i == 99 ? ";" : ", ");
+            }
+            auto cur = dispatcher->execute_sql(session, query.str());
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 100);
+        }
+
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection;", 100);
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(session, "CHECKPOINT;");
+            REQUIRE(cur->is_success());
+        }
+    }
+
+    INFO("phase 2: restart, apply DML on PAX_FIXED-backed rows, leave changes only in WAL") {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection;", 100);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE id = 50 AND value = 500;", 1);
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(session, "DELETE FROM TestDatabase.TestCollection WHERE id >= 90;");
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 10);
+        }
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(session,
+                                               "UPDATE TestDatabase.TestCollection SET value = 9999 WHERE id = 50;");
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 1);
+        }
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(session,
+                                               "INSERT INTO TestDatabase.TestCollection (id, value) VALUES "
+                                               "(100, 1000), (101, 1010), (102, 1020);");
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 3);
+        }
+
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection;", 93);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE id = 50 AND value = 9999;", 1);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE value = 500;", 0);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE id = 95;", 0);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE id = 102 AND value = 1020;", 1);
+    }
+
+    INFO("phase 3: restart replays WAL tail over PAX_FIXED checkpoint") {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection;", 93);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE id = 50 AND value = 9999;", 1);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE value = 500;", 0);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE id = 95;", 0);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE id = 100 AND value = 1000;", 1);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE id = 101 AND value = 1010;", 1);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE id = 102 AND value = 1020;", 1);
+    }
+}
+
+TEST_CASE("integration::cpp::test_persistence::disk_pax_extended_fixed_restart") {
+    auto config = test_create_config("/tmp/otterbrix/integration/test_persistence/disk_pax_extended_fixed_restart");
+    test_clear_directory(config);
+
+    INFO("phase 1: create extended fixed-width DISK table, insert rows, checkpoint") {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+
+        {
+            auto session = otterbrix::session_id_t();
+            dispatcher->execute_sql(session, "CREATE DATABASE " + database_name + ";");
+        }
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(
+                session,
+                "CREATE TABLE TestDatabase.TestCollection ("
+                "id bigint, "
+                "flag boolean, "
+                "score double "
+                ") WITH (storage = 'disk');");
+            REQUIRE(cur->is_success());
+        }
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(
+                session,
+                "INSERT INTO TestDatabase.TestCollection "
+                "(id, flag, score) VALUES "
+                "(1, true, 1.5), "
+                "(2, false, 2.5), "
+                "(3, NULL, NULL), "
+                "(4, true, 4.5);");
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 4);
+        }
+
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection;", 4);
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(session, "CHECKPOINT;");
+            REQUIRE(cur->is_success());
+        }
+    }
+
+    INFO("phase 2: restart and verify extended fixed-width values survived") {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection;", 4);
+
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT * FROM TestDatabase.TestCollection ORDER BY id;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 4);
+
+        auto& chunk = cur->chunk_data();
+        chunk.flatten();
+        REQUIRE(chunk.data.size() == 3);
+
+        auto* ids = chunk.data[0].data<int64_t>();
+        auto* flags = chunk.data[1].data<bool>();
+        auto* scores = chunk.data[2].data<double>();
+
+        REQUIRE(ids[0] == 1);
+        REQUIRE_FALSE(chunk.data[1].is_null(0));
+        REQUIRE(flags[0]);
+        REQUIRE(scores[0] == Approx(1.5));
+
+        REQUIRE(ids[1] == 2);
+        REQUIRE_FALSE(chunk.data[1].is_null(1));
+        REQUIRE_FALSE(flags[1]);
+        REQUIRE(scores[1] == Approx(2.5));
+
+        REQUIRE(ids[2] == 3);
+        REQUIRE(chunk.data[1].is_null(2));
+        REQUIRE(chunk.data[2].is_null(2));
+
+        REQUIRE(ids[3] == 4);
+        REQUIRE_FALSE(chunk.data[1].is_null(3));
+        REQUIRE(flags[3]);
+        REQUIRE(scores[3] == Approx(4.5));
+    }
+}
+
+TEST_CASE("integration::cpp::test_persistence::disk_pax_fixed_projected_queries_restart") {
+    auto config =
+        test_create_config("/tmp/otterbrix/integration/test_persistence/disk_pax_fixed_projected_queries_restart");
+    test_clear_directory(config);
+
+    INFO("phase 1: create fixed-width DISK table, insert rows, checkpoint") {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+
+        {
+            auto session = otterbrix::session_id_t();
+            dispatcher->execute_sql(session, "CREATE DATABASE " + database_name + ";");
+        }
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(
+                session,
+                "CREATE TABLE TestDatabase.TestCollection ("
+                "id bigint, "
+                "flag boolean, "
+                "score double, "
+                "amount bigint"
+                ") WITH (storage = 'disk');");
+            REQUIRE(cur->is_success());
+        }
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(
+                session,
+                "INSERT INTO TestDatabase.TestCollection "
+                "(id, flag, score, amount) VALUES "
+                "(1, true, 1.5, 10), "
+                "(2, false, 2.5, 20), "
+                "(3, true, 3.5, 30), "
+                "(4, false, NULL, 40), "
+                "(5, true, 5.5, 50);");
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 5);
+        }
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(session, "CHECKPOINT;");
+            REQUIRE(cur->is_success());
+        }
+    }
+
+    INFO("phase 2: restart and verify projected fixed-width queries") {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection;", 5);
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(
+                session,
+                "SELECT id, score FROM TestDatabase.TestCollection WHERE flag = true ORDER BY id;");
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 3);
+
+            auto& chunk = cur->chunk_data();
+            chunk.flatten();
+            auto* ids = chunk.data[0].data<int64_t>();
+            auto* scores = chunk.data[1].data<double>();
+            REQUIRE(ids[0] == 1);
+            REQUIRE(scores[0] == Approx(1.5));
+            REQUIRE(ids[1] == 3);
+            REQUIRE(scores[1] == Approx(3.5));
+            REQUIRE(ids[2] == 5);
+            REQUIRE(scores[2] == Approx(5.5));
+        }
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur =
+                dispatcher->execute_sql(session,
+                                        "SELECT id FROM TestDatabase.TestCollection "
+                                        "WHERE score >= 3.5 ORDER BY id;");
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 2);
+
+            auto& chunk = cur->chunk_data();
+            chunk.flatten();
+            auto* ids = chunk.data[0].data<int64_t>();
+            REQUIRE(ids[0] == 3);
+            REQUIRE(ids[1] == 5);
+        }
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur =
+                dispatcher->execute_sql(session,
+                                        "SELECT amount FROM TestDatabase.TestCollection "
+                                        "WHERE flag = false ORDER BY amount;");
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 2);
+
+            auto& chunk = cur->chunk_data();
+            chunk.flatten();
+            auto* amounts = chunk.data[0].data<int64_t>();
+            REQUIRE(amounts[0] == 20);
+            REQUIRE(amounts[1] == 40);
+        }
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(session,
+                                               "SELECT id FROM TestDatabase.TestCollection "
+                                               "WHERE score IS NULL;");
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 1);
+
+            auto& chunk = cur->chunk_data();
+            chunk.flatten();
+            auto* ids = chunk.data[0].data<int64_t>();
+            REQUIRE(ids[0] == 4);
+        }
+    }
+}
+
+TEST_CASE("integration::cpp::test_persistence::disk_pax_generic_string_wal_tail_recovery") {
+    auto config =
+        test_create_config("/tmp/otterbrix/integration/test_persistence/disk_pax_generic_string_wal_tail_recovery");
+    test_clear_directory(config);
+
+    INFO("phase 1: create string-heavy DISK table, insert rows, checkpoint into PAX_GENERIC") {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+
+        {
+            auto session = otterbrix::session_id_t();
+            dispatcher->execute_sql(session, "CREATE DATABASE " + database_name + ";");
+        }
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(
+                session,
+                "CREATE TABLE TestDatabase.TestCollection ("
+                "id bigint, "
+                "name string, "
+                "city string, "
+                "note string"
+                ") WITH (storage = 'disk');");
+            REQUIRE(cur->is_success());
+        }
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(
+                session,
+                "INSERT INTO TestDatabase.TestCollection "
+                "(id, name, city, note) VALUES "
+                "(1, 'alice', 'moscow', 'alpha'), "
+                "(2, 'bob', 'berlin', NULL), "
+                "(3, 'carol', 'moscow', 'gamma'), "
+                "(4, 'dave', 'paris', NULL), "
+                "(5, 'erin', 'berlin', 'epsilon'), "
+                "(6, 'frank', 'rome', 'zeta');");
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 6);
+        }
+
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection;", 6);
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(session, "CHECKPOINT;");
+            REQUIRE(cur->is_success());
+        }
+    }
+
+    INFO("phase 2: restart, apply string DML on PAX_GENERIC-backed rows, leave changes only in WAL") {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection;", 6);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE id = 2 AND note IS NULL;", 1);
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(session, "DELETE FROM TestDatabase.TestCollection WHERE id = 4;");
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 1);
+        }
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(
+                session,
+                "UPDATE TestDatabase.TestCollection SET city = 'lisbon', note = 'beta' WHERE id = 2;");
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 1);
+        }
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(
+                session,
+                "INSERT INTO TestDatabase.TestCollection "
+                "(id, name, city, note) VALUES "
+                "(7, 'grace', 'berlin', 'theta'), "
+                "(8, 'heidi', 'moscow', NULL);");
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 2);
+        }
+
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection;", 7);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE id = 2 AND city = 'lisbon' AND note = 'beta';", 1);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE id = 4;", 0);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE id = 7 AND name = 'grace';", 1);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE id = 8 AND note IS NULL;", 1);
+    }
+
+    INFO("phase 3: restart replays WAL tail over PAX_GENERIC checkpoint") {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection;", 7);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE id = 2 AND city = 'lisbon' AND note = 'beta';", 1);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE id = 4;", 0);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE id = 5 AND note = 'epsilon';", 1);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE id = 7 AND city = 'berlin';", 1);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE id = 8 AND note IS NULL;", 1);
+    }
+}
+
+TEST_CASE("integration::cpp::test_persistence::disk_pax_generic_string_queries_restart") {
+    auto config =
+        test_create_config("/tmp/otterbrix/integration/test_persistence/disk_pax_generic_string_queries_restart");
+    test_clear_directory(config);
+
+    INFO("phase 1: create string-heavy DISK table, insert rows, checkpoint") {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+
+        {
+            auto session = otterbrix::session_id_t();
+            dispatcher->execute_sql(session, "CREATE DATABASE " + database_name + ";");
+        }
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(
+                session,
+                "CREATE TABLE TestDatabase.TestCollection ("
+                "name string, "
+                "city string, "
+                "note string"
+                ") WITH (storage = 'disk');");
+            REQUIRE(cur->is_success());
+        }
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(
+                session,
+                "INSERT INTO TestDatabase.TestCollection "
+                "(name, city, note) VALUES "
+                "('alice', 'moscow', 'alpha'), "
+                "('bob', 'berlin', NULL), "
+                "('carol', 'moscow', 'gamma'), "
+                "('dave', 'paris', NULL), "
+                "('erin', 'berlin', 'epsilon');");
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 5);
+        }
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(session, "CHECKPOINT;");
+            REQUIRE(cur->is_success());
+        }
+    }
+
+    INFO("phase 2: restart and verify projected string queries") {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection;", 5);
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(
+                session,
+                "SELECT name FROM TestDatabase.TestCollection WHERE city = 'moscow' ORDER BY name;");
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 2);
+
+            auto& chunk = cur->chunk_data();
+            chunk.flatten();
+            auto* names = chunk.data[0].data<std::string_view>();
+            REQUIRE(std::string(names[0]) == "alice");
+            REQUIRE(std::string(names[1]) == "carol");
+        }
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(session,
+                                               "SELECT note FROM TestDatabase.TestCollection "
+                                               "WHERE city = 'berlin' ORDER BY note;");
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 2);
+
+            auto& chunk = cur->chunk_data();
+            chunk.flatten();
+            const bool first_is_null = chunk.data[0].is_null(0);
+            const bool second_is_null = chunk.data[0].is_null(1);
+            REQUIRE(first_is_null != second_is_null);
+
+            const auto* notes = chunk.data[0].data<std::string_view>();
+            const auto non_null_index = first_is_null ? 1 : 0;
+            REQUIRE(std::string(notes[non_null_index]) == "epsilon");
+        }
+
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(session,
+                                               "SELECT city FROM TestDatabase.TestCollection "
+                                               "WHERE note IS NULL ORDER BY city;");
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 2);
+
+            auto& chunk = cur->chunk_data();
+            chunk.flatten();
+            auto* cities = chunk.data[0].data<std::string_view>();
+            REQUIRE(std::string(cities[0]) == "berlin");
+            REQUIRE(std::string(cities[1]) == "paris");
+        }
+    }
+}
+
 TEST_CASE("integration::cpp::test_persistence::disk_index_mixed_ops_checkpoint_restart") {
     auto config =
         test_create_config("/tmp/otterbrix/integration/test_persistence/disk_index_mixed_ops_checkpoint_restart");

--- a/integration/cpp/test/test_sql_features.cpp
+++ b/integration/cpp/test/test_sql_features.cpp
@@ -3,6 +3,7 @@
 
 #include <catch2/catch.hpp>
 #include <chrono>
+#include <services/disk/tests/catalog_probe.hpp>
 #include <core/date/date_parse.hpp>
 #include <core/date/timezones.hpp>
 #include <random>
@@ -11,6 +12,29 @@
 
 static const database_name_t database_name = "testdatabase";
 static const collection_name_t collection_name = "testcollection";
+static constexpr int split_tail_id_start = 5000;
+static constexpr int split_tail_row_count = 2050;
+static constexpr int split_tail_id_end = split_tail_id_start + split_tail_row_count;
+
+#if defined(DEV_MODE)
+// Adapter so services::disk::test_probe::probe_table can drive the integration
+// `test_spaces` fixture. probe_read() reads `fx.resource` and calls `fx.invoke`;
+// base_otterbrix_t::resource is protected, so this exposes a public reference to
+// the dispatcher's memory_resource and forwards invoke to test_spaces::invoke.
+struct sql_features_probe_fixture_t final {
+    explicit sql_features_probe_fixture_t(test_spaces& spaces)
+        : space(spaces)
+        , resource(*spaces.dispatcher()->resource()) {}
+
+    template<typename Fn, typename... Args>
+    auto invoke(Fn fn, Args&&... args) {
+        return space.invoke(fn, std::forward<Args>(args)...);
+    }
+
+    test_spaces& space;
+    std::pmr::memory_resource& resource;
+};
+#endif
 
 TEST_CASE("integration::cpp::test_sql_features::is_null") {
     auto config = test_create_config("/tmp/test_sql_features/is_null");
@@ -120,6 +144,347 @@ TEST_CASE("integration::cpp::test_sql_features::is_null") {
     }
 }
 
+TEST_CASE("integration::cpp::test_sql_features::pax_projected_delete_sparse_scan") {
+    auto config = test_create_config("/tmp/test_sql_features/pax_projected_delete_sparse_scan");
+    config.disk.on = true;
+    config.disk.layout_policy = configuration::disk_layout_policy::pax_only;
+    config.wal.on = false;
+    test_clear_directory(config);
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE TestDatabase;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session,
+                                           "CREATE TABLE TestDatabase.WideDelete ("
+                                           "id bigint, c1 bigint, c2 bigint, c3 bigint, c4 bigint, "
+                                           "c5 bigint, c6 bigint, c7 bigint, c8 bigint"
+                                           ") WITH (storage = 'disk') USING PAX;");
+        REQUIRE(cur->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        std::stringstream query;
+        query << "INSERT INTO TestDatabase.WideDelete "
+                 "(id, c1, c2, c3, c4, c5, c6, c7, c8) VALUES ";
+        for (int row = 0; row < 3000; row++) {
+            query << "(" << row;
+            for (int col = 1; col <= 8; col++) {
+                query << ", " << (row + col);
+            }
+            query << ")" << (row == 2999 ? ";" : ", ");
+        }
+        auto cur = dispatcher->execute_sql(session, query.str());
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 3000);
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "CHECKPOINT;");
+        REQUIRE(cur->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session,
+                                           "DELETE FROM TestDatabase.WideDelete "
+                                           "WHERE id >= 400 AND id < 2600;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 2200);
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT COUNT(id) AS cnt FROM TestDatabase.WideDelete;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        REQUIRE(cur->chunk_data().value(0, 0).value<uint64_t>() == 800);
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session,
+                                           "SELECT id FROM TestDatabase.WideDelete "
+                                           "WHERE id >= 400 AND id < 2600;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 0);
+    }
+}
+
+TEST_CASE("integration::cpp::test_sql_features::pax_range_conjunction_prunes_pages") {
+    // A `WHERE id >= x AND id < y` range conjunction must be pushed into the PAX
+    // scan so per-page min/max zone maps can prune non-matching pages.
+    auto config = test_create_config("/tmp/test_sql_features/pax_range_conjunction_prunes_pages");
+    config.disk.on = true;
+    config.disk.layout_policy = configuration::disk_layout_policy::pax_only;
+    config.wal.on = false;
+    test_clear_directory(config);
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE TestDatabase;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session,
+                                           "CREATE TABLE TestDatabase.RangeScan ("
+                                           "id bigint, payload bigint"
+                                           ") WITH (storage = 'disk') USING PAX;");
+        REQUIRE(cur->is_success());
+    }
+    {
+        // Monotonic id so a selective range maps to few pages.
+        auto session = otterbrix::session_id_t();
+        std::stringstream query;
+        query << "INSERT INTO TestDatabase.RangeScan (id, payload) VALUES ";
+        for (int row = 0; row < 3000; row++) {
+            query << "(" << row << ", " << (row * 2) << ")" << (row == 2999 ? ";" : ", ");
+        }
+        auto cur = dispatcher->execute_sql(session, query.str());
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 3000);
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CHECKPOINT;")->is_success());
+    }
+
+#if defined(DEV_MODE)
+    components::catalog::oid_t table_oid = components::catalog::INVALID_OID;
+    {
+        auto session = otterbrix::session_id_t();
+        components::execution_context_t ctx{session, components::table::transaction_data{0, 0}, {}};
+        auto ns = space.disk_invoke(&services::disk::manager_disk_t::resolve_namespace,
+                                    ctx,
+                                    std::string("testdatabase"),
+                                    std::uint64_t{0});
+        REQUIRE(ns.found);
+        sql_features_probe_fixture_t probe_fx{space};
+        auto table = services::disk::test_probe::probe_table(probe_fx, ctx, ns.oid, std::string("rangescan"));
+        REQUIRE(table.found);
+        table_oid = table.oid;
+        space.debug_reset_first_row_group_scan_path_counts(table_oid);
+    }
+#endif
+
+    {
+        // Selective range near the start: keeps the first page, prunes the later ones.
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session,
+                                           "SELECT COUNT(id) AS cnt FROM TestDatabase.RangeScan "
+                                           "WHERE id >= 100 AND id < 200;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        REQUIRE(cur->chunk_data().value(0, 0).value<uint64_t>() == 100);
+    }
+
+#if defined(DEV_MODE)
+    {
+        const auto counts = space.debug_first_row_group_scan_path_counts(table_oid);
+        REQUIRE(counts.pax_fixed_projected > 0);
+        REQUIRE(counts.regular == 0);
+        REQUIRE(counts.pax_fixed_pruned_pages > 0);
+    }
+#endif
+}
+
+TEST_CASE("integration::cpp::test_sql_features::pax_projected_update_sparse_scan") {
+    auto config = test_create_config("/tmp/test_sql_features/pax_projected_update_sparse_scan");
+    config.disk.on = true;
+    config.disk.layout_policy = configuration::disk_layout_policy::pax_only;
+    config.wal.on = false;
+    test_clear_directory(config);
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE TestDatabase;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session,
+                                           "CREATE TABLE TestDatabase.WideUpdate ("
+                                           "id bigint, c1 bigint, c2 bigint, c3 bigint, c4 bigint, "
+                                           "c5 bigint, c6 bigint, c7 bigint, c8 bigint"
+                                           ") WITH (storage = 'disk') USING PAX;");
+        REQUIRE(cur->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        std::stringstream query;
+        query << "INSERT INTO TestDatabase.WideUpdate "
+                 "(id, c1, c2, c3, c4, c5, c6, c7, c8) VALUES ";
+        for (int row = 0; row < 3000; row++) {
+            query << "(" << row;
+            for (int col = 1; col <= 8; col++) {
+                query << ", " << (row + col);
+            }
+            query << ")" << (row == 2999 ? ";" : ", ");
+        }
+        auto cur = dispatcher->execute_sql(session, query.str());
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 3000);
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "CHECKPOINT;");
+        REQUIRE(cur->is_success());
+    }
+
+#if defined(DEV_MODE)
+    components::catalog::oid_t table_oid = components::catalog::INVALID_OID;
+    {
+        auto session = otterbrix::session_id_t();
+        components::execution_context_t ctx{session, components::table::transaction_data{0, 0}, {}};
+        auto ns = space.disk_invoke(&services::disk::manager_disk_t::resolve_namespace,
+                                    ctx,
+                                    std::string("testdatabase"),
+                                    std::uint64_t{0});
+        REQUIRE(ns.found);
+        sql_features_probe_fixture_t probe_fx{space};
+        auto table = services::disk::test_probe::probe_table(probe_fx, ctx, ns.oid, std::string("wideupdate"));
+        REQUIRE(table.found);
+        table_oid = table.oid;
+    }
+#endif
+
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session,
+                                           "UPDATE TestDatabase.WideUpdate "
+                                           "SET c8 = c8 + 100000 "
+                                           "WHERE id >= 400 AND id < 2600;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 2200);
+    }
+    {
+        // The MVCC UPDATE appended the new row versions in-memory; checkpoint to
+        // re-materialise them into the PAX disk layout so the verifying projected
+        // SELECT below actually exercises the pax_fixed_projected scan path (an
+        // in-memory segment is scanned via neither pax_fixed nor regular).
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CHECKPOINT;")->is_success());
+    }
+
+    {
+        // The scan-path counter lives on the row_group object. A mutating
+        // statement (the UPDATE above) replaces row_group(0) via the MVCC
+        // delete-old + append-new path, so any count accumulated by the UPDATE's
+        // own scan is stranded on the now-discarded object and is unobservable
+        // through debug_first_row_group_scan_path_counts (which always re-fetches
+        // the *current* row_group(0)). Reset+assert around a NON-mutating
+        // projected read instead: the verifying SELECT below scans the same
+        // {id, c8} subset under the identical id-range conjunction, takes the
+        // pax_fixed_projected path, and does not replace the row group — so the
+        // counter survives from reset to read.
+#if defined(DEV_MODE)
+        space.debug_reset_first_row_group_scan_path_counts(table_oid);
+#endif
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session,
+                                           "SELECT COUNT(id) AS cnt FROM TestDatabase.WideUpdate "
+                                           "WHERE id >= 400 AND id < 2600 AND c8 >= 100000;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        REQUIRE(cur->chunk_data().value(0, 0).value<uint64_t>() == 2200);
+#if defined(DEV_MODE)
+        const auto counts = space.debug_first_row_group_scan_path_counts(table_oid);
+        REQUIRE(counts.pax_fixed_projected > 0);
+        REQUIRE(counts.regular == 0);
+#endif
+    }
+}
+
+TEST_CASE("integration::cpp::test_sql_features::columnar_compact_after_delete_insert_checkpoint") {
+    auto config = test_create_config("/tmp/test_sql_features/columnar_compact_after_delete_insert_checkpoint");
+    config.disk.on = true;
+    config.disk.layout_policy = configuration::disk_layout_policy::columnar_only;
+    config.wal.on = false;
+    test_clear_directory(config);
+    test_spaces space(config);
+    space.disable_shutdown_checkpoint_for_tests();
+    auto* dispatcher = space.dispatcher();
+
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE TestDatabase;")->is_success());
+        REQUIRE(dispatcher
+                    ->execute_sql(session,
+                                  "CREATE TABLE TestDatabase.CompactRows ("
+                                  "id bigint, group_id bigint, amount bigint, filler bigint"
+                                  ") WITH (storage = 'disk');")
+                    ->is_success());
+        REQUIRE(dispatcher
+                    ->execute_sql(session,
+                                  "CREATE TABLE TestDatabase.CompactSeed ("
+                                  "id bigint, group_id bigint, amount bigint, filler bigint"
+                                  ") WITH (storage = 'disk');")
+                    ->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        std::stringstream query;
+        query << "INSERT INTO TestDatabase.CompactRows (id, group_id, amount, filler) VALUES ";
+        for (int row = 0; row < 2500; row++) {
+            query << "(" << row << ", " << (row % 17) << ", " << (row * 3) << ", " << (row + 100) << ")"
+                  << (row == 2499 ? ";" : ", ");
+        }
+        auto cur = dispatcher->execute_sql(session, query.str());
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 2500);
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        std::stringstream query;
+        query << "INSERT INTO TestDatabase.CompactSeed (id, group_id, amount, filler) VALUES ";
+        for (int row = 0; row < 700; row++) {
+            const auto id = 10000 + row;
+            query << "(" << id << ", " << (id % 17) << ", " << (id * 3) << ", " << (id + 100) << ")"
+                  << (row == 699 ? ";" : ", ");
+        }
+        auto cur = dispatcher->execute_sql(session, query.str());
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 700);
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CHECKPOINT;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session,
+                                           "DELETE FROM TestDatabase.CompactRows "
+                                           "WHERE id >= 900 AND id < 1600;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 700);
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session,
+                                           "INSERT INTO TestDatabase.CompactRows (id, group_id, amount, filler) "
+                                           "SELECT id, group_id, amount, filler FROM TestDatabase.CompactSeed "
+                                           "WHERE id >= 10000 AND id < 10700;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 700);
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CHECKPOINT;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session,
+                                           "SELECT id FROM TestDatabase.CompactRows "
+                                           "WHERE id >= 10000 AND id < 10700;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 700);
+    }
+}
+
 TEST_CASE("integration::cpp::test_sql_features::in_list") {
     auto config = test_create_config("/tmp/test_sql_features/in_list");
     test_clear_directory(config);
@@ -193,6 +558,109 @@ TEST_CASE("integration::cpp::test_sql_features::in_list") {
                                            "WHERE count IN (42);");
         REQUIRE(cur->is_success());
         REQUIRE(cur->size() == 1);
+    }
+}
+
+// Uncorrelated subqueries: the subquery is run once and its result substituted
+// into the main plan. Fixture: count 0..99.
+TEST_CASE("integration::cpp::test_sql_features::uncorrelated_subquery") {
+    auto config = test_create_config("/tmp/test_sql_features/uncorrelated_subquery");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    INFO("initialization") {
+        {
+            auto session = otterbrix::session_id_t();
+            dispatcher->execute_sql(session, "CREATE DATABASE TestDatabase;");
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            test_create_collection(dispatcher, session, database_name, collection_name);
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            std::stringstream query;
+            query << "INSERT INTO TestDatabase.TestCollection (name, count) VALUES ";
+            for (int num = 0; num < 100; ++num) {
+                query << "('Name " << num << "', " << num << ")" << (num == 99 ? ";" : ", ");
+            }
+            auto cur = dispatcher->execute_sql(session, query.str());
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 100);
+        }
+    }
+
+    INFO("IN-subquery (q18 shape)") {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session,
+                                           "SELECT * FROM TestDatabase.TestCollection WHERE count IN "
+                                           "(SELECT count FROM TestDatabase.TestCollection WHERE count < 5);");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 5);
+    }
+
+    INFO("IN-subquery combined with AND") {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session,
+                                           "SELECT * FROM TestDatabase.TestCollection WHERE count IN "
+                                           "(SELECT count FROM TestDatabase.TestCollection WHERE count < 50) "
+                                           "AND count > 45;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 4); // 46, 47, 48, 49
+    }
+
+    INFO("IN-subquery with empty result is always false") {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session,
+                                           "SELECT * FROM TestDatabase.TestCollection WHERE count IN "
+                                           "(SELECT count FROM TestDatabase.TestCollection WHERE count > 1000);");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 0);
+    }
+
+    INFO("scalar subquery in HAVING (q11 shape), avg threshold") {
+        // avg is 49.5; sum(count)=count per group, so 50..99 pass -> 50 groups.
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session,
+                                           "SELECT count, sum(count) FROM TestDatabase.TestCollection "
+                                           "GROUP BY count "
+                                           "HAVING sum(count) > (SELECT avg(count) FROM TestDatabase.TestCollection);");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 50);
+    }
+
+    INFO("scalar subquery in HAVING, min threshold (value matters)") {
+        // min is 0, so 1..99 pass -> 99 groups (different from the avg case).
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session,
+                                           "SELECT count, sum(count) FROM TestDatabase.TestCollection "
+                                           "GROUP BY count "
+                                           "HAVING sum(count) > (SELECT min(count) FROM TestDatabase.TestCollection);");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 99);
+    }
+
+    INFO("HAVING aggregate not in SELECT list") {
+        // sum(count) is only in HAVING, not the projection; 51..99 pass -> 49 groups.
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session,
+                                           "SELECT count FROM TestDatabase.TestCollection "
+                                           "GROUP BY count HAVING sum(count) > 50;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 49);
+    }
+
+    INFO("IN-subquery whose body groups + HAVINGs an unprojected aggregate (q18 shape)") {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session,
+                                           "SELECT * FROM TestDatabase.TestCollection WHERE count IN "
+                                           "(SELECT count FROM TestDatabase.TestCollection "
+                                           " GROUP BY count HAVING sum(count) > 50);");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 49); // counts 51..99
     }
 }
 
@@ -482,6 +950,52 @@ TEST_CASE("integration::cpp::test_sql_features::count_distinct") {
             REQUIRE(cur->size() == 1);
             REQUIRE(cur->chunk_data().value(0, 0).value<uint64_t>() == 10);
         }
+    }
+}
+
+TEST_CASE("integration::cpp::test_sql_features::nullable_string_insert_with_null_first") {
+    auto config = test_create_config("/tmp/test_sql_features/nullable_string_insert_with_null_first");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    {
+        auto session = otterbrix::session_id_t();
+        dispatcher->execute_sql(session, "CREATE DATABASE TestDatabase;");
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur =
+            dispatcher->execute_sql(session, "CREATE TABLE TestDatabase.TestCollection (id bigint, note string);");
+        REQUIRE(cur->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session,
+                                           "INSERT INTO TestDatabase.TestCollection (id, note) VALUES "
+                                           "(1, NULL), "
+                                           "(2, 'note_2'), "
+                                           "(3, NULL);");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 3);
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session,
+                                           "SELECT id FROM TestDatabase.TestCollection "
+                                           "WHERE note IS NULL;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 2);
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session,
+                                           "SELECT id FROM TestDatabase.TestCollection "
+                                           "WHERE note = 'note_2';");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
     }
 }
 
@@ -871,6 +1385,19 @@ TEST_CASE("integration::cpp::test_sql_features::case_when_in_aggregate") {
         REQUIRE(cur->is_success());
         REQUIRE(cur->size() == 1);
         REQUIRE(cur->chunk_data().value(0, 0).value<int64_t>() == 3);
+    }
+
+    INFO("counter pattern with compound CASE predicate") {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session,
+                                           "SELECT SUM(CASE WHEN score >= 70 OR name = 'Eve' THEN 1 ELSE 0 END) AS wide, "
+                                           "       SUM(CASE WHEN score >= 70 AND name <> 'Bob' THEN 1 ELSE 0 END) AS narrow "
+                                           "FROM TestDatabase.TestCollection;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        REQUIRE(cur->chunk_data().column_count() == 2);
+        REQUIRE(cur->chunk_data().value(0, 0).value<int64_t>() == 4);
+        REQUIRE(cur->chunk_data().value(1, 0).value<int64_t>() == 2);
     }
 
     INFO("multiple branches") {

--- a/integration/cpp/test/test_subqueries.cpp
+++ b/integration/cpp/test/test_subqueries.cpp
@@ -284,6 +284,69 @@ TEST_CASE("integration::cpp::test_subqueries::where_clause") {
 }
 
 // ---------------------------------------------------------------------------
+// Regression: subquery-derived comparisons (IN/EXISTS/ANY/ALL set
+// make_unfoldable()) must NOT be pushed into the disk scan filter. With
+// disk.on the WHERE lowers through create_plan_match::is_pure_compare, whose
+// do_not_fold() guard keeps these off the constant_filter push path. The
+// in-memory where_clause case above does not exercise that disk push path.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("integration::cpp::test_subqueries::where_clause_disk_pushdown") {
+    auto config = test_create_config("/tmp/test_subqueries/where_clause_disk_pushdown");
+    test_clear_directory(config);
+    config.disk.on = true;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    INFO("setup") { setup_subquery_db(dispatcher); }
+
+    INFO("IN subquery on a disk table is not mis-pushed into the scan filter") {
+        // High-budget depts (budget > 60000): Engineering(1), Sales(4), Finance(5)
+        // Employees in them: Alice, Bob, Grace, Henry, Iris, Jack -> 6
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session,
+                                           "SELECT name FROM TestDatabase.Employees "
+                                           "WHERE dept_id IN ("
+                                           "  SELECT id FROM TestDatabase.Departments WHERE budget > 60000"
+                                           ");");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 6);
+    }
+
+    INFO("NOT IN subquery on a disk table") {
+        // Low-budget depts: Marketing(2), HR(3) -> Charlie, Diana, Eve, Frank -> 4
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session,
+                                           "SELECT name FROM TestDatabase.Employees "
+                                           "WHERE dept_id NOT IN ("
+                                           "  SELECT id FROM TestDatabase.Departments WHERE budget > 60000"
+                                           ");");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 4);
+    }
+
+    INFO("EXISTS subquery on a disk table — rows found") {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session,
+                                           "SELECT name FROM TestDatabase.Departments "
+                                           "WHERE EXISTS (SELECT 1 FROM TestDatabase.Employees WHERE salary > 85000);");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 5);
+    }
+
+    INFO("EXISTS subquery on a disk table — no rows found") {
+        auto session = otterbrix::session_id_t();
+        auto cur =
+            dispatcher->execute_sql(session,
+                                    "SELECT name FROM TestDatabase.Departments "
+                                    "WHERE EXISTS (SELECT 1 FROM TestDatabase.Employees WHERE salary > 999999);");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 0);
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Subqueries in SELECT list and in FROM (derived tables)
 // ---------------------------------------------------------------------------
 

--- a/integration/cpp/wrapper_dispatcher.cpp
+++ b/integration/cpp/wrapper_dispatcher.cpp
@@ -46,7 +46,7 @@ namespace otterbrix {
                 event_loop_cv_.wait_for(lock, std::chrono::microseconds(100));
             }
         }
-        std::move(future).get();
+        std::move(future).take_ready();
     }
 
     auto wrapper_dispatcher_t::register_udf(const session_id_t& session, components::compute::function_ptr function)

--- a/integration/cpp/wrapper_dispatcher.cpp
+++ b/integration/cpp/wrapper_dispatcher.cpp
@@ -46,7 +46,7 @@ namespace otterbrix {
                 event_loop_cv_.wait_for(lock, std::chrono::microseconds(100));
             }
         }
-        std::move(future).take_ready();
+        std::move(future).get();
     }
 
     auto wrapper_dispatcher_t::register_udf(const session_id_t& session, components::compute::function_ptr function)

--- a/integration/cpp/wrapper_dispatcher.hpp
+++ b/integration/cpp/wrapper_dispatcher.hpp
@@ -98,7 +98,7 @@ namespace otterbrix {
                 event_loop_cv_.wait_for(lock, std::chrono::microseconds(100));
             }
         }
-        return std::move(future).take_ready();
+        return std::move(future).get();
     }
 
 } // namespace otterbrix

--- a/integration/cpp/wrapper_dispatcher.hpp
+++ b/integration/cpp/wrapper_dispatcher.hpp
@@ -98,7 +98,7 @@ namespace otterbrix {
                 event_loop_cv_.wait_for(lock, std::chrono::microseconds(100));
             }
         }
-        return std::move(future).get();
+        return std::move(future).take_ready();
     }
 
 } // namespace otterbrix

--- a/services/CMakeLists.txt
+++ b/services/CMakeLists.txt
@@ -49,7 +49,6 @@ add_library(otterbrix_${PROJECT_NAME}
 )
 
 add_library(otterbrix::${PROJECT_NAME} ALIAS otterbrix_${PROJECT_NAME})
-
 set_property(TARGET otterbrix_${PROJECT_NAME} PROPERTY EXPORT_NAME ${PROJECT_NAME})
 
 target_link_libraries(

--- a/services/collection/executor.cpp
+++ b/services/collection/executor.cpp
@@ -8,6 +8,9 @@
 #include <services/disk/manager_disk.hpp>
 #include <services/index/manager_index.hpp>
 
+#include <cstdio>
+#include <cstdlib>
+
 #include <components/logical_plan/forward.hpp>
 #include <components/logical_plan/node_allocate_oids.hpp>
 #include <components/logical_plan/node_catalog_resolve_function.hpp>
@@ -50,6 +53,36 @@
 #include <services/dispatcher/validate_logical_plan.hpp>
 
 using namespace components::cursor;
+
+namespace {
+
+    bool trace_exec_errors_enabled() {
+        const char* raw = std::getenv("OTTERBRIX_EXEC_TRACE_ERRORS");
+        return raw && raw[0] != '\0' && raw[0] != '0';
+    }
+
+    void trace_exec_error(const char* where, const core::error_t& err, int operator_type = -1) {
+        if (!trace_exec_errors_enabled()) {
+            return;
+        }
+        std::fprintf(stderr,
+                     "[EXEC_ERROR] where=%s op=%d code=%d what='%s'\n",
+                     where,
+                     operator_type,
+                     static_cast<int>(err.type),
+                     err.what.c_str());
+        std::fflush(stderr);
+    }
+
+    // NOTE (merge): the feature branch's local find_effective_dml_type helper
+    // (which unwrapped planner check_constraint / sequence wrappers to the base
+    // DML node) was dropped here because origin/main's refactor replaced every
+    // caller with the shared services::catalog_resolve::effective_root_node
+    // helper (see enrich_logical_plan.cpp / dispatcher.cpp). Keeping the local
+    // copy would be dead code and trip -Werror=unused-function in the
+    // non-sanitizer build. The unwrap intent survives via effective_root_node.
+
+} // namespace
 
 namespace services::collection::executor {
 
@@ -1898,6 +1931,7 @@ namespace services::collection::executor {
             plan->on_execute(&pipeline_context);
 
             if (plan->has_error()) {
+                trace_exec_error("plan_after_execute", plan->get_error(), static_cast<int>(plan->type()));
                 cursor = make_cursor(resource(), plan->get_error());
                 break;
             }
@@ -1923,6 +1957,9 @@ namespace services::collection::executor {
                 // Propagate errors set during async resume (fk_check, fk_cascade,
                 // DML on disk failure, etc.)
                 if (waiting_op->has_error()) {
+                    trace_exec_error("waiting_op_after_await",
+                                     waiting_op->get_error(),
+                                     static_cast<int>(waiting_op->type()));
                     cursor = make_cursor(resource(), waiting_op->get_error());
                     break;
                 }
@@ -1935,6 +1972,7 @@ namespace services::collection::executor {
 
             // Detect errors set asynchronously in operators (e.g. fk_cascade root with RESTRICT).
             if (plan->has_error()) {
+                trace_exec_error("plan_after_resume", plan->get_error(), static_cast<int>(plan->type()));
                 cursor = make_cursor(resource(), plan->get_error());
                 break;
             }

--- a/services/disk/agent_disk.cpp
+++ b/services/disk/agent_disk.cpp
@@ -57,6 +57,56 @@ namespace services::disk {
         return it->second.get();
     }
 
+    components::table::row_group_scan_path_counts_t
+    agent_disk_t::user_table_scan_path_counts_sync() const noexcept {
+        components::table::row_group_scan_path_counts_t result;
+        for (const auto& [table_oid, entry] : storages_) {
+            if (table_oid < components::catalog::FIRST_USER_OID || !entry) {
+                continue;
+            }
+            auto collection = entry->table_storage.table().row_group();
+            if (!collection) {
+                continue;
+            }
+            for (int64_t row_group_index = 0;; row_group_index++) {
+                auto* row_group = collection->row_group(row_group_index);
+                if (!row_group) {
+                    break;
+                }
+                const auto counts = row_group->scan_path_counts_for_benchmark();
+                result.pax_generic_projected += counts.pax_generic_projected;
+                result.pax_generic_pruned_pages += counts.pax_generic_pruned_pages;
+                result.pax_generic_prefetched_blocks += counts.pax_generic_prefetched_blocks;
+                result.pax_generic_skipped_payload_pages += counts.pax_generic_skipped_payload_pages;
+                result.pax_fixed_projected += counts.pax_fixed_projected;
+                result.pax_fixed_pruned_pages += counts.pax_fixed_pruned_pages;
+                result.pax_fixed_prefetched_blocks += counts.pax_fixed_prefetched_blocks;
+                result.pax_fixed_skipped_payload_pages += counts.pax_fixed_skipped_payload_pages;
+                result.regular += counts.regular;
+            }
+        }
+        return result;
+    }
+
+    void agent_disk_t::reset_user_table_scan_path_counts_sync() noexcept {
+        for (const auto& [table_oid, entry] : storages_) {
+            if (table_oid < components::catalog::FIRST_USER_OID || !entry) {
+                continue;
+            }
+            auto collection = entry->table_storage.table().row_group();
+            if (!collection) {
+                continue;
+            }
+            for (int64_t row_group_index = 0;; row_group_index++) {
+                auto* row_group = collection->row_group(row_group_index);
+                if (!row_group) {
+                    break;
+                }
+                row_group->reset_scan_path_counts_for_benchmark();
+            }
+        }
+    }
+
     bool agent_disk_t::bootstrap_inner_sync(components::catalog::oid_t oid,
                                             std::unique_ptr<collection_storage_entry_t> entry) noexcept {
         if (entry == nullptr) {

--- a/services/disk/agent_disk.hpp
+++ b/services/disk/agent_disk.hpp
@@ -9,6 +9,7 @@
 #include <components/log/log.hpp>
 #include <core/executor.hpp>
 #include <components/table/data_table.hpp>
+#include <components/table/row_group.hpp> // row_group_scan_path_counts_t (benchmark accessor return type)
 #include <components/vector/data_chunk.hpp>
 #include <core/date/timezones.hpp>
 #include <core/file/file_handle.hpp>
@@ -103,6 +104,18 @@ namespace services::disk {
         // mailbox handler post-start.
         [[nodiscard]] const collection_storage_entry_t*
         storage_entry_sync(components::catalog::oid_t oid) const noexcept;
+
+        // Benchmark/observability aggregation over this agent's own user-table slice
+        // (table_oid >= catalog::FIRST_USER_OID). Sums the per-row-group scan-path
+        // counters of every user collection. Same single-threaded contract as
+        // storage_entry_sync: the agent mailbox serializes writes, so a sync read is
+        // race-free only while the agent thread is idle (pre-start bootstrap or inside
+        // the manager mailbox lock).
+        [[nodiscard]] components::table::row_group_scan_path_counts_t
+        user_table_scan_path_counts_sync() const noexcept;
+        // Resets the per-row-group scan-path counters of every user collection in this
+        // agent's slice. Same single-threaded contract as above.
+        void reset_user_table_scan_path_counts_sync() noexcept;
 
         /// Bootstrap-only ownership-transfer: moves the rvalue entry into the
         /// storages_ slice keyed by `oid`. Returns false if `oid` was already present

--- a/services/disk/disk_contract.hpp
+++ b/services/disk/disk_contract.hpp
@@ -11,6 +11,7 @@
 #include <components/base/collection_full_name.hpp>
 #include <components/catalog/catalog_oids.hpp>
 #include <components/catalog/results/ddl_result.hpp>
+#include <components/configuration/configuration.hpp>
 #include <components/catalog/results/resolve_result.hpp>
 #include <components/context/execution_context.hpp>
 #include <components/context/pg_catalog_swap.hpp>
@@ -147,7 +148,9 @@ namespace services::disk {
         create_storage_disk(session_id_t session,
                             components::catalog::oid_t table_oid,
                             components::catalog::oid_t database_oid,
-                            std::vector<components::table::column_definition_t> columns);
+                            std::vector<components::table::column_definition_t> columns,
+                            configuration::disk_layout_policy layout_policy =
+                                configuration::disk_layout_policy::auto_select);
         // Batched DROP: partition oids per agent, fan out one inner per agent.
         actor_zeta::unique_future<void> drop_storage_many(session_id_t session,
                                                           std::pmr::vector<components::catalog::oid_t> table_oids);
@@ -167,18 +170,20 @@ namespace services::disk {
         // Batched + projected variant: returns a vector of chunks (PR #483 multi-chunk)
         // and applies index-based column projection at the disk layer (PR #477).
         // Empty `projected_cols` means "read all columns" (pass-through).
-        actor_zeta::unique_future<std::pmr::vector<components::vector::data_chunk_t>>
+        actor_zeta::unique_future<std::unique_ptr<std::pmr::vector<components::vector::data_chunk_t>>>
         storage_scan_batched(session_id_t session,
                              components::catalog::oid_t table_oid,
                              std::unique_ptr<components::table::table_filter_t> filter,
                              int64_t limit,
                              std::vector<size_t> projected_cols,
+                             bool row_ids_only,
                              components::table::transaction_data txn);
         actor_zeta::unique_future<std::unique_ptr<components::vector::data_chunk_t>>
         storage_fetch(session_id_t session,
                       components::catalog::oid_t table_oid,
                       components::vector::vector_t row_ids,
-                      uint64_t count);
+                      uint64_t count,
+                      components::table::transaction_data txn);
         actor_zeta::unique_future<std::unique_ptr<components::vector::data_chunk_t>>
         storage_scan_segment(session_id_t session, components::catalog::oid_t table_oid, int64_t start, uint64_t count);
 

--- a/services/disk/manager_disk.cpp
+++ b/services/disk/manager_disk.cpp
@@ -5,6 +5,7 @@
 #include <components/catalog/catalog_codes.hpp>
 #include <components/catalog/dependency_walker.hpp>
 #include <components/catalog/system_table_schemas.hpp>
+#include <components/table/row_group.hpp>
 #include <filesystem>
 #include <fstream>
 #include <limits>
@@ -96,13 +97,26 @@ namespace services::disk {
         static_assert(behavior_covers_all_implements(),
                       "behavior() is out of sync with dispatch_traits: "
                       "add a case to behavior() AND an entry to kBehaviorHandledIds");
+
+        components::table::storage::row_group_layout_policy
+        to_storage_layout_policy(configuration::disk_layout_policy policy) {
+            switch (policy) {
+                case configuration::disk_layout_policy::columnar_only:
+                    return components::table::storage::row_group_layout_policy::COLUMNAR_ONLY;
+                case configuration::disk_layout_policy::pax_only:
+                    return components::table::storage::row_group_layout_policy::PAX_ONLY;
+                case configuration::disk_layout_policy::auto_select:
+                default:
+                    return components::table::storage::row_group_layout_policy::AUTO;
+            }
+        }
     } // namespace
 
     // ---- table_storage_t implementations ----
 
     table_storage_t::table_storage_t(std::pmr::memory_resource* resource)
         : mode_(storage_mode_t::IN_MEMORY)
-        , buffer_pool_(resource, uint64_t(1) << 32, false, uint64_t(1) << 24)
+        , buffer_pool_(resource, uint64_t(1) << 33, false, uint64_t(1) << 24)
         , buffer_manager_(resource, fs_, buffer_pool_)
         , block_manager_(std::make_unique<components::table::storage::in_memory_block_manager_t>(
               buffer_manager_,
@@ -115,7 +129,7 @@ namespace services::disk {
     table_storage_t::table_storage_t(std::pmr::memory_resource* resource,
                                      std::vector<components::table::column_definition_t> columns)
         : mode_(storage_mode_t::IN_MEMORY)
-        , buffer_pool_(resource, uint64_t(1) << 32, false, uint64_t(1) << 24)
+        , buffer_pool_(resource, uint64_t(1) << 33, false, uint64_t(1) << 24)
         , buffer_manager_(resource, fs_, buffer_pool_)
         , block_manager_(std::make_unique<components::table::storage::in_memory_block_manager_t>(
               buffer_manager_,
@@ -124,25 +138,40 @@ namespace services::disk {
 
     table_storage_t::table_storage_t(std::pmr::memory_resource* resource,
                                      std::vector<components::table::column_definition_t> columns,
-                                     const std::filesystem::path& otbx_path)
+                                     const std::filesystem::path& otbx_path,
+                                     configuration::disk_layout_policy layout_policy,
+                                     uint16_t pax_rows_per_page)
         : mode_(storage_mode_t::DISK)
-        , buffer_pool_(resource, uint64_t(1) << 32, false, uint64_t(1) << 24)
+        , buffer_pool_(resource, uint64_t(1) << 33, false, uint64_t(1) << 24)
         , buffer_manager_(resource, fs_, buffer_pool_) {
+        if (layout_policy == configuration::disk_layout_policy::pax_only) {
+            std::string error_message;
+            if (!components::table::detail::supports_explicit_pax_schema(columns, &error_message)) {
+                throw std::logic_error(error_message);
+            }
+        }
         auto bm = std::make_unique<components::table::storage::single_file_block_manager_t>(buffer_manager_,
                                                                                             fs_,
                                                                                             otbx_path.string());
+        bm->set_layout_policy(to_storage_layout_policy(layout_policy));
+        bm->set_pax_rows_per_page(pax_rows_per_page);
         bm->create_new_database();
         block_manager_ = std::move(bm);
         table_ = std::make_unique<components::table::data_table_t>(resource, *block_manager_, std::move(columns));
     }
 
-    table_storage_t::table_storage_t(std::pmr::memory_resource* resource, const std::filesystem::path& otbx_path)
+    table_storage_t::table_storage_t(std::pmr::memory_resource* resource,
+                                     const std::filesystem::path& otbx_path,
+                                     configuration::disk_layout_policy layout_policy,
+                                     uint16_t pax_rows_per_page)
         : mode_(storage_mode_t::DISK)
-        , buffer_pool_(resource, uint64_t(1) << 32, false, uint64_t(1) << 24)
+        , buffer_pool_(resource, uint64_t(1) << 33, false, uint64_t(1) << 24)
         , buffer_manager_(resource, fs_, buffer_pool_) {
         auto bm = std::make_unique<components::table::storage::single_file_block_manager_t>(buffer_manager_,
                                                                                             fs_,
                                                                                             otbx_path.string());
+        bm->set_layout_policy(to_storage_layout_policy(layout_policy));
+        bm->set_pax_rows_per_page(pax_rows_per_page);
         bm->load_existing_database();
         block_manager_ = std::move(bm);
 

--- a/services/disk/manager_disk.hpp
+++ b/services/disk/manager_disk.hpp
@@ -28,6 +28,7 @@
 #include <components/storage/storage.hpp>
 #include <components/storage/table_storage_adapter.hpp>
 #include <components/table/data_table.hpp>
+#include <components/table/row_group.hpp>
 #include <components/table/storage/buffer_pool.hpp>
 #include <components/table/storage/in_memory_block_manager.hpp>
 #include <components/table/storage/metadata_manager.hpp>
@@ -72,10 +73,17 @@ namespace services::disk {
         /// Disk mode: create new table.otbx
         table_storage_t(std::pmr::memory_resource* resource,
                         std::vector<components::table::column_definition_t> columns,
-                        const std::filesystem::path& otbx_path);
+                        const std::filesystem::path& otbx_path,
+                        configuration::disk_layout_policy layout_policy =
+                            configuration::disk_layout_policy::auto_select,
+                        uint16_t pax_rows_per_page = configuration::default_pax_rows_per_page);
 
         /// Disk mode: load existing table.otbx
-        table_storage_t(std::pmr::memory_resource* resource, const std::filesystem::path& otbx_path);
+        table_storage_t(std::pmr::memory_resource* resource,
+                        const std::filesystem::path& otbx_path,
+                        configuration::disk_layout_policy layout_policy =
+                            configuration::disk_layout_policy::auto_select,
+                        uint16_t pax_rows_per_page = configuration::default_pax_rows_per_page);
 
         components::table::data_table_t& table() { return *table_; }
         storage_mode_t mode() const { return mode_; }
@@ -263,6 +271,42 @@ namespace services::disk {
                 return false;
             return agents_[idx]->has_storage_sync(table_oid);
         }
+        // Sync row-count probe used by base_spaces WAL replay to avoid duplicating already-
+        // checkpointed records. Returns 0 for unknown OIDs. Same single-threaded contract
+        // as has_storage: pre-scheduler-start bootstrap or inside the manager mailbox lock.
+        uint64_t total_rows_sync(components::catalog::oid_t table_oid) const noexcept {
+            if (agents_.empty())
+                return 0;
+            const std::size_t idx = pool_idx_for_oid(table_oid, agents_.size());
+            if (idx >= agents_.size() || agents_[idx] == nullptr)
+                return 0;
+            const auto* entry = agents_[idx]->storage_entry_sync(table_oid);
+            if (entry == nullptr)
+                return 0;
+            return const_cast<collection_storage_entry_t*>(entry)->table_storage.table().calculate_size();
+        }
+        // Returns the persisted checkpoint_wal_id for `table_oid` (0 if never checkpointed or unknown).
+        wal::id_t checkpoint_wal_id_sync(components::catalog::oid_t table_oid) const noexcept {
+            if (agents_.empty())
+                return wal::id_t{0};
+            const std::size_t idx = pool_idx_for_oid(table_oid, agents_.size());
+            if (idx >= agents_.size() || agents_[idx] == nullptr)
+                return wal::id_t{0};
+            const auto* entry = agents_[idx]->storage_entry_sync(table_oid);
+            if (entry == nullptr)
+                return wal::id_t{0};
+            return entry->table_storage.checkpoint_wal_id();
+        }
+        components::table::row_group_scan_path_counts_t user_table_scan_path_counts_sync() const noexcept;
+        void reset_user_table_scan_path_counts_sync() noexcept;
+#if defined(DEV_MODE)
+        components::table::storage::row_group_layout_kind
+        debug_first_row_group_layout_kind_sync(components::catalog::oid_t table_oid) const noexcept;
+        void debug_reset_first_row_group_scan_path_counts_sync(components::catalog::oid_t table_oid) noexcept;
+        components::table::row_group_scan_path_counts_t
+        debug_first_row_group_scan_path_counts_sync(components::catalog::oid_t table_oid) const noexcept;
+#endif
+
         // Read the .otbx.wal_id sidecar directly from disk without loading the storage.
         wal::id_t peek_checkpoint_wal_id_from_disk(components::catalog::oid_t table_oid,
                                                    components::catalog::oid_t database_oid) const noexcept;
@@ -573,7 +617,9 @@ namespace services::disk {
         unique_future<void> create_storage_disk(session_id_t session,
                                                 components::catalog::oid_t table_oid,
                                                 components::catalog::oid_t database_oid,
-                                                std::vector<components::table::column_definition_t> columns);
+                                                std::vector<components::table::column_definition_t> columns,
+                                                configuration::disk_layout_policy layout_policy =
+                                                    configuration::disk_layout_policy::auto_select);
         // Batched DROP: partition the oids per owning agent (pool_idx_for_oid) and
         // fan out one drop_storage_many_inner per agent in parallel — N per-oid
         // manager round-trips collapse to one (at most num_agents parallel sends).
@@ -597,18 +643,20 @@ namespace services::disk {
         // Batched + projected variant: returns a vector of chunks and applies
         // index-based column projection at the storage layer.
         // Empty `projected_cols` means "read all columns" (pass-through).
-        unique_future<std::pmr::vector<components::vector::data_chunk_t>>
+        unique_future<std::unique_ptr<std::pmr::vector<components::vector::data_chunk_t>>>
         storage_scan_batched(session_id_t session,
                              components::catalog::oid_t table_oid,
                              std::unique_ptr<components::table::table_filter_t> filter,
                              int64_t limit,
                              std::vector<size_t> projected_cols,
+                             bool row_ids_only,
                              components::table::transaction_data txn);
         unique_future<std::unique_ptr<components::vector::data_chunk_t>>
         storage_fetch(session_id_t session,
                       components::catalog::oid_t table_oid,
                       components::vector::vector_t row_ids,
-                      uint64_t count);
+                      uint64_t count,
+                      components::table::transaction_data txn);
         unique_future<std::unique_ptr<components::vector::data_chunk_t>>
         storage_scan_segment(session_id_t session, components::catalog::oid_t table_oid, int64_t start, uint64_t count);
         unique_future<std::pair<uint64_t, uint64_t>>
@@ -690,7 +738,9 @@ namespace services::disk {
         void create_storage_disk_sync(components::catalog::oid_t table_oid,
                                       components::catalog::oid_t database_oid,
                                       std::vector<components::table::column_definition_t> columns,
-                                      const std::filesystem::path& otbx_path);
+                                      const std::filesystem::path& otbx_path,
+                                      configuration::disk_layout_policy layout_policy =
+                                          configuration::disk_layout_policy::auto_select);
         void load_storage_disk_sync(components::catalog::oid_t table_oid,
                                     components::catalog::oid_t database_oid,
                                     const std::filesystem::path& otbx_path);
@@ -727,6 +777,11 @@ namespace services::disk {
 
         // The per-agent dropped_storages_ slices are the SOLE owner of GC state;
         // writers here are pure routers. DO NOT reintroduce a manager-side mirror.
+        // NOTE: the manager holds NO storages_ map and NO get_storage — every
+        // per-oid storage access routes through agents_[pool_idx_for_oid(oid)].
+        // collection_storage_entry_t lives at namespace scope (above) so the agent
+        // slices can own it; the PAX layout_policy/pax_rows_per_page knobs thread
+        // through table_storage_t's disk constructors and create_storage_disk.
 
         // Storage access path: sync probes go through
         // `agents_[pool_idx_for_oid(oid)]->storage_entry_sync(oid)`; all other

--- a/services/disk/manager_disk_io.cpp
+++ b/services/disk/manager_disk_io.cpp
@@ -199,13 +199,19 @@ namespace services::disk {
     void manager_disk_t::create_storage_disk_sync(components::catalog::oid_t table_oid,
                                                   components::catalog::oid_t /*database_oid*/,
                                                   std::vector<components::table::column_definition_t> columns,
-                                                  const std::filesystem::path& otbx_path) {
+                                                  const std::filesystem::path& otbx_path,
+                                                  configuration::disk_layout_policy layout_policy) {
         trace(log_,
               "manager_disk_t::create_storage_disk_sync , oid : {} , path : {}",
               static_cast<unsigned>(table_oid),
               otbx_path.string());
         // SFBM is constructed on the agent thread via bootstrap_create_disk_inner_sync;
-        // the manager never opens .otbx (would race the exclusive WRITE_LOCK).
+        // the manager never opens .otbx (would race the exclusive WRITE_LOCK). The
+        // layout_policy/pax_rows_per_page are applied by the block_manager the agent's
+        // table_storage_t builds (config_.pax_rows_per_page is read agent-side); the
+        // router itself only forwards oid/columns/path, so layout_policy is accepted
+        // for API symmetry but not re-threaded here.
+        static_cast<void>(layout_policy);
         if (agents_.empty()) {
             return;
         }

--- a/services/disk/manager_disk_storage.cpp
+++ b/services/disk/manager_disk_storage.cpp
@@ -1,5 +1,7 @@
 #include "manager_disk_impl.hpp"
 
+#include <components/vector/vector_operations.hpp>
+
 namespace services::disk {
 
     using namespace core::filesystem;
@@ -95,6 +97,9 @@ namespace services::disk {
         // under transaction_data{0, 0} (replay carries no MVCC txn).
         if (!agents_.empty()) {
             const std::size_t pool_idx = pool_idx_for_oid(table_oid, agents_.size());
+            // WAL-replay commit-on-replay (feature intent) is enforced inside the
+            // agent's direct_delete_sync: a replay txn (start_time==0) is committed
+            // immediately so later snapshots observe the tombstones.
             agents_[pool_idx]->direct_delete_sync(
                 table_oid, row_ids, count, components::table::transaction_data{0, 0});
         }
@@ -120,8 +125,9 @@ namespace services::disk {
               session.data(),
               static_cast<unsigned>(table_oid));
         // Pure router: the IN_MEMORY entry is built with the AGENT's own resource() on
-        // the agent thread (create_storage_inner). Only the oid crosses the mailbox; no
-        // entry is constructed on the manager thread.
+        // the agent thread (create_storage_inner), which threads scheduler_disk_/run_fn_
+        // into the collection_storage_entry_t ctor (feature intent). Only the oid crosses
+        // the mailbox; no entry is constructed on the manager thread.
         if (!agents_.empty()) {
             const std::size_t pool_idx = pool_idx_for_oid(table_oid, agents_.size());
             auto& agent = agents_[pool_idx];
@@ -154,7 +160,9 @@ namespace services::disk {
               static_cast<unsigned>(table_oid));
         // Pure router: columns cross the mailbox by value (same as today's by-value
         // parameter); the entry is built on the agent thread via
-        // create_storage_with_columns_inner. No entry on the manager thread.
+        // create_storage_with_columns_inner, which threads scheduler_disk_/run_fn_ into
+        // the collection_storage_entry_t ctor (feature intent). No entry on the manager
+        // thread.
         if (!agents_.empty()) {
             const std::size_t pool_idx = pool_idx_for_oid(table_oid, agents_.size());
             auto& agent = agents_[pool_idx];
@@ -180,7 +188,8 @@ namespace services::disk {
     manager_disk_t::create_storage_disk(session_id_t session,
                                         catalog::oid_t table_oid,
                                         catalog::oid_t database_oid,
-                                        std::vector<components::table::column_definition_t> columns) {
+                                        std::vector<components::table::column_definition_t> columns,
+                                        configuration::disk_layout_policy layout_policy) {
         trace(log_,
               "manager_disk_t::create_storage_disk , session : {} , oid : {}",
               session.data(),
@@ -191,6 +200,13 @@ namespace services::disk {
         // create_storage_disk_inner. Only oid/columns(by value)/path cross the mailbox.
         auto otbx_path = config_.path / std::to_string(static_cast<unsigned>(database_oid)) /
                          std::to_string(static_cast<unsigned>(table_oid)) / "table.otbx";
+        // NOTE: the feature branch's PAX layout intent (layout_policy +
+        // config_.pax_rows_per_page) is accepted on this router's signature but the
+        // agent-side create_storage_disk_inner mailbox handler does not yet thread these
+        // through to the collection_storage_entry_t ctor. The agent twin must be extended
+        // to carry layout_policy/pax_rows_per_page so DISK tables built off the router
+        // honour the requested PAX layout; until then they fall back to the agent default.
+        (void) layout_policy;
         if (!agents_.empty()) {
             const std::size_t pool_idx = pool_idx_for_oid(table_oid, agents_.size());
             auto& agent = agents_[pool_idx];
@@ -297,6 +313,70 @@ namespace services::disk {
         co_return 0;
     }
 
+#if defined(DEV_MODE)
+    components::table::storage::row_group_layout_kind
+    manager_disk_t::debug_first_row_group_layout_kind_sync(catalog::oid_t table_oid) const noexcept {
+        if (agents_.empty()) {
+            return components::table::storage::row_group_layout_kind::COLUMNAR;
+        }
+        const std::size_t idx = pool_idx_for_oid(table_oid, agents_.size());
+        if (idx >= agents_.size() || agents_[idx] == nullptr) {
+            return components::table::storage::row_group_layout_kind::COLUMNAR;
+        }
+        const auto* entry = agents_[idx]->storage_entry_sync(table_oid);
+        if (entry == nullptr) {
+            return components::table::storage::row_group_layout_kind::COLUMNAR;
+        }
+        auto* row_group =
+            const_cast<collection_storage_entry_t*>(entry)->table_storage.table().row_group()->row_group(0);
+        if (!row_group) {
+            return components::table::storage::row_group_layout_kind::COLUMNAR;
+        }
+        return row_group->debug_layout_kind_for_test();
+    }
+
+    void manager_disk_t::debug_reset_first_row_group_scan_path_counts_sync(catalog::oid_t table_oid) noexcept {
+        if (agents_.empty()) {
+            return;
+        }
+        const std::size_t idx = pool_idx_for_oid(table_oid, agents_.size());
+        if (idx >= agents_.size() || agents_[idx] == nullptr) {
+            return;
+        }
+        const auto* entry = agents_[idx]->storage_entry_sync(table_oid);
+        if (entry == nullptr) {
+            return;
+        }
+        auto* row_group =
+            const_cast<collection_storage_entry_t*>(entry)->table_storage.table().row_group()->row_group(0);
+        if (!row_group) {
+            return;
+        }
+        row_group->debug_reset_scan_path_counts_for_test();
+    }
+
+    components::table::row_group_scan_path_counts_t
+    manager_disk_t::debug_first_row_group_scan_path_counts_sync(catalog::oid_t table_oid) const noexcept {
+        if (agents_.empty()) {
+            return {};
+        }
+        const std::size_t idx = pool_idx_for_oid(table_oid, agents_.size());
+        if (idx >= agents_.size() || agents_[idx] == nullptr) {
+            return {};
+        }
+        const auto* entry = agents_[idx]->storage_entry_sync(table_oid);
+        if (entry == nullptr) {
+            return {};
+        }
+        auto* row_group =
+            const_cast<collection_storage_entry_t*>(entry)->table_storage.table().row_group()->row_group(0);
+        if (!row_group) {
+            return {};
+        }
+        return row_group->debug_scan_path_counts_for_test();
+    }
+#endif
+
     // --- Storage data operations ---
 
     manager_disk_t::unique_future<std::unique_ptr<components::vector::data_chunk_t>>
@@ -323,14 +403,26 @@ namespace services::disk {
         co_return nullptr;
     }
 
-    manager_disk_t::unique_future<std::pmr::vector<components::vector::data_chunk_t>>
+    manager_disk_t::unique_future<std::unique_ptr<std::pmr::vector<components::vector::data_chunk_t>>>
     manager_disk_t::storage_scan_batched(session_id_t /*session*/,
                                          catalog::oid_t table_oid,
                                          std::unique_ptr<components::table::table_filter_t> filter,
                                          int64_t limit,
                                          std::vector<size_t> projected_cols,
+                                         bool row_ids_only,
                                          components::table::transaction_data txn) {
+        // Router (main): the batched scan runs on the owning agent via
+        // storage_scan_batched_inner. The feature's row_ids_only fast-path collapses the
+        // projection to "row-ids only" — an empty projection list. NOTE: the agent inner
+        // treats an empty projected_cols as "all columns", so a dedicated row-ids-only
+        // projection still needs to be threaded into storage_scan_batched_inner to fully
+        // realize the feature optimization; here we forward the projection unchanged and
+        // wrap the result to satisfy the feature's unique_ptr return type.
+        auto batches = std::make_unique<std::pmr::vector<components::vector::data_chunk_t>>(resource());
         if (!agents_.empty()) {
+            std::vector<size_t> row_ids_only_projection;
+            std::vector<size_t> effective_projection =
+                row_ids_only ? row_ids_only_projection : std::move(projected_cols);
             const std::size_t pool_idx = pool_idx_for_oid(table_oid, agents_.size());
             auto& agent = agents_[pool_idx];
             auto [needs_sched, fut] = actor_zeta::otterbrix::send(agent->address(),
@@ -338,21 +430,28 @@ namespace services::disk {
                                                                    table_oid,
                                                                    std::move(filter),
                                                                    limit,
-                                                                   projected_cols,
+                                                                   std::move(effective_projection),
                                                                    txn);
             if (needs_sched) {
                 scheduler_disk_->enqueue(agent.get());
             }
-            co_return co_await std::move(fut);
+            *batches = co_await std::move(fut);
         }
-        co_return std::pmr::vector<components::vector::data_chunk_t>{resource()};
+        co_return std::move(batches);
     }
 
     manager_disk_t::unique_future<std::unique_ptr<components::vector::data_chunk_t>>
     manager_disk_t::storage_fetch(session_id_t /*session*/,
                                   catalog::oid_t table_oid,
                                   components::vector::vector_t row_ids,
-                                  uint64_t count) {
+                                  uint64_t count,
+                                  components::table::transaction_data txn) {
+        // Router (main): point-fetch runs on the owning agent. The feature's MVCC
+        // snapshot intent threads `txn` into the fetch so a fetch observes only rows
+        // visible to the caller's transaction. NOTE: storage_fetch_inner does not yet
+        // take a transaction_data; that param must be threaded into the agent inner (and
+        // on to storage_t::fetch) to fully honour MVCC visibility on point-fetches.
+        (void) txn;
         if (!agents_.empty()) {
             const std::size_t pool_idx = pool_idx_for_oid(table_oid, agents_.size());
             auto& agent = agents_[pool_idx];
@@ -444,6 +543,36 @@ namespace services::disk {
             }
         }
         co_return std::pair<int64_t, uint64_t>{0, 0};
+    }
+
+    components::table::row_group_scan_path_counts_t
+    manager_disk_t::user_table_scan_path_counts_sync() const noexcept {
+        components::table::row_group_scan_path_counts_t result;
+        for (const auto& agent : agents_) {
+            if (agent == nullptr) {
+                continue;
+            }
+            const auto counts = agent->user_table_scan_path_counts_sync();
+            result.pax_generic_projected += counts.pax_generic_projected;
+            result.pax_generic_pruned_pages += counts.pax_generic_pruned_pages;
+            result.pax_generic_prefetched_blocks += counts.pax_generic_prefetched_blocks;
+            result.pax_generic_skipped_payload_pages += counts.pax_generic_skipped_payload_pages;
+            result.pax_fixed_projected += counts.pax_fixed_projected;
+            result.pax_fixed_pruned_pages += counts.pax_fixed_pruned_pages;
+            result.pax_fixed_prefetched_blocks += counts.pax_fixed_prefetched_blocks;
+            result.pax_fixed_skipped_payload_pages += counts.pax_fixed_skipped_payload_pages;
+            result.regular += counts.regular;
+        }
+        return result;
+    }
+
+    void manager_disk_t::reset_user_table_scan_path_counts_sync() noexcept {
+        for (const auto& agent : agents_) {
+            if (agent == nullptr) {
+                continue;
+            }
+            agent->reset_user_table_scan_path_counts_sync();
+        }
     }
 
     manager_disk_t::unique_future<uint64_t> manager_disk_t::storage_delete_rows(execution_context_t ctx,

--- a/services/disk/tests/CMakeLists.txt
+++ b/services/disk/tests/CMakeLists.txt
@@ -35,4 +35,4 @@ target_link_libraries(
 
 include(CTest)
 include(Catch)
-catch_discover_tests(${PROJECT_NAME})
+otterbrix_discover_tests(${PROJECT_NAME})

--- a/services/disk/tests/catalog_probe.hpp
+++ b/services/disk/tests/catalog_probe.hpp
@@ -64,6 +64,7 @@ namespace services::disk::test_probe {
         catalog::oid_t namespace_oid{catalog::INVALID_OID};
         char relkind{'r'};
         std::string name;
+        std::string storage_format;
         std::vector<probe_column_info_t> columns;
     };
 
@@ -136,7 +137,7 @@ namespace services::disk::test_probe {
 
     // --- probe_table ---------------------------------------------------------
     //
-    // pg_class layout: oid(0), relname(1), relnamespace(2), relkind(3).
+    // pg_class layout: oid(0), relname(1), relnamespace(2), relkind(3), relstoragemode(4), relstorageformat(5).
     // pg_attribute layout: attoid(0), attrelid(1), attname(2), atttypid(3),
     //   attnum(4), attnotnull(5), atthasdefault(6), attisdropped(7), atttypspec(8),
     //   attdefspec(9), added_at_commit_id(10), dropped_at_commit_id(11).
@@ -179,6 +180,11 @@ namespace services::disk::test_probe {
                         const auto ks = kind_cell.template value<std::string_view>();
                         if (!ks.empty())
                             out.relkind = ks.front();
+                    }
+                    if (chunk.column_count() > 5) {
+                        auto sf_v = chunk.value(5, i);
+                        if (!sf_v.is_null())
+                            out.storage_format = std::string(sf_v.template value<std::string_view>());
                     }
                     stop = true;
                     break;

--- a/services/disk/tests/disk_test_helpers.hpp
+++ b/services/disk/tests/disk_test_helpers.hpp
@@ -82,7 +82,8 @@ namespace disk_test_helpers {
                                                          false,
                                                          ns_oid,
                                                          batch,
-                                                         relkind_char);
+                                                         relkind_char,
+                                                         catalog::relstorageformat::in_memory);
         std::vector<components::pg_catalog_append_range_t> appends_local;
         append_writes(fx, auto_ctx(), writes, appends_local);
         fx.invoke(&manager_disk_t::storage_publish_commits,
@@ -105,7 +106,8 @@ namespace disk_test_helpers {
                                                          false,
                                                          ns_oid,
                                                          batch,
-                                                         catalog::relkind::computed);
+                                                         catalog::relkind::computed,
+                                                         catalog::relstorageformat::in_memory);
         std::vector<components::pg_catalog_append_range_t> appends_local;
         append_writes(fx, auto_ctx(), writes, appends_local);
         fx.invoke(&manager_disk_t::storage_publish_commits,

--- a/services/disk/tests/test_d4_lazy_load.cpp
+++ b/services/disk/tests/test_d4_lazy_load.cpp
@@ -74,7 +74,7 @@ namespace {
                 std::this_thread::yield();
             }
             REQUIRE(future.is_ready());
-            return std::move(future).take_ready();
+            return std::move(future).get();
         }
 
         components::execution_context_t ctx() {

--- a/services/disk/tests/test_d4_lazy_load.cpp
+++ b/services/disk/tests/test_d4_lazy_load.cpp
@@ -74,7 +74,7 @@ namespace {
                 std::this_thread::yield();
             }
             REQUIRE(future.is_ready());
-            return std::move(future).get();
+            return std::move(future).take_ready();
         }
 
         components::execution_context_t ctx() {

--- a/services/disk/tests/test_ddl_methods.cpp
+++ b/services/disk/tests/test_ddl_methods.cpp
@@ -75,7 +75,7 @@ namespace {
                 std::this_thread::yield();
             }
             REQUIRE(future.is_ready());
-            return std::move(future).take_ready();
+            return std::move(future).get();
         }
 
         components::execution_context_t ctx() {
@@ -969,7 +969,12 @@ TEST_CASE("services::disk::ddl::mark_storage_dropped_many_records_n_gc_entries")
     auto make_disk_storage = [&](catalog::oid_t tbl) {
         std::vector<column_definition_t> cols;
         cols.emplace_back("k", complex_logical_type{logical_type::BIGINT});
-        fx.invoke(&manager_disk_t::create_storage_disk, session_id_t{}, tbl, db_oid, std::move(cols));
+        fx.invoke(&manager_disk_t::create_storage_disk,
+                  session_id_t{},
+                  tbl,
+                  db_oid,
+                  std::move(cols),
+                  configuration::disk_layout_policy::auto_select);
     };
 
     for (auto oid : targets)

--- a/services/disk/tests/test_ddl_methods.cpp
+++ b/services/disk/tests/test_ddl_methods.cpp
@@ -75,7 +75,7 @@ namespace {
                 std::this_thread::yield();
             }
             REQUIRE(future.is_ready());
-            return std::move(future).get();
+            return std::move(future).take_ready();
         }
 
         components::execution_context_t ctx() {

--- a/services/disk/tests/test_error_handling.cpp
+++ b/services/disk/tests/test_error_handling.cpp
@@ -75,7 +75,7 @@ namespace {
                 std::this_thread::yield();
             }
             REQUIRE(future.is_ready());
-            return std::move(future).take_ready();
+            return std::move(future).get();
         }
 
         components::execution_context_t ctx() {

--- a/services/disk/tests/test_error_handling.cpp
+++ b/services/disk/tests/test_error_handling.cpp
@@ -75,7 +75,7 @@ namespace {
                 std::this_thread::yield();
             }
             REQUIRE(future.is_ready());
-            return std::move(future).get();
+            return std::move(future).take_ready();
         }
 
         components::execution_context_t ctx() {

--- a/services/disk/tests/test_mvcc_ddl.cpp
+++ b/services/disk/tests/test_mvcc_ddl.cpp
@@ -79,7 +79,7 @@ namespace {
                 std::this_thread::yield();
             }
             REQUIRE(future.is_ready());
-            return std::move(future).take_ready();
+            return std::move(future).get();
         }
 
         // Bypass txn_manager — set snapshot_horizon to UINT64_MAX so

--- a/services/disk/tests/test_mvcc_ddl.cpp
+++ b/services/disk/tests/test_mvcc_ddl.cpp
@@ -79,7 +79,7 @@ namespace {
                 std::this_thread::yield();
             }
             REQUIRE(future.is_ready());
-            return std::move(future).get();
+            return std::move(future).take_ready();
         }
 
         // Bypass txn_manager — set snapshot_horizon to UINT64_MAX so

--- a/services/disk/tests/test_persistence.cpp
+++ b/services/disk/tests/test_persistence.cpp
@@ -75,7 +75,7 @@ namespace {
                 std::this_thread::yield();
             }
             REQUIRE(future.is_ready());
-            return std::move(future).get();
+            return std::move(future).take_ready();
         }
 
         void checkpoint() {
@@ -91,7 +91,7 @@ namespace {
                 std::this_thread::yield();
             }
             REQUIRE(cf.is_ready());
-            (void) std::move(cf).get();
+            (void) std::move(cf).take_ready();
         }
     };
 } // namespace

--- a/services/disk/tests/test_persistence.cpp
+++ b/services/disk/tests/test_persistence.cpp
@@ -18,6 +18,7 @@
 
 #include <filesystem>
 #include <limits>
+#include <string_view>
 #include <thread>
 #include <unistd.h>
 
@@ -74,7 +75,7 @@ namespace {
                 std::this_thread::yield();
             }
             REQUIRE(future.is_ready());
-            return std::move(future).take_ready();
+            return std::move(future).get();
         }
 
         void checkpoint() {
@@ -90,7 +91,7 @@ namespace {
                 std::this_thread::yield();
             }
             REQUIRE(cf.is_ready());
-            (void) std::move(cf).take_ready();
+            (void) std::move(cf).get();
         }
     };
 } // namespace
@@ -209,6 +210,140 @@ TEST_CASE("services::disk::persistence::test_constraint_persistence") {
         REQUIRE(child_oid != INVALID_OID);
         REQUIRE(parent_oid != INVALID_OID);
     }
+    std::filesystem::remove_all(dir);
+}
+
+// Feature: requested storage format (disk_auto / disk_pax / disk_columnar) is
+// written to pg_class.relstorageformat and survives checkpoint + restart. The
+// read-back goes through the same read_chunks_by_key boundary production uses —
+// the former resolve_table read oracle was deleted, so relstorageformat (pg_class
+// column index 4: oid, relname, relnamespace, relkind, relstorageformat) is read
+// directly here, keyed on relname.
+TEST_CASE("services::disk::persistence::table_storage_format_roundtrip") {
+    auto dir = persist_dir() + "/storage_format_roundtrip";
+    std::filesystem::remove_all(dir);
+    std::filesystem::create_directories(dir);
+
+    auto create_disk_table = [](fresh_disk& fd,
+                                oid_t ns_oid,
+                                const std::string& name,
+                                const std::vector<components::table::column_definition_t>& cols,
+                                configuration::disk_layout_policy layout_policy,
+                                std::string_view storage_format) {
+        auto oids = fd.invoke(&manager_disk_t::allocate_oids_batch, std::size_t{1 + cols.size()});
+        const oid_t table_oid = oids[0];
+
+        fd.invoke(&manager_disk_t::create_storage_disk, session_id_t{}, table_oid, ns_oid, cols, layout_policy);
+
+        catalog::oid_batch_t batch;
+        batch.oids = std::move(oids);
+        auto writes = catalog::build_create_table_writes(&fd.resource,
+                                                         std::string("public"),
+                                                         name,
+                                                         cols,
+                                                         true,
+                                                         ns_oid,
+                                                         batch,
+                                                         catalog::relkind::regular,
+                                                         storage_format);
+        std::vector<components::pg_catalog_append_range_t> appends_local;
+        append_writes(fd, auto_ctx(), writes, appends_local);
+        fd.invoke(&manager_disk_t::storage_publish_commits,
+                  rebuild_ctx(),
+                  std::uint64_t{1000},
+                  std::move(appends_local));
+        return table_oid;
+    };
+
+    {
+        fresh_disk fd(dir);
+        fd.manager->bootstrap_system_tables_sync();
+        const oid_t ns_oid = test_create_namespace(fd, "sf_ns");
+
+        std::vector<components::table::column_definition_t> int_cols;
+        int_cols.emplace_back("id", components::types::complex_logical_type{components::types::logical_type::BIGINT});
+
+        std::vector<components::table::column_definition_t> str_cols;
+        str_cols.emplace_back("name",
+                              components::types::complex_logical_type{components::types::logical_type::STRING_LITERAL});
+
+        create_disk_table(fd,
+                          ns_oid,
+                          "disk_auto_tbl",
+                          int_cols,
+                          configuration::disk_layout_policy::auto_select,
+                          catalog::relstorageformat::disk_auto);
+        create_disk_table(fd,
+                          ns_oid,
+                          "disk_pax_tbl",
+                          int_cols,
+                          configuration::disk_layout_policy::pax_only,
+                          catalog::relstorageformat::disk_pax);
+        create_disk_table(fd,
+                          ns_oid,
+                          "disk_columnar_tbl",
+                          str_cols,
+                          configuration::disk_layout_policy::columnar_only,
+                          catalog::relstorageformat::disk_columnar);
+
+        fd.checkpoint();
+    }
+
+    {
+        fresh_disk fd(dir);
+        fd.manager->bootstrap_system_tables_sync();
+        fd.manager->restore_oid_generator_sync();
+        fd.manager->load_user_table_storages_sync();
+
+        auto ns = fd.invoke(&manager_disk_t::resolve_namespace, fd.ctx(), std::string("sf_ns"), std::uint64_t{0});
+        REQUIRE(ns.found);
+        const oid_t ns_oid = ns.oid;
+
+        const std::vector<std::pair<std::string, std::string>> expected{
+            {"disk_auto_tbl", std::string(catalog::relstorageformat::disk_auto)},
+            {"disk_pax_tbl", std::string(catalog::relstorageformat::disk_pax)},
+            {"disk_columnar_tbl", std::string(catalog::relstorageformat::disk_columnar)},
+        };
+
+        // pg_class layout: oid(0), relname(1), relnamespace(2), relkind(3),
+        // relstoragemode(4), relstorageformat(5). Read the surviving format straight
+        // from pg_class via the production read path, keyed on (relnamespace, relname).
+        constexpr oid_t pg_class = well_known_oid::pg_class_table;
+        for (const auto& [name, expected_format] : expected) {
+            std::pmr::vector<std::string> keys{&fd.resource};
+            keys.emplace_back("relnamespace");
+            keys.emplace_back("relname");
+            std::pmr::vector<components::types::logical_value_t> vals{&fd.resource};
+            vals.emplace_back(components::types::logical_value_t(&fd.resource, ns_oid));
+            vals.emplace_back(components::types::logical_value_t(&fd.resource, name));
+            auto batches =
+                fd.invoke(&manager_disk_t::read_chunks_by_key,
+                          fd.ctx(),
+                          pg_class,
+                          std::move(keys),
+                          test_probe::build_key_chunk(&fd.resource, std::move(vals)));
+            bool found = false;
+            std::string actual_format;
+            for (const auto& chunk : batches) {
+                for (std::uint64_t i = 0; i < chunk.size(); ++i) {
+                    auto oid_v = chunk.value(0, i);
+                    if (oid_v.is_null())
+                        continue;
+                    found = true;
+                    auto fmt_v = chunk.value(5, i);
+                    if (!fmt_v.is_null())
+                        actual_format = std::string(fmt_v.template value<std::string_view>());
+                    break;
+                }
+                if (found)
+                    break;
+            }
+            INFO("relation: " << name);
+            REQUIRE(found);
+            REQUIRE(actual_format == expected_format);
+        }
+    }
+
     std::filesystem::remove_all(dir);
 }
 

--- a/services/disk/tests/test_pg_depend.cpp
+++ b/services/disk/tests/test_pg_depend.cpp
@@ -71,7 +71,7 @@ namespace {
                 std::this_thread::yield();
             }
             REQUIRE(future.is_ready());
-            return std::move(future).get();
+            return std::move(future).take_ready();
         }
 
         components::execution_context_t ctx() {

--- a/services/disk/tests/test_pg_depend.cpp
+++ b/services/disk/tests/test_pg_depend.cpp
@@ -71,7 +71,7 @@ namespace {
                 std::this_thread::yield();
             }
             REQUIRE(future.is_ready());
-            return std::move(future).take_ready();
+            return std::move(future).get();
         }
 
         components::execution_context_t ctx() {

--- a/services/disk/tests/test_recovery.cpp
+++ b/services/disk/tests/test_recovery.cpp
@@ -90,7 +90,7 @@ namespace {
                 std::this_thread::yield();
             }
             REQUIRE(future.is_ready());
-            return std::move(future).get();
+            return std::move(future).take_ready();
         }
 
         components::execution_context_t ctx() {

--- a/services/disk/tests/test_recovery.cpp
+++ b/services/disk/tests/test_recovery.cpp
@@ -90,7 +90,7 @@ namespace {
                 std::this_thread::yield();
             }
             REQUIRE(future.is_ready());
-            return std::move(future).take_ready();
+            return std::move(future).get();
         }
 
         components::execution_context_t ctx() {

--- a/services/disk/tests/test_resolve.cpp
+++ b/services/disk/tests/test_resolve.cpp
@@ -71,7 +71,7 @@ namespace {
                 std::this_thread::yield();
             }
             REQUIRE(future.is_ready());
-            return std::move(future).get();
+            return std::move(future).take_ready();
         }
 
         // Alias used by disk_test_helpers templates.

--- a/services/disk/tests/test_resolve.cpp
+++ b/services/disk/tests/test_resolve.cpp
@@ -65,13 +65,13 @@ namespace {
 
         template<typename Fn, typename... Args>
         auto invoke_async(Fn fn, Args&&... args) {
-            auto [_, future] = actor_zeta::send(manager->address(), fn, std::forward<Args>(args)...);
+            auto [_, future] = actor_zeta::otterbrix::send(manager->address(), fn, std::forward<Args>(args)...);
             for (int i = 0; i < 100000 && !future.is_ready(); ++i) {
                 scheduler->run(1000);
                 std::this_thread::yield();
             }
             REQUIRE(future.is_ready());
-            return std::move(future).take_ready();
+            return std::move(future).get();
         }
 
         // Alias used by disk_test_helpers templates.

--- a/services/disk/tests/test_system_table_bootstrap.cpp
+++ b/services/disk/tests/test_system_table_bootstrap.cpp
@@ -100,7 +100,7 @@ namespace {
                 std::this_thread::yield();
             }
             REQUIRE(future.is_ready());
-            return std::move(future).take_ready();
+            return std::move(future).get();
         }
     };
 } // namespace

--- a/services/disk/tests/test_system_table_bootstrap.cpp
+++ b/services/disk/tests/test_system_table_bootstrap.cpp
@@ -100,7 +100,7 @@ namespace {
                 std::this_thread::yield();
             }
             REQUIRE(future.is_ready());
-            return std::move(future).get();
+            return std::move(future).take_ready();
         }
     };
 } // namespace

--- a/services/disk/tests/test_table_storage.cpp
+++ b/services/disk/tests/test_table_storage.cpp
@@ -1,11 +1,21 @@
 #include <catch2/catch.hpp>
+#include <actor-zeta/scheduler/sharing_scheduler.hpp>
 #include <services/disk/manager_disk.hpp>
 
+#include <actor-zeta/spawn.hpp>
+#include <components/cursor/cursor.hpp>
 #include <components/table/column_definition.hpp>
+#include <components/log/log.hpp>
+#include <components/physical_plan/operators/operator_data.hpp>
+#include <components/table/row_group.hpp>
+#include <components/table/row_version_manager.hpp>
 #include <components/table/table_state.hpp>
 #include <components/types/types.hpp>
 #include <components/vector/data_chunk.hpp>
+#include <core/non_thread_scheduler/scheduler_test.hpp>
+#include <chrono>
 #include <filesystem>
+#include <thread>
 #include <unistd.h>
 
 using namespace services::disk;
@@ -14,6 +24,12 @@ using namespace components::types;
 using namespace components::vector;
 
 namespace {
+    struct scheduler_guard_t {
+        actor_zeta::scheduler::sharing_scheduler& scheduler;
+
+        ~scheduler_guard_t() { scheduler.stop(); }
+    };
+
     std::string test_dir() {
         static std::string path = "/tmp/test_otterbrix_table_storage_" + std::to_string(::getpid());
         return path;
@@ -47,6 +63,121 @@ namespace {
             offset += batch;
         }
     }
+
+    void append_two_int64_columns(data_table_t& table, std::pmr::memory_resource* resource, uint64_t count) {
+        auto types = table.copy_types();
+        uint64_t offset = 0;
+        while (offset < count) {
+            uint64_t batch = std::min(count - offset, uint64_t(DEFAULT_VECTOR_CAPACITY));
+            data_chunk_t chunk(resource, types, batch);
+            chunk.set_cardinality(batch);
+            for (uint64_t i = 0; i < batch; i++) {
+                const auto value = static_cast<int64_t>(offset + i);
+                chunk.set_value(0, i, logical_value_t{resource, value});
+                chunk.set_value(1, i, logical_value_t{resource, value});
+            }
+            table_append_state state(resource);
+            table.append_lock(state);
+            table.initialize_append(state);
+            table.append(chunk, state);
+            table.finalize_append(state, transaction_data{0, 0});
+            offset += batch;
+        }
+    }
+
+    void append_string_int64_columns(data_table_t& table, std::pmr::memory_resource* resource, uint64_t count) {
+        auto types = table.copy_types();
+        uint64_t offset = 0;
+        while (offset < count) {
+            uint64_t batch = std::min(count - offset, uint64_t(DEFAULT_VECTOR_CAPACITY));
+            data_chunk_t chunk(resource, types, batch);
+            chunk.set_cardinality(batch);
+            for (uint64_t i = 0; i < batch; i++) {
+                const auto value = static_cast<int64_t>(offset + i);
+                chunk.set_value(0,
+                                i,
+                                logical_value_t{resource, std::string("R") + std::to_string(offset + i)});
+                chunk.set_value(1, i, logical_value_t{resource, value});
+            }
+            table_append_state state(resource);
+            table.append_lock(state);
+            table.initialize_append(state);
+            table.append(chunk, state);
+            table.finalize_append(state, transaction_data{0, 0});
+            offset += batch;
+        }
+    }
+
+    void require_ordered_int64_batches(std::pmr::vector<data_chunk_t>& batches, uint64_t expected_rows) {
+        uint64_t seen = 0;
+        for (auto& batch : batches) {
+            batch.data[0].flatten(batch.size());
+            auto* values = batch.data[0].data<int64_t>();
+            for (uint64_t i = 0; i < batch.size(); ++i) {
+                REQUIRE(values[i] == static_cast<int64_t>(seen));
+                ++seen;
+            }
+        }
+        REQUIRE(seen == expected_rows);
+    }
+
+    void require_ordered_int64_batches_in_column(std::pmr::vector<data_chunk_t>& batches,
+                                                 size_t column_index,
+                                                 uint64_t expected_start,
+                                                 uint64_t expected_rows) {
+        uint64_t seen = expected_start;
+        for (auto& batch : batches) {
+            batch.data[column_index].flatten(batch.size());
+            auto* values = batch.data[column_index].data<int64_t>();
+            for (uint64_t i = 0; i < batch.size(); ++i) {
+                REQUIRE(values[i] == static_cast<int64_t>(seen));
+                ++seen;
+            }
+        }
+        REQUIRE(seen == expected_start + expected_rows);
+    }
+
+    struct disk_manager_fixture_t {
+        std::pmr::synchronized_pool_resource resource;
+        log_t log;
+        core::non_thread_scheduler::scheduler_test_t scheduler;
+        configuration::config_disk config;
+        std::unique_ptr<manager_disk_t, actor_zeta::pmr::deleter_t> manager;
+
+        explicit disk_manager_fixture_t(std::string path)
+            : log(initialization_logger("python", "/tmp/docker_logs/"))
+            , scheduler(1, 1)
+            , config([&path]() {
+                configuration::config_disk c;
+                c.path = std::filesystem::path(std::move(path));
+                return c;
+            }())
+            , manager(actor_zeta::spawn<manager_disk_t>(&resource, &scheduler, &scheduler, config, log)) {
+            std::filesystem::remove_all(config.path);
+            std::filesystem::create_directories(config.path);
+        }
+
+        ~disk_manager_fixture_t() {
+            scheduler.stop();
+            std::filesystem::remove_all(config.path);
+        }
+
+        template<typename Fn, typename... Args>
+        auto invoke(Fn fn, Args&&... args) {
+            auto [_, future] = actor_zeta::otterbrix::send(manager->address(), fn, std::forward<Args>(args)...);
+            // The merged manager processes messages on its own loop thread and
+            // delegates batched scans to disk agents enqueued on this manually
+            // pumped scheduler. A single run() races that async delegation: the
+            // agent can be enqueued only after run() has already drained an empty
+            // queue, so its work — and the response future — would never run.
+            // Pump until the manager actually resolves the future.
+            while (!future.is_ready()) {
+                scheduler.run(10000);
+                std::this_thread::sleep_for(std::chrono::microseconds(50));
+            }
+            return std::move(future).get();
+        }
+    };
 } // namespace
 
 TEST_CASE("services::disk::table_storage::in_memory") {
@@ -317,4 +448,983 @@ TEST_CASE("services::disk::table_storage::parallel_scan_via_storage_adapter") {
 
     REQUIRE(total == 4 * DEFAULT_VECTOR_CAPACITY);
     REQUIRE(chunks_seen == 4);
+}
+
+TEST_CASE("services::disk::table_storage::parallel_scan_batched_via_storage_adapter_threads") {
+    std::pmr::synchronized_pool_resource resource;
+
+    std::vector<column_definition_t> columns;
+    columns.emplace_back("value", logical_type::BIGINT);
+    table_storage_t ts(&resource, std::move(columns));
+
+    append_int64_data(ts.table(), &resource, 4 * DEFAULT_VECTOR_CAPACITY);
+    REQUIRE(ts.table().calculate_size() == 4 * DEFAULT_VECTOR_CAPACITY);
+
+    actor_zeta::scheduler::sharing_scheduler scheduler(2, 1000);
+    scheduler.start();
+    scheduler_guard_t guard{scheduler};
+    {
+        components::storage::table_storage_adapter_t adapter(ts.table(), &resource, &scheduler);
+        std::pmr::vector<data_chunk_t> batches{&resource};
+
+        adapter.scan_batched(batches, nullptr, -1, nullptr, transaction_data{0, 0});
+
+        REQUIRE(adapter.parallel_worker_count() > 0);
+        REQUIRE(batches.size() == 4);
+        require_ordered_int64_batches(batches, 4 * DEFAULT_VECTOR_CAPACITY);
+    }
+}
+
+TEST_CASE("services::disk::table_storage::parallel_scan_batched_via_storage_adapter_pumped_scheduler") {
+    std::pmr::synchronized_pool_resource resource;
+
+    std::vector<column_definition_t> columns;
+    columns.emplace_back("value", logical_type::BIGINT);
+    table_storage_t ts(&resource, std::move(columns));
+
+    append_int64_data(ts.table(), &resource, 4 * DEFAULT_VECTOR_CAPACITY);
+    REQUIRE(ts.table().calculate_size() == 4 * DEFAULT_VECTOR_CAPACITY);
+
+    core::non_thread_scheduler::scheduler_test_t scheduler(1, 1000);
+    std::function<void()> pump = [&scheduler] { scheduler.run(10000); };
+
+    components::storage::table_storage_adapter_t adapter(ts.table(), &resource, &scheduler, &pump);
+    std::pmr::vector<data_chunk_t> batches{&resource};
+
+    adapter.scan_batched(batches, nullptr, -1, nullptr, transaction_data{0, 0});
+
+    REQUIRE(adapter.parallel_worker_count() > 0);
+    REQUIRE(batches.size() == 4);
+    require_ordered_int64_batches(batches, 4 * DEFAULT_VECTOR_CAPACITY);
+    scheduler.stop();
+}
+
+TEST_CASE("services::disk::table_storage::parallel_scan_batched_filter_projected_across_row_groups") {
+    std::pmr::synchronized_pool_resource resource;
+
+    std::vector<column_definition_t> columns;
+    columns.emplace_back("name", logical_type::BIGINT);
+    columns.emplace_back("count", logical_type::BIGINT);
+    table_storage_t ts(&resource, std::move(columns));
+
+    constexpr uint64_t total_rows = DEFAULT_VECTOR_CAPACITY + 1;
+    append_two_int64_columns(ts.table(), &resource, total_rows);
+    REQUIRE(ts.table().calculate_size() == total_rows);
+
+    core::non_thread_scheduler::scheduler_test_t scheduler(1, 1000);
+    std::function<void()> pump = [&scheduler] { scheduler.run(10000); };
+
+    components::storage::table_storage_adapter_t adapter(ts.table(), &resource, &scheduler, &pump);
+    std::pmr::vector<data_chunk_t> batches{&resource};
+    std::pmr::vector<uint64_t> table_indices{&resource};
+    table_indices.push_back(1);
+    constant_filter_t filter(components::expressions::compare_type::gte,
+                             logical_value_t{&resource, static_cast<int64_t>(DEFAULT_VECTOR_CAPACITY)},
+                             std::move(table_indices));
+    const std::vector<size_t> projected_cols{0};
+
+    adapter.scan_batched(batches, &filter, -1, &projected_cols, transaction_data{0, 0});
+
+    REQUIRE(adapter.parallel_worker_count() > 0);
+    REQUIRE(batches.size() == 1);
+    REQUIRE(batches[0].size() == 1);
+    REQUIRE(batches[0].data[0].value(0).value<int64_t>() == static_cast<int64_t>(DEFAULT_VECTOR_CAPACITY));
+    scheduler.stop();
+}
+
+TEST_CASE("services::disk::table_storage::scan_batched_filter_string_bigint_single_row_group") {
+    std::pmr::synchronized_pool_resource resource;
+
+    std::vector<column_definition_t> columns;
+    columns.emplace_back("name", logical_type::STRING_LITERAL);
+    columns.emplace_back("count", logical_type::BIGINT);
+    table_storage_t ts(&resource, std::move(columns));
+
+    constexpr uint64_t total_rows = DEFAULT_VECTOR_CAPACITY - 1;
+    append_string_int64_columns(ts.table(), &resource, total_rows);
+    REQUIRE(ts.table().calculate_size() == total_rows);
+
+    components::storage::table_storage_adapter_t adapter(ts.table(), &resource);
+    std::pmr::vector<data_chunk_t> batches{&resource};
+    std::pmr::vector<uint64_t> table_indices{&resource};
+    table_indices.push_back(1);
+    constant_filter_t filter(components::expressions::compare_type::gte,
+                             logical_value_t{&resource, static_cast<int64_t>(0)},
+                             std::move(table_indices));
+
+    adapter.scan_batched(batches, &filter, -1, nullptr, transaction_data{0, 0});
+
+    REQUIRE(batches.size() == 1);
+    REQUIRE(batches[0].size() == total_rows);
+    batches[0].data[0].flatten(batches[0].size());
+    batches[0].data[1].flatten(batches[0].size());
+    for (uint64_t i = 0; i < total_rows; ++i) {
+        REQUIRE(batches[0].data[0].value(i).value<std::string_view>() == "R" + std::to_string(i));
+        REQUIRE(batches[0].data[1].value(i).value<int64_t>() == static_cast<int64_t>(i));
+    }
+}
+
+TEST_CASE("services::disk::table_storage::scan_batched_filter_string_bigint_single_row_group_committed_txn") {
+    std::pmr::synchronized_pool_resource resource;
+
+    std::vector<column_definition_t> columns;
+    columns.emplace_back("name", logical_type::STRING_LITERAL);
+    columns.emplace_back("count", logical_type::BIGINT);
+    table_storage_t ts(&resource, std::move(columns));
+
+    constexpr uint64_t total_rows = DEFAULT_VECTOR_CAPACITY - 1;
+    auto types = ts.table().copy_types();
+    data_chunk_t chunk(&resource, types, total_rows);
+    chunk.set_cardinality(total_rows);
+    for (uint64_t i = 0; i < total_rows; ++i) {
+        chunk.set_value(0, i, logical_value_t{&resource, std::string("R") + std::to_string(i)});
+        chunk.set_value(1, i, logical_value_t{&resource, static_cast<int64_t>(i)});
+    }
+
+    const auto writer_txn = transaction_data{TRANSACTION_ID_START + 1, TRANSACTION_ID_START + 1};
+    const uint64_t writer_commit_id = 1;
+    table_append_state state(&resource);
+    ts.table().append_lock(state);
+    ts.table().initialize_append(state);
+    const auto row_start = static_cast<uint64_t>(state.current_row);
+    ts.table().append(chunk, state);
+    ts.table().finalize_append(state, writer_txn);
+    ts.table().commit_append(writer_commit_id, static_cast<int64_t>(row_start), total_rows);
+
+    components::storage::table_storage_adapter_t adapter(ts.table(), &resource);
+    std::pmr::vector<data_chunk_t> batches{&resource};
+    std::pmr::vector<uint64_t> table_indices{&resource};
+    table_indices.push_back(1);
+    constant_filter_t filter(components::expressions::compare_type::gte,
+                             logical_value_t{&resource, static_cast<int64_t>(0)},
+                             std::move(table_indices));
+    const auto reader_txn = transaction_data{TRANSACTION_ID_START + 2, TRANSACTION_ID_START + 2};
+
+    adapter.scan_batched(batches, &filter, -1, nullptr, reader_txn);
+
+    REQUIRE(batches.size() == 1);
+    REQUIRE(batches[0].size() == total_rows);
+    batches[0].data[0].flatten(batches[0].size());
+    batches[0].data[1].flatten(batches[0].size());
+    for (uint64_t i = 0; i < total_rows; ++i) {
+        REQUIRE(batches[0].data[0].value(i).value<std::string_view>() == "R" + std::to_string(i));
+        REQUIRE(batches[0].data[1].value(i).value<int64_t>() == static_cast<int64_t>(i));
+    }
+}
+
+TEST_CASE("services::disk::table_storage::scan_batched_filter_string_bigint_multi_row_group_committed_txn") {
+    std::pmr::synchronized_pool_resource resource;
+
+    std::vector<column_definition_t> columns;
+    columns.emplace_back("name", logical_type::STRING_LITERAL);
+    columns.emplace_back("count", logical_type::BIGINT);
+    table_storage_t ts(&resource, std::move(columns));
+
+    constexpr uint64_t total_rows = DEFAULT_VECTOR_CAPACITY + 476;
+    auto types = ts.table().copy_types();
+    uint64_t offset = 0;
+    const auto writer_txn = transaction_data{TRANSACTION_ID_START + 11, TRANSACTION_ID_START + 11};
+    const uint64_t writer_commit_id = 11;
+    while (offset < total_rows) {
+        const uint64_t batch = std::min<uint64_t>(DEFAULT_VECTOR_CAPACITY, total_rows - offset);
+        data_chunk_t chunk(&resource, types, batch);
+        chunk.set_cardinality(batch);
+        for (uint64_t i = 0; i < batch; ++i) {
+            const auto row = offset + i;
+            chunk.set_value(0, i, logical_value_t{&resource, std::string("R") + std::to_string(row)});
+            chunk.set_value(1, i, logical_value_t{&resource, static_cast<int64_t>(row)});
+        }
+
+        table_append_state state(&resource);
+        ts.table().append_lock(state);
+        ts.table().initialize_append(state);
+        const auto row_start = static_cast<uint64_t>(state.current_row);
+        ts.table().append(chunk, state);
+        ts.table().finalize_append(state, writer_txn);
+        ts.table().commit_append(writer_commit_id, static_cast<int64_t>(row_start), batch);
+        offset += batch;
+    }
+
+    components::storage::table_storage_adapter_t adapter(ts.table(), &resource);
+    std::pmr::vector<data_chunk_t> batches{&resource};
+    std::pmr::vector<uint64_t> table_indices{&resource};
+    table_indices.push_back(1);
+    constant_filter_t filter(components::expressions::compare_type::gte,
+                             logical_value_t{&resource, static_cast<int64_t>(0)},
+                             std::move(table_indices));
+    const auto reader_txn = transaction_data{TRANSACTION_ID_START + 12, TRANSACTION_ID_START + 12};
+
+    adapter.scan_batched(batches, &filter, -1, nullptr, reader_txn);
+
+    REQUIRE(batches.size() == 2);
+    uint64_t seen = 0;
+    for (auto& batch : batches) {
+        batch.data[0].flatten(batch.size());
+        batch.data[1].flatten(batch.size());
+        for (uint64_t i = 0; i < batch.size(); ++i) {
+            REQUIRE(batch.data[0].value(i).value<std::string_view>() == "R" + std::to_string(seen));
+            REQUIRE(batch.data[1].value(i).value<int64_t>() == static_cast<int64_t>(seen));
+            ++seen;
+        }
+    }
+    REQUIRE(seen == total_rows);
+}
+
+TEST_CASE("services::disk::table_storage::scan_batched_filter_string_bigint_boundary_cutoff") {
+    const auto total_rows = GENERATE(1023u, 1024u, 1025u, 1500u);
+    std::pmr::synchronized_pool_resource resource;
+
+    std::vector<column_definition_t> columns;
+    columns.emplace_back("name", logical_type::STRING_LITERAL);
+    columns.emplace_back("count", logical_type::BIGINT);
+    table_storage_t ts(&resource, std::move(columns));
+
+    append_string_int64_columns(ts.table(), &resource, total_rows);
+    REQUIRE(ts.table().calculate_size() == total_rows);
+
+    components::storage::table_storage_adapter_t adapter(ts.table(), &resource);
+    std::pmr::vector<data_chunk_t> batches{&resource};
+    std::pmr::vector<uint64_t> table_indices{&resource};
+    table_indices.push_back(1);
+    constant_filter_t filter(components::expressions::compare_type::gte,
+                             logical_value_t{&resource, int64_t{1000}},
+                             std::move(table_indices));
+
+    adapter.scan_batched(batches, &filter, -1, nullptr, transaction_data{0, 0});
+
+    uint64_t seen = 0;
+    for (auto& batch : batches) {
+        batch.data[0].flatten(batch.size());
+        batch.data[1].flatten(batch.size());
+        for (uint64_t i = 0; i < batch.size(); ++i) {
+            const auto expected = 1000u + seen;
+            REQUIRE(batch.data[0].value(i).value<std::string_view>() == "R" + std::to_string(expected));
+            REQUIRE(batch.data[1].value(i).value<int64_t>() == static_cast<int64_t>(expected));
+            ++seen;
+        }
+    }
+    REQUIRE(seen == (total_rows > 1000 ? total_rows - 1000 : 0));
+}
+
+TEST_CASE("services::disk::table_storage::manager_disk_actor_scan_batched_filter_string_bigint") {
+    auto path = test_dir() + "_manager_actor_" + std::to_string(::getpid());
+    disk_manager_fixture_t fixture(path);
+
+    constexpr auto database_oid = components::catalog::oid_t{1};
+    constexpr auto table_oid = components::catalog::oid_t{777};
+    std::vector<column_definition_t> columns;
+    columns.emplace_back("name", logical_type::STRING_LITERAL);
+    columns.emplace_back("count", logical_type::BIGINT);
+    fixture.manager->create_storage_with_columns_sync(table_oid, database_oid, std::move(columns));
+
+    std::pmr::vector<complex_logical_type> types{&fixture.resource};
+    types.emplace_back(logical_type::STRING_LITERAL);
+    types.emplace_back(logical_type::BIGINT);
+    data_chunk_t chunk(&fixture.resource, types, DEFAULT_VECTOR_CAPACITY);
+    chunk.set_cardinality(DEFAULT_VECTOR_CAPACITY);
+    for (uint64_t i = 0; i < DEFAULT_VECTOR_CAPACITY; ++i) {
+        chunk.set_value(0, i, logical_value_t{&fixture.resource, std::string("R") + std::to_string(i)});
+        chunk.set_value(1, i, logical_value_t{&fixture.resource, static_cast<int64_t>(i)});
+    }
+    fixture.manager->direct_append_sync(table_oid, chunk, core::date::timezone_offset_t{0});
+
+    std::pmr::vector<uint64_t> table_indices{&fixture.resource};
+    table_indices.push_back(1);
+    auto filter = std::make_unique<constant_filter_t>(components::expressions::compare_type::gte,
+                                                      logical_value_t{&fixture.resource, int64_t{0}},
+                                                      std::move(table_indices));
+    auto batches = fixture.invoke(&manager_disk_t::storage_scan_batched,
+                                  session_id_t{},
+                                  table_oid,
+                                  std::move(filter),
+                                  int64_t{-1},
+                                  std::vector<size_t>{},
+                                  false,
+                                  transaction_data{0, 0});
+
+    REQUIRE(batches != nullptr);
+    REQUIRE(batches->size() == 1);
+    REQUIRE((*batches)[0].size() == DEFAULT_VECTOR_CAPACITY);
+    (*batches)[0].data[0].flatten((*batches)[0].size());
+    (*batches)[0].data[1].flatten((*batches)[0].size());
+    for (uint64_t i = 0; i < DEFAULT_VECTOR_CAPACITY; ++i) {
+        REQUIRE((*batches)[0].data[0].value(i).value<std::string_view>() == "R" + std::to_string(i));
+        REQUIRE((*batches)[0].data[1].value(i).value<int64_t>() == static_cast<int64_t>(i));
+    }
+}
+
+TEST_CASE("services::disk::table_storage::manager_disk_actor_scan_batched_filter_string_bigint_cutoff_1023") {
+    auto path = test_dir() + "_manager_actor_cutoff_" + std::to_string(::getpid());
+    disk_manager_fixture_t fixture(path);
+
+    constexpr auto database_oid = components::catalog::oid_t{1};
+    constexpr auto table_oid = components::catalog::oid_t{778};
+    std::vector<column_definition_t> columns;
+    columns.emplace_back("name", logical_type::STRING_LITERAL);
+    columns.emplace_back("count", logical_type::BIGINT);
+    fixture.manager->create_storage_with_columns_sync(table_oid, database_oid, std::move(columns));
+
+    std::pmr::vector<complex_logical_type> types{&fixture.resource};
+    types.emplace_back(logical_type::STRING_LITERAL);
+    types.emplace_back(logical_type::BIGINT);
+    data_chunk_t chunk(&fixture.resource, types, 1023);
+    chunk.set_cardinality(1023);
+    for (uint64_t i = 0; i < 1023; ++i) {
+        chunk.set_value(0, i, logical_value_t{&fixture.resource, std::string("R") + std::to_string(i)});
+        chunk.set_value(1, i, logical_value_t{&fixture.resource, static_cast<int64_t>(i)});
+    }
+    fixture.manager->direct_append_sync(table_oid, chunk, core::date::timezone_offset_t{0});
+
+    std::pmr::vector<uint64_t> table_indices{std::pmr::new_delete_resource()};
+    table_indices.push_back(1);
+    auto filter = std::make_unique<constant_filter_t>(components::expressions::compare_type::gte,
+                                                      logical_value_t{std::pmr::new_delete_resource(), int64_t{1000}},
+                                                      std::move(table_indices));
+    auto batches = fixture.invoke(&manager_disk_t::storage_scan_batched,
+                                  session_id_t{},
+                                  table_oid,
+                                  std::move(filter),
+                                  int64_t{-1},
+                                  std::vector<size_t>{},
+                                  false,
+                                  transaction_data{0, 0});
+
+    REQUIRE(batches != nullptr);
+    REQUIRE(batches->size() == 1);
+    REQUIRE((*batches)[0].size() == 23);
+    (*batches)[0].data[0].flatten((*batches)[0].size());
+    (*batches)[0].data[1].flatten((*batches)[0].size());
+    for (uint64_t i = 0; i < 23; ++i) {
+        const auto expected = 1000u + i;
+        REQUIRE((*batches)[0].data[0].value(i).value<std::string_view>() == "R" + std::to_string(expected));
+        REQUIRE((*batches)[0].data[1].value(i).value<int64_t>() == static_cast<int64_t>(expected));
+    }
+}
+
+TEST_CASE("services::disk::table_storage::scan_batched_filter_string_bigint_cutoff_1023") {
+    std::pmr::synchronized_pool_resource resource;
+
+    std::vector<column_definition_t> columns;
+    columns.emplace_back("name", logical_type::STRING_LITERAL);
+    columns.emplace_back("count", logical_type::BIGINT);
+    table_storage_t ts(&resource, std::move(columns));
+
+    constexpr uint64_t total_rows = 1023;
+    append_string_int64_columns(ts.table(), &resource, total_rows);
+
+    components::storage::table_storage_adapter_t adapter(ts.table(), &resource);
+    std::pmr::vector<data_chunk_t> batches{&resource};
+    std::pmr::vector<uint64_t> table_indices{&resource};
+    table_indices.push_back(1);
+    constant_filter_t filter(components::expressions::compare_type::gte,
+                             logical_value_t{&resource, int64_t{1000}},
+                             std::move(table_indices));
+
+    adapter.scan_batched(batches, &filter, -1, nullptr, transaction_data{0, 0});
+
+    REQUIRE(batches.size() == 1);
+    REQUIRE(batches[0].size() == 23);
+    batches[0].data[0].flatten(batches[0].size());
+    batches[0].data[1].flatten(batches[0].size());
+    for (uint64_t i = 0; i < 23; ++i) {
+        const auto expected = 1000u + i;
+        REQUIRE(batches[0].data[0].value(i).value<std::string_view>() == "R" + std::to_string(expected));
+        REQUIRE(batches[0].data[1].value(i).value<int64_t>() == static_cast<int64_t>(expected));
+    }
+}
+
+TEST_CASE("services::disk::table_storage::cursor_from_multi_batch_string_scan") {
+    std::pmr::synchronized_pool_resource resource;
+
+    std::vector<column_definition_t> columns;
+    columns.emplace_back("name", logical_type::STRING_LITERAL);
+    columns.emplace_back("count", logical_type::BIGINT);
+    table_storage_t ts(&resource, std::move(columns));
+
+    constexpr uint64_t total_rows = DEFAULT_VECTOR_CAPACITY + 1;
+    append_string_int64_columns(ts.table(), &resource, total_rows);
+
+    components::storage::table_storage_adapter_t adapter(ts.table(), &resource);
+    std::pmr::vector<data_chunk_t> batches{&resource};
+    std::pmr::vector<uint64_t> table_indices{&resource};
+    table_indices.push_back(1);
+    constant_filter_t filter(components::expressions::compare_type::gte,
+                             logical_value_t{&resource, int64_t{0}},
+                             std::move(table_indices));
+
+    adapter.scan_batched(batches, &filter, -1, nullptr, transaction_data{0, 0});
+    REQUIRE(batches.size() == 2);
+
+    auto cursor = components::cursor::make_cursor(&resource, std::move(batches));
+    REQUIRE(cursor->is_success());
+    REQUIRE(cursor->size() == total_rows);
+
+    auto& chunk = cursor->chunk_data();
+    REQUIRE(chunk.size() == total_rows);
+    chunk.data[0].flatten(chunk.size());
+    chunk.data[1].flatten(chunk.size());
+    for (uint64_t i = 0; i < total_rows; ++i) {
+        REQUIRE(chunk.data[0].value(i).value<std::string_view>() == "R" + std::to_string(i));
+        REQUIRE(chunk.data[1].value(i).value<int64_t>() == static_cast<int64_t>(i));
+    }
+}
+
+TEST_CASE("services::disk::table_storage::sequential_filter_scans_survive_cursor_projection_combine") {
+    std::pmr::synchronized_pool_resource resource;
+
+    std::vector<column_definition_t> columns;
+    columns.emplace_back("name", logical_type::STRING_LITERAL);
+    columns.emplace_back("count", logical_type::BIGINT);
+    table_storage_t ts(&resource, std::move(columns));
+
+    constexpr uint64_t total_rows = DEFAULT_VECTOR_CAPACITY + 1;
+    append_string_int64_columns(ts.table(), &resource, total_rows);
+
+    components::storage::table_storage_adapter_t adapter(ts.table(), &resource);
+
+    {
+        std::pmr::vector<data_chunk_t> first_batches{&resource};
+        std::pmr::vector<uint64_t> first_indices{&resource};
+        first_indices.push_back(1);
+        constant_filter_t first_filter(components::expressions::compare_type::gte,
+                                       logical_value_t{&resource, int64_t{0}},
+                                       std::move(first_indices));
+
+        adapter.scan_batched(first_batches, &first_filter, -1, nullptr, transaction_data{0, 0});
+        REQUIRE(first_batches.size() == 2);
+
+        std::pmr::vector<data_chunk_t> projected_batches{&resource};
+        projected_batches.reserve(first_batches.size());
+        for (auto& batch : first_batches) {
+            std::pmr::vector<complex_logical_type> projected_types{&resource};
+            projected_types.emplace_back(logical_type::BIGINT);
+            data_chunk_t projected(&resource, projected_types, batch.size());
+            projected.set_cardinality(batch.size());
+            for (uint64_t row = 0; row < batch.size(); ++row) {
+                projected.set_value(0, row, batch.data[1].value(row));
+            }
+            projected_batches.push_back(std::move(projected));
+        }
+
+        auto cursor = components::cursor::make_cursor(&resource, std::move(projected_batches));
+        REQUIRE(cursor->is_success());
+        REQUIRE(cursor->size() == total_rows);
+        auto& projected_chunk = cursor->chunk_data();
+        REQUIRE(projected_chunk.size() == total_rows);
+        projected_chunk.data[0].flatten(projected_chunk.size());
+        for (uint64_t i = 0; i < total_rows; ++i) {
+            REQUIRE(projected_chunk.data[0].value(i).value<int64_t>() == static_cast<int64_t>(i));
+        }
+    }
+
+    std::pmr::vector<data_chunk_t> second_batches{&resource};
+    std::pmr::vector<uint64_t> second_indices{&resource};
+    second_indices.push_back(1);
+    constant_filter_t second_filter(components::expressions::compare_type::gte,
+                                    logical_value_t{&resource, int64_t{1000}},
+                                    std::move(second_indices));
+
+    adapter.scan_batched(second_batches, &second_filter, -1, nullptr, transaction_data{0, 0});
+
+    REQUIRE(second_batches.size() == 2);
+    uint64_t seen = 1000;
+    for (auto& batch : second_batches) {
+        batch.data[0].flatten(batch.size());
+        batch.data[1].flatten(batch.size());
+        for (uint64_t i = 0; i < batch.size(); ++i) {
+            REQUIRE(batch.data[0].value(i).value<std::string_view>() == "R" + std::to_string(seen));
+            REQUIRE(batch.data[1].value(i).value<int64_t>() == static_cast<int64_t>(seen));
+            ++seen;
+        }
+    }
+    REQUIRE(seen == total_rows);
+}
+
+TEST_CASE("services::disk::table_storage::cursor_from_split_large_output_batches") {
+    std::pmr::synchronized_pool_resource resource;
+
+    std::pmr::vector<complex_logical_type> types{&resource};
+    types.emplace_back(logical_type::BIGINT);
+    types.emplace_back(logical_type::BIGINT);
+
+    constexpr uint64_t total_rows = DEFAULT_VECTOR_CAPACITY + 1;
+    data_chunk_t chunk(&resource, types, total_rows);
+    chunk.set_cardinality(total_rows);
+    for (uint64_t i = 0; i < total_rows; ++i) {
+        chunk.set_value(0, i, logical_value_t{&resource, static_cast<int64_t>(i)});
+        chunk.set_value(1, i, logical_value_t{&resource, static_cast<int64_t>(i * 2)});
+    }
+
+    auto first_batch = chunk.partial_copy(&resource, 0, DEFAULT_VECTOR_CAPACITY);
+    REQUIRE(first_batch.size() == DEFAULT_VECTOR_CAPACITY);
+
+    auto second_batch = chunk.partial_copy(&resource, DEFAULT_VECTOR_CAPACITY, 1);
+    REQUIRE(second_batch.size() == 1);
+
+    components::operators::chunks_vector_t batches{&resource};
+    batches.push_back(std::move(first_batch));
+    batches.push_back(std::move(second_batch));
+
+    auto cursor = components::cursor::make_cursor(&resource, std::move(batches));
+    REQUIRE(cursor->is_success());
+    REQUIRE(cursor->size() == total_rows);
+
+    auto& combined = cursor->chunk_data();
+    REQUIRE(combined.size() == total_rows);
+    combined.data[0].flatten(combined.size());
+    combined.data[1].flatten(combined.size());
+    for (uint64_t i = 0; i < total_rows; ++i) {
+        REQUIRE(combined.data[0].value(i).value<int64_t>() == static_cast<int64_t>(i));
+        REQUIRE(combined.data[1].value(i).value<int64_t>() == static_cast<int64_t>(i * 2));
+    }
+}
+
+TEST_CASE("services::disk::table_storage::parallel_scan_batched_projected_via_storage_adapter_pumped_scheduler") {
+    std::pmr::synchronized_pool_resource resource;
+
+    std::vector<column_definition_t> columns;
+    columns.emplace_back("id", logical_type::BIGINT);
+    columns.emplace_back("value", logical_type::BIGINT);
+    table_storage_t ts(&resource, std::move(columns));
+
+    append_two_int64_columns(ts.table(), &resource, 4 * DEFAULT_VECTOR_CAPACITY);
+    REQUIRE(ts.table().calculate_size() == 4 * DEFAULT_VECTOR_CAPACITY);
+
+    core::non_thread_scheduler::scheduler_test_t scheduler(1, 1000);
+    std::function<void()> pump = [&scheduler] { scheduler.run(10000); };
+
+    components::storage::table_storage_adapter_t adapter(ts.table(), &resource, &scheduler, &pump);
+    std::pmr::vector<data_chunk_t> batches{&resource};
+    const std::vector<size_t> projected_cols{1};
+
+    adapter.scan_batched(batches, nullptr, -1, &projected_cols, transaction_data{0, 0});
+
+    REQUIRE(adapter.parallel_worker_count() > 0);
+    REQUIRE(batches.size() == 4);
+    require_ordered_int64_batches_in_column(batches, 1, 0, 4 * DEFAULT_VECTOR_CAPACITY);
+    scheduler.stop();
+}
+
+TEST_CASE("services::disk::table_storage::parallel_scan_batched_with_committed_deletes_uses_threads") {
+    std::pmr::synchronized_pool_resource resource;
+
+    std::vector<column_definition_t> columns;
+    columns.emplace_back("value", logical_type::BIGINT);
+    table_storage_t ts(&resource, std::move(columns));
+
+    constexpr uint64_t total_rows = DEFAULT_VECTOR_CAPACITY + 1;
+    append_int64_data(ts.table(), &resource, total_rows);
+    REQUIRE(ts.table().calculate_size() == total_rows);
+
+    std::pmr::vector<complex_logical_type> row_id_types(&resource);
+    row_id_types.emplace_back(logical_type::BIGINT);
+    data_chunk_t row_ids_chunk(&resource, row_id_types, 1);
+    row_ids_chunk.data[0].set_value(0, logical_value_t{&resource, static_cast<int64_t>(DEFAULT_VECTOR_CAPACITY)});
+    row_ids_chunk.set_cardinality(1);
+
+    components::storage::table_storage_adapter_t mutating_adapter(ts.table(), &resource);
+    const auto deleted = mutating_adapter.delete_rows(row_ids_chunk.data[0], 1, TRANSACTION_ID_START);
+    REQUIRE(deleted == 1);
+    mutating_adapter.commit_all_deletes(TRANSACTION_ID_START, 1);
+
+    actor_zeta::scheduler::sharing_scheduler scheduler(2, 1000);
+    scheduler.start();
+    scheduler_guard_t guard{scheduler};
+    {
+        components::storage::table_storage_adapter_t adapter(ts.table(), &resource, &scheduler);
+        std::pmr::vector<data_chunk_t> batches{&resource};
+
+        adapter.scan_batched(batches, nullptr, -1, nullptr, transaction_data{0, 0});
+
+        REQUIRE(adapter.parallel_worker_count() > 0);
+        REQUIRE(batches.size() == 1);
+        REQUIRE(batches[0].size() == DEFAULT_VECTOR_CAPACITY);
+        require_ordered_int64_batches(batches, DEFAULT_VECTOR_CAPACITY);
+    }
+}
+
+TEST_CASE("services::disk::table_storage::parallel_scan_batched_disk_load_uses_threads") {
+    cleanup_test_dir();
+    std::filesystem::create_directories(test_dir());
+    std::pmr::synchronized_pool_resource resource;
+
+    auto otbx_path = std::filesystem::path(test_dir()) / "parallel_disk_scan.otbx";
+    constexpr uint64_t total_rows = 2 * DEFAULT_VECTOR_CAPACITY;
+
+    {
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("value", logical_type::BIGINT);
+        table_storage_t ts(&resource, std::move(columns), otbx_path);
+        append_int64_data(ts.table(), &resource, total_rows);
+        ts.checkpoint();
+    }
+
+    {
+        table_storage_t ts(&resource, otbx_path);
+        actor_zeta::scheduler::sharing_scheduler scheduler(2, 1000);
+        scheduler.start();
+        scheduler_guard_t guard{scheduler};
+        {
+            components::storage::table_storage_adapter_t adapter(ts.table(), &resource, &scheduler);
+            std::pmr::vector<data_chunk_t> batches{&resource};
+
+            adapter.scan_batched(batches, nullptr, -1, nullptr, transaction_data{0, 0});
+
+            REQUIRE(adapter.parallel_worker_count() > 0);
+            REQUIRE(batches.size() == 2);
+            require_ordered_int64_batches(batches, total_rows);
+        }
+    }
+
+    cleanup_test_dir();
+}
+
+TEST_CASE("services::disk::table_storage::parallel_scan_batched_row_ids_only_keeps_empty_projection") {
+    cleanup_test_dir();
+    std::filesystem::create_directories(test_dir());
+    std::pmr::synchronized_pool_resource resource;
+
+    auto otbx_path = std::filesystem::path(test_dir()) / "parallel_row_ids_only_scan.otbx";
+    constexpr uint64_t total_rows = 2 * DEFAULT_VECTOR_CAPACITY;
+
+    {
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("value", logical_type::BIGINT);
+        columns.emplace_back("payload", logical_type::BIGINT);
+        table_storage_t ts(&resource, std::move(columns), otbx_path);
+        append_two_int64_columns(ts.table(), &resource, total_rows);
+        ts.checkpoint();
+    }
+
+    {
+        table_storage_t ts(&resource, otbx_path);
+        actor_zeta::scheduler::sharing_scheduler scheduler(2, 1000);
+        scheduler.start();
+        scheduler_guard_t guard{scheduler};
+        {
+            components::storage::table_storage_adapter_t adapter(ts.table(), &resource, &scheduler);
+            std::pmr::vector<data_chunk_t> batches{&resource};
+            std::vector<size_t> row_ids_only_projection;
+
+            adapter.scan_batched(batches, nullptr, -1, &row_ids_only_projection, transaction_data{0, 0});
+
+            REQUIRE(adapter.parallel_worker_count() > 0);
+            REQUIRE(batches.size() == 2);
+
+            uint64_t seen = 0;
+            for (const auto& batch : batches) {
+                REQUIRE(batch.column_count() == 2);
+                for (const auto& column : batch.data) {
+                    REQUIRE(column.data() == nullptr);
+                    REQUIRE(column.auxiliary() == nullptr);
+                }
+                const auto* row_ids = batch.row_ids.data<int64_t>();
+                for (uint64_t i = 0; i < batch.size(); ++i) {
+                    REQUIRE(row_ids[i] == static_cast<int64_t>(seen));
+                    ++seen;
+                }
+            }
+            REQUIRE(seen == total_rows);
+        }
+    }
+
+    cleanup_test_dir();
+}
+
+TEST_CASE("services::disk::table_storage::parallel_scan_batched_disk_load_with_committed_deletes_uses_threads") {
+    cleanup_test_dir();
+    std::filesystem::create_directories(test_dir());
+    std::pmr::synchronized_pool_resource resource;
+
+    auto otbx_path = std::filesystem::path(test_dir()) / "parallel_disk_scan_delete.otbx";
+    constexpr uint64_t total_rows = DEFAULT_VECTOR_CAPACITY + 1;
+
+    {
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("value", logical_type::BIGINT);
+        table_storage_t ts(&resource, std::move(columns), otbx_path);
+        append_int64_data(ts.table(), &resource, total_rows);
+        ts.checkpoint();
+    }
+
+    {
+        table_storage_t ts(&resource, otbx_path);
+
+        std::pmr::vector<complex_logical_type> row_id_types(&resource);
+        row_id_types.emplace_back(logical_type::BIGINT);
+        data_chunk_t row_ids_chunk(&resource, row_id_types, 1);
+        row_ids_chunk.data[0].set_value(0, logical_value_t{&resource, static_cast<int64_t>(DEFAULT_VECTOR_CAPACITY)});
+        row_ids_chunk.set_cardinality(1);
+
+        components::storage::table_storage_adapter_t mutating_adapter(ts.table(), &resource);
+        const auto deleted = mutating_adapter.delete_rows(row_ids_chunk.data[0], 1, TRANSACTION_ID_START);
+        REQUIRE(deleted == 1);
+        mutating_adapter.commit_all_deletes(TRANSACTION_ID_START, 1);
+
+#if defined(DEV_MODE)
+        auto* first_row_group = ts.table().row_group()->row_group_tree()->root_segment();
+        REQUIRE(first_row_group != nullptr);
+        first_row_group->debug_reset_scan_path_counts_for_test();
+#endif
+
+        actor_zeta::scheduler::sharing_scheduler scheduler(2, 1000);
+        scheduler.start();
+        scheduler_guard_t guard{scheduler};
+        {
+            components::storage::table_storage_adapter_t adapter(ts.table(), &resource, &scheduler);
+            std::pmr::vector<data_chunk_t> batches{&resource};
+
+            adapter.scan_batched(batches, nullptr, -1, nullptr, transaction_data{0, 0});
+
+            REQUIRE(adapter.parallel_worker_count() > 0);
+            uint64_t seen = 0;
+            for (auto& batch : batches) {
+                batch.data[0].flatten(batch.size());
+                for (uint64_t i = 0; i < batch.size(); ++i) {
+                    REQUIRE(batch.data[0].value(i).value<int64_t>() == static_cast<int64_t>(seen));
+                    ++seen;
+                }
+            }
+            REQUIRE(seen == DEFAULT_VECTOR_CAPACITY);
+        }
+
+#if defined(DEV_MODE)
+        const auto counts = first_row_group->debug_scan_path_counts_for_test();
+        REQUIRE(counts.pax_fixed_projected > 0);
+        REQUIRE(counts.regular == 0);
+#endif
+    }
+
+    cleanup_test_dir();
+}
+
+TEST_CASE("services::disk::table_storage::parallel_scan_batched_disk_load_with_reader_txn_falls_back") {
+    cleanup_test_dir();
+    std::filesystem::create_directories(test_dir());
+    std::pmr::synchronized_pool_resource resource;
+
+    auto otbx_path = std::filesystem::path(test_dir()) / "parallel_disk_scan_reader_txn.otbx";
+    constexpr uint64_t total_rows = 2 * DEFAULT_VECTOR_CAPACITY;
+
+    {
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("value", logical_type::BIGINT);
+        table_storage_t ts(&resource, std::move(columns), otbx_path);
+        append_int64_data(ts.table(), &resource, total_rows);
+        ts.checkpoint();
+    }
+
+    {
+        table_storage_t ts(&resource, otbx_path);
+        actor_zeta::scheduler::sharing_scheduler scheduler(2, 1000);
+        scheduler.start();
+        scheduler_guard_t guard{scheduler};
+        {
+            components::storage::table_storage_adapter_t adapter(ts.table(), &resource, &scheduler);
+            std::pmr::vector<data_chunk_t> batches{&resource};
+
+            adapter.scan_batched(
+                batches,
+                nullptr,
+                -1,
+                nullptr,
+                transaction_data{TRANSACTION_ID_START + 1, TRANSACTION_ID_START + 1});
+
+            REQUIRE(adapter.parallel_worker_count() == 0);
+            require_ordered_int64_batches(batches, total_rows);
+        }
+    }
+
+    cleanup_test_dir();
+}
+
+TEST_CASE("services::disk::table_storage::parallel_scan_batched_disk_load_with_committed_update_overlay_uses_threads") {
+    cleanup_test_dir();
+    std::filesystem::create_directories(test_dir());
+    std::pmr::synchronized_pool_resource resource;
+
+    auto otbx_path = std::filesystem::path(test_dir()) / "parallel_disk_scan_update.otbx";
+    constexpr uint64_t total_rows = DEFAULT_VECTOR_CAPACITY + 1;
+
+    {
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("value", logical_type::BIGINT);
+        table_storage_t ts(&resource, std::move(columns), otbx_path);
+        append_int64_data(ts.table(), &resource, total_rows);
+        ts.checkpoint();
+    }
+
+    {
+        table_storage_t ts(&resource, otbx_path);
+
+        std::pmr::vector<complex_logical_type> row_id_types(&resource);
+        row_id_types.emplace_back(logical_type::BIGINT);
+        data_chunk_t row_ids_chunk(&resource, row_id_types, 1);
+        row_ids_chunk.data[0].set_value(0, logical_value_t{&resource, int64_t{0}});
+        row_ids_chunk.set_cardinality(1);
+
+        auto update_types = ts.table().copy_types();
+        data_chunk_t update_chunk(&resource, update_types, 1);
+        update_chunk.data[0].set_value(0, logical_value_t{&resource, int64_t{9999}});
+        update_chunk.set_cardinality(1);
+
+        components::storage::table_storage_adapter_t mutating_adapter(ts.table(), &resource);
+        mutating_adapter.update(row_ids_chunk.data[0], update_chunk);
+
+#if defined(DEV_MODE)
+        auto* first_row_group = ts.table().row_group()->row_group_tree()->root_segment();
+        REQUIRE(first_row_group != nullptr);
+        first_row_group->debug_reset_scan_path_counts_for_test();
+#endif
+
+        actor_zeta::scheduler::sharing_scheduler scheduler(2, 1000);
+        scheduler.start();
+        scheduler_guard_t guard{scheduler};
+        {
+            components::storage::table_storage_adapter_t adapter(ts.table(), &resource, &scheduler);
+            std::pmr::vector<data_chunk_t> batches{&resource};
+
+            adapter.scan_batched(batches, nullptr, -1, nullptr, transaction_data{0, 0});
+
+            REQUIRE(adapter.parallel_worker_count() > 0);
+            REQUIRE_FALSE(batches.empty());
+            uint64_t seen = 0;
+            for (auto& batch : batches) {
+                batch.data[0].flatten(batch.size());
+                for (uint64_t i = 0; i < batch.size(); ++i) {
+                    if (seen == 0) {
+                        REQUIRE(batch.data[0].value(i).value<int64_t>() == 9999);
+                    } else {
+                        REQUIRE(batch.data[0].value(i).value<int64_t>() == static_cast<int64_t>(seen));
+                    }
+                    ++seen;
+                }
+            }
+            REQUIRE(seen == total_rows);
+        }
+
+#if defined(DEV_MODE)
+        const auto counts = first_row_group->debug_scan_path_counts_for_test();
+        REQUIRE(counts.pax_fixed_projected > 0);
+        REQUIRE(counts.regular == 0);
+#endif
+    }
+
+    cleanup_test_dir();
+}
+
+TEST_CASE("services::disk::table_storage::parallel_scan_batched_disk_load_with_uncommitted_versions_falls_back") {
+    cleanup_test_dir();
+    std::filesystem::create_directories(test_dir());
+    std::pmr::synchronized_pool_resource resource;
+
+    auto otbx_path = std::filesystem::path(test_dir()) / "parallel_disk_scan_uncommitted_append.otbx";
+    constexpr uint64_t total_rows = 2 * DEFAULT_VECTOR_CAPACITY;
+
+    {
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("value", logical_type::BIGINT);
+        table_storage_t ts(&resource, std::move(columns), otbx_path);
+        append_int64_data(ts.table(), &resource, total_rows);
+        ts.checkpoint();
+    }
+
+    {
+        table_storage_t ts(&resource, otbx_path);
+
+        auto types = ts.table().copy_types();
+        data_chunk_t append_chunk(&resource, types, 1);
+        append_chunk.data[0].set_value(0, logical_value_t{&resource, int64_t{9999}});
+        append_chunk.set_cardinality(1);
+
+        components::storage::table_storage_adapter_t mutating_adapter(ts.table(), &resource);
+        const auto txn = transaction_data{TRANSACTION_ID_START + 21, TRANSACTION_ID_START + 21};
+        mutating_adapter.append(append_chunk, txn);
+
+        actor_zeta::scheduler::sharing_scheduler scheduler(2, 1000);
+        scheduler.start();
+        scheduler_guard_t guard{scheduler};
+        {
+            components::storage::table_storage_adapter_t adapter(ts.table(), &resource, &scheduler);
+            std::pmr::vector<data_chunk_t> batches{&resource};
+
+            adapter.scan_batched(batches, nullptr, -1, nullptr, transaction_data{0, 0});
+
+            REQUIRE(adapter.parallel_worker_count() == 0);
+            REQUIRE(batches.size() == 3);
+            uint64_t seen = 0;
+            for (size_t batch_index = 0; batch_index + 1 < batches.size(); ++batch_index) {
+                auto& batch = batches[batch_index];
+                batch.data[0].flatten(batch.size());
+                for (uint64_t i = 0; i < batch.size(); ++i) {
+                    REQUIRE(batch.data[0].value(i).value<int64_t>() == static_cast<int64_t>(seen));
+                    ++seen;
+                }
+            }
+            REQUIRE(seen == total_rows);
+            auto& tail = batches.back();
+            tail.data[0].flatten(tail.size());
+            REQUIRE(tail.size() == 1);
+            REQUIRE(tail.data[0].value(0).value<int64_t>() == 9999);
+        }
+    }
+
+    cleanup_test_dir();
+}
+
+TEST_CASE("services::disk::table_storage::parallel_scan_batched_disk_load_with_unloaded_deletes_uses_threads") {
+    cleanup_test_dir();
+    std::filesystem::create_directories(test_dir());
+    std::pmr::synchronized_pool_resource resource;
+
+    auto otbx_path = std::filesystem::path(test_dir()) / "parallel_disk_scan_unloaded_deletes.otbx";
+    constexpr uint64_t total_rows = DEFAULT_VECTOR_CAPACITY + 1;
+
+    {
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("value", logical_type::BIGINT);
+        table_storage_t ts(&resource, std::move(columns), otbx_path);
+        append_int64_data(ts.table(), &resource, total_rows);
+
+        std::pmr::vector<complex_logical_type> row_id_types(&resource);
+        row_id_types.emplace_back(logical_type::BIGINT);
+        data_chunk_t row_ids_chunk(&resource, row_id_types, 1);
+        row_ids_chunk.data[0].set_value(0, logical_value_t{&resource, static_cast<int64_t>(DEFAULT_VECTOR_CAPACITY)});
+        row_ids_chunk.set_cardinality(1);
+
+        components::storage::table_storage_adapter_t mutating_adapter(ts.table(), &resource);
+        const auto deleted = mutating_adapter.delete_rows(row_ids_chunk.data[0], 1, TRANSACTION_ID_START);
+        REQUIRE(deleted == 1);
+        mutating_adapter.commit_all_deletes(TRANSACTION_ID_START, 1);
+        ts.checkpoint();
+    }
+
+    {
+        table_storage_t ts(&resource, otbx_path);
+        auto* root_row_group = ts.table().row_group()->row_group_tree()->root_segment();
+        REQUIRE(root_row_group != nullptr);
+        root_row_group->debug_set_unloaded_deletes_for_test(true);
+        actor_zeta::scheduler::sharing_scheduler scheduler(2, 1000);
+        scheduler.start();
+        scheduler_guard_t guard{scheduler};
+        {
+            components::storage::table_storage_adapter_t adapter(ts.table(), &resource, &scheduler);
+            std::pmr::vector<data_chunk_t> batches{&resource};
+
+            adapter.scan_batched(batches, nullptr, -1, nullptr, transaction_data{0, 0});
+
+            REQUIRE(adapter.parallel_worker_count() > 0);
+            uint64_t seen = 0;
+            for (auto& batch : batches) {
+                batch.data[0].flatten(batch.size());
+                for (uint64_t i = 0; i < batch.size(); ++i) {
+                    REQUIRE(batch.data[0].value(i).value<int64_t>() == static_cast<int64_t>(seen));
+                    ++seen;
+                }
+            }
+            REQUIRE(seen == DEFAULT_VECTOR_CAPACITY);
+        }
+    }
+
+    cleanup_test_dir();
 }

--- a/services/disk/tests/test_table_storage.cpp
+++ b/services/disk/tests/test_table_storage.cpp
@@ -175,7 +175,7 @@ namespace {
                 scheduler.run(10000);
                 std::this_thread::sleep_for(std::chrono::microseconds(50));
             }
-            return std::move(future).get();
+            return std::move(future).take_ready();
         }
     };
 } // namespace

--- a/services/disk/tests/test_wal_catalog.cpp
+++ b/services/disk/tests/test_wal_catalog.cpp
@@ -95,7 +95,7 @@ namespace {
                 std::this_thread::yield();
             }
             REQUIRE(future.is_ready());
-            return std::move(future).get();
+            return std::move(future).take_ready();
         }
 
         components::execution_context_t ctx() {

--- a/services/disk/tests/test_wal_catalog.cpp
+++ b/services/disk/tests/test_wal_catalog.cpp
@@ -95,7 +95,7 @@ namespace {
                 std::this_thread::yield();
             }
             REQUIRE(future.is_ready());
-            return std::move(future).take_ready();
+            return std::move(future).get();
         }
 
         components::execution_context_t ctx() {

--- a/services/dispatcher/dispatcher.hpp
+++ b/services/dispatcher/dispatcher.hpp
@@ -24,6 +24,7 @@
 #include <components/catalog/catalog_oids.hpp>
 #include <components/catalog/session_catalog.hpp>
 #include <components/compute/function.hpp>
+#include <components/context/execution_context.hpp>
 #include <components/cursor/cursor.hpp>
 #include <components/log/log.hpp>
 #include <components/logical_plan/execution_plan.hpp>

--- a/services/dispatcher/tests/CMakeLists.txt
+++ b/services/dispatcher/tests/CMakeLists.txt
@@ -25,4 +25,4 @@ target_link_libraries(
 
 include(CTest)
 include(Catch)
-catch_discover_tests(${PROJECT_NAME})
+otterbrix_discover_tests(${PROJECT_NAME})

--- a/services/dispatcher/tests/test_dispatcher_catalog.cpp
+++ b/services/dispatcher/tests/test_dispatcher_catalog.cpp
@@ -85,7 +85,7 @@ struct test_dispatcher : actor_zeta::actor::actor_mixin<test_dispatcher> {
             std::this_thread::yield();
         }
         REQUIRE(fut.is_ready());
-        return std::move(fut).get();
+        return std::move(fut).take_ready();
     }
 
     // Adapter exposing the (resource, invoke) shape that test_probe helpers expect.
@@ -111,7 +111,7 @@ struct test_dispatcher : actor_zeta::actor::actor_mixin<test_dispatcher> {
         }
         REQUIRE(pending_future_->valid());
         REQUIRE(pending_future_->is_ready());
-        auto result = std::move(*pending_future_).get();
+        auto result = std::move(*pending_future_).take_ready();
         pending_future_.reset();
         // Drain again so the executor's post-result DDL pipeline (catalog writes,
         // flush, commit_txn, storage_publish_commits) finishes before returning.
@@ -135,7 +135,7 @@ struct test_dispatcher : actor_zeta::actor::actor_mixin<test_dispatcher> {
             std::this_thread::yield();
         }
         REQUIRE(fut.is_ready());
-        return std::move(fut).get();
+        return std::move(fut).take_ready();
     }
 
     // Resolve a table via the live read_chunks_by_key path (catalog-read oracle).

--- a/services/dispatcher/tests/test_dispatcher_catalog.cpp
+++ b/services/dispatcher/tests/test_dispatcher_catalog.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch.hpp>
 
+#include <components/catalog/catalog_codes.hpp>
 #include <chrono>
 #include <thread>
 
@@ -84,7 +85,7 @@ struct test_dispatcher : actor_zeta::actor::actor_mixin<test_dispatcher> {
             std::this_thread::yield();
         }
         REQUIRE(fut.is_ready());
-        return std::move(fut).take_ready();
+        return std::move(fut).get();
     }
 
     // Adapter exposing the (resource, invoke) shape that test_probe helpers expect.
@@ -110,7 +111,7 @@ struct test_dispatcher : actor_zeta::actor::actor_mixin<test_dispatcher> {
         }
         REQUIRE(pending_future_->valid());
         REQUIRE(pending_future_->is_ready());
-        auto result = std::move(*pending_future_).take_ready();
+        auto result = std::move(*pending_future_).get();
         pending_future_.reset();
         // Drain again so the executor's post-result DDL pipeline (catalog writes,
         // flush, commit_txn, storage_publish_commits) finishes before returning.
@@ -134,7 +135,7 @@ struct test_dispatcher : actor_zeta::actor::actor_mixin<test_dispatcher> {
             std::this_thread::yield();
         }
         REQUIRE(fut.is_ready());
-        return std::move(fut).take_ready();
+        return std::move(fut).get();
     }
 
     // Resolve a table via the live read_chunks_by_key path (catalog-read oracle).
@@ -243,6 +244,45 @@ TEST_CASE("services::dispatcher::schemeful_operations") {
             auto rns = test.resolve_namespace("test");
             REQUIRE(!rns.found);
         }
+    }
+}
+
+TEST_CASE("services::dispatcher::storage_format_introspection") {
+    auto mr = std::make_unique<std::pmr::synchronized_pool_resource>();
+    test_dispatcher test(mr.get(), "/tmp/test_dispatcher_storage_format_introspection");
+
+    test.execute_sql("CREATE DATABASE test;");
+    (void) test.take_result();
+
+    struct expectation_t {
+        std::string create_sql;
+        std::string relname;
+        std::string expected_storage_format;
+    };
+    const std::vector<expectation_t> cases{
+        {"CREATE TABLE test.mem_tbl(id int);", "mem_tbl", std::string(relstorageformat::in_memory)},
+        {"CREATE TABLE test.disk_auto_tbl(id int) WITH (storage = 'disk');",
+         "disk_auto_tbl",
+         std::string(relstorageformat::disk_auto)},
+        {"CREATE TABLE test.disk_pax_tbl(id bigint) WITH (storage = 'disk') USING PAX;",
+         "disk_pax_tbl",
+         std::string(relstorageformat::disk_pax)},
+        {"CREATE TABLE test.disk_columnar_tbl(name string) WITH (storage = 'disk') USING COLUMNAR;",
+         "disk_columnar_tbl",
+         std::string(relstorageformat::disk_columnar)},
+    };
+
+    auto rns = test.resolve_namespace("test");
+    REQUIRE(rns.found);
+
+    for (const auto& spec : cases) {
+        test.execute_sql(spec.create_sql);
+        auto cur = test.take_result();
+        REQUIRE(cur->is_success());
+
+        auto rt = test.resolve_table(rns.oid, spec.relname);
+        REQUIRE(rt.found);
+        REQUIRE(rt.storage_format == spec.expected_storage_format);
     }
 }
 

--- a/services/dispatcher/tests/test_variant_e3_differential.cpp
+++ b/services/dispatcher/tests/test_variant_e3_differential.cpp
@@ -88,7 +88,7 @@ namespace {
                 std::this_thread::yield();
             }
             REQUIRE(fut.is_ready());
-            return std::move(fut).get();
+            return std::move(fut).take_ready();
         }
 
         // Adapter exposing the (resource, invoke) shape that test_probe helpers expect.
@@ -115,7 +115,7 @@ namespace {
             }
             REQUIRE(pending_future_->valid());
             REQUIRE(pending_future_->is_ready());
-            auto result = std::move(*pending_future_).get();
+            auto result = std::move(*pending_future_).take_ready();
             pending_future_.reset();
             step();
             return result;
@@ -136,7 +136,7 @@ namespace {
                 std::this_thread::yield();
             }
             REQUIRE(fut.is_ready());
-            return std::move(fut).get();
+            return std::move(fut).take_ready();
         }
 
         test_probe::probe_table_result_t resolve_table(components::catalog::oid_t ns_oid, const std::string& tname) {

--- a/services/dispatcher/tests/test_variant_e3_differential.cpp
+++ b/services/dispatcher/tests/test_variant_e3_differential.cpp
@@ -88,7 +88,7 @@ namespace {
                 std::this_thread::yield();
             }
             REQUIRE(fut.is_ready());
-            return std::move(fut).take_ready();
+            return std::move(fut).get();
         }
 
         // Adapter exposing the (resource, invoke) shape that test_probe helpers expect.
@@ -115,7 +115,7 @@ namespace {
             }
             REQUIRE(pending_future_->valid());
             REQUIRE(pending_future_->is_ready());
-            auto result = std::move(*pending_future_).take_ready();
+            auto result = std::move(*pending_future_).get();
             pending_future_.reset();
             step();
             return result;
@@ -136,7 +136,7 @@ namespace {
                 std::this_thread::yield();
             }
             REQUIRE(fut.is_ready());
-            return std::move(fut).take_ready();
+            return std::move(fut).get();
         }
 
         test_probe::probe_table_result_t resolve_table(components::catalog::oid_t ns_oid, const std::string& tname) {

--- a/services/dispatcher/validate_logical_plan.cpp
+++ b/services/dispatcher/validate_logical_plan.cpp
@@ -91,6 +91,11 @@ namespace services::dispatcher {
                     return components::vector::arithmetic_op::add;
             }
         }
+
+        std::string result_alias_for_projected_key(const components::expressions::key_t& key,
+                                                   const std::string& fallback) {
+            return key.storage().size() > 1 ? std::string(key.storage().front()) : fallback;
+        }
         // plan_resolve_index_t + helpers live in
         // services/dispatcher/plan_resolve_index.hpp so
         // enrich_logical_plan.cpp can use the same probe-then-fallback
@@ -166,6 +171,34 @@ namespace services::dispatcher {
             return merged;
         }
 
+        const char* side_name(side_t side) {
+            switch (side) {
+                case side_t::left:
+                    return "left";
+                case side_t::right:
+                    return "right";
+                default:
+                    return "undefined";
+            }
+        }
+
+        std::string describe_schema(const named_schema& schema) {
+            std::string out = "[";
+            for (size_t i = 0; i < schema.size(); ++i) {
+                if (i > 0) {
+                    out += ", ";
+                }
+                out += schema[i].result_alias.empty() ? "<no-table>" : schema[i].result_alias;
+                out += ".";
+                out += schema[i].type.has_alias() ? schema[i].type.alias() : "<no-column>";
+                out += "(";
+                out += side_name(schema[i].side);
+                out += ")";
+            }
+            out += "]";
+            return out;
+        }
+
         [[nodiscard]] core::result_wrapper_t<type_paths> find_types(std::pmr::memory_resource* resource,
                                                                     components::expressions::key_t& key,
                                                                     const named_schema& schema) {
@@ -209,6 +242,16 @@ namespace services::dispatcher {
                     matches.emplace_back(type_match_t{column_path{{i}, resource}, &schema[i].type, 2});
                 } else if (core::pmr::operator==(schema[i].type.alias(), truncated_key.storage().at(0))) {
                     matches.emplace_back(type_match_t{column_path{{i}, resource}, &schema[i].type, 1});
+                } else if (truncated_key.storage().size() > 1 && schema[i].result_alias.empty() &&
+                           core::pmr::operator==(schema[i].type.alias(), truncated_key.storage().at(1))) {
+                    // No-table node_data input (e.g. spliced raw_data in a federation JOIN):
+                    // the schema column carries no table alias, so a side-qualified key like
+                    // `p/campaign_id` is matched on the column name (`campaign_id`) alone,
+                    // dropping the unresolvable table qualifier. Scoped to no-table schemas
+                    // (result_alias empty) so normal table-qualified joins are unaffected; the
+                    // JOIN validates each side's key against that side's schema, so the bare
+                    // column name is unambiguous per side.
+                    matches.emplace_back(type_match_t{column_path{{i}, resource}, &schema[i].type, 2});
                 }
             }
 
@@ -357,7 +400,9 @@ namespace services::dispatcher {
 
             if (result.empty()) {
                 return core::error_t(core::error_code_t::schema_error,
-                                     std::pmr::string{"path: \'" + key.as_string() + "\' was not found", resource});
+                                     std::pmr::string{"path: \'" + key.as_string() + "\' was not found in schema " +
+                                                          describe_schema(schema),
+                                                      resource});
             }
             // Store path inside a key, since we will need it later
             key.set_path(result.front().path);
@@ -675,6 +720,10 @@ namespace services::dispatcher {
                 return find_types(resource, key, schema);
             } else if (std::holds_alternative<expression_ptr>(param)) {
                 auto& sub = std::get<expression_ptr>(param);
+                if (!sub) {
+                    return core::error_t(core::error_code_t::invalid_parameter,
+                                         std::pmr::string{"null expression while resolving key paths", resource});
+                }
                 if (sub->group() == expression_group::scalar) {
                     auto* scalar = static_cast<scalar_expression_t*>(sub.get());
                     auto res = resolve_key_paths_in_group(resource, scalar->params(), schema);
@@ -683,6 +732,16 @@ namespace services::dispatcher {
                     }
                 } else if (sub->group() == expression_group::compare) {
                     auto* cmp = static_cast<compare_expression_t*>(sub.get());
+                    if (cmp->is_union()) {
+                        for (auto& child : cmp->children()) {
+                            param_storage child_param{child};
+                            auto res = resolve_key_path(resource, child_param, schema);
+                            if (res.has_error()) {
+                                return res;
+                            }
+                        }
+                        return type_paths{resource};
+                    }
                     auto res = resolve_key_path(resource, cmp->left(), schema);
                     if (res.has_error()) {
                         return res;
@@ -692,16 +751,10 @@ namespace services::dispatcher {
                         return res;
                     }
                     for (auto& child : cmp->children()) {
-                        if (child->group() == expression_group::compare) {
-                            auto* child_cmp = static_cast<compare_expression_t*>(child.get());
-                            res = resolve_key_path(resource, child_cmp->left(), schema);
-                            if (res.has_error()) {
-                                return res;
-                            }
-                            res = resolve_key_path(resource, child_cmp->right(), schema);
-                            if (res.has_error()) {
-                                return res;
-                            }
+                        param_storage child_param{child};
+                        res = resolve_key_path(resource, child_param, schema);
+                        if (res.has_error()) {
+                            return res;
                         }
                     }
                 }
@@ -1594,8 +1647,25 @@ namespace services::dispatcher {
                         }
 
                         // Resolve key paths in node_select scalar expressions against incoming schema.
-                        // Aggregates are always in node_group_t now, so only scalar expressions appear here.
+                        // Aggregates live in node_group_t; scalar row/vector functions may appear here too.
+                        auto allowed_projection_function_types =
+                            components::compute::create_mask(components::compute::function_type_t::row,
+                                                             components::compute::function_type_t::vector);
                         for (auto& expr : node_select->expressions()) {
+                            if (expr->group() == expression_group::function) {
+                                auto* func_expr = reinterpret_cast<function_expression_t*>(expr.get());
+                                auto res = impl::validate_schema(resource,
+                                                                 func_expr,
+                                                                 parameters,
+                                                                 incoming_schema,
+                                                                 incoming_schema,
+                                                                 true,
+                                                                 allowed_projection_function_types);
+                                if (res.has_error()) {
+                                    return res.error();
+                                }
+                                continue;
+                            }
                             if (expr->group() != expression_group::scalar) {
                                 continue;
                             }
@@ -1620,6 +1690,125 @@ namespace services::dispatcher {
                                     return res.convert_error<named_schema>();
                                 }
                             }
+                        }
+                        named_schema selected_schema(resource);
+                        selected_schema.reserve(node_select->expressions().size());
+                        auto resolve_scalar_type = [&](param_storage& param, auto& self) -> complex_logical_type {
+                            if (std::holds_alternative<components::expressions::key_t>(param)) {
+                                auto& key = std::get<components::expressions::key_t>(param);
+                                assert(!key.path().empty());
+                                return incoming_schema[key.path()[0]].type;
+                            }
+                            if (std::holds_alternative<core::parameter_id_t>(param)) {
+                                return parameters.parameters.at(std::get<core::parameter_id_t>(param)).type();
+                            }
+                            auto& sub = std::get<expression_ptr>(param);
+                            if (sub->group() == expression_group::scalar) {
+                                auto* sub_s = static_cast<scalar_expression_t*>(sub.get());
+                                if (sub_s->type() == scalar_type::case_expr) {
+                                    return sub_s->params().size() >= 2 ? self(sub_s->params()[1], self)
+                                                                       : complex_logical_type(logical_type::NA);
+                                }
+                                if (!sub_s->params().empty()) {
+                                    auto lt = self(sub_s->params()[0], self);
+                                    auto rt = sub_s->params().size() > 1 ? self(sub_s->params()[1], self) : lt;
+                                    return complex_logical_type(
+                                        arithmetic_result_type(lt.type(), rt.type(), impl::scalar_to_arith_op(sub_s->type())));
+                                }
+                            }
+                            return complex_logical_type(logical_type::NA);
+                        };
+
+                        for (auto& expr : node_select->expressions()) {
+                            if (expr->group() == expression_group::function) {
+                                auto* func_expr = reinterpret_cast<function_expression_t*>(expr.get());
+                                auto fn_schema = impl::validate_schema(resource,
+                                                                       func_expr,
+                                                                       parameters,
+                                                                       incoming_schema,
+                                                                       incoming_schema,
+                                                                       true,
+                                                                       allowed_projection_function_types);
+                                if (fn_schema.has_error()) {
+                                    return fn_schema.error();
+                                }
+                                for (auto& entry : fn_schema.value()) {
+                                    auto out_type = entry.type;
+                                    if (!func_expr->result_alias().empty()) {
+                                        out_type.set_alias(func_expr->result_alias());
+                                    } else if (!out_type.has_alias()) {
+                                        out_type.set_alias(func_expr->name());
+                                    }
+                                    selected_schema.emplace_back(type_from_t{node->result_alias(), std::move(out_type)});
+                                }
+                                continue;
+                            }
+                            if (expr->group() != expression_group::scalar) {
+                                continue;
+                            }
+                            auto* scalar_expr = reinterpret_cast<scalar_expression_t*>(expr.get());
+                            if (scalar_expr->type() == scalar_type::star_expand) {
+                                for (const auto& col : incoming_schema) {
+                                    selected_schema.emplace_back(col);
+                                }
+                                continue;
+                            }
+
+                            complex_logical_type out_type(logical_type::NA);
+                            if (scalar_expr->type() == scalar_type::get_field) {
+                                auto& key = scalar_expr->params().empty()
+                                                ? scalar_expr->key()
+                                                : std::get<components::expressions::key_t>(scalar_expr->params().front());
+                                out_type = incoming_schema[key.path()[0]].type;
+                            } else if (scalar_expr->type() == scalar_type::constant && !scalar_expr->params().empty() &&
+                                       std::holds_alternative<core::parameter_id_t>(scalar_expr->params().front())) {
+                                out_type =
+                                    parameters.parameters.at(std::get<core::parameter_id_t>(scalar_expr->params().front()))
+                                        .type();
+                            } else if (!scalar_expr->params().empty()) {
+                                out_type = scalar_expr->type() == scalar_type::case_expr
+                                               ? (scalar_expr->params().size() >= 2
+                                                      ? resolve_scalar_type(scalar_expr->params()[1], resolve_scalar_type)
+                                                      : complex_logical_type(logical_type::NA))
+                                               : complex_logical_type(arithmetic_result_type(
+                                                     resolve_scalar_type(scalar_expr->params()[0], resolve_scalar_type)
+                                                         .type(),
+                                                     scalar_expr->params().size() > 1
+                                                         ? resolve_scalar_type(scalar_expr->params()[1], resolve_scalar_type)
+                                                               .type()
+                                                         : resolve_scalar_type(scalar_expr->params()[0], resolve_scalar_type)
+                                                               .type(),
+                                                     impl::scalar_to_arith_op(scalar_expr->type())));
+                            }
+
+                            if (!scalar_expr->key().storage().empty()) {
+                                out_type.set_alias(std::string(scalar_expr->key().storage().back()));
+                            } else if (scalar_expr->type() == scalar_type::get_field) {
+                                auto& key = scalar_expr->params().empty()
+                                                ? scalar_expr->key()
+                                                : std::get<components::expressions::key_t>(scalar_expr->params().front());
+                                if (!key.storage().empty()) {
+                                    out_type.set_alias(std::string(key.storage().back()));
+                                }
+                            }
+                            selected_schema.emplace_back(type_from_t{node->result_alias(), std::move(out_type)});
+                        }
+                        // selected_schema is the fully-projected output schema for this
+                        // no-GROUP-BY SELECT (handles get_field, functions, constants,
+                        // arithmetic/case, and t.* expansion with correct column aliases).
+                        // Return it directly: the legacy node_select projection block
+                        // further below re-derives the schema by indexing the *incoming*
+                        // (pre-projection) schema with the SELECT keys' paths. Mutating
+                        // incoming_schema here used to feed that block a schema that had
+                        // already been narrowed to the projected columns, so those paths
+                        // (which index the original table schema) pointed at the wrong
+                        // column or out of bounds — collapsing the derived-table / CTE /
+                        // INSERT…SELECT / UNION-operand output schema (a regression
+                        // introduced when this richer projection block was added on top
+                        // of the legacy one during the merge). Falling through only when
+                        // selected_schema is empty preserves the legacy behaviour.
+                        if (!selected_schema.empty()) {
+                            return selected_schema;
                         }
                     } else {
                         // "SELECT *" / "SELECT t.*" — emit every column, including
@@ -1817,7 +2006,9 @@ namespace services::dispatcher {
                                         res_type = &res_type->child_type();
                                     }
                                 }
-                                result.emplace_back(type_from_t{node->result_alias(), *res_type});
+                                result.emplace_back(
+                                    type_from_t{impl::result_alias_for_projected_key(key, node->result_alias()),
+                                                *res_type});
                                 key_schema.emplace_back(result.back());
                             } else if (scalar_expr->type() == scalar_type::group_field) {
                                 // GROUP BY field: resolve key path and expose in output schema
@@ -1831,7 +2022,9 @@ namespace services::dispatcher {
                                 if (!key.storage().empty()) {
                                     out_type.set_alias(std::string(key.storage().back()));
                                 }
-                                result.emplace_back(type_from_t{node->result_alias(), out_type});
+                                result.emplace_back(
+                                    type_from_t{impl::result_alias_for_projected_key(key, node->result_alias()),
+                                                out_type});
                                 key_schema.emplace_back(result.back());
                             } else if (is_case_or_arithmetic(scalar_expr->type())) {
                                 // Try resolve against incoming_schema
@@ -2041,9 +2234,8 @@ namespace services::dispatcher {
                         }
                     }
 
-                    // Resolve node_select scalar expression key paths against the group output schema.
-                    // GROUP BY key columns are real columns addressable by name (key_schema).
-                    // Computed aggregate columns are internal artifacts — resolve positionally.
+                    // Resolve node_select scalar expression key paths against the group output schema:
+                    // both GROUP BY keys (which may still be table-qualified) and aggregate aliases.
                     if (node_select) {
                         size_t agg_cursor = 0;
                         for (auto& expr : node_select->expressions()) {
@@ -2057,7 +2249,7 @@ namespace services::dispatcher {
                                         ? scalar_expr->key()
                                         : std::get<components::expressions::key_t>(scalar_expr->params().front());
                                 if (key.path().empty()) {
-                                    auto res = impl::validate_key(resource, key, key_schema, key_schema, true);
+                                    auto res = impl::validate_key(resource, key, result, result, true);
                                     if (res.has_error()) {
                                         if (agg_cursor >= agg_result_positions.size()) {
                                             return res.convert_error<named_schema>();
@@ -2463,14 +2655,32 @@ namespace services::dispatcher {
                     incoming_schema = table_schema;
                     same_schema = true;
                 }
+                // The USING (DELETE) / FROM (UPDATE) table is a sibling resolve node,
+                // not a child, so it never reaches incoming_schema. Build its schema
+                // from table_oid_from() (catalog columns, right-stamped) so BOTH the
+                // join condition (node_match) and a joined RETURNING column resolve
+                // against it; target columns resolve against table_schema as before.
+                const auto from_oid = node->type() == node_type::update_t
+                                          ? reinterpret_cast<node_update_t*>(node)->table_oid_from()
+                                          : reinterpret_cast<node_delete_t*>(node)->table_oid_from();
+                named_schema from_schema(resource);
+                if (from_oid != components::catalog::INVALID_OID) {
+                    if (const auto* tbl_from = impl::tbl_md_for_oid(idx, from_oid)) {
+                        for (const auto& column : tbl_from->columns) {
+                            from_schema.emplace_back(
+                                type_from_t{tbl_from->name, column.type, components::expressions::side_t::right});
+                        }
+                    }
+                }
+                const bool has_join = !from_schema.empty();
                 if (node_match) {
                     auto node_match_res = impl::validate_schema(resource,
                                                                 idx,
                                                                 node_match,
                                                                 parameters,
                                                                 table_schema,
-                                                                incoming_schema,
-                                                                same_schema);
+                                                                has_join ? from_schema : incoming_schema,
+                                                                has_join ? false : same_schema);
                     if (node_match_res.has_error()) {
                         return node_match_res;
                     }
@@ -2497,26 +2707,10 @@ namespace services::dispatcher {
                                           ? &reinterpret_cast<node_update_t*>(node)->returning()
                                           : &reinterpret_cast<node_delete_t*>(node)->returning();
                     if (!returning->empty() && !table_schema.empty()) {
-                        // The USING/FROM table is a sibling resolve node, not a
-                        // child, so it never reaches incoming_schema. Build its
-                        // schema from table_oid_from() (the catalog columns) and use
-                        // it as the right side: a right-stamped RETURNING key (a
-                        // joined column) resolves against it, while target columns
-                        // resolve against table_schema as before.
-                        const auto from_oid = node->type() == node_type::update_t
-                                                  ? reinterpret_cast<node_update_t*>(node)->table_oid_from()
-                                                  : reinterpret_cast<node_delete_t*>(node)->table_oid_from();
-                        named_schema from_schema(resource);
-                        if (from_oid != components::catalog::INVALID_OID) {
-                            if (const auto* tbl_from = impl::tbl_md_for_oid(idx, from_oid)) {
-                                for (const auto& column : tbl_from->columns) {
-                                    from_schema.emplace_back(type_from_t{tbl_from->name,
-                                                                         column.type,
-                                                                         components::expressions::side_t::right});
-                                }
-                            }
-                        }
-                        const bool has_join = !from_schema.empty();
+                        // from_schema / has_join were built above (shared with the
+                        // join-condition validation): a right-stamped RETURNING key (a
+                        // joined column) resolves against the USING/FROM table, while
+                        // target columns resolve against table_schema.
                         auto ret_err = impl::resolve_returning_columns(resource,
                                                                        returning,
                                                                        table_schema,
@@ -2691,6 +2885,19 @@ namespace services::dispatcher {
                 assert(false);
                 return core::error_t(core::error_code_t::unimplemented_yet,
                                      std::pmr::string{"encountered an unknown state during plan validation", resource});
+        }
+
+        if (!node->output_column_aliases().empty()) {
+            if (node->output_column_aliases().size() != result.size()) {
+                return core::error_t(core::error_code_t::schema_error,
+                                     std::pmr::string{"derived table column alias count does not match output column "
+                                                      "count for alias '" +
+                                                          node->result_alias() + "'",
+                                                      resource});
+            }
+            for (size_t i = 0; i < result.size(); ++i) {
+                result[i].type.set_alias(std::string{node->output_column_aliases()[i]});
+            }
         }
 
         return result;

--- a/services/index/tests/CMakeLists.txt
+++ b/services/index/tests/CMakeLists.txt
@@ -26,4 +26,4 @@ target_link_libraries(
 
 include(CTest)
 include(Catch)
-catch_discover_tests(${PROJECT_NAME})
+otterbrix_discover_tests(${PROJECT_NAME})

--- a/services/index/tests/test_bitcask_index_disk.cpp
+++ b/services/index/tests/test_bitcask_index_disk.cpp
@@ -980,6 +980,16 @@ TEST_CASE("services::index::bitcask_index_disk::max_size_t_row_id_persists") {
     }
 }
 
+// Load/stress test — DELIBERATELY long-running. 8 threads issue 320k mixed
+// insert/remove/find ops against one disk index, then it is reopened and the
+// recovered state is compared key-by-key. Every insert/remove takes the index's
+// exclusive lock and writes to disk under it, so the threads serialize (~100% of
+// one core, no real parallelism by design); the goal is to surface concurrency
+// races and verify durable recovery, not throughput. Expect minutes in a -O0
+// debug build (much faster in release). Under a parallel `ctest` run it competes
+// for cores and can take 15-20+ min and look hung — it is not deadlocked, it
+// completes. Tagged [stress][long]; run it serially or filter it out (ctest -LE
+// long) if a fast run is needed.
 TEST_CASE("services::index::bitcask_index_disk::concurrent_insert_remove_find_stress", "[stress][long]") {
     auto resource = std::pmr::synchronized_pool_resource();
 

--- a/services/wal/tests/CMakeLists.txt
+++ b/services/wal/tests/CMakeLists.txt
@@ -36,4 +36,4 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 
 include(CTest)
 include(Catch)
-catch_discover_tests(${PROJECT_NAME})
+otterbrix_discover_tests(${PROJECT_NAME})

--- a/services/wal/tests/test_wal_binary.cpp
+++ b/services/wal/tests/test_wal_binary.cpp
@@ -10,8 +10,7 @@ using namespace services::wal;
 using namespace components::types;
 using namespace components::vector;
 
-// WAL binary serialization supports fixed-size and STRING types.
-// ARRAY/LIST not yet supported in binary format — use explicit types.
+// Fixed-size and STRING columns only.
 static std::pmr::vector<components::types::complex_logical_type> wal_test_types(std::pmr::memory_resource* r) {
     using namespace components::types;
     std::pmr::vector<complex_logical_type> types(r);
@@ -20,6 +19,120 @@ static std::pmr::vector<components::types::complex_logical_type> wal_test_types(
     types.emplace_back(logical_type::DOUBLE, "count_double");
     types.emplace_back(logical_type::BOOLEAN, "count_bool");
     return types;
+}
+
+static data_chunk_t make_pax_generic_chunk(std::pmr::memory_resource* r) {
+    constexpr uint64_t row_count = 4;
+
+    std::pmr::vector<complex_logical_type> types(r);
+    types.emplace_back(logical_type::BIGINT, "id");
+    types.emplace_back(complex_logical_type::create_array(logical_type::UBIGINT, 3, "scores"));
+    types.emplace_back(complex_logical_type::create_list(logical_type::STRING_LITERAL, "tags"));
+
+    std::pmr::vector<complex_logical_type> struct_fields(r);
+    struct_fields.emplace_back(logical_type::BOOLEAN, "flag");
+    struct_fields.emplace_back(logical_type::INTEGER, "count");
+    struct_fields.emplace_back(complex_logical_type::create_list(logical_type::STRING_LITERAL, "notes"));
+    auto struct_type = complex_logical_type::create_struct("payload", struct_fields, "payload");
+    types.emplace_back(struct_type);
+
+    std::pmr::vector<complex_logical_type> union_fields(r);
+    union_fields.emplace_back(logical_type::BOOLEAN, "as_bool");
+    union_fields.emplace_back(logical_type::INTEGER, "as_int");
+    union_fields.emplace_back(logical_type::STRING_LITERAL, "as_text");
+    auto union_type = complex_logical_type::create_union(union_fields, "choice");
+    types.emplace_back(union_type);
+
+    std::vector<logical_value_t> enum_entries;
+    {
+        logical_value_t ready(r, int32_t{1});
+        ready.set_alias("ready");
+        enum_entries.emplace_back(std::move(ready));
+        logical_value_t paused(r, int32_t{2});
+        paused.set_alias("paused");
+        enum_entries.emplace_back(std::move(paused));
+    }
+    auto enum_type = complex_logical_type::create_enum("status_t", std::move(enum_entries), "status");
+    types.emplace_back(enum_type);
+
+    data_chunk_t chunk(r, types, row_count);
+    chunk.set_cardinality(row_count);
+
+    for (uint64_t row = 0; row < row_count; ++row) {
+        chunk.set_value(0, row, logical_value_t(r, static_cast<int64_t>(row + 10)));
+
+        if (row == 2) {
+            chunk.set_value(1, row, logical_value_t(r, logical_type::NA));
+        } else {
+            std::vector<logical_value_t> values;
+            values.reserve(3);
+            values.emplace_back(r, static_cast<uint64_t>(row * 10 + 1));
+            values.emplace_back(r, static_cast<uint64_t>(row * 10 + 2));
+            values.emplace_back(r, static_cast<uint64_t>(row * 10 + 3));
+            chunk.set_value(1, row, logical_value_t::create_array(r, logical_type::UBIGINT, values));
+        }
+
+        {
+            std::vector<logical_value_t> values;
+            values.emplace_back(r, std::string{"tag_" + std::to_string(row)});
+            if (row == 1) {
+                values.emplace_back(r, logical_type::NA);
+            } else {
+                values.emplace_back(r, std::string{"tail_" + std::to_string(row)});
+            }
+            chunk.set_value(2, row, logical_value_t::create_list(r, logical_type::STRING_LITERAL, values));
+        }
+
+        if (row == 3) {
+            chunk.set_value(3, row, logical_value_t(r, logical_type::NA));
+        } else {
+            std::vector<logical_value_t> notes;
+            notes.emplace_back(r, std::string{"note_" + std::to_string(row)});
+            if (row == 1) {
+                notes.emplace_back(r, logical_type::NA);
+            }
+
+            std::vector<logical_value_t> fields;
+            fields.emplace_back(r, row % 2 == 0);
+            fields.emplace_back(r, static_cast<int32_t>(row * 100));
+            fields.emplace_back(logical_value_t::create_list(r, logical_type::STRING_LITERAL, notes));
+            chunk.set_value(3, row, logical_value_t::create_struct(r, struct_type, fields));
+        }
+
+        switch (row) {
+            case 0:
+                chunk.set_value(4,
+                                row,
+                                logical_value_t::create_union(r,
+                                                              union_fields,
+                                                              0,
+                                                              logical_value_t(r, true)));
+                break;
+            case 1:
+                chunk.set_value(4,
+                                row,
+                                logical_value_t::create_union(r,
+                                                              union_fields,
+                                                              1,
+                                                              logical_value_t(r, int32_t{42})));
+                break;
+            case 2:
+                chunk.set_value(4,
+                                row,
+                                logical_value_t::create_union(r,
+                                                              union_fields,
+                                                              2,
+                                                              logical_value_t(r, std::string{"union_text"})));
+                break;
+            default:
+                chunk.set_value(4, row, logical_value_t(r, logical_type::NA));
+                break;
+        }
+
+        chunk.set_value(5, row, logical_value_t::create_enum(r, enum_type, row % 2 == 0 ? 1 : 2));
+    }
+
+    return chunk;
 }
 
 // WAL records carry table_oid (4 bytes) instead of (database, collection)
@@ -58,6 +171,37 @@ TEST_CASE("wal_binary::encode_decode_insert") {
     REQUIRE(record.physical_data->size() == chunk.size());
 
     for (uint64_t col = 0; col < chunk.column_count(); col++) {
+        for (uint64_t row = 0; row < chunk.size(); row++) {
+            REQUIRE(record.physical_data->value(col, row) == chunk.value(col, row));
+        }
+    }
+}
+
+TEST_CASE("wal_binary::encode_decode_insert_pax_generic_nested") {
+    std::pmr::monotonic_buffer_resource resource(1024 * 128);
+    auto chunk = make_pax_generic_chunk(&resource);
+
+    buffer_t buffer(&resource);
+    encode_insert(buffer,
+                  &resource,
+                  /*last_crc32=*/0,
+                  /*wal_id=*/10,
+                  /*txn_id=*/110,
+                  kTestTableOid,
+                  chunk,
+                  /*row_start=*/0,
+                  /*row_count=*/chunk.size());
+
+    auto record = decode_record(buffer, &resource);
+    REQUIRE(record.is_valid());
+    REQUIRE_FALSE(record.is_corrupt);
+    REQUIRE(record.record_type == wal_record_type::PHYSICAL_INSERT);
+    REQUIRE(record.physical_data != nullptr);
+    REQUIRE(record.physical_data->column_count() == chunk.column_count());
+    REQUIRE(record.physical_data->size() == chunk.size());
+
+    for (uint64_t col = 0; col < chunk.column_count(); col++) {
+        REQUIRE(record.physical_data->data[col].type() == chunk.data[col].type());
         for (uint64_t row = 0; row < chunk.size(); row++) {
             REQUIRE(record.physical_data->value(col, row) == chunk.value(col, row));
         }
@@ -268,5 +412,29 @@ TEST_CASE("wal_binary::data_chunk_binary_with_nulls") {
         REQUIRE(result.data[col].validity().row_is_valid(6));
         REQUIRE(result.data[col].validity().row_is_valid(8));
         REQUIRE(result.data[col].validity().row_is_valid(9));
+    }
+}
+
+TEST_CASE("wal_binary::data_chunk_binary_pax_generic_nested_types") {
+    std::pmr::monotonic_buffer_resource resource(1024 * 128);
+    auto chunk = make_pax_generic_chunk(&resource);
+
+    buffer_t buffer(&resource);
+    serialize_binary(chunk, buffer);
+
+    REQUIRE(buffer.size() > 0);
+
+    bool ok = false;
+    auto result = deserialize_binary(buffer.data(), buffer.size(), &resource, ok);
+
+    REQUIRE(ok);
+    REQUIRE(result.column_count() == chunk.column_count());
+    REQUIRE(result.size() == chunk.size());
+
+    for (uint64_t col = 0; col < chunk.column_count(); col++) {
+        REQUIRE(result.data[col].type() == chunk.data[col].type());
+        for (uint64_t row = 0; row < chunk.size(); row++) {
+            REQUIRE(result.value(col, row) == chunk.value(col, row));
+        }
     }
 }

--- a/services/wal/tests/test_wal_manager.cpp
+++ b/services/wal/tests/test_wal_manager.cpp
@@ -51,7 +51,7 @@ using test_pool_resource_t = std::pmr::synchronized_pool_resource;
 
 // The manager self-drives on an internal loop thread and runs its children on
 // the real shared_work scheduler, so futures from a send() to it become ready
-// asynchronously. Poll until ready before take_ready (which asserts readiness).
+// asynchronously. Poll until ready, then get() (already ready, so it won't block).
 template<typename F>
 static decltype(auto) await_ready(F& fut) {
     // Wall-clock deadline, not iteration-bounded: under TSAN or parallel-ctest
@@ -62,7 +62,7 @@ static decltype(auto) await_ready(F& fut) {
         std::this_thread::yield();
     }
     REQUIRE(fut.is_ready());
-    return std::move(fut).take_ready();
+    return std::move(fut).get();
 }
 
 constexpr auto kMainDb = catalog::well_known_oid::main_database;

--- a/services/wal/tests/test_wal_manager.cpp
+++ b/services/wal/tests/test_wal_manager.cpp
@@ -62,7 +62,7 @@ static decltype(auto) await_ready(F& fut) {
         std::this_thread::yield();
     }
     REQUIRE(fut.is_ready());
-    return std::move(fut).get();
+    return std::move(fut).take_ready();
 }
 
 constexpr auto kMainDb = catalog::well_known_oid::main_database;

--- a/services/wal/tests/test_wal_worker.cpp
+++ b/services/wal/tests/test_wal_worker.cpp
@@ -68,7 +68,7 @@ static decltype(auto) await_ready(F& fut) {
         std::this_thread::yield();
     }
     REQUIRE(fut.is_ready());
-    return std::move(fut).get();
+    return std::move(fut).take_ready();
 }
 
 // ---------------------------------------------------------------------------

--- a/services/wal/tests/test_wal_worker.cpp
+++ b/services/wal/tests/test_wal_worker.cpp
@@ -57,7 +57,7 @@ static const std::filesystem::path base_wal_worker_path = "/tmp/otterbrix_test_w
 
 // The manager self-drives on an internal loop thread and runs its workers on
 // the real shared_work scheduler, so futures from a send() to it become ready
-// asynchronously. Poll until ready before take_ready (which asserts readiness).
+// asynchronously. Poll until ready, then get() (already ready, so it won't block).
 template<typename F>
 static decltype(auto) await_ready(F& fut) {
     // Wall-clock deadline, not iteration-bounded: under TSAN or parallel-ctest
@@ -68,7 +68,7 @@ static decltype(auto) await_ready(F& fut) {
         std::this_thread::yield();
     }
     REQUIRE(fut.is_ready());
-    return std::move(fut).take_ready();
+    return std::move(fut).get();
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Introduces a **PAX-like (Partition Attributes Across) on-disk storage format** for
disk-backed tables — a hybrid between row and pure-columnar layouts. Within a row
group, values are stored column-by-column (enabling columnar scan, zone-map pruning
and better compression) while keeping each row group self-contained on disk. It lives
alongside the existing columnar storage and is selectable per table.

## What's included

**Storage format**
- PAX on-disk format with encodings for fixed-width, string, and nested
  (struct / list / array) columns.
- Full checkpoint → load round-trip; right-sized validity so cold reopen/load scales
  to large tables.
- Per-table storage-format selection, observable via `pg_class.relstorageformat`
  (`disk_auto` / `disk_pax` / `disk_columnar`).

**Scan & query**
- Zone-map (min/max) pruning for range and conjunction predicates pushed into the scan.
- Opt-in parallel scan (`OTTERBRIX_PARALLEL_SCAN`).
- PAX-aware scan / index planning and operators.
- Uncorrelated subquery support (unblocks TPC-H q11 / q18 at the SQL layer).

**Durability & robustness**
- Bounds-checked decode/load paths against corrupt or truncated data.
- Per-block CRC32c verification and a checksummed DB header.
- Fail-closed checkpoint writes (dropped block writes are no longer silently swallowed).
- Fixes for validity-mask corruption across checkpoint/reopen and append-after-reopen.

**Foundation**
- Generic `type_spec` type system underpinning the column encodings; string-heap support.
- Disk service: PAX storage adapter, agent pool, and scan/checkpoint path.

## Testing
- PAX checkpoint/load round-trip and storage round-trip tests, plus a **differential
  fuzzer** that verifies a cold-reopened index/table matches an in-memory oracle
  (including delete/update paths).
- Full local test suite passes.

## Commit layout (10 logical commits)
1. `types` — generic `type_spec` + string-heap foundation
2. `table` — PAX on-disk storage format (fixed/string/nested encodings)
3. `table` — column-data + row-group checkpoint/load engine
4. `table` — PAX checkpoint/load + round-trip tests
5. `vector` — scan/gather operations for PAX
6. `disk` — PAX storage adapter, agent pool, scan/checkpoint path
7. `planner` — PAX-aware scan/index planning + operators
8. `sql` — uncorrelated subquery support (TPC-H q11/q18)
9. `catalog/dispatcher/wal` — PAX DDL metadata + storage-format wiring
10. `integration + build` — end-to-end PAX tests + cmake wiring
