### PR TITLE
refactor(executor): normalize plan→execute flow and remove duplication

### DIFF
--- a/components/physical_plan/operators/arithmetic_eval.cpp
+++ b/components/physical_plan/operators/arithmetic_eval.cpp
@@ -7,20 +7,26 @@ namespace components::operators {
     namespace detail {
 
         // TODO: consider removing arithmetic_op enum in favor of using scalar_type directly
-        vector::arithmetic_op scalar_to_arithmetic_op(expressions::scalar_type t) {
+        // Returns false if t is not an arithmetic scalar_type.
+        bool scalar_to_arithmetic_op(expressions::scalar_type t, vector::arithmetic_op& out) {
             switch (t) {
                 case expressions::scalar_type::add:
-                    return vector::arithmetic_op::add;
+                    out = vector::arithmetic_op::add;
+                    return true;
                 case expressions::scalar_type::subtract:
-                    return vector::arithmetic_op::subtract;
+                    out = vector::arithmetic_op::subtract;
+                    return true;
                 case expressions::scalar_type::multiply:
-                    return vector::arithmetic_op::multiply;
+                    out = vector::arithmetic_op::multiply;
+                    return true;
                 case expressions::scalar_type::divide:
-                    return vector::arithmetic_op::divide;
+                    out = vector::arithmetic_op::divide;
+                    return true;
                 case expressions::scalar_type::mod:
-                    return vector::arithmetic_op::mod;
+                    out = vector::arithmetic_op::mod;
+                    return true;
                 default:
-                    throw std::logic_error("Not an arithmetic scalar_type");
+                    return false;
             }
         }
 
@@ -52,7 +58,12 @@ namespace components::operators {
                     auto* scalar_expr = static_cast<const expressions::scalar_expression_t*>(expr_ptr.get());
 
                     if (scalar_expr->type() == expressions::scalar_type::case_expr) {
-                        auto computed = evaluate_case_expr(resource, scalar_expr->params(), chunk, params, session_tz);
+                        core::error_t case_error = core::error_t::no_error();
+                        auto computed =
+                            evaluate_case_expr(resource, scalar_expr->params(), chunk, params, session_tz, case_error);
+                        if (case_error.contains_error()) {
+                            return std::move(case_error);
+                        }
                         temp_vecs.emplace_back(std::move(computed));
                         result.vec = &temp_vecs.back();
                         return result;
@@ -61,7 +72,8 @@ namespace components::operators {
                     if (scalar_expr->type() == expressions::scalar_type::unary_minus) {
                         auto& operands = scalar_expr->params();
                         if (operands.empty()) {
-                            throw std::logic_error("Unary minus requires 1 operand");
+                            return core::error_t(core::error_code_t::arithmetics_failure,
+                                                 std::pmr::string{"Unary minus requires 1 operand", resource});
                         }
                         std::deque<vector::vector_t> sub_temps;
                         auto inner_op = resolve_operand(operands[0], chunk, params, resource, sub_temps, session_tz);
@@ -89,10 +101,16 @@ namespace components::operators {
                         return result;
                     }
 
-                    auto op = scalar_to_arithmetic_op(scalar_expr->type());
+                    vector::arithmetic_op op;
+                    if (!scalar_to_arithmetic_op(scalar_expr->type(), op)) {
+                        return core::error_t(core::error_code_t::arithmetics_failure,
+                                             std::pmr::string{"Not an arithmetic scalar_type", resource});
+                    }
                     auto& operands = scalar_expr->params();
                     if (operands.size() < 2) {
-                        throw std::logic_error("Arithmetic expression requires at least 2 operands");
+                        return core::error_t(core::error_code_t::arithmetics_failure,
+                                             std::pmr::string{"Arithmetic expression requires at least 2 operands",
+                                                              resource});
                     }
 
                     std::deque<vector::vector_t> sub_temps;
@@ -140,7 +158,8 @@ namespace components::operators {
                     result.vec = &temp_vecs.back();
                     return result;
                 }
-                throw std::logic_error("Unsupported expression type in arithmetic operand");
+                return core::error_t(core::error_code_t::arithmetics_failure,
+                                     std::pmr::string{"Unsupported expression type in arithmetic operand", resource});
             }
         }
 
@@ -149,7 +168,12 @@ namespace components::operators {
                                                  const vector::data_chunk_t& chunk,
                                                  const logical_plan::storage_parameters& params,
                                                  size_t row_idx,
-                                                 core::date::timezone_offset_t session_tz) {
+                                                 core::date::timezone_offset_t session_tz,
+                                                 core::error_t& error) {
+            // L1: per-row CASE arithmetic still boxes operands into logical_value_t and uses
+            // logical_value_t::sum/subtract/mult/divide/modulus below. No typed scalar arithmetic
+            // path exists for a single logical_value_t pair, so left as-is.
+            // TODO(L1): provide a typed per-row scalar arithmetic helper to avoid logical_value_t round-trips.
             if (std::holds_alternative<expressions::key_t>(param)) {
                 auto& key = std::get<expressions::key_t>(param);
                 assert(!key.path().empty() && "key path must be resolved before execution");
@@ -157,7 +181,9 @@ namespace components::operators {
                 if (vec) {
                     return vec->value(row_idx);
                 }
-                throw std::logic_error("CASE: column not found: " + key.as_string());
+                error = core::error_t(core::error_code_t::arithmetics_failure,
+                                      std::pmr::string{"CASE: column not found: " + key.as_string(), resource});
+                return types::logical_value_t(resource, types::complex_logical_type{types::logical_type::NA});
             } else if (std::holds_alternative<core::parameter_id_t>(param)) {
                 auto id = std::get<core::parameter_id_t>(param);
                 return params.parameters.at(id);
@@ -174,36 +200,67 @@ namespace components::operators {
                             auto& cond_param = ops[w * 2];
                             if (std::holds_alternative<expressions::expression_ptr>(cond_param)) {
                                 auto& cond_expr = std::get<expressions::expression_ptr>(cond_param);
-                                if (evaluate_row_condition(resource, cond_expr, chunk, params, row_idx, session_tz)) {
+                                bool matched = evaluate_row_condition(resource,
+                                                                      cond_expr,
+                                                                      chunk,
+                                                                      params,
+                                                                      row_idx,
+                                                                      session_tz,
+                                                                      error);
+                                if (error.contains_error()) {
+                                    return types::logical_value_t(
+                                        resource,
+                                        types::complex_logical_type{types::logical_type::NA});
+                                }
+                                if (matched) {
                                     return resolve_row_value(resource,
                                                              ops[w * 2 + 1],
                                                              chunk,
                                                              params,
                                                              row_idx,
-                                                             session_tz);
+                                                             session_tz,
+                                                             error);
                                 }
                             }
                         }
                         if (has_default) {
-                            return resolve_row_value(resource, ops.back(), chunk, params, row_idx, session_tz);
+                            return resolve_row_value(resource, ops.back(), chunk, params, row_idx, session_tz, error);
                         }
                         return types::logical_value_t(resource, types::complex_logical_type{types::logical_type::NA});
                     }
                     // Unary minus sub-expression
                     if (scalar->type() == expressions::scalar_type::unary_minus) {
                         if (scalar->params().empty()) {
-                            throw std::logic_error("CASE: unary minus requires 1 operand");
+                            error = core::error_t(core::error_code_t::arithmetics_failure,
+                                                  std::pmr::string{"CASE: unary minus requires 1 operand", resource});
+                            return types::logical_value_t(resource,
+                                                          types::complex_logical_type{types::logical_type::NA});
                         }
                         auto inner =
-                            resolve_row_value(resource, scalar->params()[0], chunk, params, row_idx, session_tz);
+                            resolve_row_value(resource, scalar->params()[0], chunk, params, row_idx, session_tz, error);
+                        if (error.contains_error()) {
+                            return types::logical_value_t(resource,
+                                                          types::complex_logical_type{types::logical_type::NA});
+                        }
                         return types::logical_value_t::subtract(types::logical_value_t(resource, int64_t(0)), inner);
                     }
                     // Arithmetic sub-expression
                     if (scalar->params().size() < 2) {
-                        throw std::logic_error("CASE: arithmetic sub-expression requires 2 operands");
+                        error = core::error_t(
+                            core::error_code_t::arithmetics_failure,
+                            std::pmr::string{"CASE: arithmetic sub-expression requires 2 operands", resource});
+                        return types::logical_value_t(resource, types::complex_logical_type{types::logical_type::NA});
                     }
-                    auto l = resolve_row_value(resource, scalar->params()[0], chunk, params, row_idx, session_tz);
-                    auto r = resolve_row_value(resource, scalar->params()[1], chunk, params, row_idx, session_tz);
+                    auto l =
+                        resolve_row_value(resource, scalar->params()[0], chunk, params, row_idx, session_tz, error);
+                    if (error.contains_error()) {
+                        return types::logical_value_t(resource, types::complex_logical_type{types::logical_type::NA});
+                    }
+                    auto r =
+                        resolve_row_value(resource, scalar->params()[1], chunk, params, row_idx, session_tz, error);
+                    if (error.contains_error()) {
+                        return types::logical_value_t(resource, types::complex_logical_type{types::logical_type::NA});
+                    }
                     switch (scalar->type()) {
                         case expressions::scalar_type::add:
                             return types::logical_value_t::sum(l, r);
@@ -219,7 +276,9 @@ namespace components::operators {
                             break;
                     }
                 }
-                throw std::logic_error("CASE: unsupported sub-expression");
+                error = core::error_t(core::error_code_t::arithmetics_failure,
+                                      std::pmr::string{"CASE: unsupported sub-expression", resource});
+                return types::logical_value_t(resource, types::complex_logical_type{types::logical_type::NA});
             }
         }
 
@@ -228,7 +287,8 @@ namespace components::operators {
                                     const vector::data_chunk_t& chunk,
                                     const logical_plan::storage_parameters& params,
                                     size_t row_idx,
-                                    core::date::timezone_offset_t session_tz) {
+                                    core::date::timezone_offset_t session_tz,
+                                    core::error_t& error) {
             if (condition->group() != expressions::expression_group::compare)
                 return false;
             auto* cmp = static_cast<const expressions::compare_expression_t*>(condition.get());
@@ -236,7 +296,10 @@ namespace components::operators {
             if (cmp->is_union()) {
                 bool is_and = (cmp->type() == expressions::compare_type::union_and);
                 for (auto& child : cmp->children()) {
-                    bool child_result = evaluate_row_condition(resource, child, chunk, params, row_idx, session_tz);
+                    bool child_result =
+                        evaluate_row_condition(resource, child, chunk, params, row_idx, session_tz, error);
+                    if (error.contains_error())
+                        return false;
                     if (is_and && !child_result)
                         return false;
                     if (!is_and && child_result)
@@ -245,8 +308,12 @@ namespace components::operators {
                 return is_and;
             }
 
-            auto left_val = resolve_row_value(resource, cmp->left(), chunk, params, row_idx, session_tz);
-            auto right_val = resolve_row_value(resource, cmp->right(), chunk, params, row_idx, session_tz);
+            auto left_val = resolve_row_value(resource, cmp->left(), chunk, params, row_idx, session_tz, error);
+            if (error.contains_error())
+                return false;
+            auto right_val = resolve_row_value(resource, cmp->right(), chunk, params, row_idx, session_tz, error);
+            if (error.contains_error())
+                return false;
             if (left_val.type() != right_val.type()) {
                 auto cast_right = right_val.cast_as(left_val.type(), session_tz);
                 if (!cast_right.is_null()) {
@@ -281,7 +348,8 @@ namespace components::operators {
                                             const std::pmr::vector<expressions::param_storage>& operands,
                                             vector::data_chunk_t& chunk,
                                             const logical_plan::storage_parameters& params,
-                                            core::date::timezone_offset_t session_tz) {
+                                            core::date::timezone_offset_t session_tz,
+                                            core::error_t& error) {
             uint64_t count = chunk.size();
             bool has_default = (operands.size() % 2 == 1);
             size_t num_whens = operands.size() / 2;
@@ -290,7 +358,10 @@ namespace components::operators {
             types::complex_logical_type result_type(types::logical_type::NA);
             if (count > 0) {
                 // Try first THEN result
-                auto val = resolve_row_value(resource, operands[1], chunk, params, 0, session_tz);
+                auto val = resolve_row_value(resource, operands[1], chunk, params, 0, session_tz, error);
+                if (error.contains_error()) {
+                    return vector::vector_t(resource, result_type, count);
+                }
                 result_type = val.type();
             }
 
@@ -312,19 +383,28 @@ namespace components::operators {
                     auto& cond_param = operands[w * 2];
                     if (std::holds_alternative<expressions::expression_ptr>(cond_param)) {
                         auto& cond_expr = std::get<expressions::expression_ptr>(cond_param);
-                        if (evaluate_row_condition(resource, cond_expr, chunk, params, i, session_tz)) {
-                            auto val = coerce_to_result(
-                                resolve_row_value(resource, operands[w * 2 + 1], chunk, params, i, session_tz));
-                            output.set_value(i, val);
+                        bool cond = evaluate_row_condition(resource, cond_expr, chunk, params, i, session_tz, error);
+                        if (error.contains_error()) {
+                            return output;
+                        }
+                        if (cond) {
+                            auto resolved =
+                                resolve_row_value(resource, operands[w * 2 + 1], chunk, params, i, session_tz, error);
+                            if (error.contains_error()) {
+                                return output;
+                            }
+                            output.set_value(i, coerce_to_result(std::move(resolved)));
                             matched = true;
                             break;
                         }
                     }
                 }
                 if (!matched && has_default) {
-                    auto val =
-                        coerce_to_result(resolve_row_value(resource, operands.back(), chunk, params, i, session_tz));
-                    output.set_value(i, val);
+                    auto resolved = resolve_row_value(resource, operands.back(), chunk, params, i, session_tz, error);
+                    if (error.contains_error()) {
+                        return output;
+                    }
+                    output.set_value(i, coerce_to_result(std::move(resolved)));
                 } else if (!matched) {
                     output.set_null(i, true);
                 }
@@ -343,7 +423,12 @@ namespace components::operators {
                         const logical_plan::storage_parameters& params,
                         core::date::timezone_offset_t session_tz) {
         if (op == expressions::scalar_type::case_expr) {
-            return detail::evaluate_case_expr(resource, operands, chunk, params, session_tz);
+            core::error_t case_error = core::error_t::no_error();
+            auto computed = detail::evaluate_case_expr(resource, operands, chunk, params, session_tz, case_error);
+            if (case_error.contains_error()) {
+                return std::move(case_error);
+            }
+            return computed;
         }
 
         if (op == expressions::scalar_type::unary_minus) {
@@ -386,7 +471,11 @@ namespace components::operators {
         }
 
         uint64_t count = chunk.size();
-        auto arith_op = detail::scalar_to_arithmetic_op(op);
+        vector::arithmetic_op arith_op;
+        if (!detail::scalar_to_arithmetic_op(op, arith_op)) {
+            return core::error_t(core::error_code_t::arithmetics_failure,
+                                 std::pmr::string{"Not an arithmetic scalar_type", resource});
+        }
 
         if (left_op.value().vec && right_op.value().vec) {
             return vector::compute_binary_arithmetic(resource,

--- a/components/physical_plan/operators/arithmetic_eval.cpp
+++ b/components/physical_plan/operators/arithmetic_eval.cpp
@@ -58,13 +58,11 @@ namespace components::operators {
                     auto* scalar_expr = static_cast<const expressions::scalar_expression_t*>(expr_ptr.get());
 
                     if (scalar_expr->type() == expressions::scalar_type::case_expr) {
-                        core::error_t case_error = core::error_t::no_error();
-                        auto computed =
-                            evaluate_case_expr(resource, scalar_expr->params(), chunk, params, session_tz, case_error);
-                        if (case_error.contains_error()) {
-                            return std::move(case_error);
+                        auto computed = evaluate_case_expr(resource, scalar_expr->params(), chunk, params, session_tz);
+                        if (computed.has_error()) {
+                            return computed.convert_error<resolved_operand>();
                         }
-                        temp_vecs.emplace_back(std::move(computed));
+                        temp_vecs.emplace_back(std::move(computed.value()));
                         result.vec = &temp_vecs.back();
                         return result;
                     }
@@ -163,13 +161,13 @@ namespace components::operators {
             }
         }
 
-        types::logical_value_t resolve_row_value(std::pmr::memory_resource* resource,
-                                                 const expressions::param_storage& param,
-                                                 const vector::data_chunk_t& chunk,
-                                                 const logical_plan::storage_parameters& params,
-                                                 size_t row_idx,
-                                                 core::date::timezone_offset_t session_tz,
-                                                 core::error_t& error) {
+        core::result_wrapper_t<types::logical_value_t>
+        resolve_row_value(std::pmr::memory_resource* resource,
+                          const expressions::param_storage& param,
+                          const vector::data_chunk_t& chunk,
+                          const logical_plan::storage_parameters& params,
+                          size_t row_idx,
+                          core::date::timezone_offset_t session_tz) {
             // L1: per-row CASE arithmetic still boxes operands into logical_value_t and uses
             // logical_value_t::sum/subtract/mult/divide/modulus below. No typed scalar arithmetic
             // path exists for a single logical_value_t pair, so left as-is.
@@ -181,9 +179,8 @@ namespace components::operators {
                 if (vec) {
                     return vec->value(row_idx);
                 }
-                error = core::error_t(core::error_code_t::arithmetics_failure,
-                                      std::pmr::string{"CASE: column not found: " + key.as_string(), resource});
-                return types::logical_value_t(resource, types::complex_logical_type{types::logical_type::NA});
+                return core::error_t(core::error_code_t::field_not_exists,
+                                     std::pmr::string{"CASE: column not found: " + key.as_string(), resource});
             } else if (std::holds_alternative<core::parameter_id_t>(param)) {
                 auto id = std::get<core::parameter_id_t>(param);
                 return params.parameters.at(id);
@@ -200,95 +197,75 @@ namespace components::operators {
                             auto& cond_param = ops[w * 2];
                             if (std::holds_alternative<expressions::expression_ptr>(cond_param)) {
                                 auto& cond_expr = std::get<expressions::expression_ptr>(cond_param);
-                                bool matched = evaluate_row_condition(resource,
-                                                                      cond_expr,
-                                                                      chunk,
-                                                                      params,
-                                                                      row_idx,
-                                                                      session_tz,
-                                                                      error);
-                                if (error.contains_error()) {
-                                    return types::logical_value_t(
-                                        resource,
-                                        types::complex_logical_type{types::logical_type::NA});
+                                auto matched =
+                                    evaluate_row_condition(resource, cond_expr, chunk, params, row_idx, session_tz);
+                                if (matched.has_error()) {
+                                    return matched.convert_error<types::logical_value_t>();
                                 }
-                                if (matched) {
-                                    return resolve_row_value(resource,
-                                                             ops[w * 2 + 1],
-                                                             chunk,
-                                                             params,
-                                                             row_idx,
-                                                             session_tz,
-                                                             error);
+                                if (matched.value()) {
+                                    return resolve_row_value(resource, ops[w * 2 + 1], chunk, params, row_idx, session_tz);
                                 }
                             }
                         }
                         if (has_default) {
-                            return resolve_row_value(resource, ops.back(), chunk, params, row_idx, session_tz, error);
+                            return resolve_row_value(resource, ops.back(), chunk, params, row_idx, session_tz);
                         }
                         return types::logical_value_t(resource, types::complex_logical_type{types::logical_type::NA});
                     }
                     // Unary minus sub-expression
                     if (scalar->type() == expressions::scalar_type::unary_minus) {
                         if (scalar->params().empty()) {
-                            error = core::error_t(core::error_code_t::arithmetics_failure,
-                                                  std::pmr::string{"CASE: unary minus requires 1 operand", resource});
-                            return types::logical_value_t(resource,
-                                                          types::complex_logical_type{types::logical_type::NA});
+                            return core::error_t(core::error_code_t::arithmetics_failure,
+                                                 std::pmr::string{"CASE: unary minus requires 1 operand", resource});
                         }
                         auto inner =
-                            resolve_row_value(resource, scalar->params()[0], chunk, params, row_idx, session_tz, error);
-                        if (error.contains_error()) {
-                            return types::logical_value_t(resource,
-                                                          types::complex_logical_type{types::logical_type::NA});
+                            resolve_row_value(resource, scalar->params()[0], chunk, params, row_idx, session_tz);
+                        if (inner.has_error()) {
+                            return inner;
                         }
-                        return types::logical_value_t::subtract(types::logical_value_t(resource, int64_t(0)), inner);
+                        return types::logical_value_t::subtract(types::logical_value_t(resource, int64_t(0)),
+                                                                inner.value());
                     }
                     // Arithmetic sub-expression
                     if (scalar->params().size() < 2) {
-                        error = core::error_t(
+                        return core::error_t(
                             core::error_code_t::arithmetics_failure,
                             std::pmr::string{"CASE: arithmetic sub-expression requires 2 operands", resource});
-                        return types::logical_value_t(resource, types::complex_logical_type{types::logical_type::NA});
                     }
-                    auto l =
-                        resolve_row_value(resource, scalar->params()[0], chunk, params, row_idx, session_tz, error);
-                    if (error.contains_error()) {
-                        return types::logical_value_t(resource, types::complex_logical_type{types::logical_type::NA});
+                    auto l = resolve_row_value(resource, scalar->params()[0], chunk, params, row_idx, session_tz);
+                    if (l.has_error()) {
+                        return l;
                     }
-                    auto r =
-                        resolve_row_value(resource, scalar->params()[1], chunk, params, row_idx, session_tz, error);
-                    if (error.contains_error()) {
-                        return types::logical_value_t(resource, types::complex_logical_type{types::logical_type::NA});
+                    auto r = resolve_row_value(resource, scalar->params()[1], chunk, params, row_idx, session_tz);
+                    if (r.has_error()) {
+                        return r;
                     }
                     switch (scalar->type()) {
                         case expressions::scalar_type::add:
-                            return types::logical_value_t::sum(l, r);
+                            return types::logical_value_t::sum(l.value(), r.value());
                         case expressions::scalar_type::subtract:
-                            return types::logical_value_t::subtract(l, r);
+                            return types::logical_value_t::subtract(l.value(), r.value());
                         case expressions::scalar_type::multiply:
-                            return types::logical_value_t::mult(l, r);
+                            return types::logical_value_t::mult(l.value(), r.value());
                         case expressions::scalar_type::divide:
-                            return types::logical_value_t::divide(l, r);
+                            return types::logical_value_t::divide(l.value(), r.value());
                         case expressions::scalar_type::mod:
-                            return types::logical_value_t::modulus(l, r);
+                            return types::logical_value_t::modulus(l.value(), r.value());
                         default:
                             break;
                     }
                 }
-                error = core::error_t(core::error_code_t::arithmetics_failure,
-                                      std::pmr::string{"CASE: unsupported sub-expression", resource});
-                return types::logical_value_t(resource, types::complex_logical_type{types::logical_type::NA});
+                return core::error_t(core::error_code_t::arithmetics_failure,
+                                     std::pmr::string{"CASE: unsupported sub-expression", resource});
             }
         }
 
-        bool evaluate_row_condition(std::pmr::memory_resource* resource,
-                                    const expressions::expression_ptr& condition,
-                                    const vector::data_chunk_t& chunk,
-                                    const logical_plan::storage_parameters& params,
-                                    size_t row_idx,
-                                    core::date::timezone_offset_t session_tz,
-                                    core::error_t& error) {
+        core::result_wrapper_t<bool> evaluate_row_condition(std::pmr::memory_resource* resource,
+                                                            const expressions::expression_ptr& condition,
+                                                            const vector::data_chunk_t& chunk,
+                                                            const logical_plan::storage_parameters& params,
+                                                            size_t row_idx,
+                                                            core::date::timezone_offset_t session_tz) {
             if (condition->group() != expressions::expression_group::compare)
                 return false;
             auto* cmp = static_cast<const expressions::compare_expression_t*>(condition.get());
@@ -296,24 +273,25 @@ namespace components::operators {
             if (cmp->is_union()) {
                 bool is_and = (cmp->type() == expressions::compare_type::union_and);
                 for (auto& child : cmp->children()) {
-                    bool child_result =
-                        evaluate_row_condition(resource, child, chunk, params, row_idx, session_tz, error);
-                    if (error.contains_error())
+                    auto child_result = evaluate_row_condition(resource, child, chunk, params, row_idx, session_tz);
+                    if (child_result.has_error())
+                        return child_result;
+                    if (is_and && !child_result.value())
                         return false;
-                    if (is_and && !child_result)
-                        return false;
-                    if (!is_and && child_result)
+                    if (!is_and && child_result.value())
                         return true;
                 }
                 return is_and;
             }
 
-            auto left_val = resolve_row_value(resource, cmp->left(), chunk, params, row_idx, session_tz, error);
-            if (error.contains_error())
-                return false;
-            auto right_val = resolve_row_value(resource, cmp->right(), chunk, params, row_idx, session_tz, error);
-            if (error.contains_error())
-                return false;
+            auto left_rw = resolve_row_value(resource, cmp->left(), chunk, params, row_idx, session_tz);
+            if (left_rw.has_error())
+                return left_rw.convert_error<bool>();
+            auto right_rw = resolve_row_value(resource, cmp->right(), chunk, params, row_idx, session_tz);
+            if (right_rw.has_error())
+                return right_rw.convert_error<bool>();
+            auto left_val = std::move(left_rw.value());
+            auto right_val = std::move(right_rw.value());
             if (left_val.type() != right_val.type()) {
                 auto cast_right = right_val.cast_as(left_val.type(), session_tz);
                 if (!cast_right.is_null()) {
@@ -344,12 +322,12 @@ namespace components::operators {
             }
         }
 
-        vector::vector_t evaluate_case_expr(std::pmr::memory_resource* resource,
-                                            const std::pmr::vector<expressions::param_storage>& operands,
-                                            vector::data_chunk_t& chunk,
-                                            const logical_plan::storage_parameters& params,
-                                            core::date::timezone_offset_t session_tz,
-                                            core::error_t& error) {
+        core::result_wrapper_t<vector::vector_t>
+        evaluate_case_expr(std::pmr::memory_resource* resource,
+                           const std::pmr::vector<expressions::param_storage>& operands,
+                           vector::data_chunk_t& chunk,
+                           const logical_plan::storage_parameters& params,
+                           core::date::timezone_offset_t session_tz) {
             uint64_t count = chunk.size();
             bool has_default = (operands.size() % 2 == 1);
             size_t num_whens = operands.size() / 2;
@@ -358,11 +336,11 @@ namespace components::operators {
             types::complex_logical_type result_type(types::logical_type::NA);
             if (count > 0) {
                 // Try first THEN result
-                auto val = resolve_row_value(resource, operands[1], chunk, params, 0, session_tz, error);
-                if (error.contains_error()) {
-                    return vector::vector_t(resource, result_type, count);
+                auto val = resolve_row_value(resource, operands[1], chunk, params, 0, session_tz);
+                if (val.has_error()) {
+                    return val.convert_error<vector::vector_t>();
                 }
-                result_type = val.type();
+                result_type = val.value().type();
             }
 
             vector::vector_t output(resource, result_type, count);
@@ -383,28 +361,28 @@ namespace components::operators {
                     auto& cond_param = operands[w * 2];
                     if (std::holds_alternative<expressions::expression_ptr>(cond_param)) {
                         auto& cond_expr = std::get<expressions::expression_ptr>(cond_param);
-                        bool cond = evaluate_row_condition(resource, cond_expr, chunk, params, i, session_tz, error);
-                        if (error.contains_error()) {
-                            return output;
+                        auto cond = evaluate_row_condition(resource, cond_expr, chunk, params, i, session_tz);
+                        if (cond.has_error()) {
+                            return cond.convert_error<vector::vector_t>();
                         }
-                        if (cond) {
+                        if (cond.value()) {
                             auto resolved =
-                                resolve_row_value(resource, operands[w * 2 + 1], chunk, params, i, session_tz, error);
-                            if (error.contains_error()) {
-                                return output;
+                                resolve_row_value(resource, operands[w * 2 + 1], chunk, params, i, session_tz);
+                            if (resolved.has_error()) {
+                                return resolved.convert_error<vector::vector_t>();
                             }
-                            output.set_value(i, coerce_to_result(std::move(resolved)));
+                            output.set_value(i, coerce_to_result(std::move(resolved.value())));
                             matched = true;
                             break;
                         }
                     }
                 }
                 if (!matched && has_default) {
-                    auto resolved = resolve_row_value(resource, operands.back(), chunk, params, i, session_tz, error);
-                    if (error.contains_error()) {
-                        return output;
+                    auto resolved = resolve_row_value(resource, operands.back(), chunk, params, i, session_tz);
+                    if (resolved.has_error()) {
+                        return resolved.convert_error<vector::vector_t>();
                     }
-                    output.set_value(i, coerce_to_result(std::move(resolved)));
+                    output.set_value(i, coerce_to_result(std::move(resolved.value())));
                 } else if (!matched) {
                     output.set_null(i, true);
                 }
@@ -423,12 +401,7 @@ namespace components::operators {
                         const logical_plan::storage_parameters& params,
                         core::date::timezone_offset_t session_tz) {
         if (op == expressions::scalar_type::case_expr) {
-            core::error_t case_error = core::error_t::no_error();
-            auto computed = detail::evaluate_case_expr(resource, operands, chunk, params, session_tz, case_error);
-            if (case_error.contains_error()) {
-                return std::move(case_error);
-            }
-            return computed;
+            return detail::evaluate_case_expr(resource, operands, chunk, params, session_tz);
         }
 
         if (op == expressions::scalar_type::unary_minus) {

--- a/components/physical_plan/operators/arithmetic_eval.hpp
+++ b/components/physical_plan/operators/arithmetic_eval.hpp
@@ -12,7 +12,8 @@ namespace components::operators {
 
     namespace detail {
 
-        vector::arithmetic_op scalar_to_arithmetic_op(expressions::scalar_type t);
+        // Returns false if t is not an arithmetic scalar_type; on success writes the op to out.
+        bool scalar_to_arithmetic_op(expressions::scalar_type t, vector::arithmetic_op& out);
 
         struct resolved_operand {
             const vector::vector_t* vec = nullptr;
@@ -27,28 +28,34 @@ namespace components::operators {
                         std::deque<vector::vector_t>& temp_vecs,
                         core::date::timezone_offset_t session_tz);
 
-        // Resolve a param_storage to logical_value_t for a specific row
+        // Resolve a param_storage to logical_value_t for a specific row.
+        // On failure, sets `error` (caller must check error.contains_error()); never throws.
         [[nodiscard]] types::logical_value_t resolve_row_value(std::pmr::memory_resource* resource,
                                                                const expressions::param_storage& param,
                                                                const vector::data_chunk_t& chunk,
                                                                const logical_plan::storage_parameters& params,
                                                                size_t row_idx,
-                                                               core::date::timezone_offset_t session_tz);
+                                                               core::date::timezone_offset_t session_tz,
+                                                               core::error_t& error);
 
-        // Evaluate a compare_expression for a specific row
+        // Evaluate a compare_expression for a specific row.
+        // On failure, sets `error` (caller must check error.contains_error()); never throws.
         [[nodiscard]] bool evaluate_row_condition(std::pmr::memory_resource* resource,
                                                   const expressions::expression_ptr& condition,
                                                   const vector::data_chunk_t& chunk,
                                                   const logical_plan::storage_parameters& params,
                                                   size_t row_idx,
-                                                  core::date::timezone_offset_t session_tz);
+                                                  core::date::timezone_offset_t session_tz,
+                                                  core::error_t& error);
 
-        // Evaluate a CASE expression per-row on a data_chunk
+        // Evaluate a CASE expression per-row on a data_chunk.
+        // On failure, sets `error` (caller must check error.contains_error()); never throws.
         [[nodiscard]] vector::vector_t evaluate_case_expr(std::pmr::memory_resource* resource,
                                                           const std::pmr::vector<expressions::param_storage>& operands,
                                                           vector::data_chunk_t& chunk,
                                                           const logical_plan::storage_parameters& params,
-                                                          core::date::timezone_offset_t session_tz);
+                                                          core::date::timezone_offset_t session_tz,
+                                                          core::error_t& error);
 
     } // namespace detail
 

--- a/components/physical_plan/operators/arithmetic_eval.hpp
+++ b/components/physical_plan/operators/arithmetic_eval.hpp
@@ -29,33 +29,33 @@ namespace components::operators {
                         core::date::timezone_offset_t session_tz);
 
         // Resolve a param_storage to logical_value_t for a specific row.
-        // On failure, sets `error` (caller must check error.contains_error()); never throws.
-        [[nodiscard]] types::logical_value_t resolve_row_value(std::pmr::memory_resource* resource,
-                                                               const expressions::param_storage& param,
-                                                               const vector::data_chunk_t& chunk,
-                                                               const logical_plan::storage_parameters& params,
-                                                               size_t row_idx,
-                                                               core::date::timezone_offset_t session_tz,
-                                                               core::error_t& error);
+        // On failure returns the error via result_wrapper_t (never throws).
+        [[nodiscard]] core::result_wrapper_t<types::logical_value_t>
+        resolve_row_value(std::pmr::memory_resource* resource,
+                          const expressions::param_storage& param,
+                          const vector::data_chunk_t& chunk,
+                          const logical_plan::storage_parameters& params,
+                          size_t row_idx,
+                          core::date::timezone_offset_t session_tz);
 
         // Evaluate a compare_expression for a specific row.
-        // On failure, sets `error` (caller must check error.contains_error()); never throws.
-        [[nodiscard]] bool evaluate_row_condition(std::pmr::memory_resource* resource,
-                                                  const expressions::expression_ptr& condition,
-                                                  const vector::data_chunk_t& chunk,
-                                                  const logical_plan::storage_parameters& params,
-                                                  size_t row_idx,
-                                                  core::date::timezone_offset_t session_tz,
-                                                  core::error_t& error);
+        // On failure returns the error via result_wrapper_t (never throws).
+        [[nodiscard]] core::result_wrapper_t<bool>
+        evaluate_row_condition(std::pmr::memory_resource* resource,
+                               const expressions::expression_ptr& condition,
+                               const vector::data_chunk_t& chunk,
+                               const logical_plan::storage_parameters& params,
+                               size_t row_idx,
+                               core::date::timezone_offset_t session_tz);
 
         // Evaluate a CASE expression per-row on a data_chunk.
-        // On failure, sets `error` (caller must check error.contains_error()); never throws.
-        [[nodiscard]] vector::vector_t evaluate_case_expr(std::pmr::memory_resource* resource,
-                                                          const std::pmr::vector<expressions::param_storage>& operands,
-                                                          vector::data_chunk_t& chunk,
-                                                          const logical_plan::storage_parameters& params,
-                                                          core::date::timezone_offset_t session_tz,
-                                                          core::error_t& error);
+        // On failure returns the error via result_wrapper_t (never throws).
+        [[nodiscard]] core::result_wrapper_t<vector::vector_t>
+        evaluate_case_expr(std::pmr::memory_resource* resource,
+                           const std::pmr::vector<expressions::param_storage>& operands,
+                           vector::data_chunk_t& chunk,
+                           const logical_plan::storage_parameters& params,
+                           core::date::timezone_offset_t session_tz);
 
     } // namespace detail
 

--- a/components/physical_plan/operators/catalog_write_helpers.hpp
+++ b/components/physical_plan/operators/catalog_write_helpers.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <components/vector/data_chunk.hpp>
+#include <components/vector/vector_buffer.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <memory_resource>
+#include <string_view>
+
+namespace components::operators {
+
+    // Typed setters shared by the catalog resolve operators. Each resolve
+    // operator builds a data_chunk with a statically-known column schema, so
+    // these helpers write directly into the column's typed buffer at
+    // (col, row) and flip the validity bit — bypassing the logical_value_t
+    // variant construct/dispatch/destroy cycle. Extracted here (TASK C9) to
+    // remove the near-identical per-file duplicates.
+
+    inline void set_uint32(vector::data_chunk_t& c, std::size_t col, std::size_t row, std::uint32_t v) {
+        auto& vec = c.data[col];
+        vec.template data<std::uint32_t>()[row] = v;
+        vec.validity().set(row, true);
+    }
+
+    inline void set_int32(vector::data_chunk_t& c, std::size_t col, std::size_t row, std::int32_t v) {
+        auto& vec = c.data[col];
+        vec.template data<std::int32_t>()[row] = v;
+        vec.validity().set(row, true);
+    }
+
+    inline void set_int64(vector::data_chunk_t& c, std::size_t col, std::size_t row, std::int64_t v) {
+        auto& vec = c.data[col];
+        vec.template data<std::int64_t>()[row] = v;
+        vec.validity().set(row, true);
+    }
+
+    inline void
+    set_str(vector::data_chunk_t& c, std::size_t col, std::size_t row, std::string_view v, std::pmr::memory_resource* r) {
+        auto& vec = c.data[col];
+        if (!vec.auxiliary()) {
+            vec.set_auxiliary(std::make_shared<vector::string_vector_buffer_t>(r));
+        }
+        auto* sb = static_cast<vector::string_vector_buffer_t*>(vec.auxiliary().get());
+        auto* ptr = sb->insert(v);
+        reinterpret_cast<std::string_view*>(vec.template data<std::byte>())[row] =
+            std::string_view(static_cast<const char*>(ptr), v.size());
+        vec.validity().set(row, true);
+    }
+
+} // namespace components::operators

--- a/components/physical_plan/operators/operator_resolve_constraint.cpp
+++ b/components/physical_plan/operators/operator_resolve_constraint.cpp
@@ -29,7 +29,13 @@ namespace components::operators {
         log_t log,
         components::logical_plan::node_catalog_resolve_constraint_t* target_node)
         : read_write_operator_t(resource, std::move(log), operator_type::resolve_constraint)
-        , target_node_(target_node) {}
+        , target_node_(target_node)
+        , output_schema_(resource) {
+        // Single-column placeholder schema, built once (TASK C10). This
+        // operator stamps data on the target logical node rather than emitting
+        // rows, so the chunk it produces is always an empty placeholder.
+        output_schema_.emplace_back(types::logical_type::UINTEGER);
+    }
 
     void operator_resolve_constraint_t::on_execute_impl(pipeline::context_t* /*ctx*/) { async_wait(); }
 
@@ -42,10 +48,9 @@ namespace components::operators {
         components::execution_context_t exec_ctx{ctx->session, ctx->txn, {}};
 
         // Empty single-column placeholder chunk — this operator's purpose is to
-        // stamp data on the target logical node, not to emit rows.
-        std::pmr::vector<types::complex_logical_type> out_types(resource_);
-        out_types.emplace_back(types::logical_type::UINTEGER);
-        output_ = make_operator_data(resource_, out_types, 0);
+        // stamp data on the target logical node, not to emit rows. Schema is
+        // cached on the operator (output_schema_), built once in the ctor.
+        output_ = make_operator_data(resource_, output_schema_, 0);
         output_->data_chunk().set_cardinality(0);
 
         if (ctx->disk_address == actor_zeta::address_t::empty_address()) {

--- a/components/physical_plan/operators/operator_resolve_constraint.hpp
+++ b/components/physical_plan/operators/operator_resolve_constraint.hpp
@@ -2,6 +2,9 @@
 
 #include <components/catalog/catalog_oids.hpp>
 #include <components/physical_plan/operators/operator.hpp>
+#include <components/types/types.hpp>
+
+#include <memory_resource>
 
 namespace components::logical_plan {
     class node_catalog_resolve_constraint_t;
@@ -41,6 +44,8 @@ namespace components::operators {
         actor_zeta::unique_future<void> await_async_and_resume(pipeline::context_t* ctx) override;
 
         components::logical_plan::node_catalog_resolve_constraint_t* target_node_{nullptr};
+        // Static placeholder output schema, built once in the constructor (TASK C10).
+        std::pmr::vector<components::types::complex_logical_type> output_schema_;
     };
 
 } // namespace components::operators

--- a/components/physical_plan/operators/operator_resolve_database.cpp
+++ b/components/physical_plan/operators/operator_resolve_database.cpp
@@ -1,5 +1,7 @@
 #include "operator_resolve_database.hpp"
 
+#include "catalog_write_helpers.hpp"
+
 #include <components/catalog/catalog_oids.hpp>
 #include <components/context/context.hpp>
 #include <components/logical_plan/node_catalog_resolve_database.hpp>
@@ -18,20 +20,17 @@ namespace components::operators {
 
     namespace catalog = components::catalog;
 
-    namespace {
-        // Direct write into the uint32_t column buffer, avoiding a logical_value_t round-trip.
-        inline void set_uint32(vector::data_chunk_t& c, size_t col, size_t row, std::uint32_t v) {
-            auto& vec = c.data[col];
-            vec.template data<std::uint32_t>()[row] = v;
-            vec.validity().set(row, true);
-        }
-    } // namespace
-
     operator_resolve_database_t::operator_resolve_database_t(std::pmr::memory_resource* resource,
                                                              log_t log,
                                                              std::string name)
         : read_write_operator_t(resource, std::move(log), operator_type::resolve_database)
-        , name_(std::move(name)) {}
+        , name_(std::move(name))
+        , output_schema_(resource) {
+        // Single-column UINTEGER (database_oid) schema, built once (TASK C10).
+        // Always emitted, even on miss, so downstream sees a consistent schema.
+        output_schema_.emplace_back(types::logical_type::UINTEGER);
+        output_schema_.back().set_alias("database_oid");
+    }
 
     operator_resolve_database_t::operator_resolve_database_t(
         std::pmr::memory_resource* resource,
@@ -40,20 +39,20 @@ namespace components::operators {
         components::logical_plan::node_catalog_resolve_database_t* target_node)
         : read_write_operator_t(resource, std::move(log), operator_type::resolve_database)
         , name_(std::move(name))
-        , target_node_(target_node) {}
+        , target_node_(target_node)
+        , output_schema_(resource) {
+        output_schema_.emplace_back(types::logical_type::UINTEGER);
+        output_schema_.back().set_alias("database_oid");
+    }
 
     void operator_resolve_database_t::on_execute_impl(pipeline::context_t* /*ctx*/) { async_wait(); }
 
     actor_zeta::unique_future<void> operator_resolve_database_t::await_async_and_resume(pipeline::context_t* ctx) {
         constexpr catalog::oid_t kPgDatabase = catalog::well_known_oid::pg_database_table;
 
-        // Single-column UINTEGER (database_oid) chunk. Always emitted, even on
-        // miss, so downstream operators see a consistent schema.
-        std::pmr::vector<types::complex_logical_type> out_types(resource_);
-        out_types.emplace_back(types::logical_type::UINTEGER);
-        out_types.back().set_alias("database_oid");
-
-        vector::data_chunk_t out_chunk(resource_, out_types);
+        // Output chunk built from the constructor-cached schema (TASK C10).
+        // Always emitted, even on miss, so downstream sees a consistent schema.
+        vector::data_chunk_t out_chunk(resource_, output_schema_);
 
         if (ctx->disk_address == actor_zeta::address_t::empty_address()) {
             out_chunk.set_cardinality(0);

--- a/components/physical_plan/operators/operator_resolve_database.hpp
+++ b/components/physical_plan/operators/operator_resolve_database.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <components/physical_plan/operators/operator.hpp>
+#include <components/types/types.hpp>
 
+#include <memory_resource>
 #include <string>
 
 namespace components::logical_plan {
@@ -30,6 +32,8 @@ namespace components::operators {
 
         std::string name_;
         components::logical_plan::node_catalog_resolve_database_t* target_node_{nullptr};
+        // Static output chunk schema, built once in the constructor (TASK C10).
+        std::pmr::vector<components::types::complex_logical_type> output_schema_;
     };
 
 } // namespace components::operators

--- a/components/physical_plan/operators/operator_resolve_function.cpp
+++ b/components/physical_plan/operators/operator_resolve_function.cpp
@@ -1,5 +1,7 @@
 #include "operator_resolve_function.hpp"
 
+#include "catalog_write_helpers.hpp"
+
 #include <components/catalog/catalog_oids.hpp>
 #include <components/context/context.hpp>
 #include <components/types/logical_value.hpp>
@@ -20,35 +22,19 @@ namespace components::operators {
     namespace catalog = components::catalog;
 
     namespace {
-        // File-local typed setters — direct typed-buffer writes that skip the
-        // logical_value_t variant construct/dispatch/destroy cycle. Layout of
-        // the destination chunk is known statically here (pg_proc schema).
-        inline void set_uint32(vector::data_chunk_t& c, size_t col, size_t row, std::uint32_t v) {
-            auto& vec = c.data[col];
-            vec.template data<std::uint32_t>()[row] = v;
-            vec.validity().set(row, true);
-        }
-        inline void set_int32(vector::data_chunk_t& c, size_t col, size_t row, std::int32_t v) {
-            auto& vec = c.data[col];
-            vec.template data<std::int32_t>()[row] = v;
-            vec.validity().set(row, true);
-        }
-        inline void set_int64(vector::data_chunk_t& c, size_t col, size_t row, std::int64_t v) {
-            auto& vec = c.data[col];
-            vec.template data<std::int64_t>()[row] = v;
-            vec.validity().set(row, true);
-        }
-        inline void
-        set_str(vector::data_chunk_t& c, size_t col, size_t row, std::string_view v, std::pmr::memory_resource* r) {
-            auto& vec = c.data[col];
-            if (!vec.auxiliary()) {
-                vec.set_auxiliary(std::make_shared<vector::string_vector_buffer_t>(r));
-            }
-            auto* sb = static_cast<vector::string_vector_buffer_t*>(vec.auxiliary().get());
-            auto* ptr = sb->insert(v);
-            reinterpret_cast<std::string_view*>(vec.template data<std::byte>())[row] =
-                std::string_view(static_cast<const char*>(ptr), v.size());
-            vec.validity().set(row, true);
+        // pg_proc output schema (column order):
+        //   [0] oid uint32, [1] proname string, [2] pronamespace uint32,
+        //   [3] pronargs int32, [4] prouid int64, [5] proargmatchers string,
+        //   [6] prorettype string. Built once into the cached member (TASK C10).
+        void build_output_schema(std::pmr::vector<types::complex_logical_type>& out_types) {
+            out_types.reserve(7);
+            out_types.emplace_back(types::logical_type::UINTEGER);       // oid
+            out_types.emplace_back(types::logical_type::STRING_LITERAL); // proname
+            out_types.emplace_back(types::logical_type::UINTEGER);       // pronamespace
+            out_types.emplace_back(types::logical_type::INTEGER);        // pronargs
+            out_types.emplace_back(types::logical_type::BIGINT);         // prouid
+            out_types.emplace_back(types::logical_type::STRING_LITERAL); // proargmatchers
+            out_types.emplace_back(types::logical_type::STRING_LITERAL); // prorettype
         }
     } // namespace
 
@@ -58,7 +44,10 @@ namespace components::operators {
                                                              std::string name)
         : read_write_operator_t(resource, std::move(log), operator_type::resolve_function)
         , namespace_oid_(namespace_oid)
-        , name_(std::move(name)) {}
+        , name_(std::move(name))
+        , output_schema_(resource) {
+        build_output_schema(output_schema_);
+    }
 
     void operator_resolve_function_t::on_execute_impl(pipeline::context_t* /*ctx*/) {
         // Pg_proc read is async; defer to await_async_and_resume.
@@ -68,28 +57,13 @@ namespace components::operators {
     actor_zeta::unique_future<void> operator_resolve_function_t::await_async_and_resume(pipeline::context_t* ctx) {
         constexpr catalog::oid_t kPgProc = catalog::well_known_oid::pg_proc_table;
 
-        // Output schema mirrors pg_proc column order:
-        //   [0] oid             UINTEGER
-        //   [1] proname         STRING
-        //   [2] pronamespace    UINTEGER
-        //   [3] pronargs        INTEGER
-        //   [4] prouid          BIGINT
-        //   [5] proargmatchers  STRING
-        //   [6] prorettype      STRING
-        std::pmr::vector<types::complex_logical_type> out_types(resource_);
-        out_types.reserve(7);
-        out_types.emplace_back(types::logical_type::UINTEGER);       // oid
-        out_types.emplace_back(types::logical_type::STRING_LITERAL); // proname
-        out_types.emplace_back(types::logical_type::UINTEGER);       // pronamespace
-        out_types.emplace_back(types::logical_type::INTEGER);        // pronargs
-        out_types.emplace_back(types::logical_type::BIGINT);         // prouid
-        out_types.emplace_back(types::logical_type::STRING_LITERAL); // proargmatchers
-        out_types.emplace_back(types::logical_type::STRING_LITERAL); // prorettype
+        // Output schema mirrors pg_proc column order; cached on the operator
+        // (output_schema_), built once in the constructor (TASK C10).
 
         // Empty-input guard: no actor wired or empty name → emit an empty
         // chunk that still carries the schema so consumers can inspect columns.
         if (ctx->disk_address == actor_zeta::address_t::empty_address() || name_.empty()) {
-            output_ = make_operator_data(resource_, out_types, 0);
+            output_ = make_operator_data(resource_, output_schema_, 0);
             output_->data_chunk().set_cardinality(0);
             mark_executed();
             co_return;
@@ -127,7 +101,7 @@ namespace components::operators {
             total_rows += batch.size();
         }
         const auto cap = std::max<std::size_t>(total_rows, 1);
-        output_ = make_operator_data(resource_, out_types, cap);
+        output_ = make_operator_data(resource_, output_schema_, cap);
         auto& chunk = output_->data_chunk();
         chunk.set_cardinality(total_rows);
 

--- a/components/physical_plan/operators/operator_resolve_function.hpp
+++ b/components/physical_plan/operators/operator_resolve_function.hpp
@@ -2,7 +2,9 @@
 
 #include <components/catalog/catalog_oids.hpp>
 #include <components/physical_plan/operators/operator.hpp>
+#include <components/types/types.hpp>
 
+#include <memory_resource>
 #include <string>
 
 namespace components::operators {
@@ -40,6 +42,8 @@ namespace components::operators {
     private:
         components::catalog::oid_t namespace_oid_;
         std::string name_;
+        // Static output chunk schema, built once in the constructor (TASK C10).
+        std::pmr::vector<components::types::complex_logical_type> output_schema_;
     };
 
 } // namespace components::operators

--- a/components/physical_plan/operators/operator_resolve_namespace.cpp
+++ b/components/physical_plan/operators/operator_resolve_namespace.cpp
@@ -1,5 +1,7 @@
 #include "operator_resolve_namespace.hpp"
 
+#include "catalog_write_helpers.hpp"
+
 #include <components/catalog/catalog_oids.hpp>
 #include <components/context/context.hpp>
 #include <components/logical_plan/node_catalog_resolve_namespace.hpp>
@@ -18,18 +20,6 @@ namespace components::operators {
 
     namespace catalog = components::catalog;
 
-    namespace {
-        // File-local typed setter — mirrors the ddl_metadata_builder.cpp helpers.
-        // Writes directly into the column's typed buffer at (col, row), avoiding
-        // a logical_value_t variant round-trip when both sides are known to be
-        // uint32_t at compile time.
-        inline void set_uint32(vector::data_chunk_t& c, size_t col, size_t row, std::uint32_t v) {
-            auto& vec = c.data[col];
-            vec.template data<std::uint32_t>()[row] = v;
-            vec.validity().set(row, true);
-        }
-    } // namespace
-
     operator_resolve_namespace_t::operator_resolve_namespace_t(std::pmr::memory_resource* resource,
                                                                log_t log,
                                                                std::string name)
@@ -37,7 +27,14 @@ namespace components::operators {
         // consumers; like operator_get_schema, the executor's generic
         // pipeline drives this operator via await_async_and_resume.
         : read_write_operator_t(resource, std::move(log), operator_type::resolve_namespace)
-        , name_(std::move(name)) {}
+        , name_(std::move(name))
+        , output_schema_(resource) {
+        // Static single-column output schema, built once here (TASK C10).
+        // We always emit a chunk (zero rows on miss, one row on hit) so
+        // downstream operators rely on a consistent schema.
+        output_schema_.emplace_back(types::logical_type::UINTEGER);
+        output_schema_.back().set_alias("namespace_oid");
+    }
 
     operator_resolve_namespace_t::operator_resolve_namespace_t(
         std::pmr::memory_resource* resource,
@@ -46,7 +43,11 @@ namespace components::operators {
         components::logical_plan::node_catalog_resolve_namespace_t* target_node)
         : read_write_operator_t(resource, std::move(log), operator_type::resolve_namespace)
         , name_(std::move(name))
-        , target_node_(target_node) {}
+        , target_node_(target_node)
+        , output_schema_(resource) {
+        output_schema_.emplace_back(types::logical_type::UINTEGER);
+        output_schema_.back().set_alias("namespace_oid");
+    }
 
     void operator_resolve_namespace_t::on_execute_impl(pipeline::context_t* /*ctx*/) {
         // All work is async (single pg_namespace read). Defer to
@@ -57,14 +58,10 @@ namespace components::operators {
     actor_zeta::unique_future<void> operator_resolve_namespace_t::await_async_and_resume(pipeline::context_t* ctx) {
         constexpr catalog::oid_t kPgNamespace = catalog::well_known_oid::pg_namespace_table;
 
-        // Build the single-column output chunk schema up-front. We always emit
-        // a chunk (zero rows on miss, one row on hit) so downstream operators
-        // can rely on a consistent schema regardless of resolution outcome.
-        std::pmr::vector<types::complex_logical_type> out_types(resource_);
-        out_types.emplace_back(types::logical_type::UINTEGER);
-        out_types.back().set_alias("namespace_oid");
-
-        vector::data_chunk_t out_chunk(resource_, out_types);
+        // Output chunk built from the constructor-cached schema (TASK C10). We
+        // always emit a chunk (zero rows on miss, one row on hit) so downstream
+        // operators can rely on a consistent schema regardless of outcome.
+        vector::data_chunk_t out_chunk(resource_, output_schema_);
 
         if (ctx->disk_address == actor_zeta::address_t::empty_address()) {
             // No disk wired (rare — some test harnesses). Emit empty chunk and

--- a/components/physical_plan/operators/operator_resolve_namespace.hpp
+++ b/components/physical_plan/operators/operator_resolve_namespace.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <components/physical_plan/operators/operator.hpp>
+#include <components/types/types.hpp>
 
+#include <memory_resource>
 #include <string>
 
 namespace components::logical_plan {
@@ -44,6 +46,8 @@ namespace components::operators {
 
         std::string name_;
         components::logical_plan::node_catalog_resolve_namespace_t* target_node_{nullptr};
+        // Static output chunk schema, built once in the constructor (TASK C10).
+        std::pmr::vector<components::types::complex_logical_type> output_schema_;
     };
 
 } // namespace components::operators

--- a/components/physical_plan/operators/operator_resolve_table.cpp
+++ b/components/physical_plan/operators/operator_resolve_table.cpp
@@ -1,5 +1,7 @@
 #include "operator_resolve_table.hpp"
 
+#include "catalog_write_helpers.hpp"
+
 #include <components/catalog/catalog_codes.hpp>
 #include <components/catalog/catalog_oids.hpp>
 #include <components/catalog/system_table_schemas.hpp>
@@ -26,30 +28,17 @@ namespace components::operators {
     namespace catalog = components::catalog;
 
     namespace {
-        // File-local typed setters — the relkind='g' output chunk has a fixed
-        // 5-column schema known here, so we skip the logical_value_t variant
-        // round-trip and write directly into the typed buffers.
-        inline void set_int32(vector::data_chunk_t& c, size_t col, size_t row, std::int32_t v) {
-            auto& vec = c.data[col];
-            vec.template data<std::int32_t>()[row] = v;
-            vec.validity().set(row, true);
-        }
-        inline void set_uint32(vector::data_chunk_t& c, size_t col, size_t row, std::uint32_t v) {
-            auto& vec = c.data[col];
-            vec.template data<std::uint32_t>()[row] = v;
-            vec.validity().set(row, true);
-        }
-        inline void
-        set_str(vector::data_chunk_t& c, size_t col, size_t row, std::string_view v, std::pmr::memory_resource* r) {
-            auto& vec = c.data[col];
-            if (!vec.auxiliary()) {
-                vec.set_auxiliary(std::make_shared<vector::string_vector_buffer_t>(r));
-            }
-            auto* sb = static_cast<vector::string_vector_buffer_t*>(vec.auxiliary().get());
-            auto* ptr = sb->insert(v);
-            reinterpret_cast<std::string_view*>(vec.template data<std::byte>())[row] =
-                std::string_view(static_cast<const char*>(ptr), v.size());
-            vec.validity().set(row, true);
+        // Output schema: (position int32, attoid uint32, attname string,
+        // atttypid uint32, atttypspec string). Built once per operator into the
+        // cached member (TASK C10) so even an empty result (table not found)
+        // yields a valid-typed empty chunk.
+        void build_output_schema(std::pmr::vector<types::complex_logical_type>& out_types) {
+            out_types.reserve(5);
+            out_types.emplace_back(types::logical_type::INTEGER);        // position
+            out_types.emplace_back(types::logical_type::UINTEGER);       // attoid
+            out_types.emplace_back(types::logical_type::STRING_LITERAL); // attname
+            out_types.emplace_back(types::logical_type::UINTEGER);       // atttypid
+            out_types.emplace_back(types::logical_type::STRING_LITERAL); // atttypspec
         }
     } // namespace
 
@@ -57,7 +46,10 @@ namespace components::operators {
                                                        log_t log,
                                                        catalog::oid_t table_oid)
         : read_write_operator_t(resource, std::move(log), operator_type::resolve_table)
-        , table_oid_(table_oid) {}
+        , table_oid_(table_oid)
+        , output_schema_(resource) {
+        build_output_schema(output_schema_);
+    }
 
     operator_resolve_table_t::operator_resolve_table_t(std::pmr::memory_resource* resource,
                                                        log_t log,
@@ -66,7 +58,10 @@ namespace components::operators {
         : read_write_operator_t(resource, std::move(log), operator_type::resolve_table)
         , table_oid_(catalog::INVALID_OID)
         , input_namespace_oid_(namespace_oid)
-        , relname_(std::move(relname)) {}
+        , relname_(std::move(relname))
+        , output_schema_(resource) {
+        build_output_schema(output_schema_);
+    }
 
     operator_resolve_table_t::operator_resolve_table_t(
         std::pmr::memory_resource* resource,
@@ -78,7 +73,10 @@ namespace components::operators {
         , table_oid_(catalog::INVALID_OID)
         , input_namespace_oid_(namespace_oid)
         , relname_(std::move(relname))
-        , target_node_(target_node) {}
+        , target_node_(target_node)
+        , output_schema_(resource) {
+        build_output_schema(output_schema_);
+    }
 
     void operator_resolve_table_t::on_execute_impl(pipeline::context_t* /*ctx*/) {
         // All catalog reads are async: defer to await_async_and_resume so the
@@ -94,21 +92,13 @@ namespace components::operators {
 
         components::execution_context_t exec_ctx{ctx->session, ctx->txn, {}};
 
-        // Output schema: (position int32, attoid uint32, attname string,
-        // atttypid uint32, atttypspec string). Pre-built here so even an
-        // empty result (table not found) yields a valid-typed empty chunk.
-        std::pmr::vector<types::complex_logical_type> out_types(resource_);
-        out_types.reserve(5);
-        out_types.emplace_back(types::logical_type::INTEGER);        // position
-        out_types.emplace_back(types::logical_type::UINTEGER);       // attoid
-        out_types.emplace_back(types::logical_type::STRING_LITERAL); // attname
-        out_types.emplace_back(types::logical_type::UINTEGER);       // atttypid
-        out_types.emplace_back(types::logical_type::STRING_LITERAL); // atttypspec
+        // Output schema is cached on the operator (output_schema_), built once
+        // in the constructor (TASK C10).
 
         // Bail with empty output when the disk actor is not wired (test
         // harnesses).
         if (ctx->disk_address == actor_zeta::address_t::empty_address()) {
-            output_ = make_operator_data(resource_, out_types, 0);
+            output_ = make_operator_data(resource_, output_schema_, 0);
             output_->data_chunk().set_cardinality(0);
             mark_executed();
             co_return;
@@ -119,7 +109,7 @@ namespace components::operators {
         // If relname_ is empty we cannot resolve — emit empty output.
         if (table_oid_ == catalog::INVALID_OID) {
             if (relname_.empty()) {
-                output_ = make_operator_data(resource_, out_types, 0);
+                output_ = make_operator_data(resource_, output_schema_, 0);
                 output_->data_chunk().set_cardinality(0);
                 mark_executed();
                 co_return;
@@ -142,7 +132,7 @@ namespace components::operators {
             if (lookup_batches.empty() || lookup_batches[0].size() == 0 || lookup_batches[0].column_count() == 0 ||
                 lookup_batches[0].value(0, 0).is_null()) {
                 // Not found — emit empty output, leave found_=false.
-                output_ = make_operator_data(resource_, out_types, 0);
+                output_ = make_operator_data(resource_, output_schema_, 0);
                 output_->data_chunk().set_cardinality(0);
                 mark_executed();
                 co_return;
@@ -192,7 +182,7 @@ namespace components::operators {
 
         if (!found_) {
             // Table not found: emit an empty, correctly-typed chunk.
-            output_ = make_operator_data(resource_, out_types, 0);
+            output_ = make_operator_data(resource_, output_schema_, 0);
             output_->data_chunk().set_cardinality(0);
             mark_executed();
             co_return;
@@ -511,7 +501,7 @@ namespace components::operators {
         // manager_disk_resolve.cpp's synthetic attnum for relkind='g').
         const auto row_count = rows.size();
         const uint64_t capacity = std::max<uint64_t>(row_count, vector::DEFAULT_VECTOR_CAPACITY);
-        output_ = make_operator_data(resource_, out_types, capacity);
+        output_ = make_operator_data(resource_, output_schema_, capacity);
         auto& out_chunk = output_->data_chunk();
         for (std::size_t i = 0; i < row_count; ++i) {
             const auto& r = rows[i];

--- a/components/physical_plan/operators/operator_resolve_table.hpp
+++ b/components/physical_plan/operators/operator_resolve_table.hpp
@@ -2,7 +2,9 @@
 
 #include <components/catalog/catalog_oids.hpp>
 #include <components/physical_plan/operators/operator.hpp>
+#include <components/types/types.hpp>
 
+#include <memory_resource>
 #include <string>
 
 namespace components::logical_plan {
@@ -82,6 +84,8 @@ namespace components::operators {
         char relkind_{0};
         components::catalog::oid_t namespace_oid_{components::catalog::INVALID_OID};
         components::logical_plan::node_catalog_resolve_table_t* target_node_{nullptr};
+        // Static output chunk schema, built once in the constructor (TASK C10).
+        std::pmr::vector<components::types::complex_logical_type> output_schema_;
     };
 
 } // namespace components::operators

--- a/components/physical_plan/operators/operator_resolve_type.cpp
+++ b/components/physical_plan/operators/operator_resolve_type.cpp
@@ -1,5 +1,7 @@
 #include "operator_resolve_type.hpp"
 
+#include "catalog_write_helpers.hpp"
+
 #include <components/catalog/catalog_codes.hpp>
 #include <components/catalog/helpers.hpp>
 #include <components/catalog/system_table_schemas.hpp>
@@ -23,25 +25,15 @@ namespace components::operators {
     namespace types = components::types;
 
     namespace {
-        // File-local typed setters — pg_type schema is statically known here,
-        // so we bypass the logical_value_t variant dispatch and write directly
-        // into the column's typed buffer.
-        inline void set_uint32(vector::data_chunk_t& c, size_t col, size_t row, std::uint32_t v) {
-            auto& vec = c.data[col];
-            vec.template data<std::uint32_t>()[row] = v;
-            vec.validity().set(row, true);
-        }
-        inline void
-        set_str(vector::data_chunk_t& c, size_t col, size_t row, std::string_view v, std::pmr::memory_resource* r) {
-            auto& vec = c.data[col];
-            if (!vec.auxiliary()) {
-                vec.set_auxiliary(std::make_shared<vector::string_vector_buffer_t>(r));
-            }
-            auto* sb = static_cast<vector::string_vector_buffer_t*>(vec.auxiliary().get());
-            auto* ptr = sb->insert(v);
-            reinterpret_cast<std::string_view*>(vec.template data<std::byte>())[row] =
-                std::string_view(static_cast<const char*>(ptr), v.size());
-            vec.validity().set(row, true);
+        // pg_type output schema: (oid uint32, typname string,
+        // typnamespace uint32, typdefspec string). Built once into the cached
+        // member (TASK C10).
+        void build_output_schema(std::pmr::vector<types::complex_logical_type>& out_types) {
+            out_types.reserve(4);
+            out_types.emplace_back(types::logical_type::UINTEGER);       // oid
+            out_types.emplace_back(types::logical_type::STRING_LITERAL); // typname
+            out_types.emplace_back(types::logical_type::UINTEGER);       // typnamespace
+            out_types.emplace_back(types::logical_type::STRING_LITERAL); // typdefspec
         }
     } // namespace
 
@@ -51,7 +43,10 @@ namespace components::operators {
                                                      std::string name)
         : read_write_operator_t(resource, std::move(log), operator_type::resolve_type)
         , namespace_oid_(namespace_oid)
-        , name_(std::move(name)) {}
+        , name_(std::move(name))
+        , output_schema_(resource) {
+        build_output_schema(output_schema_);
+    }
 
     operator_resolve_type_t::operator_resolve_type_t(std::pmr::memory_resource* resource,
                                                      log_t log,
@@ -62,7 +57,10 @@ namespace components::operators {
         , namespace_oid_(catalog::INVALID_OID)
         , dbname_(std::move(dbname))
         , name_(std::move(name))
-        , target_node_(target_node) {}
+        , target_node_(target_node)
+        , output_schema_(resource) {
+        build_output_schema(output_schema_);
+    }
 
     void operator_resolve_type_t::on_execute_impl(pipeline::context_t* /*ctx*/) { async_wait(); }
 
@@ -70,12 +68,8 @@ namespace components::operators {
         constexpr catalog::oid_t kPgType = catalog::well_known_oid::pg_type_table;
         constexpr catalog::oid_t kPgNamespace = catalog::well_known_oid::pg_namespace_table;
 
-        std::pmr::vector<types::complex_logical_type> out_types(resource_);
-        out_types.reserve(4);
-        out_types.emplace_back(types::logical_type::UINTEGER);       // oid
-        out_types.emplace_back(types::logical_type::STRING_LITERAL); // typname
-        out_types.emplace_back(types::logical_type::UINTEGER);       // typnamespace
-        out_types.emplace_back(types::logical_type::STRING_LITERAL); // typdefspec
+        // Output schema is cached on the operator (output_schema_), built once
+        // in the constructor (TASK C10).
 
         components::execution_context_t exec_ctx{ctx->session, ctx->txn, {}};
 
@@ -110,7 +104,7 @@ namespace components::operators {
             }
         }
 
-        vector::data_chunk_t chunk(resource_, out_types, /*capacity=*/1);
+        vector::data_chunk_t chunk(resource_, output_schema_, /*capacity=*/1);
 
         if (namespace_oid_ != catalog::INVALID_OID && ctx->disk_address != actor_zeta::address_t::empty_address()) {
             types::logical_value_t name_lv(resource_, std::string_view{name_});

--- a/components/physical_plan/operators/operator_resolve_type.hpp
+++ b/components/physical_plan/operators/operator_resolve_type.hpp
@@ -2,7 +2,9 @@
 
 #include <components/catalog/catalog_oids.hpp>
 #include <components/physical_plan/operators/operator.hpp>
+#include <components/types/types.hpp>
 
+#include <memory_resource>
 #include <string>
 
 namespace components::logical_plan {
@@ -63,6 +65,8 @@ namespace components::operators {
         std::string dbname_;
         std::string name_;
         components::logical_plan::node_catalog_resolve_type_t* target_node_{nullptr};
+        // Static output chunk schema, built once in the constructor (TASK C10).
+        std::pmr::vector<components::types::complex_logical_type> output_schema_;
     };
 
 } // namespace components::operators

--- a/components/physical_plan/operators/predicates/function_predicate.cpp
+++ b/components/physical_plan/operators/predicates/function_predicate.cpp
@@ -61,7 +61,10 @@ namespace {
         if (std::holds_alternative<std::pmr::vector<types::logical_value_t>>(res.value())) {
             const auto& values = std::get<std::pmr::vector<types::logical_value_t>>(res.value());
             if (values.size() < N) {
-                throw std::runtime_error("batch function predicate: function returned fewer results than inputs");
+                return core::error_t(
+                    core::error_code_t::incorrect_function_return_type,
+                    std::pmr::string{"batch function predicate: function returned fewer results than inputs",
+                                     batch.resource()});
             }
             for (size_t k = 0; k < N; ++k) {
                 results[k] = values[k].value<bool>();
@@ -70,7 +73,10 @@ namespace {
             // vector_function returns data_chunk_t; result column is data[0]
             const auto& chunk = std::get<vector::data_chunk_t>(res.value());
             if (chunk.data.empty() || chunk.size() < N) {
-                throw std::runtime_error("batch function predicate: function returned fewer results than inputs");
+                return core::error_t(
+                    core::error_code_t::incorrect_function_return_type,
+                    std::pmr::string{"batch function predicate: function returned fewer results than inputs",
+                                     batch.resource()});
             }
             for (size_t k = 0; k < N; ++k) {
                 results[k] = chunk.data.front().value(k).value<bool>();

--- a/components/physical_plan/operators/predicates/utils.cpp
+++ b/components/physical_plan/operators/predicates/utils.cpp
@@ -134,6 +134,10 @@ namespace components::operators::predicates::impl {
             if (right_val.has_error()) {
                 return right_val;
             }
+            // TODO(L2): per-row predicate arithmetic boxes operands into logical_value_t. No typed
+            // scalar-scalar arithmetic helper exists (only vector::compute_* over vectors/scalars,
+            // and logical_value_t::sum/...); using vectors per row would be the L4 anti-pattern.
+            // Skipped: a typed path would require a new helper, which is out of scope here.
             switch (op) {
                 case expressions::scalar_type::add:
                     return types::logical_value_t::sum(left_val.value(), right_val.value());

--- a/components/physical_plan_generator/impl/create_plan_group.cpp
+++ b/components/physical_plan_generator/impl/create_plan_group.cpp
@@ -22,7 +22,9 @@ namespace services::planner::impl {
                    t == scalar_type::unary_minus;
         }
 
-        void add_group_scalar(boost::intrusive_ptr<components::operators::operator_group_t>& group,
+        // Returns false on a defensive validation failure so the caller can return nullptr ->
+        // executor surfaces the error (rule 9: no throw on the operator-build path).
+        bool add_group_scalar(boost::intrusive_ptr<components::operators::operator_group_t>& group,
                               const components::expressions::scalar_expression_t* expr,
                               std::pmr::memory_resource* resource,
                               const components::logical_plan::storage_parameters* storage_params,
@@ -164,9 +166,10 @@ namespace services::planner::impl {
                 default: {
                     if (is_arithmetic_scalar_type(expr->type())) {
                         if (expr->key().storage().empty()) {
-                            throw std::logic_error(
-                                "create_plan_group: arithmetic expression has empty storage for key: " +
-                                expr->key().as_string());
+                            // Defensive guard (validation guarantees this never fires): signal
+                            // failure so the caller returns nullptr -> executor surfaces the error
+                            // (rule 9: no throw on the operator-build path).
+                            return false;
                         }
                         auto alias = std::pmr::string(expr->key().storage().back(), resource);
                         if (!expr->key().path().empty() && expr->key().path()[0] == SIZE_MAX) {
@@ -183,6 +186,7 @@ namespace services::planner::impl {
                     break;
                 }
             }
+            return true;
         }
 
         void add_group_aggregate(std::pmr::memory_resource* resource,
@@ -238,7 +242,11 @@ namespace services::planner::impl {
 
             if (expr->group() == expression_group::scalar) {
                 auto* scalar_expr = static_cast<const components::expressions::scalar_expression_t*>(expr.get());
-                add_group_scalar(group, scalar_expr, plan_resource, params, key_idx);
+                if (!add_group_scalar(group, scalar_expr, plan_resource, params, key_idx)) {
+                    // Defensive guard tripped: return nullptr -> executor surfaces the error
+                    // (rule 9: no throw on the operator-build path).
+                    return nullptr;
+                }
                 // Track key_idx for arithmetic computed columns
                 switch (scalar_expr->type()) {
                     case scalar_type::group_field:

--- a/components/physical_plan_generator/impl/create_plan_hash_join.cpp
+++ b/components/physical_plan_generator/impl/create_plan_hash_join.cpp
@@ -45,7 +45,9 @@ namespace services::planner::impl {
                 break;
             case join_type::cross:
             case join_type::invalid:
-                throw std::logic_error("create_plan_hash_join: non-equi join type");
+                // Defensive guard (validation guarantees this never fires): return nullptr ->
+                // executor surfaces the error (rule 9: no throw on the operator-build path).
+                return nullptr;
         }
         components::operators::operator_ptr left;
         components::operators::operator_ptr right;

--- a/components/physical_plan_generator/impl/create_plan_join.cpp
+++ b/components/physical_plan_generator/impl/create_plan_join.cpp
@@ -50,7 +50,9 @@ namespace services::planner::impl {
             case join_type::full:
                 break;
             case join_type::invalid:
-                throw std::logic_error("create_plan_join: INVALID join type");
+                // Defensive guard (validation guarantees this never fires): return nullptr ->
+                // executor surfaces the error (rule 9: no throw on the operator-build path).
+                return nullptr;
         }
         components::operators::operator_ptr left;
         components::operators::operator_ptr right;

--- a/components/physical_plan_generator/impl/create_plan_sort.cpp
+++ b/components/physical_plan_generator/impl/create_plan_sort.cpp
@@ -23,7 +23,9 @@ namespace services::planner::impl {
                 const auto* sort_expr = static_cast<components::expressions::sort_expression_t*>(expr.get());
                 const auto& path = sort_expr->key().path();
                 if (path.empty()) {
-                    throw std::logic_error("Sort key has unresolved path: " + sort_expr->key().as_string());
+                    // Defensive guard (validation resolves the path so this never fires): return
+                    // nullptr -> executor surfaces the error (rule 9: no throw on the operator-build path).
+                    return nullptr;
                 }
                 sort->add(path, components::operators::operator_sort_t::order(sort_expr->order()));
             } else if (expr->group() == components::expressions::expression_group::scalar) {

--- a/components/planner/optimizer.cpp
+++ b/components/planner/optimizer.cpp
@@ -1,6 +1,5 @@
 #include "optimizer.hpp"
 
-#include "optimizer/rules/column_pruning.hpp"
 #include "optimizer/rules/constant_folding.hpp"
 #include "optimizer/rules/hash_join.hpp"
 #include "optimizer/rules/pushdown_filter.hpp"
@@ -14,28 +13,16 @@ namespace components::planner {
             return nullptr;
         }
 
-        // Constant folding: resolve arithmetic on parameters at plan time.
+        // Single post-planner pass. Order matters: fold constants on parameter
+        // expressions, push filters down, then select hash joins. Hash-join
+        // selection reads key.side()/key.path() stamped by validate_schema,
+        // which has already run. All rules are safe here — the planner wraps
+        // DML on top and lowers DDL to sequences, leaving the
+        // match_t/join_t/aggregate_t these rules target intact.
         if (parameters) {
             optimizer::fold_constants(resource, node, parameters);
         }
-
         node = optimizer::pushdown_filter(resource, node);
-
-        return node;
-    }
-
-    logical_plan::node_ptr post_validate_optimize(std::pmr::memory_resource* resource, logical_plan::node_ptr node) {
-        if (!node) {
-            return nullptr;
-        }
-
-        // Column pruning is intentionally disabled in the current work; the rule
-        // (optimizer::prune_columns) is left in place but not run here.
-
-        // Hash-join selection: rewrite eligible nested-loop joins (single
-        // eq(left.key, right.key) condition) into node_hash_join_t so the planner
-        // can lower them to operator_hash_join_t. Relies on key.side()/key.path()
-        // stamped by validate_schema, which has already run at this point.
         node = optimizer::rewrite_hash_joins(resource, std::move(node));
 
         return node;

--- a/components/planner/optimizer.hpp
+++ b/components/planner/optimizer.hpp
@@ -5,22 +5,20 @@
 
 namespace components::planner {
 
-    // Early optimization pass. Runs BEFORE the schema validator / enrich.
-    // Safe rules only — those that don't need resolved column indices or
-    // table OIDs.
+    // Single optimization pass. Runs AFTER the planner rewrite, i.e. after
+    // resolve → validate → enrich → planner.create_plan, so node->table_oid()
+    // is populated, sibling catalog_resolve_table_t nodes carry
+    // resolved_metadata(), and the schema stamps key.side()/key.path() set by
+    // validate_schema are present.
+    // Rules (in order):
     //   - constant_folding (on parameter expressions)
+    //   - pushdown_filter
+    //   - hash_join selection (needs the validate_schema stamps)
+    // On DDL trees (sequence_t of primitive writes) it is a harmless no-op:
+    // the planner leaves the match_t/join_t/aggregate_t these rules target
+    // intact (DML wrappers sit on top; DDL has no such nodes).
     logical_plan::node_ptr optimize(std::pmr::memory_resource* resource,
                                     logical_plan::node_ptr node,
                                     logical_plan::parameter_node_t* parameters);
-
-    // Late optimization pass. Runs AFTER validate_schema +
-    // stamp_oids_from_resolves, so node->table_oid() is populated and
-    // sibling catalog_resolve_table_t nodes carry resolved_metadata().
-    // Schema-aware rules go here.
-    //   - column_pruning (annotates node_aggregate_t with projected_cols)
-    //
-    // Schema info is read from the plan tree itself (sibling resolves);
-    // the optimizer is self-contained and needs no external catalog handle.
-    logical_plan::node_ptr post_validate_optimize(std::pmr::memory_resource* resource, logical_plan::node_ptr node);
 
 } // namespace components::planner

--- a/components/planner/optimizer/rules/constant_folding.cpp
+++ b/components/planner/optimizer/rules/constant_folding.cpp
@@ -72,6 +72,10 @@ namespace components::planner::optimizer {
             }
 
             // TODO: this is even worse than using logical_value_t...
+            // TODO(L4): skipped — the only non-throwing alternatives are this 1-element-vector
+            // boxing or a brand-new scalar arithmetic helper (a new abstraction, forbidden).
+            // logical_value_t::sum/subtract/... throw on unprocessable types, and this function
+            // returns bool (cannot propagate an error), so switching to them would add a throw.
             // Create single-element vectors from the values
             vector_t left_vec(resource, left_val, 1);
             vector_t right_vec(resource, right_val, 1);

--- a/components/planner/planner.cpp
+++ b/components/planner/planner.cpp
@@ -717,4 +717,43 @@ namespace components::planner {
         return walk_ddl(resource, std::move(node), oid_batch);
     }
 
+    std::size_t compute_oid_demand(const logical_plan::node_t* node) {
+        using LT = components::types::logical_type;
+        using nt = logical_plan::node_type;
+        if (!node) {
+            return 0;
+        }
+        switch (node->type()) {
+            case nt::create_collection_t:
+                return std::size_t{1} +
+                       static_cast<const logical_plan::node_create_collection_t*>(node)->column_definitions().size();
+            case nt::create_database_t:
+                return 1;
+            case nt::create_type_t: {
+                const auto* ct = static_cast<const logical_plan::node_create_type_t*>(node);
+                return ct->type().type() == LT::STRUCT ? std::size_t{1} + ct->type().child_types().size()
+                                                       : std::size_t{1};
+            }
+            case nt::create_sequence_t:
+                return 1;
+            case nt::create_view_t:
+            case nt::create_macro_t:
+                return 2;
+            case nt::create_matview_t: {
+                const auto* cm = static_cast<const logical_plan::node_create_matview_t*>(node);
+                // Empty inferred columns → rewrite_create_matview returns the node
+                // unchanged and consumes nothing.
+                return cm->inferred_columns().empty() ? std::size_t{0}
+                                                      : std::size_t{2} + cm->inferred_columns().size();
+            }
+            case nt::create_index_t:
+                return 1;
+            case nt::create_constraint_t:
+                return 1;
+            default:
+                // DROP * / ALTER TABLE / DML / non-DDL — no pre-allocated OIDs.
+                return 0;
+        }
+    }
+
 } // namespace components::planner

--- a/components/planner/planner.hpp
+++ b/components/planner/planner.hpp
@@ -17,4 +17,13 @@ namespace components::planner {
                          catalog::oid_batch_t oid_batch) -> logical_plan::node_ptr;
     };
 
+    // OID demand for a DDL node: the exact number of OIDs the DDL create_plan
+    // path (walk_ddl → rewrite_create_*) consumes from the oid_batch. The single
+    // source of truth for the per-kind counts, so callers (the executor) need
+    // not duplicate the formulas. Returns 0 for DROP/ALTER (no pre-allocation),
+    // for CREATE MATERIALIZED VIEW with no inferred columns (planner bails), and
+    // for DML / non-DDL nodes. `node` must be the effective DDL node (the result
+    // of catalog_resolve::effective_root_node after resolve-wrap).
+    std::size_t compute_oid_demand(const logical_plan::node_t* node);
+
 } // namespace components::planner

--- a/core/result_wrapper.hpp
+++ b/core/result_wrapper.hpp
@@ -55,6 +55,7 @@ namespace core {
         unrecognized_function,
         incorrect_function_argument,
         incorrect_function_return_type,
+        invalid_constraint,
     };
 
     struct error_t {

--- a/services/collection/executor.cpp
+++ b/services/collection/executor.cpp
@@ -1250,7 +1250,7 @@ namespace services::collection::executor {
                     if (cstr->kind() == constraint_kind::check && cstr->check_expr().empty()) {
                         co_return execute_result_t{make_cursor(
                             resource(),
-                            core::error_t{core::error_code_t::other_error,
+                            core::error_t{core::error_code_t::invalid_constraint,
                                           std::pmr::string{"CHECK constraint expression is empty or contains "
                                                            "unsupported constructs (functions, subqueries, and CASE "
                                                            "expressions are not allowed; valid: comparisons, AND/OR/NOT, "

--- a/services/collection/executor.cpp
+++ b/services/collection/executor.cpp
@@ -342,10 +342,10 @@ namespace services::collection::executor {
             pending_set_tz_name.assign(tz_node->timezone_name().c_str(), tz_node->timezone_name().size());
         }
 
-        // Optimizer: constant folding, etc. Needs the parameter NODE (before
-        // the destructive take_parameters below).
-        plan.sub_queries.back() =
-            components::planner::optimize(resource(), plan.sub_queries.back(), plan.parameters.get());
+        // (O1) The optimizer used to run here, early, before resolve. It now
+        // runs as a SINGLE pass AFTER the planner rewrite — see the
+        // components::planner::optimize(...) call just before the execute_plan
+        // delegate below. This gives the canonical planner → optimizer order.
 
         // Wrap the plan with catalog_resolve_namespace + catalog_resolve_table
         // for every (db, rel) pair found in the tree. Validate/enrich consume
@@ -533,6 +533,36 @@ namespace services::collection::executor {
         // mutable state) and run in this same actor coroutine. resolve_txn is
         // forwarded into both the resolve sub-plan and the final execute_plan
         // delegate so they share one MVCC snapshot.
+        //
+        // (C4) Shared resolve sub-plan runner — build a sequence_t over the given
+        // resolve nodes and run it. The resolve operators are read-only catalog
+        // probes that stamp OIDs onto the SAME nodes still in the parent tree
+        // (operator_resolve_*_t holds raw pointers to them). Used by the outer
+        // resolve pass and the view-expansion fresh-resolve pass. Takes `self` so
+        // the coroutine frame allocator finds the PMR resource (the [this] capture
+        // is not visible to promise_type::operator new). The throw-away
+        // context_storage keeps the caller's own context_storage untouched.
+        auto run_resolve_subplan =
+            [this, session, resolve_txn, &session_ctx, &context_storage](
+                executor_t* self,
+                std::pmr::vector<components::logical_plan::node_ptr> resolve_nodes)
+            -> executor_t::unique_future<execute_result_t> {
+            (void) self;
+            auto root = boost::intrusive_ptr<components::logical_plan::node_t>(
+                new components::logical_plan::node_sequence_t(resource()));
+            for (auto& n : resolve_nodes) {
+                root->append_child(n);
+            }
+            auto params = components::logical_plan::make_parameter_node(resource());
+            services::context_storage_t cstor{resource(), log_.clone(), context_storage.session_timezone};
+            co_return co_await this->execute_plan(
+                session,
+                components::logical_plan::execution_plan_t{resource(), root, params},
+                std::move(cstor),
+                resolve_txn,
+                session_ctx.lowest_active_start_time);
+        };
+
         if (plan.sub_queries.back() &&
             plan.sub_queries.back()->type() == components::logical_plan::node_type::sequence_t) {
             auto& kids = plan.sub_queries.back()->children();
@@ -548,30 +578,13 @@ namespace services::collection::executor {
                 ++resolve_count;
             }
             if (resolve_count > 0) {
-                // Resolve sub-plan over the front children. operator_resolve_*_t
-                // holds a raw pointer to each logical node — the SAME objects
-                // still in the parent sequence_t — so OIDs stamped during resolve
-                // become visible to the parent's validate/enrich pass.
-                auto pass1_root = boost::intrusive_ptr<components::logical_plan::node_t>(
-                    new components::logical_plan::node_sequence_t(resource()));
+                // Resolve sub-plan over the front children (see run_resolve_subplan).
+                std::pmr::vector<components::logical_plan::node_ptr> resolve_nodes{resource()};
+                resolve_nodes.reserve(resolve_count);
                 for (std::size_t i = 0; i < resolve_count; ++i) {
-                    pass1_root->append_child(kids[i]);
+                    resolve_nodes.push_back(kids[i]);
                 }
-                auto pass1_params = components::logical_plan::make_parameter_node(resource());
-                // Throw-away context_storage_t so the caller's `context_storage`
-                // (move-consumed by the final delegate) survives untouched. It
-                // carries only what the resolve operators read (resource / log /
-                // session_timezone); known_oids / table_metadata stay empty
-                // because resolves stamp onto the plan tree, not context_storage.
-                services::context_storage_t pass1_context_storage{resource(),
-                                                                  log_.clone(),
-                                                                  context_storage.session_timezone};
-                auto pass1_result = co_await this->execute_plan(
-                    session,
-                    components::logical_plan::execution_plan_t{resource(), pass1_root, pass1_params},
-                    std::move(pass1_context_storage),
-                    resolve_txn,
-                    session_ctx.lowest_active_start_time);
+                auto pass1_result = co_await run_resolve_subplan(this, std::move(resolve_nodes));
                 if (pass1_result.cursor->is_error()) {
                     trace(log_,
                           "executor::execute_plan_full: resolve failed: {}",
@@ -631,23 +644,12 @@ namespace services::collection::executor {
                     // === Resolve sub-plan's fresh resolves ===
                     auto fresh = services::catalog_resolve::extract_unresolved_resolves(plan.sub_queries.back().get());
                     if (!fresh.empty()) {
-                        auto pass2_root = boost::intrusive_ptr<components::logical_plan::node_t>(
-                            new components::logical_plan::node_sequence_t(resource()));
+                        std::pmr::vector<components::logical_plan::node_ptr> resolve_nodes{resource()};
+                        resolve_nodes.reserve(fresh.size());
                         for (auto& n : fresh) {
-                            pass2_root->append_child(n);
+                            resolve_nodes.push_back(n);
                         }
-                        auto pass2_params = components::logical_plan::make_parameter_node(resource());
-                        // Throw-away context_storage_t, as in the outer resolve
-                        // loop, so the caller's context_storage survives untouched.
-                        services::context_storage_t pass2_context_storage{resource(),
-                                                                          log_.clone(),
-                                                                          context_storage.session_timezone};
-                        auto pass2_result = co_await this->execute_plan(
-                            session,
-                            components::logical_plan::execution_plan_t{resource(), pass2_root, pass2_params},
-                            std::move(pass2_context_storage),
-                            resolve_txn,
-                            session_ctx.lowest_active_start_time);
+                        auto pass2_result = co_await run_resolve_subplan(this, std::move(resolve_nodes));
                         if (pass2_result.cursor->is_error()) {
                             trace(log_,
                                   "executor::execute_plan_full: view sub-plan resolve failed: {}",
@@ -1044,16 +1046,14 @@ namespace services::collection::executor {
         components::catalog::oid_t create_index_table_oid = components::catalog::INVALID_OID;
         std::pmr::string create_index_name{resource()};
 
-        // Destructive rewrites. post_validate_optimize / enrich_plan /
-        // planner.create_plan are NOT idempotent — in particular create_plan
-        // wraps insert/update/delete in check_constraint_t / fk_check_t, and
-        // running it twice re-wraps on top of the previous wrap (broken plan).
-        // The executor is the ONLY side running these passes (the dispatcher
-        // routes the raw plan straight here).
+        // Destructive rewrites. enrich_plan / planner.create_plan are NOT
+        // idempotent — in particular create_plan wraps insert/update/delete in
+        // check_constraint_t / fk_check_t, and running it twice re-wraps on top
+        // of the previous wrap (broken plan). The executor is the ONLY side
+        // running these passes (the dispatcher routes the raw plan straight here).
+        // (O1) The optimizer no longer runs here — it runs as one pass after the
+        // planner rewrite, just before the execute_plan delegate.
         {
-            plan.sub_queries.back() =
-                components::planner::post_validate_optimize(resource(), std::move(plan.sub_queries.back()));
-
             // Enrich DML node fields with catalog metadata (NOT NULL, DEFAULT,
             // CHECK exprs), reading exclusively from the plan-tree idx. ctx
             // carries resolve_txn so enrich sees the same MVCC snapshot.
@@ -1062,9 +1062,14 @@ namespace services::collection::executor {
                                                         plan.sub_queries.back(),
                                                         disk_address_,
                                                         enrich_ctx,
+                                                        &dispatcher_idx,
                                                         index_address_,
                                                         &context_storage);
-            co_await std::move(ef);
+            auto enrich_err = co_await std::move(ef);
+            if (enrich_err.contains_error()) {
+                trace(log_, "executor::execute_plan_full: enrich error: {}", enrich_err.what);
+                co_return execute_result_t{make_cursor(resource(), std::move(enrich_err))};
+            }
             // Logical plan rewrite: insert constraint wrapper nodes driven
             // by enriched fields.
             components::planner::planner_t planner;
@@ -1141,7 +1146,6 @@ namespace services::collection::executor {
             };
 
             using components::catalog::relkind::computed;
-            using components::logical_plan::node_create_matview_t;
             using components::logical_plan::node_sequence_t;
 
             // INSERT relkind='g' wrap — wraps INSERT into
@@ -1204,168 +1208,108 @@ namespace services::collection::executor {
                 }
             }
 
-            // CREATE COLLECTION → planner rewrite to
-            // sequence_t(create_collection_t, primitive_write × N).
-            if (original_type == node_type::create_collection_t &&
-                disk_address_ != actor_zeta::address_t::empty_address()) {
-                auto* cc = static_cast<node_create_collection_t*>(
-                    services::catalog_resolve::effective_root_node(plan.sub_queries.back().get()));
-                const std::size_t need = 1 + cc->column_definitions().size();
-                components::catalog::oid_batch_t oid_batch;
-                oid_batch.oids = co_await allocate_oids_inline(this, need);
-                components::planner::planner_t ddl_planner;
-                plan.sub_queries.back() =
-                    ddl_planner.create_plan(resource(), std::move(plan.sub_queries.back()), std::move(oid_batch));
-            }
+            // DDL OID-batch allocation + planner rewrite — ONE path for all DDL
+            // kinds (C1). The per-kind OID count lives in
+            // planner::compute_oid_demand (single source of truth, mirrors
+            // walk_ddl's consumption), so the count formulas are no longer
+            // duplicated here. Pre-check (CREATE CONSTRAINT) and post-steps
+            // (CREATE INDEX capture, ALTER re-enrich) stay inline.
+            auto is_ddl_oid_rewrite = [](node_type t) {
+                switch (t) {
+                    case node_type::create_collection_t:
+                    case node_type::create_database_t:
+                    case node_type::create_type_t:
+                    case node_type::create_sequence_t:
+                    case node_type::create_view_t:
+                    case node_type::create_macro_t:
+                    case node_type::create_matview_t:
+                    case node_type::create_index_t:
+                    case node_type::drop_index_t:
+                    case node_type::alter_table_t:
+                    case node_type::drop_database_t:
+                    case node_type::drop_collection_t:
+                    case node_type::drop_type_t:
+                    case node_type::drop_sequence_t:
+                    case node_type::drop_view_t:
+                    case node_type::drop_macro_t:
+                    case node_type::create_constraint_t:
+                        return true;
+                    default:
+                        return false;
+                }
+            };
+            // DROP INDEX rewrites even without a disk actor; every other DDL kind
+            // needs disk (OID alloc + catalog writes route through disk_address_).
+            const bool has_disk = disk_address_ != actor_zeta::address_t::empty_address();
+            if (is_ddl_oid_rewrite(original_type) && (original_type == node_type::drop_index_t || has_disk)) {
+                auto* eff = services::catalog_resolve::effective_root_node(plan.sub_queries.back().get());
 
-            // CREATE DATABASE → planner rewrite into sequence_t(primitive_write
-            // on pg_namespace).
-            if (original_type == node_type::create_database_t &&
-                disk_address_ != actor_zeta::address_t::empty_address()) {
-                components::catalog::oid_batch_t oid_batch;
-                oid_batch.oids = co_await allocate_oids_inline(this, std::size_t{1});
-                components::planner::planner_t ddl_planner;
-                plan.sub_queries.back() =
-                    ddl_planner.create_plan(resource(), std::move(plan.sub_queries.back()), std::move(oid_batch));
-            }
-
-            // CREATE TYPE → planner rewrite.
-            //   STRUCT → 1 + N OIDs (pg_class.oid + N×pg_attribute.attoid).
-            //   ENUM/other → 1 OID (pg_type.oid).
-            if (original_type == node_type::create_type_t && disk_address_ != actor_zeta::address_t::empty_address()) {
-                auto* ct = static_cast<node_create_type_t*>(
-                    services::catalog_resolve::effective_root_node(plan.sub_queries.back().get()));
-                const std::size_t need = (ct->type().type() == logical_type::STRUCT)
-                                             ? std::size_t{1} + ct->type().child_types().size()
-                                             : std::size_t{1};
-                components::catalog::oid_batch_t oid_batch;
-                oid_batch.oids = co_await allocate_oids_inline(this, need);
-                components::planner::planner_t ddl_planner;
-                plan.sub_queries.back() =
-                    ddl_planner.create_plan(resource(), std::move(plan.sub_queries.back()), std::move(oid_batch));
-            }
-
-            // CREATE SEQUENCE/VIEW/MACRO → planner rewrite to
-            // sequence_t(primitive_write × N).
-            //   SEQUENCE → 1 OID; VIEW → 2 OIDs; MACRO → 2 OIDs.
-            if ((original_type == node_type::create_sequence_t || original_type == node_type::create_view_t ||
-                 original_type == node_type::create_macro_t) &&
-                disk_address_ != actor_zeta::address_t::empty_address()) {
-                const std::size_t need =
-                    (original_type == node_type::create_sequence_t) ? std::size_t{1} : std::size_t{2};
-                components::catalog::oid_batch_t oid_batch;
-                oid_batch.oids = co_await allocate_oids_inline(this, need);
-                components::planner::planner_t ddl_planner;
-                plan.sub_queries.back() =
-                    ddl_planner.create_plan(resource(), std::move(plan.sub_queries.back()), std::move(oid_batch));
-            }
-
-            // CREATE MATERIALIZED VIEW → mv_oid + N×attoid + rule_oid = 2 + N.
-            if (original_type == node_type::create_matview_t &&
-                disk_address_ != actor_zeta::address_t::empty_address()) {
-                auto* cm = static_cast<node_create_matview_t*>(
-                    services::catalog_resolve::effective_root_node(plan.sub_queries.back().get()));
-                const std::size_t col_count = cm ? cm->inferred_columns().size() : std::size_t{0};
-                const std::size_t need = 2 + col_count;
-                components::catalog::oid_batch_t oid_batch;
-                oid_batch.oids = co_await allocate_oids_inline(this, need);
-                components::planner::planner_t ddl_planner;
-                plan.sub_queries.back() =
-                    ddl_planner.create_plan(resource(), std::move(plan.sub_queries.back()), std::move(oid_batch));
-            }
-
-            // CREATE INDEX → planner rewrite to
-            // sequence_t(primitive_write × N, create_index_t).
-            if (original_type == node_type::create_index_t && disk_address_ != actor_zeta::address_t::empty_address()) {
-                components::catalog::oid_batch_t oid_batch;
-                oid_batch.oids = co_await allocate_oids_inline(this, std::size_t{1});
-                components::planner::planner_t ddl_planner;
-                plan.sub_queries.back() =
-                    ddl_planner.create_plan(resource(), std::move(plan.sub_queries.back()), std::move(oid_batch));
-                // Capture the indexed table oid NOW for the post-pipeline
-                // backfill commit_insert: logical_plan is move-consumed by the
-                // execute_plan delegate below, so the tail cannot probe the
-                // plan tree anymore. The trailing create_index_t (the last
-                // child of the rewritten sequence_t) also carries the pg_index
-                // row oid (set by rewrite_create_index via set_index_oid) and
-                // the index name — both needed by the CREATE INDEX failure path.
-                if (auto* eff = services::catalog_resolve::effective_root_node(plan.sub_queries.back().get());
-                    eff && !eff->children().empty()) {
-                    auto* back = eff->children().back().get();
-                    if (back && back->type() == node_type::create_index_t) {
-                        const auto* ci = static_cast<const components::logical_plan::node_create_index_t*>(back);
-                        create_index_table_oid = ci->table_oid();
-                        create_index_name.assign(ci->name().c_str(), ci->name().size());
+                // CREATE CONSTRAINT: reject an empty/invalid CHECK before allocating an OID.
+                if (original_type == node_type::create_constraint_t) {
+                    auto* cstr = static_cast<node_create_constraint_t*>(eff);
+                    if (cstr->kind() == constraint_kind::check && cstr->check_expr().empty()) {
+                        co_return execute_result_t{make_cursor(
+                            resource(),
+                            core::error_t{core::error_code_t::other_error,
+                                          std::pmr::string{"CHECK constraint expression is empty or contains "
+                                                           "unsupported constructs (functions, subqueries, and CASE "
+                                                           "expressions are not allowed; valid: comparisons, AND/OR/NOT, "
+                                                           "IS NULL/IS NOT NULL, column references, and constants)",
+                                                           resource()}})};
                     }
                 }
-            }
 
-            // DROP INDEX → planner rewrite to
-            // sequence_t(primitive_delete × N, drop_index_t). No OIDs.
-            if (original_type == node_type::drop_index_t) {
+                const std::size_t need = components::planner::compute_oid_demand(eff);
                 components::catalog::oid_batch_t oid_batch;
-                components::planner::planner_t ddl_planner;
-                plan.sub_queries.back() =
-                    ddl_planner.create_plan(resource(), std::move(plan.sub_queries.back()), std::move(oid_batch));
-            }
-
-            // ALTER TABLE → planner rewrite to
-            // sequence_t(alter_column_{add,rename,drop}_t × N). No OID batch
-            // (alter_column_add_t allocates its own attoid at execution).
-            // Re-enrich afterwards: the planner stamps fresh attoids on rename /
-            // computed_field_unregister primitives that didn't exist before it
-            // ran. Use resolve_txn so enrich's pg_computed_column scan sees the
-            // INSERT-time register rows committed under that txn.
-            if (original_type == node_type::alter_table_t && disk_address_ != actor_zeta::address_t::empty_address()) {
-                components::catalog::oid_batch_t oid_batch; // intentionally empty
-                components::planner::planner_t ddl_planner;
-                plan.sub_queries.back() =
-                    ddl_planner.create_plan(resource(), std::move(plan.sub_queries.back()), std::move(oid_batch));
-                components::execution_context_t enriched_ctx{session, resolve_txn, context_storage.session_timezone};
-                auto ef2 = services::dispatcher::enrich_plan(resource(),
-                                                             plan.sub_queries.back(),
-                                                             disk_address_,
-                                                             enriched_ctx,
-                                                             index_address_,
-                                                             &context_storage);
-                co_await std::move(ef2);
-            }
-
-            // DROP DATABASE / TABLE / TYPE / SEQUENCE / VIEW / MACRO →
-            // planner rewrite to node_dynamic_cascade_delete_t. No OIDs.
-            if ((original_type == node_type::drop_database_t || original_type == node_type::drop_collection_t ||
-                 original_type == node_type::drop_type_t || original_type == node_type::drop_sequence_t ||
-                 original_type == node_type::drop_view_t || original_type == node_type::drop_macro_t) &&
-                disk_address_ != actor_zeta::address_t::empty_address()) {
-                components::catalog::oid_batch_t oid_batch; // intentionally empty
-                components::planner::planner_t ddl_planner;
-                plan.sub_queries.back() =
-                    ddl_planner.create_plan(resource(), std::move(plan.sub_queries.back()), std::move(oid_batch));
-            }
-
-            // CREATE CONSTRAINT → planner rewrite to sequence_t(primitive_write
-            // on pg_constraint+pg_depend). CHECK expressions are
-            // pre-validated for non-empty here so we do not waste an OID on
-            // a doomed constraint.
-            if (original_type == node_type::create_constraint_t &&
-                disk_address_ != actor_zeta::address_t::empty_address()) {
-                auto* cstr = static_cast<node_create_constraint_t*>(
-                    services::catalog_resolve::effective_root_node(plan.sub_queries.back().get()));
-                if (cstr->kind() == constraint_kind::check && cstr->check_expr().empty()) {
-                    co_return execute_result_t{make_cursor(
-                        resource(),
-                        core::error_t{core::error_code_t::other_error,
-                                      std::pmr::string{"CHECK constraint expression is empty or contains "
-                                                       "unsupported constructs (functions, subqueries, and CASE "
-                                                       "expressions are not allowed; valid: comparisons, AND/OR/NOT, "
-                                                       "IS NULL/IS NOT NULL, column references, and constants)",
-                                                       resource()}})};
+                if (need > 0) {
+                    oid_batch.oids = co_await allocate_oids_inline(this, need);
                 }
-                components::catalog::oid_batch_t oid_batch;
-                oid_batch.oids = co_await allocate_oids_inline(this, std::size_t{1});
                 components::planner::planner_t ddl_planner;
                 plan.sub_queries.back() =
                     ddl_planner.create_plan(resource(), std::move(plan.sub_queries.back()), std::move(oid_batch));
+
+                // CREATE INDEX: capture indexed table oid + index name NOW — the
+                // plan is move-consumed by the execute_plan delegate below, so the
+                // backfill/undo tail can no longer probe the tree. The trailing
+                // create_index_t (last child of the rewritten sequence_t) carries
+                // the pg_index row oid (set by rewrite_create_index) and the name.
+                if (original_type == node_type::create_index_t) {
+                    if (auto* eff2 = services::catalog_resolve::effective_root_node(plan.sub_queries.back().get());
+                        eff2 && !eff2->children().empty()) {
+                        auto* back = eff2->children().back().get();
+                        if (back && back->type() == node_type::create_index_t) {
+                            const auto* ci = static_cast<const components::logical_plan::node_create_index_t*>(back);
+                            create_index_table_oid = ci->table_oid();
+                            create_index_name.assign(ci->name().c_str(), ci->name().size());
+                        }
+                    }
+                }
+                // ALTER TABLE: re-enrich — the planner stamps fresh attoids on
+                // rename / computed_field_unregister primitives that didn't exist
+                // before it ran. resolve_txn so enrich's pg_computed_column scan
+                // sees the INSERT-time register rows committed under that txn.
+                else if (original_type == node_type::alter_table_t) {
+                    // Re-gather the resolve index against the planner-rewritten
+                    // tree (the DDL rewrite replaced the consumer nodes; the
+                    // pre-rewrite dispatcher_idx may not cover the new ones).
+                    services::catalog_resolve::plan_resolve_index_t reenrich_idx;
+                    services::catalog_resolve::gather_plan_resolve_index(plan.sub_queries.back().get(), &reenrich_idx);
+                    components::execution_context_t enriched_ctx{session, resolve_txn, context_storage.session_timezone};
+                    auto ef2 = services::dispatcher::enrich_plan(resource(),
+                                                                 plan.sub_queries.back(),
+                                                                 disk_address_,
+                                                                 enriched_ctx,
+                                                                 &reenrich_idx,
+                                                                 index_address_,
+                                                                 &context_storage);
+                    auto enrich_err2 = co_await std::move(ef2);
+                    if (enrich_err2.contains_error()) {
+                        trace(log_,
+                              "executor::execute_plan_full: ALTER re-enrich error: {}",
+                              enrich_err2.what);
+                        co_return execute_result_t{make_cursor(resource(), std::move(enrich_err2))};
+                    }
+                }
             }
         }
         // Unresolved-ALTER no-op guard: a plan whose LITERAL root is still
@@ -1378,6 +1322,14 @@ namespace services::collection::executor {
             co_return execute_result_t{make_cursor(resource())};
         }
 
+        // (O1) Single optimizer pass — runs HERE, after every planner rewrite
+        // (DML constraint-wrap + DDL lowering), so the schema stamps
+        // key.side()/key.path() and table OIDs are present. const-fold +
+        // pushdown_filter + hash-join selection; a no-op on DDL sequences.
+        // The execute_plan delegate below lowers this optimized tree.
+        plan.sub_queries.back() =
+            components::planner::optimize(resource(), std::move(plan.sub_queries.back()), plan.parameters.get());
+
         trace(log_, "executor::execute_plan_full: delegating to execute_plan, session: {}", session.data());
         // Operator-pipeline run, forwarding resolve_txn so the operator path
         // sees the same MVCC snapshot the resolves did.
@@ -1386,6 +1338,82 @@ namespace services::collection::executor {
                                                  std::move(context_storage),
                                                  resolve_txn,
                                                  session_ctx.lowest_active_start_time);
+
+        // (C2) Shared failure-revert — undo this statement's storage appends +
+        // index mirrors and abort the txn. Identical for the DML and DDL failure
+        // paths (was copy-pasted). Takes `self` so the coroutine frame allocator
+        // finds the PMR resource — the [this] capture is not visible to
+        // promise_type::operator new (same pattern as allocate_oids_inline).
+        auto revert_failed_txn =
+            [this, session, resolve_txn, &session_ctx](executor_t* self,
+                                                       execute_result_t& exec_result) -> executor_t::unique_future<void> {
+            (void) self;
+            // Storage revert: fold DML append ranges + pg_catalog append ranges
+            // into a single storage_revert_appends (each range carries its own
+            // table_oid; the handler routes per-range).
+            std::vector<components::pg_catalog_append_range_t> revert_ranges;
+            revert_ranges.reserve(exec_result.dml_appends.size() + exec_result.pg_catalog_appends.size());
+            for (const auto& app : exec_result.dml_appends) {
+                revert_ranges.push_back(
+                    components::pg_catalog_append_range_t{app.table_oid, app.row_start, app.row_count});
+            }
+            for (auto& pgc : exec_result.pg_catalog_appends) {
+                revert_ranges.push_back(std::move(pgc));
+            }
+            exec_result.pg_catalog_appends.clear();
+            if (!revert_ranges.empty() && disk_address_ != actor_zeta::address_t::empty_address()) {
+                components::execution_context_t pgc_ctx{session, resolve_txn, {}};
+                auto [_pa, paf] = actor_zeta::send(disk_address_,
+                                                   &services::disk::manager_disk_t::storage_revert_appends,
+                                                   pgc_ctx,
+                                                   std::move(revert_ranges));
+                co_await std::move(paf);
+            }
+
+            // Index revert, two-phase (send-all then await-all), deduped per
+            // table_oid. revert_insert ← pending index INSERT bucket (dml_appends);
+            // revert_delete ← pending index DELETE bucket (dml_deletes). Both are
+            // keyed per (table_oid, txn) and idempotent across duplicate oids.
+            if (index_address_ != actor_zeta::address_t::empty_address()) {
+                std::pmr::set<components::catalog::oid_t> revert_insert_oids{resource()};
+                for (const auto& app : exec_result.dml_appends) {
+                    revert_insert_oids.insert(app.table_oid);
+                }
+                std::pmr::set<components::catalog::oid_t> revert_delete_oids{resource()};
+                for (const auto& del : exec_result.dml_deletes) {
+                    revert_delete_oids.insert(del.table_oid);
+                }
+                std::pmr::vector<actor_zeta::unique_future<void>> revert_index_futures{resource()};
+                revert_index_futures.reserve(revert_insert_oids.size() + revert_delete_oids.size());
+                for (auto oid : revert_insert_oids) {
+                    components::execution_context_t abort_ctx{session, resolve_txn, session_ctx.session_tz, oid};
+                    auto [_ri, rif] = actor_zeta::send(index_address_,
+                                                       &services::index::manager_index_t::revert_insert,
+                                                       abort_ctx,
+                                                       oid);
+                    revert_index_futures.push_back(std::move(rif));
+                }
+                for (auto oid : revert_delete_oids) {
+                    components::execution_context_t abort_ctx{session, resolve_txn, session_ctx.session_tz, oid};
+                    auto [_rd, rdf] = actor_zeta::send(index_address_,
+                                                       &services::index::manager_index_t::revert_delete,
+                                                       abort_ctx,
+                                                       oid);
+                    revert_index_futures.push_back(std::move(rdf));
+                }
+                for (auto& rif : revert_index_futures) {
+                    co_await std::move(rif);
+                }
+            }
+
+            auto [_ab, abf] = actor_zeta::send(parent_address_,
+                                               &services::dispatcher::manager_dispatcher_t::txn_abort_msg,
+                                               session);
+            co_await std::move(abf);
+
+            exec_result.dml_appends.clear();
+            exec_result.dml_deletes.clear();
+        };
 
         // ===== DML commit / accumulate tail =====
         // ONE publish channel for everything: every successful DML statement
@@ -1453,81 +1481,9 @@ namespace services::collection::executor {
                     }
                 }
             } else {
-                // Failed DML statement: revert this statement's local ranges
-                // and abort the txn (also ends a failed statement's explicit
-                // txn).
-                //
-                // Storage revert: fold every DML append range AND the
-                // pg_catalog append ranges into a SINGLE storage_revert_appends
-                // call. Each range carries its own table_oid (the handler routes
-                // per-range), so one send covers both sets. The ctx table_oid is
-                // unused by storage_revert_appends.
-                std::vector<components::pg_catalog_append_range_t> revert_ranges;
-                revert_ranges.reserve(exec_result.dml_appends.size() + exec_result.pg_catalog_appends.size());
-                for (const auto& app : exec_result.dml_appends) {
-                    revert_ranges.push_back(
-                        components::pg_catalog_append_range_t{app.table_oid, app.row_start, app.row_count});
-                }
-                for (auto& pgc : exec_result.pg_catalog_appends) {
-                    revert_ranges.push_back(std::move(pgc));
-                }
-                exec_result.pg_catalog_appends.clear();
-                if (!revert_ranges.empty()) {
-                    components::execution_context_t pgc_ctx{session, resolve_txn, {}};
-                    auto [_pa, paf] = actor_zeta::send(disk_address_,
-                                                       &services::disk::manager_disk_t::storage_revert_appends,
-                                                       pgc_ctx,
-                                                       std::move(revert_ranges));
-                    co_await std::move(paf);
-                }
-
-                // Index revert, two-phase (send-all then await-all). Both
-                // revert_insert and revert_delete are keyed per (table_oid, txn)
-                // and clear ALL uncommitted entries of that kind for the pair, so
-                // they are idempotent across duplicate oids — dedup each side.
-                //   revert_insert  ← PENDING index INSERT entries (dml_appends).
-                //   revert_delete  ← PENDING index DELETE markers: an aborted
-                //     DELETE left tombstones in the pending bucket that never
-                //     reached disk; clear them per unique base dml_delete oid.
-                if (index_address_ != actor_zeta::address_t::empty_address()) {
-                    std::pmr::set<components::catalog::oid_t> revert_insert_oids{resource()};
-                    for (const auto& app : exec_result.dml_appends) {
-                        revert_insert_oids.insert(app.table_oid);
-                    }
-                    std::pmr::set<components::catalog::oid_t> revert_delete_oids{resource()};
-                    for (const auto& del : exec_result.dml_deletes) {
-                        revert_delete_oids.insert(del.table_oid);
-                    }
-                    std::pmr::vector<actor_zeta::unique_future<void>> revert_index_futures{resource()};
-                    revert_index_futures.reserve(revert_insert_oids.size() + revert_delete_oids.size());
-                    for (auto oid : revert_insert_oids) {
-                        components::execution_context_t abort_ctx{session, resolve_txn, session_ctx.session_tz, oid};
-                        auto [_ri, rif] = actor_zeta::send(index_address_,
-                                                           &services::index::manager_index_t::revert_insert,
-                                                           abort_ctx,
-                                                           oid);
-                        revert_index_futures.push_back(std::move(rif));
-                    }
-                    for (auto oid : revert_delete_oids) {
-                        components::execution_context_t abort_ctx{session, resolve_txn, session_ctx.session_tz, oid};
-                        auto [_rd, rdf] = actor_zeta::send(index_address_,
-                                                           &services::index::manager_index_t::revert_delete,
-                                                           abort_ctx,
-                                                           oid);
-                        revert_index_futures.push_back(std::move(rdf));
-                    }
-                    for (auto& rif : revert_index_futures) {
-                        co_await std::move(rif);
-                    }
-                }
-
-                auto [_ab, abf] = actor_zeta::send(parent_address_,
-                                                   &services::dispatcher::manager_dispatcher_t::txn_abort_msg,
-                                                   session);
-                co_await std::move(abf);
-
-                exec_result.dml_appends.clear();
-                exec_result.dml_deletes.clear();
+                // Failed DML statement: revert this statement's local ranges and
+                // abort the txn (also ends a failed statement's explicit txn).
+                co_await revert_failed_txn(this, exec_result);
             }
         }
 
@@ -1719,72 +1675,7 @@ namespace services::collection::executor {
                   resolve_txn.transaction_id,
                   session.data());
 
-            // Storage revert: one storage_revert_appends folds every catalog
-            // append AND any CREATE INDEX backfill dml_append into a single send
-            // (each range carries its own table_oid; the handler routes per-range).
-            std::vector<components::pg_catalog_append_range_t> revert_ranges;
-            revert_ranges.reserve(exec_result.dml_appends.size() + exec_result.pg_catalog_appends.size());
-            for (const auto& app : exec_result.dml_appends) {
-                revert_ranges.push_back(
-                    components::pg_catalog_append_range_t{app.table_oid, app.row_start, app.row_count});
-            }
-            for (auto& pgc : exec_result.pg_catalog_appends) {
-                revert_ranges.push_back(std::move(pgc));
-            }
-            exec_result.pg_catalog_appends.clear();
-            if (!revert_ranges.empty() && disk_address_ != actor_zeta::address_t::empty_address()) {
-                components::execution_context_t pgc_ctx{session, resolve_txn, {}};
-                auto [_pa, paf] = actor_zeta::send(disk_address_,
-                                                   &services::disk::manager_disk_t::storage_revert_appends,
-                                                   pgc_ctx,
-                                                   std::move(revert_ranges));
-                co_await std::move(paf);
-            }
-
-            // Index revert, two-phase (send-all then await-all), deduped to
-            // unique oids. revert_insert clears the PENDING index INSERT bucket
-            // for (table_oid, txn); revert_delete clears the PENDING index DELETE
-            // bucket (nothing reached disk pre-commit). The insert oids come from
-            // the backfill dml_appends; the delete oids from base dml_deletes
-            // (the only oids that actually carry pending index deletes).
-            if (index_address_ != actor_zeta::address_t::empty_address()) {
-                std::pmr::set<components::catalog::oid_t> revert_insert_oids{resource()};
-                for (const auto& app : exec_result.dml_appends) {
-                    revert_insert_oids.insert(app.table_oid);
-                }
-                std::pmr::set<components::catalog::oid_t> revert_delete_oids{resource()};
-                for (const auto& del : exec_result.dml_deletes) {
-                    revert_delete_oids.insert(del.table_oid);
-                }
-                std::pmr::vector<actor_zeta::unique_future<void>> revert_index_futures{resource()};
-                revert_index_futures.reserve(revert_insert_oids.size() + revert_delete_oids.size());
-                for (auto oid : revert_insert_oids) {
-                    components::execution_context_t abort_ctx{session, resolve_txn, session_ctx.session_tz, oid};
-                    auto [_ri, rif] = actor_zeta::send(index_address_,
-                                                       &services::index::manager_index_t::revert_insert,
-                                                       abort_ctx,
-                                                       oid);
-                    revert_index_futures.push_back(std::move(rif));
-                }
-                for (auto oid : revert_delete_oids) {
-                    components::execution_context_t abort_ctx{session, resolve_txn, session_ctx.session_tz, oid};
-                    auto [_rd, rdf] = actor_zeta::send(index_address_,
-                                                       &services::index::manager_index_t::revert_delete,
-                                                       abort_ctx,
-                                                       oid);
-                    revert_index_futures.push_back(std::move(rdf));
-                }
-                for (auto& f : revert_index_futures) {
-                    co_await std::move(f);
-                }
-            }
-
-            exec_result.dml_appends.clear();
-            exec_result.dml_deletes.clear();
-
-            auto [_ab, abf] =
-                actor_zeta::send(parent_address_, &services::dispatcher::manager_dispatcher_t::txn_abort_msg, session);
-            co_await std::move(abf);
+            co_await revert_failed_txn(this, exec_result);
         }
 
         // SET TIMEZONE — the operator pipeline persisted the ('TimeZone', name)

--- a/services/dispatcher/enrich_logical_plan.cpp
+++ b/services/dispatcher/enrich_logical_plan.cpp
@@ -724,7 +724,7 @@ namespace services::dispatcher { namespace {
     // core::error_t through the recursion (no-error state on success). idx is
     // the executor-built plan-tree resolve index; never null here (enrich_plan
     // is the only caller and it requires a non-null idx).
-    actor_zeta::unique_future<core::error_t>
+    [[nodiscard]] actor_zeta::unique_future<core::error_t>
     enrich_node(std::pmr::memory_resource* resource,
                 components::logical_plan::node_ptr root,
                 components::execution_context_t ctx,

--- a/services/dispatcher/enrich_logical_plan.cpp
+++ b/services/dispatcher/enrich_logical_plan.cpp
@@ -66,28 +66,9 @@
 
 namespace services::dispatcher { namespace {
 
-    // Helpers: probe enrich_resolve_idx_t (plan-tree resolves stamped by
-    // operator_resolve_*_t). All catalog reads in enrich flow through
-    // these.
-    const components::logical_plan::resolved_table_metadata_t*
-    lookup_table_md_local(const enrich_resolve_idx_t* idx, std::string_view db, std::string_view rel) {
-        if (!idx)
-            return nullptr;
-        std::string key;
-        key.reserve(db.size() + 1 + rel.size());
-        key.append(db).push_back('|');
-        key.append(rel);
-        auto it = idx->tbl_md_by_qname.find(key);
-        return it != idx->tbl_md_by_qname.end() ? it->second : nullptr;
-    }
-
-    const components::logical_plan::resolved_table_metadata_t*
-    lookup_table_md_by_oid_local(const enrich_resolve_idx_t* idx, components::catalog::oid_t oid) {
-        if (!idx)
-            return nullptr;
-        auto it = idx->tbl_md_by_oid.find(oid);
-        return it != idx->tbl_md_by_oid.end() ? it->second : nullptr;
-    }
+    using services::catalog_resolve::plan_resolve_index_t;
+    using services::catalog_resolve::tbl_md_for;
+    using services::catalog_resolve::tbl_md_for_oid;
 
     void fill_not_null(const components::logical_plan::resolved_table_metadata_t& md,
                        std::vector<std::string>& out,
@@ -100,14 +81,14 @@ namespace services::dispatcher { namespace {
     }
 
     void enrich_insert_sync(components::logical_plan::node_insert_t* node,
-                            const enrich_resolve_idx_t* idx,
+                            const plan_resolve_index_t* idx,
                             core::date::timezone_offset_t session_tz) {
         // Insert node carries only its table_oid (stamped by
         // stamp_drop_oids_from_resolves from the sibling resolve_table);
         // look up table metadata by OID rather than (db, rel) strings.
         if (node->table_oid() == components::catalog::INVALID_OID)
             return;
-        const auto* md = lookup_table_md_by_oid_local(idx, node->table_oid());
+        const auto* md = tbl_md_for_oid(idx, node->table_oid());
         if (!md)
             return;
         std::vector<std::string> nn;
@@ -171,6 +152,15 @@ namespace services::dispatcher { namespace {
                 // copy every row via cast_as. complex_logical_type::cast_as
                 // recurses STRUCT children, so nested ROW(int_literal,...)
                 // → STRUCT(INTEGER,...) is fully retyped.
+                //
+                // TODO(L3): drop the per-row logical_value_t round-trip once a
+                // typed cast accessor on vector_t/data_chunk covers this case.
+                // vector_operations::cast_vector exists but is FLAT numeric-only
+                // (asserts on strings, no STRUCT/LIST/ARRAY/MAP recursion, no
+                // session_tz for timestamps); this loop relies on cast_as's
+                // recursive composite descent + tz-aware temporal casts + null
+                // preservation. No suitable batch accessor today, so left as-is
+                // rather than inventing a new abstraction.
                 components::vector::vector_t replacement(col.resource(), *target_type, chunk.capacity());
                 const auto rows = chunk.size();
                 for (std::uint64_t row = 0; row < rows; ++row) {
@@ -190,11 +180,11 @@ namespace services::dispatcher { namespace {
         }
     }
 
-    void enrich_update_sync(components::logical_plan::node_update_t* node, const enrich_resolve_idx_t* idx) {
+    void enrich_update_sync(components::logical_plan::node_update_t* node, const plan_resolve_index_t* idx) {
         // Lookup by table_oid stamped from the sibling resolve_table.
         if (node->table_oid() == components::catalog::INVALID_OID)
             return;
-        const auto* md = lookup_table_md_by_oid_local(idx, node->table_oid());
+        const auto* md = tbl_md_for_oid(idx, node->table_oid());
         if (!md)
             return;
         std::vector<std::string> nn;
@@ -203,84 +193,19 @@ namespace services::dispatcher { namespace {
     }
 
     void enrich_create_collection_sync(components::logical_plan::node_create_collection_t* node,
-                                       const enrich_resolve_idx_t* /*idx*/) {
+                                       const plan_resolve_index_t* /*idx*/) {
         // namespace_oid stamped by stamp_drop_oids_from_resolves from the
         // sibling catalog_resolve_namespace_t; no per-node work here.
         (void) node;
     }
 
-    // Walk the plan tree, harvest namespace_oid / table_oid stamped
-    // by operator_resolve_*_t into a flat hashmap. Empty when
-    // the plan has no resolve wrap (DDL paths, disk-less harnesses).
-    // The caller (enrich_plan top-level) builds this once and threads
-    // the const-ptr through recursive calls.
-    void gather_enrich_resolve_idx(components::logical_plan::node_t* root, enrich_resolve_idx_t& out) {
-        using namespace components::logical_plan;
-        if (!root)
-            return;
-        std::queue<node_t*> q;
-        q.push(root);
-        while (!q.empty()) {
-            auto* n = q.front();
-            q.pop();
-            switch (n->type()) {
-                case node_type::catalog_resolve_table_t: {
-                    auto* rt = static_cast<node_catalog_resolve_table_t*>(n);
-                    if (rt->table_oid() != components::catalog::INVALID_OID) {
-                        std::string key;
-                        key.reserve(rt->dbname().size() + 1 + rt->relname().size());
-                        key.append(rt->dbname()).push_back('|');
-                        key.append(rt->relname());
-                        out.tbl_oid_by_qname[key] = rt->table_oid();
-                        // Stamp the full metadata pointer too when
-                        // operator_resolve_table_t populated it.
-                        if (rt->resolved_metadata().has_value()) {
-                            const auto* md_ptr = &rt->resolved_metadata().value();
-                            out.tbl_md_by_qname[std::move(key)] = md_ptr;
-                            out.tbl_md_by_oid[rt->table_oid()] = md_ptr;
-                        }
-                    }
-                    break;
-                }
-                case node_type::catalog_resolve_constraint_t: {
-                    auto* cr = static_cast<node_catalog_resolve_constraint_t*>(n);
-                    if (!cr->target())
-                        break;
-                    const auto& md = cr->target()->resolved_metadata();
-                    if (!md.has_value() || md->table_oid == components::catalog::INVALID_OID) {
-                        break;
-                    }
-                    using direction_t = node_catalog_resolve_constraint_t::direction_t;
-                    if (cr->direction() == direction_t::outgoing) {
-                        out.outgoing_fks_by_oid[md->table_oid] = cr->fks();
-                        out.check_exprs_by_oid[md->table_oid] = cr->check_exprs();
-                    } else {
-                        out.referencing_fks_by_oid[md->table_oid] = cr->fks();
-                    }
-                    break;
-                }
-                default:
-                    break;
-            }
-            for (const auto& c : n->children()) {
-                if (c)
-                    q.push(c.get());
-            }
-        }
-    }
-
-    // Name→OID lookup via plan-tree index. Returns INVALID_OID on miss;
-    // the caller decides whether a miss is fatal.
+    // Name→OID lookup via the plan-tree index. Returns INVALID_OID on miss;
+    // the caller decides whether a miss is fatal. Reads the same metadata
+    // pointers gather_plan_resolve_index harvested, keyed by (db, rel).
     components::catalog::oid_t
-    lookup_table_oid(const enrich_resolve_idx_t* idx, std::string_view db, std::string_view rel) {
-        if (!idx)
-            return components::catalog::INVALID_OID;
-        std::string key;
-        key.reserve(db.size() + 1 + rel.size());
-        key.append(db).push_back('|');
-        key.append(rel);
-        auto it = idx->tbl_oid_by_qname.find(key);
-        return it != idx->tbl_oid_by_qname.end() ? it->second : components::catalog::INVALID_OID;
+    lookup_table_oid(const plan_resolve_index_t* idx, std::string_view db, std::string_view rel) {
+        const auto* md = tbl_md_for(idx, db, rel);
+        return md ? md->table_oid : components::catalog::INVALID_OID;
     }
 
 }} // namespace services::dispatcher::
@@ -793,65 +718,20 @@ namespace services::catalog_resolve {
 
 } // namespace services::catalog_resolve
 
-namespace services::dispatcher {
+namespace services::dispatcher { namespace {
 
-    actor_zeta::unique_future<void> enrich_plan(std::pmr::memory_resource* resource,
-                                                components::logical_plan::node_ptr root,
-                                                actor_zeta::address_t disk_address,
-                                                components::execution_context_t ctx,
-                                                actor_zeta::address_t index_address,
-                                                services::context_storage_t* collections_ctx,
-                                                const enrich_resolve_idx_t* idx) {
+    // Per-node enrichment worker, recursing through children. Threads a
+    // core::error_t through the recursion (no-error state on success). idx is
+    // the executor-built plan-tree resolve index; never null here (enrich_plan
+    // is the only caller and it requires a non-null idx).
+    actor_zeta::unique_future<core::error_t>
+    enrich_node(std::pmr::memory_resource* resource,
+                components::logical_plan::node_ptr root,
+                components::execution_context_t ctx,
+                const services::catalog_resolve::plan_resolve_index_t* idx) {
         using namespace components::logical_plan;
         if (!root)
-            co_return;
-        // Top-level entry: gather plan-tree resolve index once, then re-enter
-        // with the gathered pointer. Recursive callers already supply a non-null
-        // `idx` so this gather runs at most once per public enrich_plan call.
-        if (idx == nullptr) {
-            enrich_resolve_idx_t local_idx;
-            gather_enrich_resolve_idx(root.get(), local_idx);
-            // drop_* nodes no longer carry user-typed names; copy OIDs
-            // from their sibling catalog_resolve_* nodes inside each sequence_t
-            // before the per-node enrich cases run.
-            stamp_oids_from_resolves(root.get());
-            co_await enrich_plan(resource, root, disk_address, ctx, index_address, collections_ctx, &local_idx);
-
-            if (collections_ctx && index_address != actor_zeta::address_t::empty_address()) {
-                // Two-phase: per-table get_indexed_keys + get_indexed_descriptions
-                // are independent across tables, so send both queries for every
-                // table first, then await and consume. collections_ctx fields are
-                // overwritten per table (last table wins, as before), so the
-                // await order must match the send order; awaiting in the same loop
-                // index sequence preserves that.
-                std::pmr::vector<actor_zeta::unique_future<std::pmr::vector<components::index::keys_base_storage_t>>>
-                    keys_futures(resource);
-                std::pmr::vector<actor_zeta::unique_future<std::pmr::vector<components::index::index_description_t>>>
-                    desc_futures(resource);
-                for (auto tbl_oid : root->table_oid_dependencies()) {
-                    if (tbl_oid == components::catalog::INVALID_OID) {
-                        continue;
-                    }
-                    auto [_ik, ikf] = actor_zeta::send(index_address,
-                                                       &index::manager_index_t::get_indexed_keys,
-                                                       ctx.session,
-                                                       tbl_oid);
-                    keys_futures.push_back(std::move(ikf));
-                    auto [_id, idf] = actor_zeta::send(index_address,
-                                                       &index::manager_index_t::get_indexed_descriptions,
-                                                       ctx.session,
-                                                       tbl_oid);
-                    desc_futures.push_back(std::move(idf));
-                }
-                for (auto& ikf : keys_futures) {
-                    collections_ctx->indexed_keys = co_await std::move(ikf);
-                }
-                for (auto& idf : desc_futures) {
-                    collections_ctx->indexed_descriptions = co_await std::move(idf);
-                }
-            }
-            co_return;
-        }
+            co_return core::error_t::no_error();
         // Stamp table_oid for any SELECT-side consumer that still carries
         // (db, rel) on the node body (aggregate/match/group/sort/join/limit/
         // having). DML consumers (insert/update/delete) have already been
@@ -965,7 +845,7 @@ namespace services::dispatcher {
                 // and defspecs are pre-populated by the resolve_constraint
                 // operator itself — see operator_resolve_constraint.cpp.
                 const auto* tbl = (node->table_oid() != components::catalog::INVALID_OID)
-                                      ? lookup_table_md_by_oid_local(idx, node->table_oid())
+                                      ? tbl_md_for_oid(idx, node->table_oid())
                                       : nullptr;
                 if (tbl && idx) {
                     const auto tbl_oid = tbl->table_oid;
@@ -996,9 +876,10 @@ namespace services::dispatcher {
                 auto* node = static_cast<node_create_collection_t*>(root.get());
                 enrich_create_collection_sync(node, idx);
                 // resolve_column_definitions takes an explicit plan-tree idx.
-                // enrich's `enrich_resolve_idx_t` is a different shape; build
-                // a small plan_resolve_index_t locally from the same root tree so
-                // UDT columns get resolved without thread_local state.
+                // Build a sub-tree-local plan_resolve_index_t from this node so
+                // UDT columns get resolved without thread_local state. (The
+                // executor-built `idx` covers the whole plan; gathering from
+                // `root` here keeps the original sub-tree scoping.)
                 impl::plan_resolve_index_t local_plan_idx;
                 impl::gather_plan_resolve_index(root.get(), &local_plan_idx);
                 resolve_column_definitions(node->column_definitions(), &local_plan_idx);
@@ -1017,7 +898,7 @@ namespace services::dispatcher {
                 auto* node = static_cast<node_create_index_t*>(root.get());
                 if (node->table_oid() == components::catalog::INVALID_OID)
                     break;
-                const auto* tbl = lookup_table_md_by_oid_local(idx, node->table_oid());
+                const auto* tbl = tbl_md_for_oid(idx, node->table_oid());
                 if (!tbl)
                     break;
 
@@ -1053,7 +934,7 @@ namespace services::dispatcher {
                 // resolve_table emitted by the transformer.
                 auto* node = static_cast<node_create_constraint_t*>(root.get());
                 const std::string& ns_name = node->dbname();
-                const auto* tbl = lookup_table_md_local(idx, ns_name, node->relname());
+                const auto* tbl = tbl_md_for(idx, ns_name, node->relname());
                 if (!tbl)
                     break;
                 node->set_table_oid(tbl->table_oid);
@@ -1075,7 +956,7 @@ namespace services::dispatcher {
                 // the 2nd resolve_table sibling (transformer emits FK ref table).
                 if (node->kind() == constraint_kind::foreign_key &&
                     node->ref_table_oid() != components::catalog::INVALID_OID) {
-                    const auto* rrt = lookup_table_md_by_oid_local(idx, node->ref_table_oid());
+                    const auto* rrt = tbl_md_for_oid(idx, node->ref_table_oid());
                     if (rrt) {
                         std::vector<components::catalog::oid_t> ref_attoids;
                         for (const auto& col_name : node->ref_col_names()) {
@@ -1097,7 +978,7 @@ namespace services::dispatcher {
                 // the planner rewrite (computed-vs-regular routing).
                 auto* node = static_cast<node_alter_table_t*>(root.get());
                 if (node->table_oid() != components::catalog::INVALID_OID) {
-                    const auto* tbl = lookup_table_md_by_oid_local(idx, node->table_oid());
+                    const auto* tbl = tbl_md_for_oid(idx, node->table_oid());
                     if (tbl) {
                         node->set_relkind(tbl->relkind);
                     }
@@ -1127,8 +1008,73 @@ namespace services::dispatcher {
         for (auto& child : root->children()) {
             if (!child)
                 continue;
-            co_await enrich_plan(resource, child, disk_address, ctx, index_address, collections_ctx, idx);
+            auto child_err = co_await enrich_node(resource, child, ctx, idx);
+            if (child_err.contains_error()) {
+                co_return child_err;
+            }
         }
+        co_return core::error_t::no_error();
+    }
+
+}} // namespace services::dispatcher::
+
+namespace services::dispatcher {
+
+    actor_zeta::unique_future<core::error_t>
+    enrich_plan(std::pmr::memory_resource* resource,
+                components::logical_plan::node_ptr root,
+                actor_zeta::address_t disk_address,
+                components::execution_context_t ctx,
+                const services::catalog_resolve::plan_resolve_index_t* idx,
+                actor_zeta::address_t index_address,
+                services::context_storage_t* collections_ctx) {
+        (void) disk_address;
+        if (!root)
+            co_return core::error_t::no_error();
+        // drop_* nodes no longer carry user-typed names; copy OIDs from their
+        // sibling catalog_resolve_* nodes inside each sequence_t before the
+        // per-node enrich cases run. (The executor already stamps before
+        // building `idx`; this is a defensive no-op for already-stamped trees.)
+        stamp_oids_from_resolves(root.get());
+        auto err = co_await enrich_node(resource, root, ctx, idx);
+        if (err.contains_error()) {
+            co_return err;
+        }
+
+        if (collections_ctx && index_address != actor_zeta::address_t::empty_address()) {
+            // Two-phase: per-table get_indexed_keys + get_indexed_descriptions
+            // are independent across tables, so send both queries for every
+            // table first, then await and consume. collections_ctx fields are
+            // overwritten per table (last table wins, as before), so the
+            // await order must match the send order; awaiting in the same loop
+            // index sequence preserves that.
+            std::pmr::vector<actor_zeta::unique_future<std::pmr::vector<components::index::keys_base_storage_t>>>
+                keys_futures(resource);
+            std::pmr::vector<actor_zeta::unique_future<std::pmr::vector<components::index::index_description_t>>>
+                desc_futures(resource);
+            for (auto tbl_oid : root->table_oid_dependencies()) {
+                if (tbl_oid == components::catalog::INVALID_OID) {
+                    continue;
+                }
+                auto [_ik, ikf] = actor_zeta::send(index_address,
+                                                   &index::manager_index_t::get_indexed_keys,
+                                                   ctx.session,
+                                                   tbl_oid);
+                keys_futures.push_back(std::move(ikf));
+                auto [_id, idf] = actor_zeta::send(index_address,
+                                                   &index::manager_index_t::get_indexed_descriptions,
+                                                   ctx.session,
+                                                   tbl_oid);
+                desc_futures.push_back(std::move(idf));
+            }
+            for (auto& ikf : keys_futures) {
+                collections_ctx->indexed_keys = co_await std::move(ikf);
+            }
+            for (auto& idf : desc_futures) {
+                collections_ctx->indexed_descriptions = co_await std::move(idf);
+            }
+        }
+        co_return core::error_t::no_error();
     }
 
 } // namespace services::dispatcher

--- a/services/dispatcher/enrich_logical_plan.hpp
+++ b/services/dispatcher/enrich_logical_plan.hpp
@@ -7,11 +7,14 @@
 // does pure structural rewrite reading those fields — no external context
 // parameter needed.
 
+#include "plan_resolve_index.hpp"
+
 #include <actor-zeta.hpp>
 #include <components/catalog/catalog_oids.hpp>
 #include <components/catalog/fk_info.hpp>
 #include <components/context/execution_context.hpp>
 #include <components/cursor/cursor.hpp>
+#include <core/result_wrapper.hpp>
 #include <components/logical_plan/node.hpp>
 #include <components/logical_plan/node_catalog_resolve_table.hpp>
 #include <components/logical_plan/node_catalog_resolve_type.hpp>
@@ -27,34 +30,6 @@
 
 namespace services::dispatcher {
 
-    // name->OID lookup table built from catalog_resolve_*_t logical-plan leaves
-    // AFTER they were stamped by operator_resolve_*_t. enrich_plan walks this
-    // map directly, so no async catalog actor messages from validate / enrich /
-    // planner. Empty when the plan has no resolve wrap (DDL paths, disk-less
-    // harnesses). Also stores pointers to full table metadata
-    // (resolved_table_metadata_t living on the resolve node) so enrich can
-    // read columns / not-null / default specs through the plan-tree idx.
-    struct enrich_resolve_idx_t {
-        // "dbname|relname" → table_oid.
-        std::unordered_map<std::string, components::catalog::oid_t> tbl_oid_by_qname;
-        // "dbname|relname" → const resolved_table_metadata_t*. Points into the
-        // resolve node's `resolved_metadata()` optional. Pointer stays valid
-        // for the lifetime of the plan tree (intrusive_ptr keeps nodes alive
-        // through the executor's coroutine).
-        std::unordered_map<std::string, const components::logical_plan::resolved_table_metadata_t*> tbl_md_by_qname;
-        // table_oid → const resolved_table_metadata_t*. Mirror for oid-keyed
-        // table metadata probes.
-        std::unordered_map<components::catalog::oid_t, const components::logical_plan::resolved_table_metadata_t*>
-            tbl_md_by_oid;
-        // Constraint snapshots keyed by parent table_oid, stamped by
-        // operator_resolve_constraint_t.
-        std::unordered_map<components::catalog::oid_t, std::vector<components::catalog::fk_info_t>> outgoing_fks_by_oid;
-        std::unordered_map<components::catalog::oid_t, std::vector<components::catalog::fk_info_t>>
-            referencing_fks_by_oid;
-        std::unordered_map<components::catalog::oid_t, std::vector<std::pair<std::string, std::string>>>
-            check_exprs_by_oid;
-    };
-
     // Walks the plan tree and fills catalog metadata fields into DML nodes
     // (node_insert_t, node_update_t, node_delete_t).  DDL nodes are left
     // untouched — they go through execute_ddl_inline unchanged.
@@ -62,18 +37,22 @@ namespace services::dispatcher {
     // Precondition: validate_schema has already co_awaited get_table() for every
     // table referenced in the plan, so try_get_table() hits the cache synchronously.
     //
-    // `idx`: when non-null, supplies the plan-tree resolve map used to stamp
-    // table_oid / namespace_oid without async catalog probes. When null,
-    // enrich gathers a local index from `root` itself (recursive calls then
-    // thread the gathered pointer through children).
-    actor_zeta::unique_future<void>
+    // `idx` supplies the plan-tree resolve map (built once by the executor via
+    // gather_plan_resolve_index) used to stamp table_oid / namespace_oid and
+    // read table metadata without async catalog probes. Recursive calls thread
+    // the same pointer through children.
+    //
+    // Returns a no-error error_t (core::error_t::no_error()) on success.
+    // On failure the returned error_t::contains_error() is true and the caller
+    // must surface it (enrich silently dropped errors before this channel).
+    actor_zeta::unique_future<core::error_t>
     enrich_plan(std::pmr::memory_resource* resource,
                 components::logical_plan::node_ptr root,
                 actor_zeta::address_t disk_address,
                 components::execution_context_t ctx,
+                const services::catalog_resolve::plan_resolve_index_t* idx,
                 actor_zeta::address_t index_address = actor_zeta::address_t::empty_address(),
-                services::context_storage_t* collections_ctx = nullptr,
-                const enrich_resolve_idx_t* idx = nullptr);
+                services::context_storage_t* collections_ctx = nullptr);
 
 } // namespace services::dispatcher
 

--- a/services/dispatcher/enrich_logical_plan.hpp
+++ b/services/dispatcher/enrich_logical_plan.hpp
@@ -45,7 +45,7 @@ namespace services::dispatcher {
     // Returns a no-error error_t (core::error_t::no_error()) on success.
     // On failure the returned error_t::contains_error() is true and the caller
     // must surface it (enrich silently dropped errors before this channel).
-    actor_zeta::unique_future<core::error_t>
+    [[nodiscard]] actor_zeta::unique_future<core::error_t>
     enrich_plan(std::pmr::memory_resource* resource,
                 components::logical_plan::node_ptr root,
                 actor_zeta::address_t disk_address,

--- a/services/dispatcher/validate_logical_plan.cpp
+++ b/services/dispatcher/validate_logical_plan.cpp
@@ -498,7 +498,13 @@ namespace services::dispatcher {
                     }
                 } else {
                     auto id = std::get<core::parameter_id_t>(field);
-                    function_input_types.emplace_back(parameters.parameters.at(id).type());
+                    auto param_it = parameters.parameters.find(id);
+                    if (param_it == parameters.parameters.end()) {
+                        return core::error_t(core::error_code_t::invalid_parameter,
+                                             std::pmr::string{"unbound parameter referenced in function arguments",
+                                                              resource});
+                    }
+                    function_input_types.emplace_back(param_it->second.type());
                 }
             }
             auto fn_lk = lookup_function(expr->name(), function_input_types);
@@ -1405,11 +1411,9 @@ namespace services::dispatcher {
                     const auto& visible_alias = node->result_alias().empty() ? agg_relname_s : node->result_alias();
                     // there will be a scan
                     const auto* tbl = impl::tbl_md_for(idx, agg_dbname_s, agg_relname_s);
-                    if (tbl && tbl->relkind != 'g') {
-                        for (const auto& column : tbl->columns) {
-                            table_schema.emplace_back(type_from_t{visible_alias, column.type});
-                        }
-                    } else if (tbl && tbl->relkind == 'g') {
+                    if (tbl) {
+                        // Both relkinds ('g' and non-'g') build the schema identically
+                        // here: same alias source (visible_alias) and same column loop.
                         for (const auto& column : tbl->columns) {
                             table_schema.emplace_back(type_from_t{visible_alias, column.type});
                         }
@@ -1757,6 +1761,10 @@ namespace services::dispatcher {
                                t == scalar_type::unary_minus;
                     };
 
+                    // resolve_type/compute_type_entry have no return-channel for
+                    // errors (they return plain types); a missing parameter is
+                    // surfaced through this flag, checked after each call site.
+                    core::error_t compute_type_error = core::error_t::no_error();
                     auto compute_type_entry = [&](scalar_expression_t* scalar_expr,
                                                   const named_schema& schema) -> type_from_t {
                         auto resolve_type = [&](param_storage& param, auto& self) -> complex_logical_type {
@@ -1765,7 +1773,15 @@ namespace services::dispatcher {
                                 assert(!key.path().empty());
                                 return schema[key.path()[0]].type;
                             } else if (std::holds_alternative<core::parameter_id_t>(param)) {
-                                return parameters.parameters.at(std::get<core::parameter_id_t>(param)).type();
+                                auto ct_it = parameters.parameters.find(std::get<core::parameter_id_t>(param));
+                                if (ct_it == parameters.parameters.end()) {
+                                    compute_type_error =
+                                        core::error_t(core::error_code_t::invalid_parameter,
+                                                      std::pmr::string{"unbound parameter in scalar expression",
+                                                                       resource});
+                                    return complex_logical_type(logical_type::INVALID);
+                                }
+                                return ct_it->second.type();
                             } else {
                                 auto& sub = std::get<expression_ptr>(param);
                                 if (sub->group() == expression_group::scalar) {
@@ -1864,6 +1880,9 @@ namespace services::dispatcher {
                                     post_agg_indices.push_back(i); // defer to Pass 2
                                 } else {
                                     auto entry = compute_type_entry(scalar_expr, incoming_schema);
+                                    if (compute_type_error.type != core::error_code_t::none) {
+                                        return compute_type_error;
+                                    }
                                     result.emplace_back(entry);
                                     key_schema.emplace_back(entry);
                                 }
@@ -1893,7 +1912,14 @@ namespace services::dispatcher {
                                     }
                                 } else if (std::holds_alternative<core::parameter_id_t>(param)) {
                                     auto id = std::get<core::parameter_id_t>(param);
-                                    function_input_types.emplace_back(parameters.parameters.at(id).type());
+                                    auto agg_param_it = parameters.parameters.find(id);
+                                    if (agg_param_it == parameters.parameters.end()) {
+                                        return core::error_t(
+                                            core::error_code_t::invalid_parameter,
+                                            std::pmr::string{"unbound parameter referenced in aggregate arguments",
+                                                             resource});
+                                    }
+                                    function_input_types.emplace_back(agg_param_it->second.type());
                                 } else {
                                     auto& sub_expr = std::get<expression_ptr>(param);
                                     if (sub_expr->group() == expression_group::scalar) {
@@ -1925,8 +1951,16 @@ namespace services::dispatcher {
                                                     assert(false);
                                                     return complex_logical_type(logical_type::INVALID);
                                                 } else if (std::holds_alternative<core::parameter_id_t>(p)) {
-                                                    return params.parameters.at(std::get<core::parameter_id_t>(p))
-                                                        .type();
+                                                    auto p_it =
+                                                        params.parameters.find(std::get<core::parameter_id_t>(p));
+                                                    if (p_it == params.parameters.end()) {
+                                                        resolve_error = core::error_t(
+                                                            core::error_code_t::invalid_parameter,
+                                                            std::pmr::string{"unbound parameter in arithmetic operand",
+                                                                             resource});
+                                                        return complex_logical_type(logical_type::INVALID);
+                                                    }
+                                                    return p_it->second.type();
                                                 } else {
                                                     auto& inner = std::get<expression_ptr>(p);
                                                     if (inner->group() == expression_group::scalar) {
@@ -2060,6 +2094,9 @@ namespace services::dispatcher {
                             scalar_expr->key().set_path({SIZE_MAX}); // Mark for planner
 
                             auto entry = compute_type_entry(scalar_expr, post_agg_schema);
+                            if (compute_type_error.type != core::error_code_t::none) {
+                                return compute_type_error;
+                            }
                             result.emplace_back(entry);
                         }
                     }
@@ -2438,6 +2475,8 @@ namespace services::dispatcher {
                             const auto& storage = set_expr->key().storage();
                             // Top-level field is the column name; nested paths (a.b.c) still
                             // require the head 'a' to be a registered column.
+                            // storage.at(0) is safe: key_t::is_null() == storage().empty(),
+                            // and the is_null() check above already skipped empty-key SETs.
                             const std::string column_name(storage.at(0).data(), storage.at(0).size());
                             if (live_columns.find(column_name) == live_columns.end()) {
                                 return core::error_t{

--- a/services/dispatcher/validate_logical_plan.cpp
+++ b/services/dispatcher/validate_logical_plan.cpp
@@ -1880,7 +1880,7 @@ namespace services::dispatcher {
                                     post_agg_indices.push_back(i); // defer to Pass 2
                                 } else {
                                     auto entry = compute_type_entry(scalar_expr, incoming_schema);
-                                    if (compute_type_error.type != core::error_code_t::none) {
+                                    if (compute_type_error.contains_error()) {
                                         return compute_type_error;
                                     }
                                     result.emplace_back(entry);
@@ -2094,7 +2094,7 @@ namespace services::dispatcher {
                             scalar_expr->key().set_path({SIZE_MAX}); // Mark for planner
 
                             auto entry = compute_type_entry(scalar_expr, post_agg_schema);
-                            if (compute_type_error.type != core::error_code_t::none) {
+                            if (compute_type_error.contains_error()) {
                                 return compute_type_error;
                             }
                             result.emplace_back(entry);


### PR DESCRIPTION
## What

Normalize the executor query path toward the canonical
`logical_plan → planner → optimizer → physical-plan-gen → executor → disk/index`
order and remove accumulated copy-paste / redundant tree walks. **Behavior preserved** — full repo test suite green.

## Changes

**Flow normalization**
- **O1** — unify the two optimizer passes into ONE post-planner pass: `optimize()` now runs `fold_constants` + `pushdown_filter` + `rewrite_hash_joins` *after* `planner.create_plan` (canonical `planner → optimizer` order); `post_validate_optimize` removed.

**Dedup**
- **C1** — collapse the ~11-arm DDL OID-alloc switch into one path driven by new `planner::compute_oid_demand` (single source of truth for per-DDL OID counts, mirrors `walk_ddl` consumption). ~160 → ~85 lines.
- **C2** — merge the byte-identical DML/DDL failure-revert blocks into one local coroutine lambda (`revert_failed_txn`).
- **C4** — merge the duplicated resolve pass1/pass2 into one runner (`run_resolve_subplan`).
- **C3** — drop the narrow `enrich_resolve_idx_t` / `gather_enrich_resolve_idx` and duplicate lookup helpers; enrich reuses the shared `plan_resolve_index_t` threaded from the executor (fewer tree walks per query).
- **C5** — collapse a duplicate relkind branch in aggregate schema validation.
- **C9/C10** — extract duplicate `set_uint32`/`set_str` into `catalog_write_helpers.hpp`; build resolve operators' static output schema once in the ctor.

**Error handling (no exceptions on the hot path)**
- **E4** — `enrich_plan` returns `core::error_t` so enrich errors propagate via the cursor instead of being silently dropped.
- **E1** — replace defensive throws in physical-plan-gen (join/hash_join/sort/group) with `return nullptr`; the executor surfaces the error cursor.
- **E2** — route `function_predicate` / `arithmetic_eval` errors through the `result_wrapper`/`error_t` channel instead of throwing.
- **E3** — replace unguarded `.at()` lookups on the parameter map with `.find()` + `error_t`.

## Intentionally out of scope / deferred
- **M1** (remove `transaction_manager` `lock_`) **reverted** — the single-thread premise is false: WAL recovery and the dispatcher loop both touch it (caught by the restart test). Pure-MVCC lock removal needs a separate recovery↔loop sequencing analysis.
- **C7** (merge `validate_types`+`validate_schema`), **L1/L2/L3/L4** (`logical_value_t` round-trips), and the `create_plan_*` handler collapse — left as TODO/out-of-scope (would change behavior or add abstractions).
- **Transformer fixes** (incl. a real `DELETE/UPDATE … WHERE func()` mis-cast bug) deferred to a separate PR.

## Testing
All repo test binaries rebuilt and green (~880 cases): `test_otterbrix` (225), `test_translator`, `test_dispatcher`, `test_table`, `test_disk`, `test_index_service`, `test_wal`, `test_catalog`, `test_sql`, `test_core`, and the rest.