### PR TITLE
fix(table): disk-backed buffer cache + eviction guard to fix HTAP scan segfault

### DIFF
--- a/components/physical_plan/operators/operator_fk_cascade.cpp
+++ b/components/physical_plan/operators/operator_fk_cascade.cpp
@@ -96,7 +96,7 @@ namespace components::operators {
                 for (const auto& child_ids : per_row_child_ids) {
                     if (!child_ids.empty()) {
                         set_error(core::error_t{
-                            core::error_code_t::other_error,
+                            core::error_code_t::invalid_constraint,
                             std::pmr::string{"FK constraint violated: child rows reference deleted parent row",
                                              resource_}});
                         co_return;

--- a/components/physical_plan/operators/operator_fk_cascade.cpp
+++ b/components/physical_plan/operators/operator_fk_cascade.cpp
@@ -206,7 +206,14 @@ namespace components::operators {
                                                    fk_.child_table_oid,
                                                    std::move(upd_ids),
                                                    std::move(fetched));
-                co_await std::move(ufut);
+                // The update reply carries any write_conflict / out_of_memory; surface it as a
+                // clean error cursor instead of silently dropping it.
+                auto update_result = co_await std::move(ufut);
+                if (update_result.has_error()) {
+                    set_error(update_result.error());
+                    mark_failed();
+                    co_return;
+                }
                 break;
             }
             default:

--- a/components/physical_plan/operators/operator_insert.cpp
+++ b/components/physical_plan/operators/operator_insert.cpp
@@ -117,7 +117,16 @@ namespace components::operators {
                                          exec_ctx,
                                          table_oid_,
                                          std::move(data_copy));
-        auto [start_row, actual_count] = co_await std::move(af);
+        // The append reply carries any write_conflict / out_of_memory the table-layer append
+        // chain surfaced; surface it as a clean error cursor (the executor turns has_error()
+        // into an error cursor) so the txn aborts gracefully.
+        auto append_result = co_await std::move(af);
+        if (append_result.has_error()) {
+            set_error(append_result.error());
+            mark_failed();
+            co_return;
+        }
+        auto [start_row, actual_count] = append_result.value();
 
         if (actual_count == 0) {
             // Nothing inserted (e.g. duplicate _id). The agent wrote no WAL for a

--- a/components/physical_plan/operators/operator_update.cpp
+++ b/components/physical_plan/operators/operator_update.cpp
@@ -313,7 +313,16 @@ namespace components::operators {
                                          table_oid_,
                                          std::move(row_ids),
                                          std::move(data_copy));
-        auto [upd_row_start, upd_row_count] = co_await std::move(uf);
+        // The update reply carries any write_conflict / out_of_memory the table-layer MVCC
+        // update surfaced; surface it as a clean error cursor (the executor turns has_error()
+        // into an error cursor) so the txn aborts gracefully.
+        auto update_result = co_await std::move(uf);
+        if (update_result.has_error()) {
+            set_error(update_result.error());
+            mark_failed();
+            co_return;
+        }
+        auto [upd_row_start, upd_row_count] = update_result.value();
 
         // 3. WAL physical_update.
         if (ctx->wal_address != actor_zeta::address_t::empty_address()) {

--- a/components/physical_plan/operators/scan/full_scan.cpp
+++ b/components/physical_plan/operators/scan/full_scan.cpp
@@ -265,7 +265,16 @@ namespace components::operators {
                                          scan_limit,
                                          projected_cols_,
                                          ctx->txn);
-        auto batches = co_await std::move(sf);
+        // The scan reply carries any buffer-pool OOM / data_corruption the table-layer scan
+        // surfaced. Surface it as a clean error cursor; the executor turns has_error() into an
+        // error cursor.
+        auto scan_result = co_await std::move(sf);
+        if (scan_result.has_error()) {
+            set_error(scan_result.error());
+            mark_failed();
+            co_return;
+        }
+        auto batches = std::move(scan_result.value());
 
         // Skip offset rows across batches.
         if (offset_val > 0) {

--- a/components/physical_plan/operators/scan/full_scan.hpp
+++ b/components/physical_plan/operators/scan/full_scan.hpp
@@ -9,7 +9,7 @@
 
 namespace components::operators {
 
-    core::result_wrapper_t<std::unique_ptr<table::table_filter_t>>
+    [[nodiscard]] core::result_wrapper_t<std::unique_ptr<table::table_filter_t>>
     transform_predicate(std::pmr::memory_resource* resource,
                         const expressions::compare_expression_ptr& expression,
                         const std::pmr::vector<types::complex_logical_type>& types,

--- a/components/physical_plan/operators/scan/transfer_scan.cpp
+++ b/components/physical_plan/operators/scan/transfer_scan.cpp
@@ -36,7 +36,16 @@ namespace components::operators {
                                          scan_limit,
                                          projected_cols_,
                                          ctx->txn);
-        auto batches = co_await std::move(sf);
+        // The scan reply carries any buffer-pool OOM / data_corruption the table-layer scan
+        // surfaced; surface it as a clean error cursor (the executor turns has_error() into an
+        // error cursor).
+        auto scan_result = co_await std::move(sf);
+        if (scan_result.has_error()) {
+            set_error(scan_result.error());
+            mark_failed();
+            co_return;
+        }
+        auto batches = std::move(scan_result.value());
 
         // Skip offset rows across batches. Partial-copy the boundary batch.
         if (offset_val > 0) {

--- a/components/storage/storage.hpp
+++ b/components/storage/storage.hpp
@@ -12,6 +12,7 @@
 #include <components/types/types.hpp>
 #include <components/vector/data_chunk.hpp>
 #include <components/vector/vector.hpp>
+#include <core/result_wrapper.hpp>
 
 namespace components::storage {
 
@@ -57,12 +58,15 @@ namespace components::storage {
         // Batched scan: emit one ≤DEFAULT_VECTOR_CAPACITY chunk per scan vector directly,
         // avoiding the accumulate-then-split round-trip. `projected_cols == nullptr` means
         // scan all columns; otherwise sparse projection.
-        // Default implementation: do a regular scan into one chunk; subclasses can override.
-        virtual void scan_batched(std::pmr::vector<vector::data_chunk_t>& batches,
-                                  const table::table_filter_t* filter,
-                                  int64_t limit,
-                                  const std::vector<size_t>* projected_cols,
-                                  table::transaction_data txn) {
+        // Returns a buffer-pool OOM / data_corruption error_t surfaced by the table-layer
+        // scan; true on success. Default implementation does a regular scan into one chunk
+        // (the void scan path leaves no scan_error), so it always reports success; subclasses
+        // that drive a batched scan override to read state.table_state.scan_error.
+        virtual core::result_wrapper_t<bool> scan_batched(std::pmr::vector<vector::data_chunk_t>& batches,
+                                                          const table::table_filter_t* filter,
+                                                          int64_t limit,
+                                                          const std::vector<size_t>* projected_cols,
+                                                          table::transaction_data txn) {
             auto t = types();
             vector::data_chunk_t one(resource(), t);
             if (projected_cols) {
@@ -73,6 +77,7 @@ namespace components::storage {
             if (one.size() > 0) {
                 batches.push_back(std::move(one));
             }
+            return true;
         }
 
         virtual void fetch(vector::data_chunk_t& output, const vector::vector_t& row_ids, uint64_t count) = 0;
@@ -86,16 +91,22 @@ namespace components::storage {
         virtual uint64_t append(vector::data_chunk_t& data) = 0;
 
         virtual void update(vector::vector_t& row_ids, vector::data_chunk_t& data) = 0;
-        virtual std::pair<int64_t, uint64_t>
+        // Returns write_conflict / out_of_memory from the table-layer update; on success
+        // {0, affected-row count}. Default fallback drives the void overload (replay path:
+        // no error surfacing).
+        virtual core::result_wrapper_t<std::pair<int64_t, uint64_t>>
         update(vector::vector_t& row_ids, vector::data_chunk_t& data, table::transaction_data /*txn*/) {
             update(row_ids, data);
-            return {0, 0};
+            return std::pair<int64_t, uint64_t>{0, 0};
         }
 
         virtual uint64_t delete_rows(vector::vector_t& row_ids, uint64_t count) = 0;
 
-        // Txn-aware overloads with default fallbacks
-        virtual uint64_t append(vector::data_chunk_t& data, table::transaction_data /*txn*/) { return append(data); }
+        // Txn-aware overloads with default fallbacks. Returns write_conflict / out_of_memory
+        // surfaced by the table-layer append chain; the start_row on success.
+        virtual core::result_wrapper_t<uint64_t> append(vector::data_chunk_t& data, table::transaction_data /*txn*/) {
+            return append(data);
+        }
         virtual uint64_t delete_rows(vector::vector_t& row_ids, uint64_t count, uint64_t /*txn_id*/) {
             return delete_rows(row_ids, count);
         }

--- a/components/storage/storage.hpp
+++ b/components/storage/storage.hpp
@@ -62,7 +62,7 @@ namespace components::storage {
         // scan; true on success. Default implementation does a regular scan into one chunk
         // (the void scan path leaves no scan_error), so it always reports success; subclasses
         // that drive a batched scan override to read state.table_state.scan_error.
-        virtual core::result_wrapper_t<bool> scan_batched(std::pmr::vector<vector::data_chunk_t>& batches,
+        [[nodiscard]] virtual core::result_wrapper_t<bool> scan_batched(std::pmr::vector<vector::data_chunk_t>& batches,
                                                           const table::table_filter_t* filter,
                                                           int64_t limit,
                                                           const std::vector<size_t>* projected_cols,
@@ -94,7 +94,7 @@ namespace components::storage {
         // Returns write_conflict / out_of_memory from the table-layer update; on success
         // {0, affected-row count}. Default fallback drives the void overload (replay path:
         // no error surfacing).
-        virtual core::result_wrapper_t<std::pair<int64_t, uint64_t>>
+        [[nodiscard]] virtual core::result_wrapper_t<std::pair<int64_t, uint64_t>>
         update(vector::vector_t& row_ids, vector::data_chunk_t& data, table::transaction_data /*txn*/) {
             update(row_ids, data);
             return std::pair<int64_t, uint64_t>{0, 0};
@@ -104,7 +104,7 @@ namespace components::storage {
 
         // Txn-aware overloads with default fallbacks. Returns write_conflict / out_of_memory
         // surfaced by the table-layer append chain; the start_row on success.
-        virtual core::result_wrapper_t<uint64_t> append(vector::data_chunk_t& data, table::transaction_data /*txn*/) {
+        [[nodiscard]] virtual core::result_wrapper_t<uint64_t> append(vector::data_chunk_t& data, table::transaction_data /*txn*/) {
             return append(data);
         }
         virtual uint64_t delete_rows(vector::vector_t& row_ids, uint64_t count, uint64_t /*txn_id*/) {

--- a/components/storage/table_storage_adapter.hpp
+++ b/components/storage/table_storage_adapter.hpp
@@ -102,11 +102,11 @@ namespace components::storage {
             }
         }
 
-        void scan_batched(std::pmr::vector<vector::data_chunk_t>& batches,
-                          const table::table_filter_t* filter,
-                          int64_t limit,
-                          const std::vector<size_t>* projected_cols,
-                          table::transaction_data txn) override {
+        core::result_wrapper_t<bool> scan_batched(std::pmr::vector<vector::data_chunk_t>& batches,
+                                                  const table::table_filter_t* filter,
+                                                  int64_t limit,
+                                                  const std::vector<size_t>* projected_cols,
+                                                  table::transaction_data txn) override {
             std::vector<table::storage_index_t> column_indices;
             if (projected_cols) {
                 column_indices.reserve(projected_cols->size());
@@ -127,6 +127,13 @@ namespace components::storage {
             state.local_state.txn = txn;
             auto types = table_.copy_types();
             table_.scan_batched(types, projected_cols, batches, state, resource_);
+            // data_table_t::scan_batched keeps its void shape and leaves any buffer-pool OOM /
+            // data_corruption in state.table_state.scan_error; surface it here as a value so the
+            // agent_disk scan reply can carry it across the mailbox. On error the partially-filled
+            // batches are discarded (the caller turns this into an error cursor).
+            if (state.table_state.has_error()) {
+                return state.table_state.scan_error;
+            }
             // Always emit at least one (possibly empty) chunk so downstream operators
             // can read types/column_count from chunks.front().
             if (batches.empty()) {
@@ -155,6 +162,7 @@ namespace components::storage {
                 // resize() doesn't compile.
                 batches.erase(batches.begin() + static_cast<std::ptrdiff_t>(keep), batches.end());
             }
+            return true;
         }
 
         void fetch(vector::data_chunk_t& output, const vector::vector_t& row_ids, uint64_t count) override {
@@ -194,36 +202,57 @@ namespace components::storage {
             return total_rows;
         }
 
+        // Replay/legacy path (no txn). The table-layer append chain returns result_wrapper_t
+        // (write_conflict / out_of_memory); replay records are already schema-aligned and
+        // single-threaded, so a failure here is a hard bug — bind the wrappers and assert success.
         uint64_t append(vector::data_chunk_t& data) override {
             table::table_append_state append_state(resource_);
-            table_.append_lock(append_state);
-            table_.initialize_append(append_state);
+            [[maybe_unused]] auto lock_r = table_.append_lock(append_state);
+            assert(!lock_r.has_error() && "replay append_lock conflict");
+            [[maybe_unused]] auto init_r = table_.initialize_append(append_state);
+            assert(!init_r.has_error() && "replay initialize_append OOM");
             auto start_row = static_cast<uint64_t>(append_state.current_row);
-            table_.append(data, append_state);
+            [[maybe_unused]] auto app_r = table_.append(data, append_state);
+            assert(!app_r.has_error() && "replay append OOM");
             table_.finalize_append(append_state, table::transaction_data{0, 0});
             return start_row;
         }
 
-        uint64_t append(vector::data_chunk_t& data, table::transaction_data txn) override {
+        // Returns the start_row on success, or write_conflict / out_of_memory surfaced by the
+        // table-layer append chain. The agent_disk append handler reads the wrapper and turns
+        // any error into a graceful txn abort.
+        core::result_wrapper_t<uint64_t> append(vector::data_chunk_t& data, table::transaction_data txn) override {
             table::table_append_state append_state(resource_);
-            table_.append_lock(append_state);
-            table_.initialize_append(append_state);
+            auto lock_r = table_.append_lock(append_state);
+            if (lock_r.has_error()) {
+                return lock_r.convert_error<uint64_t>();
+            }
+            auto init_r = table_.initialize_append(append_state);
+            if (init_r.has_error()) {
+                return init_r.convert_error<uint64_t>();
+            }
             auto start_row = static_cast<uint64_t>(append_state.current_row);
-            table_.append(data, append_state);
+            auto app_r = table_.append(data, append_state);
+            if (app_r.has_error()) {
+                return app_r.convert_error<uint64_t>();
+            }
             table_.finalize_append(append_state, txn);
             return start_row;
         }
 
         void update(vector::vector_t& row_ids, vector::data_chunk_t& data) override {
             auto update_state = table_.initialize_update({});
-            table_.update(*update_state, row_ids, data);
+            [[maybe_unused]] auto upd_r = table_.update(*update_state, row_ids, data);
+            assert(!upd_r.has_error() && "replay update conflict/OOM");
         }
 
-        std::pair<int64_t, uint64_t>
+        // Returns {start_row, count} on success, or write_conflict / out_of_memory surfaced by
+        // the table-layer delete+append MVCC update; agent_disk surfaces it.
+        core::result_wrapper_t<std::pair<int64_t, uint64_t>>
         update(vector::vector_t& row_ids, vector::data_chunk_t& data, table::transaction_data txn) override {
             auto count = static_cast<uint64_t>(data.size());
             if (count == 0)
-                return {0, 0};
+                return std::pair<int64_t, uint64_t>{0, 0};
 
             // Step 1: Mark old rows as deleted with txn_id
             auto delete_state = table_.initialize_delete({});
@@ -231,13 +260,22 @@ namespace components::storage {
 
             // Step 2: Append new rows with txn version stamps
             table::table_append_state append_state(resource_);
-            table_.append_lock(append_state);
-            table_.initialize_append(append_state);
+            auto lock_r = table_.append_lock(append_state);
+            if (lock_r.has_error()) {
+                return lock_r.convert_error<std::pair<int64_t, uint64_t>>();
+            }
+            auto init_r = table_.initialize_append(append_state);
+            if (init_r.has_error()) {
+                return init_r.convert_error<std::pair<int64_t, uint64_t>>();
+            }
             auto start_row = static_cast<int64_t>(append_state.current_row);
-            table_.append(data, append_state);
+            auto app_r = table_.append(data, append_state);
+            if (app_r.has_error()) {
+                return app_r.convert_error<std::pair<int64_t, uint64_t>>();
+            }
             table_.finalize_append(append_state, txn);
 
-            return {start_row, count};
+            return std::pair<int64_t, uint64_t>{start_row, count};
         }
 
         uint64_t delete_rows(vector::vector_t& row_ids, uint64_t count) override {

--- a/components/storage/table_storage_adapter.hpp
+++ b/components/storage/table_storage_adapter.hpp
@@ -102,7 +102,7 @@ namespace components::storage {
             }
         }
 
-        core::result_wrapper_t<bool> scan_batched(std::pmr::vector<vector::data_chunk_t>& batches,
+        [[nodiscard]] core::result_wrapper_t<bool> scan_batched(std::pmr::vector<vector::data_chunk_t>& batches,
                                                   const table::table_filter_t* filter,
                                                   int64_t limit,
                                                   const std::vector<size_t>* projected_cols,
@@ -221,7 +221,7 @@ namespace components::storage {
         // Returns the start_row on success, or write_conflict / out_of_memory surfaced by the
         // table-layer append chain. The agent_disk append handler reads the wrapper and turns
         // any error into a graceful txn abort.
-        core::result_wrapper_t<uint64_t> append(vector::data_chunk_t& data, table::transaction_data txn) override {
+        [[nodiscard]] core::result_wrapper_t<uint64_t> append(vector::data_chunk_t& data, table::transaction_data txn) override {
             table::table_append_state append_state(resource_);
             auto lock_r = table_.append_lock(append_state);
             if (lock_r.has_error()) {
@@ -248,7 +248,7 @@ namespace components::storage {
 
         // Returns {start_row, count} on success, or write_conflict / out_of_memory surfaced by
         // the table-layer delete+append MVCC update; agent_disk surfaces it.
-        core::result_wrapper_t<std::pair<int64_t, uint64_t>>
+        [[nodiscard]] core::result_wrapper_t<std::pair<int64_t, uint64_t>>
         update(vector::vector_t& row_ids, vector::data_chunk_t& data, table::transaction_data txn) override {
             auto count = static_cast<uint64_t>(data.size());
             if (count == 0)

--- a/components/table/array_column_data.cpp
+++ b/components/table/array_column_data.cpp
@@ -116,30 +116,44 @@ namespace components::table {
         child_column->skip(state.child_states[1], count * size);
     }
 
-    void array_column_data_t::initialize_append(column_append_state& state) {
+    core::result_wrapper_t<bool> array_column_data_t::initialize_append(column_append_state& state) {
         column_append_state validity_append;
-        validity.initialize_append(validity_append);
+        auto v = validity.initialize_append(validity_append);
+        if (v.has_error()) {
+            return v; // out_of_memory (rules 2/9)
+        }
         state.child_appends.push_back(std::move(validity_append));
 
         column_append_state child_append;
-        child_column->initialize_append(child_append);
+        auto child = child_column->initialize_append(child_append);
+        if (child.has_error()) {
+            return child;
+        }
         state.child_appends.push_back(std::move(child_append));
+        return true;
     }
 
-    void array_column_data_t::append(column_append_state& state, vector::vector_t& vector, uint64_t count) {
+    core::result_wrapper_t<bool>
+    array_column_data_t::append(column_append_state& state, vector::vector_t& vector, uint64_t count) {
         if (vector.get_vector_type() != vector::vector_type::FLAT) {
             vector::vector_t append_vector(vector);
             append_vector.flatten(count);
-            append(state, append_vector, count);
-            return;
+            return append(state, append_vector, count);
         }
 
-        validity.append(state.child_appends[0], vector, count);
+        auto v = validity.append(state.child_appends[0], vector, count);
+        if (v.has_error()) {
+            return v; // out_of_memory (rules 2/9)
+        }
         auto& child_vec = vector.entry();
         auto size = array_size();
-        child_column->append(state.child_appends[1], child_vec, count * size);
+        auto child = child_column->append(state.child_appends[1], child_vec, count * size);
+        if (child.has_error()) {
+            return child;
+        }
 
         count_ += count;
+        return true;
     }
 
     void array_column_data_t::revert_append(int64_t start_row) {
@@ -154,10 +168,10 @@ namespace components::table {
         throw std::logic_error("Function is not implemented: Array fetch");
     }
 
-    void array_column_data_t::update(uint64_t column_index,
-                                     vector::vector_t& update_vector,
-                                     int64_t* row_ids,
-                                     uint64_t update_count) {
+    core::result_wrapper_t<bool> array_column_data_t::update(uint64_t column_index,
+                                                           vector::vector_t& update_vector,
+                                                           int64_t* row_ids,
+                                                           uint64_t update_count) {
         size_t arr_size = array_size();
         size_t remaining_count = arr_size * update_count;
         std::pmr::vector<int64_t> sub_column_ids(resource_);
@@ -173,28 +187,31 @@ namespace components::table {
         uint64_t remaining_column_index = column_index;
         while (remaining_count > 0) {
             if (remaining_count >= vector::DEFAULT_VECTOR_CAPACITY) {
-                child_column->update(remaining_column_index,
-                                     update_vector.entry(),
-                                     remaining_sub_column_ids,
-                                     vector::DEFAULT_VECTOR_CAPACITY);
+                auto child = child_column->update(remaining_column_index,
+                                                  update_vector.entry(),
+                                                  remaining_sub_column_ids,
+                                                  vector::DEFAULT_VECTOR_CAPACITY);
+                if (child.has_error()) {
+                    return child;
+                }
                 remaining_sub_column_ids += vector::DEFAULT_VECTOR_CAPACITY;
                 remaining_count -= vector::DEFAULT_VECTOR_CAPACITY;
                 remaining_column_index++;
             } else {
-                child_column->update(remaining_column_index,
-                                     update_vector.entry(),
-                                     remaining_sub_column_ids,
-                                     remaining_count);
-                break;
+                return child_column->update(remaining_column_index,
+                                            update_vector.entry(),
+                                            remaining_sub_column_ids,
+                                            remaining_count);
             }
         }
+        return true;
     }
 
-    void array_column_data_t::update_column(const std::vector<uint64_t>& column_path,
-                                            vector::vector_t& update_vector,
-                                            int64_t* row_ids,
-                                            uint64_t update_count,
-                                            uint64_t depth) {
+    core::result_wrapper_t<bool> array_column_data_t::update_column(const std::vector<uint64_t>& column_path,
+                                                                 vector::vector_t& update_vector,
+                                                                 int64_t* row_ids,
+                                                                 uint64_t update_count,
+                                                                 uint64_t depth) {
         size_t arr_size = array_size();
         size_t remaining_count = arr_size * update_count;
         std::pmr::vector<int64_t> sub_column_ids(resource_);
@@ -209,27 +226,33 @@ namespace components::table {
         int64_t* remaining_sub_column_ids = sub_column_ids.data();
         while (remaining_count > 0) {
             if (remaining_count >= vector::DEFAULT_VECTOR_CAPACITY) {
-                child_column->update_column(column_path,
-                                            update_vector.entry(),
-                                            remaining_sub_column_ids,
-                                            vector::DEFAULT_VECTOR_CAPACITY,
-                                            depth);
+                auto child = child_column->update_column(column_path,
+                                                         update_vector.entry(),
+                                                         remaining_sub_column_ids,
+                                                         vector::DEFAULT_VECTOR_CAPACITY,
+                                                         depth);
+                if (child.has_error()) {
+                    return child;
+                }
                 remaining_sub_column_ids += vector::DEFAULT_VECTOR_CAPACITY;
                 remaining_count -= vector::DEFAULT_VECTOR_CAPACITY;
             } else {
-                child_column->update_column(column_path,
-                                            update_vector.entry(),
-                                            remaining_sub_column_ids,
-                                            remaining_count,
-                                            depth);
+                auto child = child_column->update_column(column_path,
+                                                         update_vector.entry(),
+                                                         remaining_sub_column_ids,
+                                                         remaining_count,
+                                                         depth);
+                if (child.has_error()) {
+                    return child;
+                }
                 break;
             }
         }
-        child_column->update_column(column_path,
-                                    update_vector.entry(),
-                                    sub_column_ids.data(),
-                                    update_count * arr_size,
-                                    depth);
+        return child_column->update_column(column_path,
+                                           update_vector.entry(),
+                                           sub_column_ids.data(),
+                                           update_count * arr_size,
+                                           depth);
     }
 
     void array_column_data_t::fetch_row(column_fetch_state& state,

--- a/components/table/array_column_data.hpp
+++ b/components/table/array_column_data.hpp
@@ -33,21 +33,21 @@ namespace components::table {
 
         void skip(column_scan_state& state, uint64_t count = vector::DEFAULT_VECTOR_CAPACITY) override;
 
-        void initialize_append(column_append_state& state) override;
-        void append(column_append_state& state, vector::vector_t& vector, uint64_t count) override;
+        core::result_wrapper_t<bool> initialize_append(column_append_state& state) override;
+        core::result_wrapper_t<bool> append(column_append_state& state, vector::vector_t& vector, uint64_t count) override;
         void revert_append(int64_t start_row) override;
         uint64_t fetch(column_scan_state& state, int64_t row_id, vector::vector_t& result) override;
         void
         fetch_row(column_fetch_state& state, int64_t row_id, vector::vector_t& result, uint64_t result_idx) override;
-        void update(uint64_t column_index,
-                    vector::vector_t& update_vector,
-                    int64_t* row_ids,
-                    uint64_t update_count) override;
-        void update_column(const std::vector<uint64_t>& column_path,
-                           vector::vector_t& update_vector,
-                           int64_t* row_ids,
-                           uint64_t update_count,
-                           uint64_t depth) override;
+        core::result_wrapper_t<bool> update(uint64_t column_index,
+                                            vector::vector_t& update_vector,
+                                            int64_t* row_ids,
+                                            uint64_t update_count) override;
+        core::result_wrapper_t<bool> update_column(const std::vector<uint64_t>& column_path,
+                                                   vector::vector_t& update_vector,
+                                                   int64_t* row_ids,
+                                                   uint64_t update_count,
+                                                   uint64_t depth) override;
 
         void get_column_segment_info(uint64_t row_group_index,
                                      std::vector<uint64_t> col_path,

--- a/components/table/array_column_data.hpp
+++ b/components/table/array_column_data.hpp
@@ -33,21 +33,22 @@ namespace components::table {
 
         void skip(column_scan_state& state, uint64_t count = vector::DEFAULT_VECTOR_CAPACITY) override;
 
-        core::result_wrapper_t<bool> initialize_append(column_append_state& state) override;
-        core::result_wrapper_t<bool> append(column_append_state& state, vector::vector_t& vector, uint64_t count) override;
+        [[nodiscard]] core::result_wrapper_t<bool> initialize_append(column_append_state& state) override;
+        [[nodiscard]] core::result_wrapper_t<bool>
+        append(column_append_state& state, vector::vector_t& vector, uint64_t count) override;
         void revert_append(int64_t start_row) override;
         uint64_t fetch(column_scan_state& state, int64_t row_id, vector::vector_t& result) override;
         void
         fetch_row(column_fetch_state& state, int64_t row_id, vector::vector_t& result, uint64_t result_idx) override;
-        core::result_wrapper_t<bool> update(uint64_t column_index,
-                                            vector::vector_t& update_vector,
-                                            int64_t* row_ids,
-                                            uint64_t update_count) override;
-        core::result_wrapper_t<bool> update_column(const std::vector<uint64_t>& column_path,
-                                                   vector::vector_t& update_vector,
-                                                   int64_t* row_ids,
-                                                   uint64_t update_count,
-                                                   uint64_t depth) override;
+        [[nodiscard]] core::result_wrapper_t<bool> update(uint64_t column_index,
+                                                          vector::vector_t& update_vector,
+                                                          int64_t* row_ids,
+                                                          uint64_t update_count) override;
+        [[nodiscard]] core::result_wrapper_t<bool> update_column(const std::vector<uint64_t>& column_path,
+                                                                 vector::vector_t& update_vector,
+                                                                 int64_t* row_ids,
+                                                                 uint64_t update_count,
+                                                                 uint64_t depth) override;
 
         void get_column_segment_info(uint64_t row_group_index,
                                      std::vector<uint64_t> col_path,

--- a/components/table/collection.cpp
+++ b/components/table/collection.cpp
@@ -4,6 +4,7 @@
 #include <components/vector/data_chunk.hpp>
 #include <queue>
 
+#include "column_data.hpp"
 #include "row_group.hpp"
 #include "row_version_manager.hpp"
 
@@ -203,7 +204,7 @@ namespace components::table {
 
     bool collection_t::is_empty(std::unique_lock<std::mutex>& l) const { return row_groups_->is_empty(l); }
 
-    void collection_t::initialize_append(table_append_state& state) {
+    core::result_wrapper_t<bool> collection_t::initialize_append(table_append_state& state) {
         state.row_start = static_cast<int64_t>(total_rows_.load());
         state.current_row = state.row_start;
         state.total_append_count = 0;
@@ -215,10 +216,10 @@ namespace components::table {
         state.start_row_group = row_groups_->last_segment(l);
         assert(row_start_ + static_cast<int64_t>(total_rows_.load()) ==
                state.start_row_group->start + static_cast<int64_t>(state.start_row_group->count));
-        state.start_row_group->initialize_append(state.append_state);
+        return state.start_row_group->initialize_append(state.append_state); // out_of_memory
     }
 
-    bool collection_t::append(vector::data_chunk_t& chunk, table_append_state& state) {
+    core::result_wrapper_t<bool> collection_t::append(vector::data_chunk_t& chunk, table_append_state& state) {
         const uint64_t prev_row_group_size = row_group_size_;
         assert(chunk.column_count() == types_.size());
 
@@ -232,8 +233,11 @@ namespace components::table {
                 std::min<uint64_t>(remaining, prev_row_group_size - state.append_state.offset_in_row_group);
             if (append_count > 0) {
                 auto previous_allocation_size = current_row_group->allocation_size();
-                current_row_group->append(state.append_state, chunk, append_count);
+                auto appended = current_row_group->append(state.append_state, chunk, append_count);
                 allocation_size_ += current_row_group->allocation_size() - previous_allocation_size;
+                if (appended.has_error()) {
+                    return appended; // out_of_memory
+                }
             }
             remaining -= append_count;
             if (remaining == 0) {
@@ -249,7 +253,18 @@ namespace components::table {
             auto l = row_groups_->lock();
             append_row_group(l, next_start);
             auto last_row_group = row_groups_->last_segment(l);
-            last_row_group->initialize_append(state.append_state);
+            auto init = last_row_group->initialize_append(state.append_state);
+            if (init.has_error()) {
+                return init; // out_of_memory
+            }
+            // Write-through: the row group we just closed is now COMPLETE (its column segments are final
+            // and the append state has moved to the new row group). Re-point its managed segments to disk so the
+            // pool can evict+reload them -> bounded memory at any table size. No-op for in-memory tables; a
+            // write/alloc failure surfaces as io_error/out_of_memory, never a throw.
+            auto transitioned = current_row_group->transition_to_disk();
+            if (transitioned.has_error()) {
+                return transitioned;
+            }
         }
         state.current_row += int64_t(total_append_count);
         return new_row_group;
@@ -350,7 +365,8 @@ namespace components::table {
         return delete_count;
     }
 
-    void collection_t::update(int64_t* ids, const std::vector<uint64_t>& column_ids, vector::data_chunk_t& updates) {
+    core::result_wrapper_t<bool>
+    collection_t::update(int64_t* ids, const std::vector<uint64_t>& column_ids, vector::data_chunk_t& updates) {
         uint64_t pos = 0;
         do {
             uint64_t start = pos;
@@ -369,13 +385,17 @@ namespace components::table {
                     break;
                 }
             }
-            row_group->update(updates, ids, start, pos - start, column_ids);
+            auto updated = row_group->update(updates, ids, start, pos - start, column_ids);
+            if (updated.has_error()) {
+                return updated; // write_conflict / out_of_memory
+            }
         } while (pos < updates.size());
+        return true;
     }
 
-    void collection_t::update_column(vector::vector_t& row_ids,
-                                     const std::vector<uint64_t>& column_path,
-                                     vector::data_chunk_t& updates) {
+    core::result_wrapper_t<bool> collection_t::update_column(vector::vector_t& row_ids,
+                                                           const std::vector<uint64_t>& column_path,
+                                                           vector::data_chunk_t& updates) {
         uint64_t pos = 0;
         do {
             uint64_t start = pos;
@@ -394,8 +414,12 @@ namespace components::table {
                     break;
                 }
             }
-            row_group->update(updates, row_ids.data<int64_t>(), start, pos - start, column_path);
+            auto updated = row_group->update(updates, row_ids.data<int64_t>(), start, pos - start, column_path);
+            if (updated.has_error()) {
+                return updated;
+            }
         } while (pos < updates.size());
+        return true;
     }
 
     std::vector<column_segment_info> collection_t::get_column_segment_info() {
@@ -404,6 +428,12 @@ namespace components::table {
             row_group.get_column_segment_info(row_group.index, result);
         }
         return result;
+    }
+
+    void collection_t::collect_disk_block_ids(std::pmr::vector<uint64_t>& out) {
+        for (auto& row_group : row_groups_->segments()) {
+            row_group.collect_disk_block_ids(out);
+        }
     }
 
     std::shared_ptr<collection_t> collection_t::add_column(column_definition_t& new_column) {
@@ -445,7 +475,7 @@ namespace components::table {
         return result;
     }
 
-    std::vector<storage::row_group_pointer_t>
+    core::result_wrapper_t<std::vector<storage::row_group_pointer_t>>
     collection_t::checkpoint(storage::partial_block_manager_t& partial_block_manager) {
         std::vector<storage::row_group_pointer_t> pointers;
 
@@ -453,7 +483,10 @@ namespace components::table {
         auto& segments = row_groups_->reference_segments(l);
         for (const auto& segment : segments) {
             auto pointer = segment.node->write_to_disk(partial_block_manager);
-            pointers.push_back(std::move(pointer));
+            if (pointer.has_error()) {
+                return pointer.convert_error<std::vector<storage::row_group_pointer_t>>(); // out_of_memory
+            }
+            pointers.push_back(std::move(pointer.value()));
         }
 
         partial_block_manager.flush_partial_blocks();

--- a/components/table/collection.hpp
+++ b/components/table/collection.hpp
@@ -73,8 +73,11 @@ namespace components::table {
                    uint64_t fetch_count,
                    column_fetch_state& state);
 
-        void initialize_append(table_append_state& state);
-        bool append(vector::data_chunk_t& chunk, table_append_state& state);
+        // The append chain returns out_of_memory when a row group / column segment allocation
+        // fails. initialize_append: true on success. append: on success the bool reports whether
+        // a new row group was started.
+        core::result_wrapper_t<bool> initialize_append(table_append_state& state);
+        core::result_wrapper_t<bool> append(vector::data_chunk_t& chunk, table_append_state& state);
         void finalize_append(table_append_state& state, transaction_data txn);
         void commit_append(uint64_t commit_id, int64_t row_start, uint64_t count);
         void revert_append(int64_t row_start, uint64_t count);
@@ -85,12 +88,19 @@ namespace components::table {
         void merge_storage(collection_t& data);
 
         uint64_t delete_rows(data_table_t& table, int64_t* ids, uint64_t count, uint64_t transaction_id);
-        void update(int64_t* ids, const std::vector<uint64_t>& column_ids, vector::data_chunk_t& updates);
-        void update_column(vector::vector_t& row_ids,
-                           const std::vector<uint64_t>& column_path,
-                           vector::data_chunk_t& updates);
+        // Update path returns write_conflict / out_of_memory; true on success.
+        core::result_wrapper_t<bool>
+        update(int64_t* ids, const std::vector<uint64_t>& column_ids, vector::data_chunk_t& updates);
+        core::result_wrapper_t<bool> update_column(vector::vector_t& row_ids,
+                                                   const std::vector<uint64_t>& column_path,
+                                                   vector::data_chunk_t& updates);
 
         std::vector<column_segment_info> get_column_segment_info();
+
+        // Append the ids of disk blocks exclusively owned by this collection's columns to `out`,
+        // so data_table_t::compact can free them after swapping the collection out for a compacted one.
+        void collect_disk_block_ids(std::pmr::vector<uint64_t>& out);
+
         const std::pmr::vector<types::complex_logical_type>& types() const;
         void adopt_types(std::pmr::vector<types::complex_logical_type> types);
 
@@ -100,7 +110,10 @@ namespace components::table {
         // std::shared_ptr<collection_t> alter_type(uint64_t changed_idx, const types::complex_logical_type &target_type,
         // std::vector<storage_index_t> bound_columns);
 
-        std::vector<storage::row_group_pointer_t> checkpoint(storage::partial_block_manager_t& partial_block_manager);
+        // The checkpoint chain returns out_of_memory when a column flush pin fails;
+        // the row group pointers on success.
+        core::result_wrapper_t<std::vector<storage::row_group_pointer_t>>
+        checkpoint(storage::partial_block_manager_t& partial_block_manager);
 
         storage::block_manager_t& block_manager() { return block_manager_; }
 

--- a/components/table/collection.hpp
+++ b/components/table/collection.hpp
@@ -76,8 +76,8 @@ namespace components::table {
         // The append chain returns out_of_memory when a row group / column segment allocation
         // fails. initialize_append: true on success. append: on success the bool reports whether
         // a new row group was started.
-        core::result_wrapper_t<bool> initialize_append(table_append_state& state);
-        core::result_wrapper_t<bool> append(vector::data_chunk_t& chunk, table_append_state& state);
+        [[nodiscard]] core::result_wrapper_t<bool> initialize_append(table_append_state& state);
+        [[nodiscard]] core::result_wrapper_t<bool> append(vector::data_chunk_t& chunk, table_append_state& state);
         void finalize_append(table_append_state& state, transaction_data txn);
         void commit_append(uint64_t commit_id, int64_t row_start, uint64_t count);
         void revert_append(int64_t row_start, uint64_t count);
@@ -89,11 +89,11 @@ namespace components::table {
 
         uint64_t delete_rows(data_table_t& table, int64_t* ids, uint64_t count, uint64_t transaction_id);
         // Update path returns write_conflict / out_of_memory; true on success.
-        core::result_wrapper_t<bool>
+        [[nodiscard]] core::result_wrapper_t<bool>
         update(int64_t* ids, const std::vector<uint64_t>& column_ids, vector::data_chunk_t& updates);
-        core::result_wrapper_t<bool> update_column(vector::vector_t& row_ids,
-                                                   const std::vector<uint64_t>& column_path,
-                                                   vector::data_chunk_t& updates);
+        [[nodiscard]] core::result_wrapper_t<bool> update_column(vector::vector_t& row_ids,
+                                                                 const std::vector<uint64_t>& column_path,
+                                                                 vector::data_chunk_t& updates);
 
         std::vector<column_segment_info> get_column_segment_info();
 
@@ -112,7 +112,7 @@ namespace components::table {
 
         // The checkpoint chain returns out_of_memory when a column flush pin fails;
         // the row group pointers on success.
-        core::result_wrapper_t<std::vector<storage::row_group_pointer_t>>
+        [[nodiscard]] core::result_wrapper_t<std::vector<storage::row_group_pointer_t>>
         checkpoint(storage::partial_block_manager_t& partial_block_manager);
 
         storage::block_manager_t& block_manager() { return block_manager_; }

--- a/components/table/column_checkpoint_state.cpp
+++ b/components/table/column_checkpoint_state.cpp
@@ -178,16 +178,49 @@ namespace components::table {
         : column_data_(column_data)
         , partial_block_manager_(partial_block_manager) {}
 
-    void column_checkpoint_state_t::flush_segment(column_segment_t& segment, uint64_t row_start, uint64_t tuple_count) {
+    core::result_wrapper_t<bool>
+    column_checkpoint_state_t::flush_segment(column_segment_t& segment, uint64_t row_start, uint64_t tuple_count) {
         auto& block_manager = column_data_.block_manager();
 
         // pin the segment's buffer to get data
-        auto handle = block_manager.buffer_manager.pin(segment.block);
+        auto pinned = block_manager.buffer_manager.pin(segment.block);
+        if (pinned.has_error()) {
+            return pinned.convert_error<bool>(); // out_of_memory
+        }
+        auto& handle = pinned.value();
         auto* data = handle.ptr();
 
         auto phys = segment.type.to_physical_type();
         bool is_fixed_size = (phys != types::physical_type::STRING && phys != types::physical_type::BIT &&
                               phys != types::physical_type::INVALID);
+
+        // A DISK-LOADED segment that is already compressed (CONSTANT/RLE/DICTIONARY) holds its COMPRESSED
+        // byte stream in the pinned buffer, NOT raw values. Re-running the compression analysis below would
+        // read those compressed bytes as raw fixed-width values and re-compress garbage (reopen corruption:
+        // a packed RLE column read back as 0x140003). Such a segment is already in its final on-disk form,
+        // so copy its bytes through VERBATIM to a fresh allocation, preserving the compression type and the
+        // (compressed) segment_size. A freshly-appended in-memory segment is UNCOMPRESSED (compression_
+        // defaults to UNCOMPRESSED until checkpoint), so this branch only fires for segments loaded from a
+        // prior checkpoint.
+        const auto loaded_compression = segment.compression();
+        if (loaded_compression != compression::compression_type::UNCOMPRESSED && data &&
+            segment.segment_size() > 0) {
+            const auto compressed_size = segment.segment_size();
+            auto* compressed_data = data + segment.block_offset();
+            auto allocation = partial_block_manager_.get_block_allocation(compressed_size);
+            partial_block_manager_.write_to_block(allocation.block_id,
+                                                  allocation.offset_in_block,
+                                                  compressed_data,
+                                                  compressed_size);
+            storage::data_pointer_t dp;
+            dp.row_start = row_start;
+            dp.tuple_count = tuple_count;
+            dp.block_pointer = storage::block_pointer_t(allocation.block_id, allocation.offset_in_block);
+            dp.compression = loaded_compression;
+            dp.segment_size = compressed_size;
+            data_pointers_.push_back(dp);
+            return true;
+        }
 
         if (is_fixed_size && tuple_count > 1 && data && segment.type_size > 0) {
             auto* segment_data = data + segment.block_offset();
@@ -208,7 +241,7 @@ namespace components::table {
                 dp.compression = compression::compression_type::CONSTANT;
                 dp.segment_size = constant_size;
                 data_pointers_.push_back(dp);
-                return;
+                return true;
             }
 
             // Try RLE compression
@@ -234,7 +267,7 @@ namespace components::table {
                 dp.compression = compression::compression_type::RLE;
                 dp.segment_size = rle_size;
                 data_pointers_.push_back(dp);
-                return;
+                return true;
             }
 
             // Try DICTIONARY compression (low-cardinality columns)
@@ -256,7 +289,7 @@ namespace components::table {
                 dp.compression = compression::compression_type::DICTIONARY;
                 dp.segment_size = dict_info.compressed_size;
                 data_pointers_.push_back(dp);
-                return;
+                return true;
             }
         }
 
@@ -275,6 +308,7 @@ namespace components::table {
         dp.compression = compression::compression_type::UNCOMPRESSED;
         dp.segment_size = segment_size;
         data_pointers_.push_back(dp);
+        return true;
     }
 
     persistent_column_data_t column_checkpoint_state_t::get_persistent_data() const {

--- a/components/table/column_checkpoint_state.hpp
+++ b/components/table/column_checkpoint_state.hpp
@@ -4,6 +4,8 @@
 #include <memory>
 #include <vector>
 
+#include <core/result_wrapper.hpp>
+
 #include <components/table/base_statistics.hpp>
 #include <components/table/persistent_column_data.hpp>
 #include <components/table/storage/data_pointer.hpp>
@@ -18,7 +20,8 @@ namespace components::table {
     public:
         column_checkpoint_state_t(column_data_t& column_data, storage::partial_block_manager_t& partial_block_manager);
 
-        void flush_segment(column_segment_t& segment, uint64_t row_start, uint64_t tuple_count);
+        // Returns out_of_memory when pinning the segment buffer fails; true on success.
+        core::result_wrapper_t<bool> flush_segment(column_segment_t& segment, uint64_t row_start, uint64_t tuple_count);
 
         persistent_column_data_t get_persistent_data() const;
 

--- a/components/table/column_checkpoint_state.hpp
+++ b/components/table/column_checkpoint_state.hpp
@@ -21,7 +21,8 @@ namespace components::table {
         column_checkpoint_state_t(column_data_t& column_data, storage::partial_block_manager_t& partial_block_manager);
 
         // Returns out_of_memory when pinning the segment buffer fails; true on success.
-        core::result_wrapper_t<bool> flush_segment(column_segment_t& segment, uint64_t row_start, uint64_t tuple_count);
+        [[nodiscard]] core::result_wrapper_t<bool>
+        flush_segment(column_segment_t& segment, uint64_t row_start, uint64_t tuple_count);
 
         persistent_column_data_t get_persistent_data() const;
 

--- a/components/table/column_data.cpp
+++ b/components/table/column_data.cpp
@@ -1,5 +1,7 @@
 #include "column_data.hpp"
 
+#include <cstring>
+
 #include <components/types/types.hpp>
 
 #include "array_column_data.hpp"
@@ -11,6 +13,8 @@
 #include "row_group.hpp"
 #include "standard_column_data.hpp"
 #include "storage/block_manager.hpp"
+#include "storage/buffer_handle.hpp"
+#include "storage/buffer_manager.hpp"
 #include "storage/partial_block_manager.hpp"
 #include "struct_column_data.hpp"
 #include "validity_column_data.hpp"
@@ -362,25 +366,44 @@ namespace components::table {
 
     void column_data_t::skip(column_scan_state& state, uint64_t count) { state.next(count); }
 
-    void column_data_t::initialize_append(column_append_state& state) {
+    core::result_wrapper_t<bool> column_data_t::initialize_append(column_append_state& state) {
         auto l = data_.lock();
         if (data_.is_empty(l)) {
-            apend_transient_segment(l, start_);
+            auto created = apend_transient_segment(l, start_);
+            if (created.has_error()) {
+                return created; // out_of_memory
+            }
         }
         auto segment = data_.last_segment(l);
-        // Disk-loaded segments have block_offset()!=0 (they share a block with other
-        // segments). They are read-only; appending to them would trip the assert in
-        // column_segment_t::append. Create a fresh in-memory segment positioned just
-        // after the last loaded segment so new rows land in appendable storage.
-        if (segment->block_offset() != 0) {
-            apend_transient_segment(l, segment->start + static_cast<int64_t>(segment->count));
+        // A disk-loaded segment is READ-ONLY: its in-memory buffer is the shared, reloadable
+        // disk block it was loaded from. Appending into it would write new rows over that buffer,
+        // corrupting both this column AND every other column packed into the same partial block.
+        //
+        // block_offset()==0 is not enough to rule a segment out: the checkpointer packs the FIRST
+        // narrow column at offset 0 of the shared partial block, so a disk-loaded segment can have
+        // block_offset()==0 and still be shared/read-only (an offset-only guard let the append land
+        // directly in the shared block's buffer -> reopen corruption). is_reloadable() is true for any
+        // registered disk block, so it forces a fresh appendable transient for EVERY disk-loaded
+        // segment regardless of offset. The offset!=0 check stays as a belt-and-braces for
+        // non-reloadable shared blocks.
+        const bool is_disk_loaded = segment->block && segment->block->is_reloadable();
+        if (is_disk_loaded || segment->block_offset() != 0) {
+            auto created = apend_transient_segment(l, segment->start + static_cast<int64_t>(segment->count));
+            if (created.has_error()) {
+                return created; // out_of_memory
+            }
             segment = data_.last_segment(l);
         }
         state.current = segment;
-        state.current->initialize_append(state);
+        auto init = state.current->initialize_append(state);
+        if (init.has_error()) {
+            return init;
+        }
+        return true;
     }
 
-    void column_data_t::append(column_append_state& state, vector::vector_t& vector, uint64_t count) {
+    core::result_wrapper_t<bool>
+    column_data_t::append(column_append_state& state, vector::vector_t& vector, uint64_t count) {
         statistics_.update(vector, count);
         // Update per-segment statistics (conservative: full vector stats go to current segment)
         if (state.current) {
@@ -396,28 +419,51 @@ namespace components::table {
         }
         vector::unified_vector_format uvf(vector.resource(), count);
         vector.to_unified_format(count, uvf);
-        append_data(state, uvf, count);
+        return append_data(state, uvf, count);
     }
 
-    void
+    core::result_wrapper_t<bool>
     column_data_t::append_data(column_append_state& state, vector::unified_vector_format& uvf, uint64_t append_count) {
         uint64_t offset = 0;
         this->count_ += append_count;
         while (true) {
-            uint64_t copied_elements = state.current->append(state, uvf, offset, append_count);
+            // append may raise out_of_memory when a string-overflow allocate fails.
+            auto appended = state.current->append(state, uvf, offset, append_count);
+            if (appended.has_error()) {
+                return appended.convert_error<bool>();
+            }
+            uint64_t copied_elements = appended.value();
             if (copied_elements == append_count) {
                 break;
             }
 
             {
                 auto l = data_.lock();
-                apend_transient_segment(l, state.current->start + static_cast<int64_t>(state.current->count));
+                // The just-filled segment is at the current tail; capture its index BEFORE appending the next
+                // segment so we can re-point it to disk. state.current is moved to the new segment below, so the
+                // filled segment is no longer referenced by the append state.
+                const uint64_t filled_index = data_.segment_count(l) - 1;
+                auto created = apend_transient_segment(l, state.current->start + static_cast<int64_t>(state.current->count));
+                if (created.has_error()) {
+                    return created; // out_of_memory
+                }
+                // Write the now-complete segment through to the data file and swap it for a disk-backed,
+                // evictable+reloadable segment (disk tables only; no-op for in-memory). A write/alloc failure
+                // surfaces as io_error/out_of_memory and aborts the append cleanly.
+                auto transitioned = transition_segment_to_disk(l, filled_index);
+                if (transitioned.has_error()) {
+                    return transitioned;
+                }
                 state.current = data_.last_segment(l);
-                state.current->initialize_append(state);
+                auto init = state.current->initialize_append(state);
+                if (init.has_error()) {
+                    return init;
+                }
             }
             offset += copied_elements;
             append_count -= copied_elements;
         }
+        return true;
     }
 
     void column_data_t::revert_append(int64_t start_row) {
@@ -438,7 +484,7 @@ namespace components::table {
         transient.revert_append(static_cast<uint64_t>(start_row));
     }
 
-    bool column_data_t::check_predicate(int64_t row_id, const table_filter_t* filter) {
+    bool column_data_t::check_predicate(int64_t row_id, const table_filter_t* filter, core::error_t& error) {
         if (updates_ &&
             updates_->has_updates(static_cast<uint64_t>(row_id - start_) / vector::DEFAULT_VECTOR_CAPACITY)) {
             // The vector has some updated rows. Check if THIS specific row is updated.
@@ -458,6 +504,10 @@ namespace components::table {
             column_fetch_state fetch_state;
             vector::vector_t result(resource_, type_, 1);
             fetch_row(fetch_state, row_id, result, 0);
+            if (fetch_state.fetch_error.contains_error()) {
+                error = fetch_state.fetch_error;
+                return false;
+            }
             if (!result.validity().row_is_valid(0)) {
                 return false;
             }
@@ -473,6 +523,10 @@ namespace components::table {
             column_fetch_state fetch_state;
             vector::vector_t result(resource_, type_, 1);
             fetch_row(fetch_state, row_id, result, 0);
+            if (fetch_state.fetch_error.contains_error()) {
+                error = fetch_state.fetch_error;
+                return false;
+            }
             if (!result.validity().row_is_valid(0)) {
                 return false;
             }
@@ -483,7 +537,12 @@ namespace components::table {
             const auto& const_filter = filter->cast<constant_filter_t>();
             return const_filter.compare(result.value(0));
         }
-        return segment->check_predicate(row_id, filter);
+        auto checked = segment->check_predicate(row_id, filter);
+        if (checked.has_error()) {
+            error = checked.error();
+            return false;
+        }
+        return checked.value();
     }
 
     bool column_data_t::check_validity(int64_t row_id) {
@@ -513,24 +572,24 @@ namespace components::table {
         fetch_update_row(row_id, result, result_idx);
     }
 
-    void column_data_t::update(uint64_t column_index,
-                               vector::vector_t& update_vector,
-                               int64_t* row_ids,
-                               uint64_t update_count) {
+    core::result_wrapper_t<bool> column_data_t::update(uint64_t column_index,
+                                                      vector::vector_t& update_vector,
+                                                      int64_t* row_ids,
+                                                      uint64_t update_count) {
         vector::vector_t base_vector(resource_, type_, count_);
         column_scan_state state;
         auto fetch_count = fetch(state, row_ids[0], base_vector);
 
         base_vector.flatten(fetch_count);
-        update_internal(column_index, update_vector, row_ids, update_count, base_vector);
+        return update_internal(column_index, update_vector, row_ids, update_count, base_vector);
     }
 
-    void column_data_t::update_column(const std::vector<uint64_t>& column_path,
-                                      vector::vector_t& update_vector,
-                                      int64_t* row_ids,
-                                      uint64_t update_count,
-                                      uint64_t) {
-        column_data_t::update(column_path[0], update_vector, row_ids, update_count);
+    core::result_wrapper_t<bool> column_data_t::update_column(const std::vector<uint64_t>& column_path,
+                                                            vector::vector_t& update_vector,
+                                                            int64_t* row_ids,
+                                                            uint64_t update_count,
+                                                            uint64_t) {
+        return column_data_t::update(column_path[0], update_vector, row_ids, update_count);
     }
 
     void column_data_t::get_column_segment_info(uint64_t row_group_index,
@@ -598,7 +657,8 @@ namespace components::table {
         return std::make_unique<standard_column_data_t>(resource, block_manager, column_index, start_row, type, parent);
     }
 
-    void column_data_t::apend_transient_segment(std::unique_lock<std::mutex>& l, int64_t start_row) {
+    core::result_wrapper_t<bool> column_data_t::apend_transient_segment(std::unique_lock<std::mutex>& l,
+                                                                        int64_t start_row) {
         const auto block_size = block_manager_.block_size();
         const auto type_size = type_.size();
         auto vector_segment_size = block_size;
@@ -608,10 +668,159 @@ namespace components::table {
         }
 
         uint64_t segment_size = block_size < vector_segment_size ? block_size : vector_segment_size;
-        allocation_size_ += segment_size;
         auto new_segment =
             column_segment_t::create_segment(block_manager_.buffer_manager, type_, start_row, segment_size, block_size);
-        data_.append_segment(l, std::move(new_segment));
+        // create_segment returns an out_of_memory error_t when register_transient_memory fails.
+        // Propagate it up the append chain instead of corrupting the segment tree.
+        if (new_segment.has_error()) {
+            return new_segment.convert_error<bool>();
+        }
+        allocation_size_ += segment_size;
+        data_.append_segment(l, std::move(new_segment.value()));
+        return true;
+    }
+
+    core::result_wrapper_t<bool> column_data_t::transition_segment_to_disk(std::unique_lock<std::mutex>& l,
+                                                                          uint64_t segment_index) {
+        // In-memory tables have no backing store, so their segments must stay managed (no disk copy ->
+        // clean OOM, never a crash). No-op.
+        if (block_manager_.in_memory()) {
+            return true;
+        }
+
+        auto* segment = data_.segment_at(l, static_cast<int64_t>(segment_index));
+        if (!segment) {
+            return true;
+        }
+
+        // Only re-point UNCOMPRESSED, fully-in-memory (managed) segments whose payload is a self-contained raw
+        // block at offset 0: a byte copy round-trips losslessly for them. Skip a segment that is already
+        // disk-backed (is_reloadable() true), shares a block (block_offset != 0), or is compressed.
+        if (segment->block && segment->block->is_reloadable()) {
+            return true; // already disk-backed
+        }
+        if (segment->block_offset() != 0) {
+            return true; // shares a block with other segments (loaded) -- not a fresh transient
+        }
+        if (segment->compression() != compression::compression_type::UNCOMPRESSED) {
+            return true;
+        }
+        // Re-pointable iff the segment's payload is a self-contained raw block at offset 0 that round-trips
+        // through a byte copy: fixed-width physical types AND validity bitmaps (BIT). STRING carries overflow
+        // blocks / a dictionary in segment_state; STRUCT/ARRAY/LIST keep their payload in child columns -- those
+        // stay managed. BIT is included: a validity bitmap is a raw block at offset 0, and a disk-backed
+        // validity segment reloads its bitmap from the file like any other block (the 0xFF-initialize in the
+        // column_segment_t ctor only fires for INVALID_BLOCK transient segments, not for a registered disk
+        // block).
+        const auto phys = segment->type.to_physical_type();
+        const bool is_raw_copyable = (phys != types::physical_type::STRING && phys != types::physical_type::INVALID &&
+                                      phys != types::physical_type::STRUCT && phys != types::physical_type::ARRAY &&
+                                      phys != types::physical_type::LIST);
+        if (!is_raw_copyable) {
+            return true;
+        }
+
+        // Snapshot the segment metadata BEFORE touching the pin: the segment is destroyed by the swap below.
+        const int64_t seg_start = segment->start;
+        const uint64_t seg_count = segment->count.load();
+        const uint64_t segment_size = segment->segment_size();
+        const uint64_t block_offset = segment->block_offset();
+        const auto block_size = block_manager_.block_size();
+        assert(segment_size <= block_size);
+        const bool has_stats = segment->segment_statistics().has_stats();
+        base_statistics_t seg_stats =
+            has_stats ? segment->segment_statistics() : base_statistics_t(resource_, type_.type());
+
+        // Allocate a disk block id (block_id < MAXIMUM_BLOCK).
+        const uint64_t disk_block_id = block_manager_.free_block_id();
+
+        // Pin the filled managed segment to read its payload, copy it into a fresh block buffer and flush
+        // that to the data file. Mirrors the checkpoint write path (partial_block_manager::write_to_block +
+        // block_manager::write): a block_t reserves the 8-byte checksum header; we copy the segment payload
+        // at offset 0 and write() stamps the checksum. The pin is released at the end of this scope, BEFORE
+        // the swap drops the old segment's block_handle -- otherwise the pin's raw handle would dangle.
+        // A pin OOM surfaces as an error_t.
+        {
+            auto& buffer_manager = block_manager_.buffer_manager;
+            auto pinned = buffer_manager.pin(segment->block);
+            if (pinned.has_error()) {
+                block_manager_.mark_as_free(disk_block_id); // reclaim the unused id
+                return pinned.convert_error<bool>();
+            }
+            auto* payload = pinned.value().ptr() + block_offset;
+
+            auto block = std::make_unique<storage::block_t>(buffer_manager.resource(),
+                                                            disk_block_id,
+                                                            static_cast<uint64_t>(block_size));
+            std::memset(block->buffer(), 0, static_cast<size_t>(block_size));
+            std::memcpy(block->buffer(), payload, static_cast<size_t>(segment_size));
+            block_manager_.write(*block, disk_block_id);
+        }
+
+        // Build a NEW disk-backed segment over the freshly-written block (block_offset 0, same range).
+        // register_block hands back an UNLOADED handle whose is_reloadable() is true: the pool can evict it
+        // and block_handle::load() reloads it from the data file.
+        auto block_handle = block_manager_.register_block(disk_block_id);
+        auto new_segment = std::make_unique<column_segment_t>(block_handle,
+                                                             type_,
+                                                             seg_start,
+                                                             seg_count,
+                                                             static_cast<uint32_t>(disk_block_id),
+                                                             0U,
+                                                             segment_size);
+        new_segment->set_compression(compression::compression_type::UNCOMPRESSED);
+        if (has_stats) {
+            new_segment->set_segment_statistics(std::move(seg_stats));
+        }
+
+        // Swap the live segment for the disk-backed one under the tree lock. The old managed
+        // column_segment_t / block_handle is then unreferenced -> its in-memory buffer is released; the
+        // pool can later evict+reload the new disk-backed block. MVCC version info is keyed by row position
+        // (unchanged: same start/count) so visibility is preserved.
+        data_.replace_segment_at_index(l, segment_index, std::move(new_segment));
+        return true;
+    }
+
+    void column_data_t::collect_disk_block_ids(std::pmr::vector<uint64_t>& out) const {
+        // Collect the ids of disk blocks EXCLUSIVELY owned by this column's segments so a caller
+        // (compact's free-list reclaim) can return them to the block manager once this collection is
+        // no longer referenced. A block is freeable ONLY when this segment is a DEDICATED WHOLE block:
+        // a reloadable handle (block_id < MAXIMUM_BLOCK), at block_offset 0, AND large enough that the
+        // write-side allocator would have given it a dedicated block rather than packing it.
+        //
+        // block_offset()==0 alone is NOT sufficient: the checkpointer packs many narrow columns into ONE
+        // shared partial block at distinct offsets, and the FIRST packed column sits at offset 0. An
+        // offset==0-only test would wrongly qualify the shared block as exclusively owned and free it,
+        // recycling its id and letting a later write clobber the still-live packed segments at non-zero
+        // offsets (reopen corruption). We mirror the write-side dedicated-vs-packed decision
+        // (partial_block_manager_t::get_block_allocation, which uses block_size() * FULL_THRESHOLD) so a
+        // packed offset-0 segment is NOT treated as whole-block owner. Packed/shared partial blocks are
+        // never freed here (a leak-until-restart is acceptable; corruption is not). FULL_THRESHOLD lives on
+        // partial_block_manager_t so the two sides cannot drift.
+        const auto dedicated_min =
+            static_cast<uint64_t>(static_cast<double>(block_manager_.block_size()) *
+                                  storage::partial_block_manager_t::FULL_THRESHOLD);
+        for (auto& segment : const_cast<segment_tree_t<column_segment_t>&>(data_).segments()) {
+            if (segment.block && segment.block->is_reloadable() && segment.block_offset() == 0 &&
+                segment.segment_size() > dedicated_min) {
+                out.push_back(segment.block->block_id());
+            }
+        }
+    }
+
+    core::result_wrapper_t<bool> column_data_t::transition_to_disk() {
+        if (block_manager_.in_memory()) {
+            return true; // no backing store -> segments stay managed (clean OOM, never a crash)
+        }
+        auto l = data_.lock();
+        const uint64_t count = data_.segment_count(l);
+        for (uint64_t i = 0; i < count; i++) {
+            auto transitioned = transition_segment_to_disk(l, i);
+            if (transitioned.has_error()) {
+                return transitioned; // io_error / out_of_memory
+            }
+        }
+        return true;
     }
 
     uint64_t column_data_t::scan_vector(column_scan_state& state,
@@ -625,6 +834,11 @@ namespace components::table {
         if (!state.initialized) {
             assert(state.current);
             state.current->initialize_scan(state);
+            // initialize_scan records a pin OOM in state.scan_error. Bail with nothing scanned;
+            // row_group_t aggregates scan_error and the scan loops stop.
+            if (state.has_error()) {
+                return 0;
+            }
             state.internal_index = state.current->start;
             state.initialized = true;
         }
@@ -649,6 +863,12 @@ namespace components::table {
                                              state.row_index + static_cast<int64_t>(i),
                                              result,
                                              result_offset + i);
+                    // Propagate a per-row pin OOM up into the scan state and bail.
+                    if (fetch_state.fetch_error.contains_error()) {
+                        state.scan_error = fetch_state.fetch_error;
+                        state.internal_index = state.row_index;
+                        return initial_remaining - remaining;
+                    }
                 }
                 state.current->scan(state, scan_count, result, result_offset, scan_type);
 
@@ -664,6 +884,10 @@ namespace components::table {
                 state.previous_states.emplace_back(std::move(state.scan_state));
                 state.current = next;
                 state.current->initialize_scan(state);
+                if (state.has_error()) {
+                    state.internal_index = state.row_index;
+                    return initial_remaining - remaining;
+                }
                 state.segment_checked = false;
                 assert(state.row_index >= state.current->start &&
                        state.row_index <= state.current->start + static_cast<int64_t>(state.current->count));
@@ -721,16 +945,16 @@ namespace components::table {
         updates_->fetch_row(row_id, result, result_idx);
     }
 
-    void column_data_t::update_internal(uint64_t column_index,
-                                        vector::vector_t& update_vector,
-                                        int64_t* row_ids,
-                                        uint64_t update_count,
-                                        vector::vector_t& base_vector) {
+    core::result_wrapper_t<bool> column_data_t::update_internal(uint64_t column_index,
+                                                              vector::vector_t& update_vector,
+                                                              int64_t* row_ids,
+                                                              uint64_t update_count,
+                                                              vector::vector_t& base_vector) {
         std::lock_guard update_guard(update_lock_);
         if (!updates_) {
             updates_ = std::make_unique<update_segment_t>(*this);
         }
-        updates_->update(column_index, update_vector, row_ids, update_count, base_vector);
+        return updates_->update(column_index, update_vector, row_ids, update_count, base_vector);
     }
 
     uint64_t column_data_t::vector_count(uint64_t vector_index) const {
@@ -739,9 +963,24 @@ namespace components::table {
                                   static_cast<uint64_t>(start_) + count_ - current_row);
     }
 
-    persistent_column_data_t column_data_t::checkpoint(storage::partial_block_manager_t& partial_block_manager) {
+    core::result_wrapper_t<persistent_column_data_t>
+    column_data_t::checkpoint(storage::partial_block_manager_t& partial_block_manager) {
         column_data_checkpointer_t checkpointer(*this, partial_block_manager);
-        return checkpointer.checkpoint();
+        auto persistent = checkpointer.checkpoint();
+        if (persistent.has_error()) {
+            return persistent;
+        }
+        // Re-point the still-managed LIVE segments (the open tail that was not filled during append, and
+        // so never went through the on-fill write-through) to disk-backed, evictable blocks so the
+        // post-checkpoint live table stays bounded. The on-disk metadata returned above is independent of
+        // the live tree (it references the partial_block_manager's allocations), so the re-point cannot
+        // corrupt the checkpoint. No-op for in-memory tables and for already-disk-backed segments. A
+        // write/alloc failure surfaces as io_error/out_of_memory.
+        auto repointed = transition_to_disk();
+        if (repointed.has_error()) {
+            return repointed.convert_error<persistent_column_data_t>();
+        }
+        return persistent;
     }
 
     void column_data_t::initialize_column(const persistent_column_data_t& persistent_data) {
@@ -776,15 +1015,35 @@ namespace components::table {
     }
 
     void column_data_t::initialize_column_validity(const persistent_column_data_t& persistent_data) {
-        // create transient in-memory segments matching the data pointers
-        // used for validity columns that don't have their own persistent data yet
+        // Validity is not persisted separately (a checkpoint flushes only the main column's
+        // segments); on reopen the bitmap is implicitly all-valid. We materialize one validity
+        // segment per main-column data pointer and, on a DISK-backed table, write each all-valid
+        // bitmap THROUGH to the data file and swap it for a disk-backed (reloadable) segment via
+        // transition_segment_to_disk -- the same mechanism used on the append fill path. Without
+        // this the reopen-rebuilt validity segments stay managed (block_id >= MAXIMUM_BLOCK), so
+        // the eviction guard pins them all resident and reopening a large table under a small pool
+        // exhausts it. The transient segment's column_segment_t ctor 0xFF-fills the bitmap
+        // (all-valid) before the transition copies it to disk, so reloaded validity reads all-valid.
         auto l = data_.lock();
         for (const auto& dp : persistent_data.data_pointers) {
-            apend_transient_segment(l, static_cast<int64_t>(dp.row_start));
+            // Disk-load path: segments are sized for known on-disk tuple counts. An OOM here
+            // is not threaded to an agent boundary; assert and skip the row on exhaustion.
+            auto created = apend_transient_segment(l, static_cast<int64_t>(dp.row_start));
+            assert(!created.has_error() && "initialize_column_validity: transient segment OOM");
+            if (created.has_error()) {
+                continue;
+            }
+            const uint64_t seg_index = data_.segment_count(l) - 1;
             auto* seg = data_.last_segment(l);
             if (seg) {
                 seg->count = dp.tuple_count;
             }
+            // Write the all-valid bitmap through to disk and re-point the live segment to a
+            // disk-backed, evictable+reloadable block (no-op for in-memory tables). A write/alloc
+            // failure surfaces as io_error/out_of_memory; the disk-load path is not threaded to an
+            // agent boundary, so assert and keep the managed segment on failure.
+            auto transitioned = transition_segment_to_disk(l, seg_index);
+            assert(!transitioned.has_error() && "initialize_column_validity: write-through failed");
         }
         if (!persistent_data.data_pointers.empty()) {
             uint64_t total = 0;

--- a/components/table/column_data.hpp
+++ b/components/table/column_data.hpp
@@ -107,24 +107,29 @@ namespace components::table {
 
         virtual void skip(column_scan_state& state, uint64_t count = vector::DEFAULT_VECTOR_CAPACITY);
 
-        virtual void initialize_append(column_append_state& state);
-        virtual void append(column_append_state& state, vector::vector_t& vector, uint64_t count);
-        virtual void append_data(column_append_state& state, vector::unified_vector_format& uvf, uint64_t count);
+        // APPEND chain returns out_of_memory when a segment allocation / pin fails; true on success.
+        virtual core::result_wrapper_t<bool> initialize_append(column_append_state& state);
+        virtual core::result_wrapper_t<bool> append(column_append_state& state, vector::vector_t& vector, uint64_t count);
+        virtual core::result_wrapper_t<bool>
+        append_data(column_append_state& state, vector::unified_vector_format& uvf, uint64_t count);
         virtual void revert_append(int64_t start_row);
 
-        virtual bool check_predicate(int64_t row_id, const table_filter_t* filter);
+        // `error` carries an out_of_memory error_t when a pin fails during the predicate check;
+        // on error the bool return is meaningless and the scan loop stops.
+        virtual bool check_predicate(int64_t row_id, const table_filter_t* filter, core::error_t& error);
         virtual bool check_validity(int64_t row_id);
         virtual uint64_t fetch(column_scan_state& state, int64_t row_id, vector::vector_t& result);
         virtual void
         fetch_row(column_fetch_state& state, int64_t row_id, vector::vector_t& result, uint64_t result_idx);
 
-        virtual void
+        // Update path returns write_conflict / out_of_memory; true on success.
+        virtual core::result_wrapper_t<bool>
         update(uint64_t column_index, vector::vector_t& update_vector, int64_t* row_ids, uint64_t update_count);
-        virtual void update_column(const std::vector<uint64_t>& column_path,
-                                   vector::vector_t& update_vector,
-                                   int64_t* row_ids,
-                                   uint64_t update_count,
-                                   uint64_t depth);
+        virtual core::result_wrapper_t<bool> update_column(const std::vector<uint64_t>& column_path,
+                                                           vector::vector_t& update_vector,
+                                                           int64_t* row_ids,
+                                                           uint64_t update_count,
+                                                           uint64_t depth);
 
         virtual void get_column_segment_info(uint64_t row_group_index,
                                              std::vector<uint64_t> col_path,
@@ -143,12 +148,39 @@ namespace components::table {
         const base_statistics_t& statistics() const noexcept { return statistics_; }
         base_statistics_t& statistics() noexcept { return statistics_; }
 
-        persistent_column_data_t checkpoint(storage::partial_block_manager_t& partial_block_manager);
+        // CHECKPOINT chain returns out_of_memory when pinning a segment buffer fails during flush;
+        // the persistent data on success.
+        core::result_wrapper_t<persistent_column_data_t>
+        checkpoint(storage::partial_block_manager_t& partial_block_manager);
         virtual void initialize_column(const persistent_column_data_t& persistent_data);
         void initialize_column_validity(const persistent_column_data_t& persistent_data);
 
+        // Write-through: re-point every COMPLETE managed (in-memory, non-reloadable) segment of this column
+        // to a disk-backed segment so the pool can evict+reload them (bounded memory). Called when a row
+        // group is closed (all its column segments are final). A no-op for in-memory tables and for
+        // non-fixed-size / compressed segments. Returns io_error/out_of_memory on failure; true on success.
+        // Sub-columns (validity / struct / list / array children) are handled by the subclass override.
+        virtual core::result_wrapper_t<bool> transition_to_disk();
+
+        // Compact reclaim: append the ids of disk blocks EXCLUSIVELY owned by this column (and its
+        // sub-columns) to `out`, so the caller can mark them free once this collection is replaced by a
+        // compacted one. Mirrors the transition_to_disk recursion: the standard subclass also collects from
+        // its validity child; struct/list/array collect their own data_ blocks only (their children's
+        // payloads stay managed, matching base transition_to_disk).
+        virtual void collect_disk_block_ids(std::pmr::vector<uint64_t>& out) const;
+
     protected:
-        void apend_transient_segment(std::unique_lock<std::mutex>& l, int64_t start_row);
+        // Returns out_of_memory when the new segment's transient memory cannot be registered; true on success.
+        core::result_wrapper_t<bool> apend_transient_segment(std::unique_lock<std::mutex>& l, int64_t start_row);
+
+        // Write-through: a just-FILLED transient (managed, block_id >= MAXIMUM_BLOCK) segment at
+        // `segment_index` in data_ is written to the table's data file and re-pointed to a fresh disk-backed
+        // segment (block_id < MAXIMUM_BLOCK -> is_reloadable()==true), so the pool can evict+reload it ->
+        // bounded memory. A no-op for in-memory tables (no backing store) and for non-fixed-size / compressed
+        // segments (a raw block copy would not round-trip losslessly). Returns io_error/out_of_memory on a
+        // write/alloc failure; true on success or no-op. Caller MUST hold the tree lock `l`.
+        core::result_wrapper_t<bool> transition_segment_to_disk(std::unique_lock<std::mutex>& l,
+                                                                uint64_t segment_index);
 
         uint64_t
         scan_vector(column_scan_state& state, vector::vector_t& result, uint64_t remaining, scan_vector_type scan_type);
@@ -164,11 +196,11 @@ namespace components::table {
                            bool allow_updates,
                            bool scan_committed);
         void fetch_update_row(int64_t row_id, vector::vector_t& result, uint64_t result_idx);
-        void update_internal(uint64_t column_index,
-                             vector::vector_t& update_vector,
-                             int64_t* row_ids,
-                             uint64_t update_count,
-                             vector::vector_t& base_vector);
+        core::result_wrapper_t<bool> update_internal(uint64_t column_index,
+                                                     vector::vector_t& update_vector,
+                                                     int64_t* row_ids,
+                                                     uint64_t update_count,
+                                                     vector::vector_t& base_vector);
 
         uint64_t vector_count(uint64_t vector_index) const;
 

--- a/components/table/column_data.hpp
+++ b/components/table/column_data.hpp
@@ -108,9 +108,10 @@ namespace components::table {
         virtual void skip(column_scan_state& state, uint64_t count = vector::DEFAULT_VECTOR_CAPACITY);
 
         // APPEND chain returns out_of_memory when a segment allocation / pin fails; true on success.
-        virtual core::result_wrapper_t<bool> initialize_append(column_append_state& state);
-        virtual core::result_wrapper_t<bool> append(column_append_state& state, vector::vector_t& vector, uint64_t count);
-        virtual core::result_wrapper_t<bool>
+        [[nodiscard]] virtual core::result_wrapper_t<bool> initialize_append(column_append_state& state);
+        [[nodiscard]] virtual core::result_wrapper_t<bool>
+        append(column_append_state& state, vector::vector_t& vector, uint64_t count);
+        [[nodiscard]] virtual core::result_wrapper_t<bool>
         append_data(column_append_state& state, vector::unified_vector_format& uvf, uint64_t count);
         virtual void revert_append(int64_t start_row);
 
@@ -123,13 +124,13 @@ namespace components::table {
         fetch_row(column_fetch_state& state, int64_t row_id, vector::vector_t& result, uint64_t result_idx);
 
         // Update path returns write_conflict / out_of_memory; true on success.
-        virtual core::result_wrapper_t<bool>
+        [[nodiscard]] virtual core::result_wrapper_t<bool>
         update(uint64_t column_index, vector::vector_t& update_vector, int64_t* row_ids, uint64_t update_count);
-        virtual core::result_wrapper_t<bool> update_column(const std::vector<uint64_t>& column_path,
-                                                           vector::vector_t& update_vector,
-                                                           int64_t* row_ids,
-                                                           uint64_t update_count,
-                                                           uint64_t depth);
+        [[nodiscard]] virtual core::result_wrapper_t<bool> update_column(const std::vector<uint64_t>& column_path,
+                                                                         vector::vector_t& update_vector,
+                                                                         int64_t* row_ids,
+                                                                         uint64_t update_count,
+                                                                         uint64_t depth);
 
         virtual void get_column_segment_info(uint64_t row_group_index,
                                              std::vector<uint64_t> col_path,
@@ -150,7 +151,7 @@ namespace components::table {
 
         // CHECKPOINT chain returns out_of_memory when pinning a segment buffer fails during flush;
         // the persistent data on success.
-        core::result_wrapper_t<persistent_column_data_t>
+        [[nodiscard]] core::result_wrapper_t<persistent_column_data_t>
         checkpoint(storage::partial_block_manager_t& partial_block_manager);
         virtual void initialize_column(const persistent_column_data_t& persistent_data);
         void initialize_column_validity(const persistent_column_data_t& persistent_data);
@@ -160,7 +161,7 @@ namespace components::table {
         // group is closed (all its column segments are final). A no-op for in-memory tables and for
         // non-fixed-size / compressed segments. Returns io_error/out_of_memory on failure; true on success.
         // Sub-columns (validity / struct / list / array children) are handled by the subclass override.
-        virtual core::result_wrapper_t<bool> transition_to_disk();
+        [[nodiscard]] virtual core::result_wrapper_t<bool> transition_to_disk();
 
         // Compact reclaim: append the ids of disk blocks EXCLUSIVELY owned by this column (and its
         // sub-columns) to `out`, so the caller can mark them free once this collection is replaced by a
@@ -171,7 +172,8 @@ namespace components::table {
 
     protected:
         // Returns out_of_memory when the new segment's transient memory cannot be registered; true on success.
-        core::result_wrapper_t<bool> apend_transient_segment(std::unique_lock<std::mutex>& l, int64_t start_row);
+        [[nodiscard]] core::result_wrapper_t<bool> apend_transient_segment(std::unique_lock<std::mutex>& l,
+                                                                           int64_t start_row);
 
         // Write-through: a just-FILLED transient (managed, block_id >= MAXIMUM_BLOCK) segment at
         // `segment_index` in data_ is written to the table's data file and re-pointed to a fresh disk-backed
@@ -179,8 +181,8 @@ namespace components::table {
         // bounded memory. A no-op for in-memory tables (no backing store) and for non-fixed-size / compressed
         // segments (a raw block copy would not round-trip losslessly). Returns io_error/out_of_memory on a
         // write/alloc failure; true on success or no-op. Caller MUST hold the tree lock `l`.
-        core::result_wrapper_t<bool> transition_segment_to_disk(std::unique_lock<std::mutex>& l,
-                                                                uint64_t segment_index);
+        [[nodiscard]] core::result_wrapper_t<bool> transition_segment_to_disk(std::unique_lock<std::mutex>& l,
+                                                                              uint64_t segment_index);
 
         uint64_t
         scan_vector(column_scan_state& state, vector::vector_t& result, uint64_t remaining, scan_vector_type scan_type);
@@ -196,11 +198,11 @@ namespace components::table {
                            bool allow_updates,
                            bool scan_committed);
         void fetch_update_row(int64_t row_id, vector::vector_t& result, uint64_t result_idx);
-        core::result_wrapper_t<bool> update_internal(uint64_t column_index,
-                                                     vector::vector_t& update_vector,
-                                                     int64_t* row_ids,
-                                                     uint64_t update_count,
-                                                     vector::vector_t& base_vector);
+        [[nodiscard]] core::result_wrapper_t<bool> update_internal(uint64_t column_index,
+                                                                   vector::vector_t& update_vector,
+                                                                   int64_t* row_ids,
+                                                                   uint64_t update_count,
+                                                                   vector::vector_t& base_vector);
 
         uint64_t vector_count(uint64_t vector_index) const;
 

--- a/components/table/column_data_checkpointer.cpp
+++ b/components/table/column_data_checkpointer.cpp
@@ -11,13 +11,18 @@ namespace components::table {
         : column_data_(column_data)
         , partial_block_manager_(partial_block_manager) {}
 
-    persistent_column_data_t column_data_checkpointer_t::checkpoint() {
+    core::result_wrapper_t<persistent_column_data_t> column_data_checkpointer_t::checkpoint() {
         column_checkpoint_state_t state(column_data_, partial_block_manager_);
 
         // Collect per-segment stats while flushing
         std::vector<base_statistics_t> seg_stats;
         for (auto& segment : column_data_.data_.segments()) {
-            state.flush_segment(segment, static_cast<uint64_t>(segment.start), segment.count);
+            // flush_segment returns out_of_memory when pinning the segment buffer fails;
+            // propagate it up the checkpoint chain to the agent_disk boundary.
+            auto flushed = state.flush_segment(segment, static_cast<uint64_t>(segment.start), segment.count);
+            if (flushed.has_error()) {
+                return flushed.convert_error<persistent_column_data_t>();
+            }
             seg_stats.push_back(segment.segment_statistics());
         }
 

--- a/components/table/column_data_checkpointer.hpp
+++ b/components/table/column_data_checkpointer.hpp
@@ -20,7 +20,7 @@ namespace components::table {
         column_data_checkpointer_t(column_data_t& column_data, storage::partial_block_manager_t& partial_block_manager);
 
         // Returns out_of_memory when a segment pin fails during flush; persistent data on success.
-        core::result_wrapper_t<persistent_column_data_t> checkpoint();
+        [[nodiscard]] core::result_wrapper_t<persistent_column_data_t> checkpoint();
 
     private:
         column_data_t& column_data_;

--- a/components/table/column_data_checkpointer.hpp
+++ b/components/table/column_data_checkpointer.hpp
@@ -3,6 +3,8 @@
 #include <cstdint>
 #include <memory>
 
+#include <core/result_wrapper.hpp>
+
 #include <components/table/persistent_column_data.hpp>
 
 namespace components::table {
@@ -17,7 +19,8 @@ namespace components::table {
     public:
         column_data_checkpointer_t(column_data_t& column_data, storage::partial_block_manager_t& partial_block_manager);
 
-        persistent_column_data_t checkpoint();
+        // Returns out_of_memory when a segment pin fails during flush; persistent data on success.
+        core::result_wrapper_t<persistent_column_data_t> checkpoint();
 
     private:
         column_data_t& column_data_;

--- a/components/table/column_segment.cpp
+++ b/components/table/column_segment.cpp
@@ -129,10 +129,10 @@ namespace components::table {
             return fetch_string(dict, base_ptr, location, string_length);
         }
 
-        void write_string_memory(column_segment_t& segment,
-                                 std::string_view string,
-                                 uint64_t& result_block,
-                                 int32_t& result_offset) {
+        core::result_wrapper_t<bool> write_string_memory(column_segment_t& segment,
+                                                         std::string_view string,
+                                                         uint64_t& result_block,
+                                                         int32_t& result_offset) {
             auto total_length = static_cast<uint32_t>(string.size() + sizeof(uint32_t));
             std::shared_ptr<storage::block_handle_t> block;
             storage::buffer_handle_t handle;
@@ -144,14 +144,22 @@ namespace components::table {
                 auto new_block = std::make_unique<string_block_t>();
                 new_block->offset = 0;
                 new_block->size = alloc_size;
-                handle = buffer_manager.allocate(storage::memory_tag::OVERFLOW_STRINGS, alloc_size, false);
+                auto allocated = buffer_manager.allocate(storage::memory_tag::OVERFLOW_STRINGS, alloc_size, false);
+                if (allocated.has_error()) {
+                    return allocated.convert_error<bool>();
+                }
+                handle = std::move(allocated.value());
                 block = handle.block_handle()->shared_from_this();
                 state.overflow_blocks.emplace(block->block_id(), new_block.get());
                 new_block->block = std::move(block);
                 new_block->next = std::move(state.head);
                 state.head = std::move(new_block);
             } else {
-                handle = buffer_manager.pin(state.head->block);
+                auto pinned = buffer_manager.pin(state.head->block);
+                if (pinned.has_error()) {
+                    return pinned.convert_error<bool>();
+                }
+                handle = std::move(pinned.value());
             }
 
             result_block = state.head->block->block_id();
@@ -162,13 +170,14 @@ namespace components::table {
             ptr += sizeof(uint32_t);
             memcpy(ptr, string.data(), string.size());
             state.head->offset += total_length;
+            return true;
         }
 
-        void write_string(column_segment_t& segment,
-                          std::string_view string,
-                          uint64_t& result_block,
-                          int32_t& result_offset) {
-            write_string_memory(segment, string, result_block, result_offset);
+        core::result_wrapper_t<bool> write_string(column_segment_t& segment,
+                                                  std::string_view string,
+                                                  uint64_t& result_block,
+                                                  int32_t& result_offset) {
+            return write_string_memory(segment, string, result_block, result_offset);
         }
 
         uint64_t remaining_space(column_segment_t& segment, storage::buffer_handle_t& handle) {
@@ -181,12 +190,17 @@ namespace components::table {
 
         template<typename T>
         void fixed_size_fetch_row(column_segment_t& segment,
-                                  column_fetch_state&,
+                                  column_fetch_state& state,
                                   int64_t row_id,
                                   vector::vector_t& result,
                                   uint64_t result_idx) {
             auto& buffer_manager = segment.block->block_manager.buffer_manager;
-            auto handle = buffer_manager.pin(segment.block);
+            auto pinned = buffer_manager.pin(segment.block);
+            if (pinned.has_error()) {
+                state.fetch_error = pinned.error();
+                return;
+            }
+            auto& handle = pinned.value();
 
             auto data_ptr = handle.ptr() + segment.block_offset() + static_cast<uint64_t>(row_id) * sizeof(T);
 
@@ -194,13 +208,18 @@ namespace components::table {
         }
 
         void validity_fetch_row(column_segment_t& segment,
-                                column_fetch_state&,
+                                column_fetch_state& state,
                                 int64_t row_id,
                                 vector::vector_t& result,
                                 uint64_t result_idx) {
             assert(row_id >= 0 && row_id < static_cast<int64_t>(segment.count.load()));
             auto& buffer_manager = segment.block->block_manager.buffer_manager;
-            auto handle = buffer_manager.pin(segment.block);
+            auto pinned = buffer_manager.pin(segment.block);
+            if (pinned.has_error()) {
+                state.fetch_error = pinned.error();
+                return;
+            }
+            auto& handle = pinned.value();
             auto dataptr = handle.ptr() + segment.block_offset();
             vector::validity_mask_t mask(buffer_manager.resource(), reinterpret_cast<uint64_t*>(dataptr));
             auto& result_mask = result.validity();
@@ -214,7 +233,11 @@ namespace components::table {
                               int64_t row_id,
                               vector::vector_t& result,
                               uint64_t result_idx) {
-            auto& handle = state.get_or_insert_handle(segment);
+            auto* handle_ptr = state.get_or_insert_handle(segment);
+            if (!handle_ptr) {
+                return; // state.fetch_error already set by get_or_insert_handle
+            }
+            auto& handle = *handle_ptr;
 
             auto baseptr = handle.ptr() + segment.block_offset();
             auto dict = dictionary(segment, handle);
@@ -231,29 +254,43 @@ namespace components::table {
         }
 
         template<typename T>
-        bool fixed_size_check_row(column_segment_t& segment, int64_t row_id, const table_filter_t* filter) {
+        core::result_wrapper_t<bool>
+        fixed_size_check_row(column_segment_t& segment, int64_t row_id, const table_filter_t* filter) {
             auto& buffer_manager = segment.block->block_manager.buffer_manager;
-            auto handle = buffer_manager.pin(segment.block);
+            auto pinned = buffer_manager.pin(segment.block);
+            if (pinned.has_error()) {
+                return pinned.convert_error<bool>();
+            }
+            auto& handle = pinned.value();
 
             auto data_ptr = handle.ptr() + segment.block_offset() + static_cast<uint64_t>(row_id) * sizeof(T);
             return table_filter_dispatch(filter, *reinterpret_cast<T*>(data_ptr));
         }
 
-        bool validity_check_row(column_segment_t& segment, int64_t row_id, const table_filter_t* filter) {
+        core::result_wrapper_t<bool>
+        validity_check_row(column_segment_t& segment, int64_t row_id, const table_filter_t* filter) {
             assert(row_id >= 0 && row_id < static_cast<int64_t>(segment.count.load()));
             auto& buffer_manager = segment.block->block_manager.buffer_manager;
-            auto handle = buffer_manager.pin(segment.block);
+            auto pinned = buffer_manager.pin(segment.block);
+            if (pinned.has_error()) {
+                return pinned.convert_error<bool>();
+            }
+            auto& handle = pinned.value();
             auto dataptr = handle.ptr() + segment.block_offset();
             vector::validity_mask_t mask(buffer_manager.resource(), reinterpret_cast<uint64_t*>(dataptr));
 
             return table_filter_dispatch(filter, mask.row_is_valid(static_cast<uint64_t>(row_id)));
         }
 
-        bool string_check_row(column_segment_t& segment,
-                              column_fetch_state& state,
-                              int64_t row_id,
-                              const table_filter_t* filter) {
-            auto& handle = state.get_or_insert_handle(segment);
+        core::result_wrapper_t<bool> string_check_row(column_segment_t& segment,
+                                                      column_fetch_state& state,
+                                                      int64_t row_id,
+                                                      const table_filter_t* filter) {
+            auto* handle_ptr = state.get_or_insert_handle(segment);
+            if (!handle_ptr) {
+                return state.fetch_error; // implicit error_t -> result_wrapper_t<bool>
+            }
+            auto& handle = *handle_ptr;
 
             auto baseptr = handle.ptr() + segment.block_offset();
             auto dict = dictionary(segment, handle);
@@ -372,10 +409,14 @@ namespace components::table {
             memcpy(target, &offset, sizeof(int64_t));
         }
 
-        uint64_t
+        core::result_wrapper_t<uint64_t>
         string_append(column_segment_t& segment, vector::unified_vector_format& data, uint64_t offset, uint64_t count) {
             auto& buffer_manager = segment.block->block_manager.buffer_manager;
-            auto handle = buffer_manager.pin(segment.block);
+            auto pinned = buffer_manager.pin(segment.block);
+            if (pinned.has_error()) {
+                return pinned.convert_error<uint64_t>();
+            }
+            auto& handle = pinned.value();
             assert(segment.block_offset() == 0);
             auto handle_ptr = handle.ptr();
             auto source_data = data.get_data<std::string_view>();
@@ -419,7 +460,10 @@ namespace components::table {
                 if (use_overflow_block) {
                     uint64_t block;
                     int32_t current_offset;
-                    write_string(segment, source_data[source_idx], block, current_offset);
+                    auto written = write_string(segment, source_data[source_idx], block, current_offset);
+                    if (written.has_error()) {
+                        return written.convert_error<uint64_t>();
+                    }
                     *dictionary_size += static_cast<uint32_t>(BIG_STRING_MARKER_BASE_SIZE);
                     remaining -= BIG_STRING_MARKER_BASE_SIZE;
                     auto dict_pos = end - *dictionary_size;
@@ -500,11 +544,16 @@ namespace components::table {
         }
 
         void constant_fetch_row(column_segment_t& segment,
-                                column_fetch_state&,
+                                column_fetch_state& state,
                                 vector::vector_t& result,
                                 uint64_t result_idx) {
             auto& buffer_manager = segment.block->block_manager.buffer_manager;
-            auto handle = buffer_manager.pin(segment.block);
+            auto pinned = buffer_manager.pin(segment.block);
+            if (pinned.has_error()) {
+                state.fetch_error = pinned.error();
+                return;
+            }
+            auto& handle = pinned.value();
             auto* src = handle.ptr() + segment.block_offset();
             auto ts = segment.type_size;
             std::memcpy(result.data() + result_idx * ts, src, ts);
@@ -607,12 +656,17 @@ namespace components::table {
         }
 
         void rle_fetch_row(column_segment_t& segment,
-                           column_fetch_state&,
+                           column_fetch_state& state,
                            int64_t row_id,
                            vector::vector_t& result,
                            uint64_t result_idx) {
             auto& buffer_manager = segment.block->block_manager.buffer_manager;
-            auto handle = buffer_manager.pin(segment.block);
+            auto pinned = buffer_manager.pin(segment.block);
+            if (pinned.has_error()) {
+                state.fetch_error = pinned.error();
+                return;
+            }
+            auto& handle = pinned.value();
             auto* base = handle.ptr() + segment.block_offset();
             auto ts = segment.type_size;
 
@@ -701,12 +755,17 @@ namespace components::table {
         }
 
         void dict_fetch_row(column_segment_t& segment,
-                            column_fetch_state&,
+                            column_fetch_state& state,
                             int64_t row_id,
                             vector::vector_t& result,
                             uint64_t result_idx) {
             auto& buffer_manager = segment.block->block_manager.buffer_manager;
-            auto handle = buffer_manager.pin(segment.block);
+            auto pinned = buffer_manager.pin(segment.block);
+            if (pinned.has_error()) {
+                state.fetch_error = pinned.error();
+                return;
+            }
+            auto& handle = pinned.value();
             auto* base = handle.ptr() + segment.block_offset();
             auto ts = segment.type_size;
 
@@ -876,17 +935,25 @@ namespace components::table {
         if (type.type() == types::logical_type::VALIDITY) {
             auto& buffer_manager = this->block->block_manager.buffer_manager;
             if (block_id_ == storage::INVALID_BLOCK) {
-                auto handle = buffer_manager.pin(this->block);
-                memset(handle.ptr(), 0xFF, this->segment_size());
+                // The block was just registered (memory reserved), so pinning it cannot OOM. A ctor
+                // cannot return an error, so we assert and skip on the impossible failure.
+                auto pinned = buffer_manager.pin(this->block);
+                assert(!pinned.has_error() && "pin of freshly-registered managed block must not OOM");
+                if (!pinned.has_error()) {
+                    memset(pinned.value().ptr(), 0xFF, this->segment_size());
+                }
             }
         } else if (type.type() == types::logical_type::STRING_LITERAL) {
             auto& buffer_manager = this->block->block_manager.buffer_manager;
             if (block_id_ == storage::INVALID_BLOCK) {
-                auto handle = buffer_manager.pin(this->block);
-                impl::string_dictionary_container_t dictionary;
-                dictionary.size = 0;
-                dictionary.end = static_cast<uint32_t>(this->segment_size());
-                set_dictionary(*this, handle, dictionary);
+                auto pinned = buffer_manager.pin(this->block);
+                assert(!pinned.has_error() && "pin of freshly-registered managed block must not OOM");
+                if (!pinned.has_error()) {
+                    impl::string_dictionary_container_t dictionary;
+                    dictionary.size = 0;
+                    dictionary.end = static_cast<uint32_t>(this->segment_size());
+                    set_dictionary(*this, pinned.value(), dictionary);
+                }
             }
             auto state = std::make_unique<uncompressed_string_segment_state>();
             if (segment_state) {
@@ -924,13 +991,17 @@ namespace components::table {
 
     uint64_t column_segment_t::segment_size() const { return segment_size_; }
 
-    std::unique_ptr<column_segment_t> column_segment_t::create_segment(storage::buffer_manager_t& manager,
-                                                                       const types::complex_logical_type& type,
-                                                                       int64_t start,
-                                                                       uint64_t segment_size,
-                                                                       uint64_t block_size) {
+    core::result_wrapper_t<std::unique_ptr<column_segment_t>>
+    column_segment_t::create_segment(storage::buffer_manager_t& manager,
+                                     const types::complex_logical_type& type,
+                                     int64_t start,
+                                     uint64_t segment_size,
+                                     uint64_t block_size) {
         auto block = manager.register_transient_memory(segment_size, block_size);
-        return std::make_unique<column_segment_t>(std::move(block),
+        if (block.has_error()) {
+            return block.convert_error<std::unique_ptr<column_segment_t>>();
+        }
+        return std::make_unique<column_segment_t>(std::move(block.value()),
                                                   type,
                                                   start,
                                                   0U,
@@ -940,22 +1011,15 @@ namespace components::table {
     }
 
     void column_segment_t::initialize_scan(column_scan_state& state) {
-        switch (type.to_physical_type()) {
-            case types::physical_type::BIT: {
-                auto& buffer_manager = block->block_manager.buffer_manager;
-                state.scan_state = std::make_unique<storage::buffer_handle_t>(buffer_manager.pin(block));
-                break;
-            }
-            case types::physical_type::STRING: {
-                auto& buffer_manager = block->block_manager.buffer_manager;
-                state.scan_state = std::make_unique<storage::buffer_handle_t>(buffer_manager.pin(block));
-                break;
-            }
-            default: {
-                auto& buffer_manager = block->block_manager.buffer_manager;
-                state.scan_state = std::make_unique<storage::buffer_handle_t>(buffer_manager.pin(block));
-            }
+        // All physical types pin the same backing block; a pin OOM is recorded in state.scan_error
+        // and column_data_t::scan_vector bails before touching the (null) scan_state.
+        auto& buffer_manager = block->block_manager.buffer_manager;
+        auto pinned = buffer_manager.pin(block);
+        if (pinned.has_error()) {
+            state.scan_error = pinned.error();
+            return;
         }
+        state.scan_state = std::make_unique<storage::buffer_handle_t>(std::move(pinned.value()));
     }
 
     void column_segment_t::scan(column_scan_state& state,
@@ -972,7 +1036,7 @@ namespace components::table {
             assert(result.get_vector_type() == vector::vector_type::FLAT);
         }
     }
-    bool column_segment_t::check_predicate(int64_t row_id, const table_filter_t* filter) {
+    core::result_wrapper_t<bool> column_segment_t::check_predicate(int64_t row_id, const table_filter_t* filter) {
         if (compression_ == compression::compression_type::CONSTANT) {
             // For CONSTANT segments, all rows have the same value at offset 0.
             // Rewrite row_id to 0 so the check reads from the single stored value.
@@ -1375,32 +1439,44 @@ namespace components::table {
 
     void column_segment_t::skip(column_scan_state& state) { state.internal_index = state.row_index; }
 
-    void column_segment_t::resize(uint64_t new_size) {
+    core::result_wrapper_t<bool> column_segment_t::resize(uint64_t new_size) {
         assert(new_size > segment_size_);
         assert(offset_ == 0);
         assert(block && new_size <= block_manager().block_size());
 
         auto& buffer_manager = block->block_manager.buffer_manager;
         auto old_handle = buffer_manager.pin(block);
+        if (old_handle.has_error()) {
+            return old_handle.convert_error<bool>();
+        }
+        // Genuine fresh allocation — this is the OOM-able site.
         auto new_handle = buffer_manager.allocate(storage::memory_tag::IN_MEMORY_TABLE, new_size);
-        auto new_block = new_handle.block_handle()->shared_from_this();
-        memcpy(new_handle.ptr(), old_handle.ptr(), segment_size_);
+        if (new_handle.has_error()) {
+            return new_handle.convert_error<bool>();
+        }
+        auto new_block = new_handle.value().block_handle()->shared_from_this();
+        memcpy(new_handle.value().ptr(), old_handle.value().ptr(), segment_size_);
 
         this->block_id_ = new_block->block_id();
         this->block = std::move(new_block);
         this->segment_size_ = new_size;
+        return true;
     }
 
-    void column_segment_t::initialize_append(column_append_state& state) {
+    core::result_wrapper_t<bool> column_segment_t::initialize_append(column_append_state& state) {
         auto& buffer_manager = block->block_manager.buffer_manager;
         auto handle = buffer_manager.pin(block);
-        state.handle = std::make_unique<storage::buffer_handle_t>(std::move(handle));
+        if (handle.has_error()) {
+            return handle.convert_error<bool>();
+        }
+        state.handle = std::make_unique<storage::buffer_handle_t>(std::move(handle.value()));
+        return true;
     }
 
-    uint64_t column_segment_t::append(column_append_state& state,
-                                      vector::unified_vector_format& data,
-                                      uint64_t offset,
-                                      uint64_t count) {
+    core::result_wrapper_t<uint64_t> column_segment_t::append(column_append_state& state,
+                                                             vector::unified_vector_format& data,
+                                                             uint64_t offset,
+                                                             uint64_t count) {
         switch (type.to_physical_type()) {
             case types::physical_type::BOOL:
             case types::physical_type::INT8:
@@ -1448,7 +1524,7 @@ namespace components::table {
         }
     }
 
-    uint64_t column_segment_t::finalize_append(column_append_state& state) {
+    core::result_wrapper_t<uint64_t> column_segment_t::finalize_append(column_append_state& state) {
         state.handle.reset();
         switch (type.to_physical_type()) {
             case types::physical_type::BOOL:
@@ -1476,7 +1552,11 @@ namespace components::table {
                        vector::validity_mask_t::STANDARD_MASK_SIZE;
             case types::physical_type::STRING: {
                 auto& buffer_manager = block->block_manager.buffer_manager;
-                auto handle = buffer_manager.pin(block);
+                auto pinned = buffer_manager.pin(block);
+                if (pinned.has_error()) {
+                    return pinned.convert_error<uint64_t>();
+                }
+                auto& handle = pinned.value();
                 auto dict = impl::dictionary(*this, handle);
                 assert(dict.end == segment_size_);
                 auto offset_size = impl::DICTIONARY_HEADER_SIZE + count * sizeof(int32_t);
@@ -1506,7 +1586,13 @@ namespace components::table {
         uint64_t start_bit = start_row - static_cast<uint64_t>(start);
 
         auto& buffer_manager = block->block_manager.buffer_manager;
-        auto handle = buffer_manager.pin(block);
+        // Resident managed block (already pinned on the append path); pin cannot OOM here.
+        auto pinned = buffer_manager.pin(block);
+        assert(!pinned.has_error() && "revert_append: pin of resident managed block must not OOM");
+        if (pinned.has_error()) {
+            return;
+        }
+        auto& handle = pinned.value();
         uint64_t revert_start;
         if (start_bit % 8 != 0) {
             uint64_t byte_pos = start_bit / 8;

--- a/components/table/column_segment.hpp
+++ b/components/table/column_segment.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <components/vector/vector.hpp>
+#include <core/result_wrapper.hpp>
 
 #include "base_statistics.hpp"
 #include "compression/compression_type.hpp"
@@ -46,11 +47,14 @@ namespace components::table {
         uint64_t type_size;
         std::shared_ptr<storage::block_handle_t> block;
 
-        static std::unique_ptr<column_segment_t> create_segment(storage::buffer_manager_t& block_manager,
-                                                                const types::complex_logical_type& type,
-                                                                int64_t start,
-                                                                uint64_t segment_size,
-                                                                uint64_t block_size);
+        // Returns an out_of_memory error_t when the backing transient block cannot be
+        // registered; otherwise the new segment.
+        static core::result_wrapper_t<std::unique_ptr<column_segment_t>>
+        create_segment(storage::buffer_manager_t& block_manager,
+                       const types::complex_logical_type& type,
+                       int64_t start,
+                       uint64_t segment_size,
+                       uint64_t block_size);
 
         void initialize_scan(column_scan_state& state);
         void scan(column_scan_state& state,
@@ -59,7 +63,8 @@ namespace components::table {
                   uint64_t result_offset,
                   scan_vector_type scan_type);
 
-        bool check_predicate(int64_t row_id, const table_filter_t* filter);
+        // Returns out_of_memory when a pin fails; otherwise the predicate result.
+        core::result_wrapper_t<bool> check_predicate(int64_t row_id, const table_filter_t* filter);
         void fetch_row(column_fetch_state& state, int64_t row_id, vector::vector_t& result, uint64_t result_idx);
 
         static uint64_t filter_indexing(vector::indexing_vector_t& indexing,
@@ -72,12 +77,13 @@ namespace components::table {
         void skip(column_scan_state& state);
 
         uint64_t segment_size() const;
-        void resize(uint64_t segment_size);
+        // OOM-propagating: pin/allocate failures surface as out_of_memory.
+        core::result_wrapper_t<bool> resize(uint64_t segment_size);
 
-        void initialize_append(column_append_state& state);
-        uint64_t
+        core::result_wrapper_t<bool> initialize_append(column_append_state& state);
+        core::result_wrapper_t<uint64_t>
         append(column_append_state& state, vector::unified_vector_format& data, uint64_t offset, uint64_t count);
-        uint64_t finalize_append(column_append_state& state);
+        core::result_wrapper_t<uint64_t> finalize_append(column_append_state& state);
         void revert_append(uint64_t start_row);
 
         uint64_t block_id() { return block_id_; }

--- a/components/table/column_segment.hpp
+++ b/components/table/column_segment.hpp
@@ -49,7 +49,7 @@ namespace components::table {
 
         // Returns an out_of_memory error_t when the backing transient block cannot be
         // registered; otherwise the new segment.
-        static core::result_wrapper_t<std::unique_ptr<column_segment_t>>
+        [[nodiscard]] static core::result_wrapper_t<std::unique_ptr<column_segment_t>>
         create_segment(storage::buffer_manager_t& block_manager,
                        const types::complex_logical_type& type,
                        int64_t start,
@@ -64,7 +64,7 @@ namespace components::table {
                   scan_vector_type scan_type);
 
         // Returns out_of_memory when a pin fails; otherwise the predicate result.
-        core::result_wrapper_t<bool> check_predicate(int64_t row_id, const table_filter_t* filter);
+        [[nodiscard]] core::result_wrapper_t<bool> check_predicate(int64_t row_id, const table_filter_t* filter);
         void fetch_row(column_fetch_state& state, int64_t row_id, vector::vector_t& result, uint64_t result_idx);
 
         static uint64_t filter_indexing(vector::indexing_vector_t& indexing,
@@ -78,12 +78,12 @@ namespace components::table {
 
         uint64_t segment_size() const;
         // OOM-propagating: pin/allocate failures surface as out_of_memory.
-        core::result_wrapper_t<bool> resize(uint64_t segment_size);
+        [[nodiscard]] core::result_wrapper_t<bool> resize(uint64_t segment_size);
 
-        core::result_wrapper_t<bool> initialize_append(column_append_state& state);
-        core::result_wrapper_t<uint64_t>
+        [[nodiscard]] core::result_wrapper_t<bool> initialize_append(column_append_state& state);
+        [[nodiscard]] core::result_wrapper_t<uint64_t>
         append(column_append_state& state, vector::unified_vector_format& data, uint64_t offset, uint64_t count);
-        core::result_wrapper_t<uint64_t> finalize_append(column_append_state& state);
+        [[nodiscard]] core::result_wrapper_t<uint64_t> finalize_append(column_append_state& state);
         void revert_append(uint64_t start_row);
 
         uint64_t block_id() { return block_id_; }

--- a/components/table/column_state.cpp
+++ b/components/table/column_state.cpp
@@ -125,17 +125,21 @@ namespace components::table {
         }
     }
 
-    storage::buffer_handle_t& column_fetch_state::get_or_insert_handle(column_segment_t& segment) {
+    storage::buffer_handle_t* column_fetch_state::get_or_insert_handle(column_segment_t& segment) {
         auto primary_id = segment.block->block_id();
 
         auto entry = handles.find(primary_id);
         if (entry == handles.end()) {
             auto& buffer_manager = segment.block->block_manager.buffer_manager;
-            auto handle = buffer_manager.pin(segment.block);
-            auto pinned_entry = handles.insert({primary_id, std::move(handle)});
-            return pinned_entry.first->second;
+            auto pinned = buffer_manager.pin(segment.block);
+            if (pinned.has_error()) {
+                fetch_error = pinned.error();
+                return nullptr;
+            }
+            auto pinned_entry = handles.insert({primary_id, std::move(pinned.value())});
+            return &pinned_entry.first->second;
         } else {
-            return entry->second;
+            return &entry->second;
         }
     }
 

--- a/components/table/column_state.hpp
+++ b/components/table/column_state.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <components/types/types.hpp>
 #include <core/operations_helper.hpp>
+#include <core/result_wrapper.hpp>
 #include <memory>
 #include <mutex>
 #include <unordered_map>
@@ -336,6 +337,12 @@ namespace components::table {
         uint64_t last_offset = 0;
         uint64_t result_offset = 0;
         std::vector<bool> scan_child_column;
+        // OOM (buffer-pool exhaustion) raised by a pin() while scanning this column.
+        // Leaf segment helpers set it; column_data_t::scan_vector bails on it and
+        // row_group_t aggregates it into collection_scan_state::scan_error. Success
+        // path leaves it as no_error().
+        core::error_t scan_error{core::error_t::no_error()};
+        bool has_error() const { return scan_error.contains_error(); }
 
         void initialize(const types::complex_logical_type& type, const std::vector<storage_index_t>& children);
         void initialize(const types::complex_logical_type& type);
@@ -345,8 +352,12 @@ namespace components::table {
     struct column_fetch_state {
         std::unordered_map<uint64_t, storage::buffer_handle_t> handles;
         std::vector<std::unique_ptr<column_fetch_state>> child_states;
+        // OOM raised by the pin() inside get_or_insert_handle(); callers that route
+        // through a column_scan_state copy it into scan_error.
+        core::error_t fetch_error{core::error_t::no_error()};
 
-        storage::buffer_handle_t& get_or_insert_handle(column_segment_t& segment);
+        // Returns nullptr and sets fetch_error on buffer-pool exhaustion.
+        storage::buffer_handle_t* get_or_insert_handle(column_segment_t& segment);
     };
 
     struct string_block_t {

--- a/components/table/data_table.cpp
+++ b/components/table/data_table.cpp
@@ -165,7 +165,11 @@ namespace components::table {
 
         {
             table_append_state append_state(resource_);
-            new_collection->initialize_append(append_state);
+            // compact is best-effort maintenance: an out_of_memory during the rebuild append
+            // leaves the original collection untouched and returns false.
+            if (new_collection->initialize_append(append_state).has_error()) {
+                return false;
+            }
 
             // Scan committed non-deleted rows from old collection
             std::vector<storage_index_t> column_ids;
@@ -183,7 +187,9 @@ namespace components::table {
                 if (chunk.size() == 0) {
                     break;
                 }
-                new_collection->append(chunk, append_state);
+                if (new_collection->append(chunk, append_state).has_error()) {
+                    return false;
+                }
                 chunk.reset();
             }
 
@@ -191,8 +197,30 @@ namespace components::table {
         }
         // scan state and buffer handles destroyed before swapping collection
 
+        // Keep a reference to the outgoing collection so its disk blocks can be reclaimed AFTER the
+        // atomic swap. The swap itself (row_groups_ = move(new_collection)) is the MVCC all-or-nothing
+        // guard and stays intact; the old collection becomes unreferenced once `old_collection` drops.
+        auto old_collection = row_groups_;
+
         // Swap old collection with compacted one
         row_groups_ = std::move(new_collection);
+
+        // Return the OLD (now-replaced) collection's disk blocks to the block manager's free list so the
+        // NEXT compact reuses them instead of bumping total_blocks() unbounded. No-op for in-memory tables
+        // (no backing store). The new collection's write-through already allocated FRESH ids (free list was
+        // empty / disjoint), so the old ids it frees are not referenced by row_groups_. The persisted free
+        // list survives checkpoint, so reclaimed space is durable. mark_as_free under the block manager's
+        // allocation lock; no live segment references the freed blocks (the old collection is being torn down).
+        if (old_collection) {
+            auto& block_manager = old_collection->block_manager();
+            if (!block_manager.in_memory()) {
+                std::pmr::vector<uint64_t> reclaimable{resource_};
+                old_collection->collect_disk_block_ids(reclaimable);
+                for (uint64_t block_id : reclaimable) {
+                    block_manager.mark_as_free(block_id);
+                }
+            }
+        }
         return true;
     }
 
@@ -227,31 +255,35 @@ namespace components::table {
         return std::make_unique<constraint_state>(bound_constraints);
     }
 
-    void data_table_t::append_lock(table_append_state& state) {
+    core::result_wrapper_t<bool> data_table_t::append_lock(table_append_state& state) {
         state.append_lock = std::unique_lock(append_lock_);
-        // Concurrent DDL altered the table. abort() rather than throw: under
-        // -fno-exceptions a throw inside an actor-zeta coroutine is silently
-        // swallowed (UB). TODO: return core::error_t for a graceful txn abort.
-        assert(is_root_ && "Transaction conflict: adding entries to a table that has been altered!");
+        // Concurrent DDL altered the table (no longer root). Report a write_conflict up to the
+        // append boundary for a graceful txn abort, instead of aborting: under -fno-exceptions a
+        // throw inside an actor-zeta coroutine is silently swallowed.
         if (!is_root_) {
-            std::abort();
+            return core::error_t(core::error_code_t::write_conflict,
+                                 std::pmr::string("Transaction conflict: adding entries to a table that has "
+                                                  "been altered!",
+                                                  resource_));
         }
         state.row_start = static_cast<int64_t>(row_groups_->total_rows());
         state.current_row = state.row_start;
+        return true;
     }
 
-    void data_table_t::initialize_append(table_append_state& state) {
+    core::result_wrapper_t<bool> data_table_t::initialize_append(table_append_state& state) {
         assert(state.append_lock &&
                "data_table_t::append_lock should be called before data_table_t::initialize_append");
         if (!state.append_lock) {
-            std::abort();
+            return core::error_t(core::error_code_t::other_error,
+                                 std::pmr::string("data_table_t::append_lock must precede initialize_append", resource_));
         }
-        row_groups_->initialize_append(state);
+        return row_groups_->initialize_append(state); // out_of_memory
     }
 
-    void data_table_t::append(vector::data_chunk_t& chunk, table_append_state& state) {
+    core::result_wrapper_t<bool> data_table_t::append(vector::data_chunk_t& chunk, table_append_state& state) {
         assert(is_root_);
-        row_groups_->append(chunk, state);
+        return row_groups_->append(chunk, state); // out_of_memory
     }
 
     void data_table_t::finalize_append(table_append_state& state, transaction_data txn) {
@@ -412,15 +444,15 @@ namespace components::table {
         return result;
     }
 
-    void data_table_t::update(table_update_state&,
-                              vector::vector_t& row_ids,
-                              // const std::vector<uint64_t>& column_ids,
-                              vector::data_chunk_t& data) {
+    core::result_wrapper_t<std::pair<int64_t, uint64_t>> data_table_t::update(table_update_state&,
+                                                                             vector::vector_t& row_ids,
+                                                                             // const std::vector<uint64_t>& column_ids,
+                                                                             vector::data_chunk_t& data) {
         assert(row_ids.type().to_physical_type() == types::physical_type::INT64);
 
         uint64_t count = data.size();
         if (count == 0) {
-            return;
+            return std::pair<int64_t, uint64_t>{0, 0};
         }
         vector::vector_t max_row_id_vec(resource_,
                                         types::logical_value_t(resource_, static_cast<int64_t>(MAX_ROW_ID)),
@@ -447,30 +479,36 @@ namespace components::table {
             for (size_t i = 0; i < column_count(); i++) {
                 column_ids.emplace_back(i);
             }
-            row_groups_->update(row_ids_slice.data<int64_t>(), column_ids, updates_slice);
+            auto updated = row_groups_->update(row_ids_slice.data<int64_t>(), column_ids, updates_slice);
+            if (updated.has_error()) {
+                return updated.convert_error<std::pair<int64_t, uint64_t>>(); // write_conflict / out_of_memory
+            }
         }
+        // pair = {0, affected-row count}; the caller's update reply reads it.
+        return std::pair<int64_t, uint64_t>{0, update_count};
     }
 
-    void data_table_t::update_column(vector::vector_t& row_ids,
-                                     const std::vector<uint64_t>& column_path,
-                                     vector::data_chunk_t& updates) {
+    core::result_wrapper_t<bool> data_table_t::update_column(vector::vector_t& row_ids,
+                                                           const std::vector<uint64_t>& column_path,
+                                                           vector::data_chunk_t& updates) {
         assert(row_ids.type().type() == types::logical_type::BIGINT);
         assert(updates.column_count() == 1);
         if (updates.size() == 0) {
-            return;
+            return true;
         }
 
-        // Concurrent DDL altered the table. abort() rather than throw: under
-        // -fno-exceptions a throw inside an actor-zeta coroutine is silently
-        // swallowed (UB). TODO: return core::error_t for a graceful txn abort.
-        assert(is_root_ && "Transaction conflict: cannot update a table that has been altered!");
+        // Concurrent DDL altered the table (no longer root). Report write_conflict for a graceful
+        // txn abort instead of aborting: under -fno-exceptions a throw inside an actor-zeta
+        // coroutine is silently swallowed (UB).
         if (!is_root_) {
-            std::abort();
+            return core::error_t(core::error_code_t::write_conflict,
+                                 std::pmr::string("Transaction conflict: cannot update a table that has been altered!",
+                                                  resource_));
         }
 
         updates.flatten();
         row_ids.flatten(updates.size());
-        row_groups_->update_column(row_ids, column_path, updates);
+        return row_groups_->update_column(row_ids, column_path, updates);
     }
 
     uint64_t data_table_t::column_count() const { return column_definitions_.size(); }
@@ -479,10 +517,14 @@ namespace components::table {
         return row_groups_->get_column_segment_info();
     }
 
-    void data_table_t::checkpoint(storage::metadata_writer_t& writer) {
+    core::result_wrapper_t<bool> data_table_t::checkpoint(storage::metadata_writer_t& writer) {
         storage::partial_block_manager_t partial_block_manager(row_groups_->block_manager());
 
-        auto row_group_pointers = row_groups_->checkpoint(partial_block_manager);
+        auto row_group_pointers_res = row_groups_->checkpoint(partial_block_manager);
+        if (row_group_pointers_res.has_error()) {
+            return row_group_pointers_res.convert_error<bool>(); // out_of_memory
+        }
+        const auto& row_group_pointers = row_group_pointers_res.value();
 
         // write table metadata
         writer.write_string(name_);
@@ -502,11 +544,13 @@ namespace components::table {
         }
 
         writer.flush();
+        return true;
     }
 
-    std::unique_ptr<data_table_t> data_table_t::load_from_disk(std::pmr::memory_resource* resource,
-                                                               storage::block_manager_t& block_manager,
-                                                               storage::metadata_reader_t& reader) {
+    core::result_wrapper_t<std::unique_ptr<data_table_t>>
+    data_table_t::load_from_disk(std::pmr::memory_resource* resource,
+                                 storage::block_manager_t& block_manager,
+                                 storage::metadata_reader_t& reader) {
         auto name = reader.read_string();
 
         auto col_count = reader.read<uint32_t>();
@@ -536,6 +580,13 @@ namespace components::table {
             }
         }
         table->row_groups_->set_total_rows(total_loaded_rows);
+
+        // Corrupt-stream check at the load boundary: if any read above ran past the end of the metadata
+        // chain, the reader recorded a sticky data_corruption error (reads became no-ops, so `table` may
+        // be partially built). Surface it instead of returning a half-loaded table.
+        if (reader.has_error()) {
+            return core::error_t(reader.error());
+        }
 
         return table;
     }

--- a/components/table/data_table.cpp
+++ b/components/table/data_table.cpp
@@ -275,7 +275,7 @@ namespace components::table {
         assert(state.append_lock &&
                "data_table_t::append_lock should be called before data_table_t::initialize_append");
         if (!state.append_lock) {
-            return core::error_t(core::error_code_t::other_error,
+            return core::error_t(core::error_code_t::invalid_parameter,
                                  std::pmr::string("data_table_t::append_lock must precede initialize_append", resource_));
         }
         return row_groups_->initialize_append(state); // out_of_memory

--- a/components/table/data_table.hpp
+++ b/components/table/data_table.hpp
@@ -55,21 +55,21 @@ namespace components::table {
         initialize_update(const std::vector<std::unique_ptr<bound_constraint_t>>& bound_constraints);
         // Returns write_conflict / out_of_memory. On success the pair is
         // {0, affected-row count}; the caller's update reply carries it.
-        core::result_wrapper_t<std::pair<int64_t, uint64_t>> update(table_update_state& state,
-                                                                    vector::vector_t& row_ids,
-                                                                    // const std::vector<uint64_t>& column_ids,
-                                                                    vector::data_chunk_t& data);
-        core::result_wrapper_t<bool> update_column(vector::vector_t& row_ids,
-                                                   const std::vector<uint64_t>& column_path,
-                                                   vector::data_chunk_t& updates);
+        [[nodiscard]] core::result_wrapper_t<std::pair<int64_t, uint64_t>> update(table_update_state& state,
+                                                                                  vector::vector_t& row_ids,
+                                                                                  // const std::vector<uint64_t>& column_ids,
+                                                                                  vector::data_chunk_t& data);
+        [[nodiscard]] core::result_wrapper_t<bool> update_column(vector::vector_t& row_ids,
+                                                                 const std::vector<uint64_t>& column_path,
+                                                                 vector::data_chunk_t& updates);
 
         // append_lock returns write_conflict when concurrent DDL altered the table
         // (the table is no longer root); true on success.
-        core::result_wrapper_t<bool> append_lock(table_append_state& state);
+        [[nodiscard]] core::result_wrapper_t<bool> append_lock(table_append_state& state);
         // The append chain returns out_of_memory when a row group / column segment
         // allocation fails; true on success.
-        core::result_wrapper_t<bool> initialize_append(table_append_state& state);
-        core::result_wrapper_t<bool> append(vector::data_chunk_t& chunk, table_append_state& state);
+        [[nodiscard]] core::result_wrapper_t<bool> initialize_append(table_append_state& state);
+        [[nodiscard]] core::result_wrapper_t<bool> append(vector::data_chunk_t& chunk, table_append_state& state);
         void finalize_append(table_append_state& state, transaction_data txn);
         void commit_append(uint64_t commit_id, int64_t row_start, uint64_t count);
         void revert_append(int64_t row_start, uint64_t count);
@@ -119,11 +119,11 @@ namespace components::table {
 
         // The checkpoint chain returns out_of_memory when a column flush pin fails;
         // true on success.
-        core::result_wrapper_t<bool> checkpoint(storage::metadata_writer_t& writer);
+        [[nodiscard]] core::result_wrapper_t<bool> checkpoint(storage::metadata_writer_t& writer);
         // Returns data_corruption when the on-disk metadata chain is truncated/corrupt (the reader records
         // a sticky error during deserialize, checked here at the boundary) instead of throwing on the
         // load path. The caller (bootstrap/load) maps the error onto its .prev recovery flow.
-        static core::result_wrapper_t<std::unique_ptr<data_table_t>>
+        [[nodiscard]] static core::result_wrapper_t<std::unique_ptr<data_table_t>>
         load_from_disk(std::pmr::memory_resource* resource,
                        storage::block_manager_t& block_manager,
                        storage::metadata_reader_t& reader);

--- a/components/table/data_table.hpp
+++ b/components/table/data_table.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "collection.hpp"
 #include "storage/metadata_reader.hpp"
 #include "storage/metadata_writer.hpp"
@@ -51,17 +53,23 @@ namespace components::table {
 
         std::unique_ptr<table_update_state>
         initialize_update(const std::vector<std::unique_ptr<bound_constraint_t>>& bound_constraints);
-        void update(table_update_state& state,
-                    vector::vector_t& row_ids,
-                    // const std::vector<uint64_t>& column_ids,
-                    vector::data_chunk_t& data);
-        void update_column(vector::vector_t& row_ids,
-                           const std::vector<uint64_t>& column_path,
-                           vector::data_chunk_t& updates);
+        // Returns write_conflict / out_of_memory. On success the pair is
+        // {0, affected-row count}; the caller's update reply carries it.
+        core::result_wrapper_t<std::pair<int64_t, uint64_t>> update(table_update_state& state,
+                                                                    vector::vector_t& row_ids,
+                                                                    // const std::vector<uint64_t>& column_ids,
+                                                                    vector::data_chunk_t& data);
+        core::result_wrapper_t<bool> update_column(vector::vector_t& row_ids,
+                                                   const std::vector<uint64_t>& column_path,
+                                                   vector::data_chunk_t& updates);
 
-        void append_lock(table_append_state& state);
-        void initialize_append(table_append_state& state);
-        void append(vector::data_chunk_t& chunk, table_append_state& state);
+        // append_lock returns write_conflict when concurrent DDL altered the table
+        // (the table is no longer root); true on success.
+        core::result_wrapper_t<bool> append_lock(table_append_state& state);
+        // The append chain returns out_of_memory when a row group / column segment
+        // allocation fails; true on success.
+        core::result_wrapper_t<bool> initialize_append(table_append_state& state);
+        core::result_wrapper_t<bool> append(vector::data_chunk_t& chunk, table_append_state& state);
         void finalize_append(table_append_state& state, transaction_data txn);
         void commit_append(uint64_t commit_id, int64_t row_start, uint64_t count);
         void revert_append(int64_t row_start, uint64_t count);
@@ -109,10 +117,16 @@ namespace components::table {
                                  table_scan_state& local_state,
                                  vector::data_chunk_t& result);
 
-        void checkpoint(storage::metadata_writer_t& writer);
-        static std::unique_ptr<data_table_t> load_from_disk(std::pmr::memory_resource* resource,
-                                                            storage::block_manager_t& block_manager,
-                                                            storage::metadata_reader_t& reader);
+        // The checkpoint chain returns out_of_memory when a column flush pin fails;
+        // true on success.
+        core::result_wrapper_t<bool> checkpoint(storage::metadata_writer_t& writer);
+        // Returns data_corruption when the on-disk metadata chain is truncated/corrupt (the reader records
+        // a sticky error during deserialize, checked here at the boundary) instead of throwing on the
+        // load path. The caller (bootstrap/load) maps the error onto its .prev recovery flow.
+        static core::result_wrapper_t<std::unique_ptr<data_table_t>>
+        load_from_disk(std::pmr::memory_resource* resource,
+                       storage::block_manager_t& block_manager,
+                       storage::metadata_reader_t& reader);
 
     private:
         void initialize_scan_with_offset(table_scan_state& state,

--- a/components/table/list_column_data.cpp
+++ b/components/table/list_column_data.cpp
@@ -148,19 +148,30 @@ namespace components::table {
         child_column->skip(state.child_states[1], child_scan_count);
     }
 
-    void list_column_data_t::initialize_append(column_append_state& state) {
-        column_data_t::initialize_append(state);
+    core::result_wrapper_t<bool> list_column_data_t::initialize_append(column_append_state& state) {
+        auto base = column_data_t::initialize_append(state);
+        if (base.has_error()) {
+            return base; // out_of_memory (rules 2/9)
+        }
 
         column_append_state validity_append_state;
-        validity.initialize_append(validity_append_state);
+        auto v = validity.initialize_append(validity_append_state);
+        if (v.has_error()) {
+            return v;
+        }
         state.child_appends.push_back(std::move(validity_append_state));
 
         column_append_state child_append_state;
-        child_column->initialize_append(child_append_state);
+        auto child = child_column->initialize_append(child_append_state);
+        if (child.has_error()) {
+            return child;
+        }
         state.child_appends.push_back(std::move(child_append_state));
+        return true;
     }
 
-    void list_column_data_t::append(column_append_state& state, vector::vector_t& vector, uint64_t count) {
+    core::result_wrapper_t<bool>
+    list_column_data_t::append(column_append_state& state, vector::vector_t& vector, uint64_t count) {
         assert(count > 0);
         vector::unified_vector_format list_data(vector.resource(), count);
         vector.to_unified_format(count, list_data);
@@ -210,11 +221,17 @@ namespace components::table {
         uvf.data = reinterpret_cast<std::byte*>(append_offsets.get());
 
         if (child_count > 0) {
-            child_column->append(state.child_appends[1], child_vector, child_count);
+            auto child = child_column->append(state.child_appends[1], child_vector, child_count);
+            if (child.has_error()) {
+                return child; // out_of_memory (rules 2/9)
+            }
         }
-        column_data_t::append_data(state, uvf, count);
+        auto base = column_data_t::append_data(state, uvf, count);
+        if (base.has_error()) {
+            return base;
+        }
         uvf.validity = append_mask;
-        validity.append_data(state.child_appends[0], uvf, count);
+        return validity.append_data(state.child_appends[0], uvf, count);
     }
 
     void list_column_data_t::revert_append(int64_t start_row) {
@@ -269,12 +286,12 @@ namespace components::table {
         return child_ids;
     }
 
-    void list_column_data_t::update(uint64_t column_index,
-                                    vector::vector_t& update_vector,
-                                    int64_t* row_ids,
-                                    uint64_t update_count) {
+    core::result_wrapper_t<bool> list_column_data_t::update(uint64_t column_index,
+                                                          vector::vector_t& update_vector,
+                                                          int64_t* row_ids,
+                                                          uint64_t update_count) {
         if (update_count == 0) {
-            return;
+            return true;
         }
         vector::vector_t child_update(resource_, type_.child_type());
         auto child_ids = gather_child_update(update_vector, row_ids, update_count, child_update);
@@ -283,20 +300,24 @@ namespace components::table {
         uint64_t remaining_column_index = column_index;
         while (remaining_count > 0) {
             const auto batch = std::min<uint64_t>(remaining_count, vector::DEFAULT_VECTOR_CAPACITY);
-            child_column->update(remaining_column_index, child_update, remaining_child_ids, batch);
+            auto child = child_column->update(remaining_column_index, child_update, remaining_child_ids, batch);
+            if (child.has_error()) {
+                return child;
+            }
             remaining_child_ids += batch;
             remaining_count -= batch;
             remaining_column_index++;
         }
+        return true;
     }
 
-    void list_column_data_t::update_column(const std::vector<uint64_t>& column_path,
-                                           vector::vector_t& update_vector,
-                                           int64_t* row_ids,
-                                           uint64_t update_count,
-                                           uint64_t depth) {
+    core::result_wrapper_t<bool> list_column_data_t::update_column(const std::vector<uint64_t>& column_path,
+                                                                vector::vector_t& update_vector,
+                                                                int64_t* row_ids,
+                                                                uint64_t update_count,
+                                                                uint64_t depth) {
         if (update_count == 0) {
-            return;
+            return true;
         }
         vector::vector_t child_update(resource_, type_.child_type());
         auto child_ids = gather_child_update(update_vector, row_ids, update_count, child_update);
@@ -304,10 +325,14 @@ namespace components::table {
         int64_t* remaining_child_ids = child_ids.data();
         while (remaining_count > 0) {
             const auto batch = std::min<uint64_t>(remaining_count, vector::DEFAULT_VECTOR_CAPACITY);
-            child_column->update_column(column_path, child_update, remaining_child_ids, batch, depth);
+            auto child = child_column->update_column(column_path, child_update, remaining_child_ids, batch, depth);
+            if (child.has_error()) {
+                return child;
+            }
             remaining_child_ids += batch;
             remaining_count -= batch;
         }
+        return true;
     }
 
     void list_column_data_t::fetch_row(column_fetch_state& state,

--- a/components/table/list_column_data.hpp
+++ b/components/table/list_column_data.hpp
@@ -33,21 +33,21 @@ namespace components::table {
 
         void skip(column_scan_state& state, uint64_t count = vector::DEFAULT_VECTOR_CAPACITY) override;
 
-        void initialize_append(column_append_state& state) override;
-        void append(column_append_state& state, vector::vector_t& vector, uint64_t count) override;
+        core::result_wrapper_t<bool> initialize_append(column_append_state& state) override;
+        core::result_wrapper_t<bool> append(column_append_state& state, vector::vector_t& vector, uint64_t count) override;
         void revert_append(int64_t start_row) override;
         uint64_t fetch(column_scan_state& state, int64_t row_id, vector::vector_t& result) override;
         void
         fetch_row(column_fetch_state& state, int64_t row_id, vector::vector_t& result, uint64_t result_idx) override;
-        void update(uint64_t column_index,
-                    vector::vector_t& update_vector,
-                    int64_t* row_ids,
-                    uint64_t update_count) override;
-        void update_column(const std::vector<uint64_t>& column_path,
-                           vector::vector_t& update_vector,
-                           int64_t* row_ids,
-                           uint64_t update_count,
-                           uint64_t depth) override;
+        core::result_wrapper_t<bool> update(uint64_t column_index,
+                                            vector::vector_t& update_vector,
+                                            int64_t* row_ids,
+                                            uint64_t update_count) override;
+        core::result_wrapper_t<bool> update_column(const std::vector<uint64_t>& column_path,
+                                                   vector::vector_t& update_vector,
+                                                   int64_t* row_ids,
+                                                   uint64_t update_count,
+                                                   uint64_t depth) override;
 
         void get_column_segment_info(uint64_t row_group_index,
                                      std::vector<uint64_t> col_path,

--- a/components/table/list_column_data.hpp
+++ b/components/table/list_column_data.hpp
@@ -33,21 +33,22 @@ namespace components::table {
 
         void skip(column_scan_state& state, uint64_t count = vector::DEFAULT_VECTOR_CAPACITY) override;
 
-        core::result_wrapper_t<bool> initialize_append(column_append_state& state) override;
-        core::result_wrapper_t<bool> append(column_append_state& state, vector::vector_t& vector, uint64_t count) override;
+        [[nodiscard]] core::result_wrapper_t<bool> initialize_append(column_append_state& state) override;
+        [[nodiscard]] core::result_wrapper_t<bool>
+        append(column_append_state& state, vector::vector_t& vector, uint64_t count) override;
         void revert_append(int64_t start_row) override;
         uint64_t fetch(column_scan_state& state, int64_t row_id, vector::vector_t& result) override;
         void
         fetch_row(column_fetch_state& state, int64_t row_id, vector::vector_t& result, uint64_t result_idx) override;
-        core::result_wrapper_t<bool> update(uint64_t column_index,
-                                            vector::vector_t& update_vector,
-                                            int64_t* row_ids,
-                                            uint64_t update_count) override;
-        core::result_wrapper_t<bool> update_column(const std::vector<uint64_t>& column_path,
-                                                   vector::vector_t& update_vector,
-                                                   int64_t* row_ids,
-                                                   uint64_t update_count,
-                                                   uint64_t depth) override;
+        [[nodiscard]] core::result_wrapper_t<bool> update(uint64_t column_index,
+                                                          vector::vector_t& update_vector,
+                                                          int64_t* row_ids,
+                                                          uint64_t update_count) override;
+        [[nodiscard]] core::result_wrapper_t<bool> update_column(const std::vector<uint64_t>& column_path,
+                                                                 vector::vector_t& update_vector,
+                                                                 int64_t* row_ids,
+                                                                 uint64_t update_count,
+                                                                 uint64_t depth) override;
 
         void get_column_segment_info(uint64_t row_group_index,
                                      std::vector<uint64_t> col_path,

--- a/components/table/row_group.cpp
+++ b/components/table/row_group.cpp
@@ -131,14 +131,23 @@ namespace components::table {
                 default_value.has_value() ? *default_value
                                           : types::logical_value_t{collection_->resource(), new_column.type()};
             column_append_state state;
-            added_column->initialize_append(state);
-            for (uint64_t i = 0; i < rows_to_write; i += vector::DEFAULT_VECTOR_CAPACITY) {
+            // DDL ADD COLUMN backfill path (synchronous, not an actor append boundary). The append
+            // chain reports out_of_memory; this constructor-style caller cannot return a
+            // result_wrapper_t, so assert and stop the backfill on exhaustion. (A graceful DDL abort
+            // would require the data_table ADD COLUMN constructors to be converted to return errors.)
+            auto init = added_column->initialize_append(state);
+            assert(!init.has_error() && "row_group::add_column: initialize_append OOM");
+            for (uint64_t i = 0; i < rows_to_write && !init.has_error(); i += vector::DEFAULT_VECTOR_CAPACITY) {
                 uint64_t rows_in_this_vector = std::min<uint64_t>(rows_to_write - i, vector::DEFAULT_VECTOR_CAPACITY);
                 result.reference(fill_value);
                 if (!default_value.has_value()) {
                     result.set_null(true);
                 }
-                added_column->append(state, result, rows_in_this_vector);
+                auto appended = added_column->append(state, result, rows_in_this_vector);
+                assert(!appended.has_error() && "row_group::add_column: append OOM");
+                if (appended.has_error()) {
+                    break;
+                }
             }
         }
 
@@ -186,10 +195,15 @@ namespace components::table {
     static bool check_array_element_predicate(column_data_t& column,
                                               int64_t row_id,
                                               uint64_t element_index,
-                                              const table_filter_t* filter) {
+                                              const table_filter_t* filter,
+                                              core::error_t& error) {
         column_fetch_state fetch_state;
         vector::vector_t result(column.resource(), column.type(), 1);
         column.fetch_row(fetch_state, row_id, result, 0);
+        if (fetch_state.fetch_error.contains_error()) {
+            error = fetch_state.fetch_error;
+            return false;
+        }
         if (!result.validity().row_is_valid(0)) {
             return false;
         }
@@ -208,13 +222,16 @@ namespace components::table {
         return filter->cast<constant_filter_t>().compare(element_value);
     }
 
-    bool row_group_t::check_predicate(int64_t row_id, const table_filter_t* filter) {
+    bool row_group_t::check_predicate(int64_t row_id, const table_filter_t* filter, core::error_t& error) {
         switch (filter->filter_type) {
             case expressions::compare_type::union_or: {
                 auto& conjunction_or = filter->cast<conjunction_or_filter_t>();
                 for (auto& child_filter : conjunction_or.child_filters) {
-                    if (check_predicate(row_id, child_filter.get())) {
+                    if (check_predicate(row_id, child_filter.get(), error)) {
                         return true;
+                    }
+                    if (error.contains_error()) {
+                        return false;
                     }
                 }
                 return false;
@@ -222,7 +239,10 @@ namespace components::table {
             case expressions::compare_type::union_and: {
                 auto& conjunction_and = filter->cast<conjunction_and_filter_t>();
                 for (auto& child_filter : conjunction_and.child_filters) {
-                    if (!check_predicate(row_id, child_filter.get())) {
+                    if (!check_predicate(row_id, child_filter.get(), error)) {
+                        return false;
+                    }
+                    if (error.contains_error()) {
                         return false;
                     }
                 }
@@ -231,7 +251,10 @@ namespace components::table {
             case expressions::compare_type::union_not: {
                 auto& conjunction_not = filter->cast<conjunction_not_filter_t>();
                 for (auto& child_filter : conjunction_not.child_filters) {
-                    if (check_predicate(row_id, child_filter.get())) {
+                    if (check_predicate(row_id, child_filter.get(), error)) {
+                        return false;
+                    }
+                    if (error.contains_error()) {
                         return false;
                     }
                 }
@@ -259,11 +282,11 @@ namespace components::table {
                 for (size_t i = 1; i < indices.size(); i++) {
                     if (column->type().type() == types::logical_type::ARRAY ||
                         column->type().type() == types::logical_type::LIST) {
-                        return check_array_element_predicate(*column, row_id, indices[i], filter);
+                        return check_array_element_predicate(*column, row_id, indices[i], filter, error);
                     }
                     column = static_cast<struct_column_data_t*>(column)->sub_columns[indices[i]].get();
                 }
-                return column->check_predicate(row_id, filter);
+                return column->check_predicate(row_id, filter, error);
             }
         }
     }
@@ -299,14 +322,20 @@ namespace components::table {
                                       uint64_t vector_index,
                                       vector::indexing_vector_t& indexing,
                                       const table_filter_t* filter,
-                                      uint64_t& approved_tuple_count) {
+                                      uint64_t& approved_tuple_count,
+                                      core::error_t& error) {
         vector::indexing_vector_t new_indexing(resource, approved_tuple_count);
         uint64_t result_count = 0;
         for (uint64_t i = 0; i < approved_tuple_count; i++) {
             auto idx = indexing.get_index(i);
             new_indexing.set_index(result_count, idx);
-            result_count +=
-                check_predicate(static_cast<int64_t>(idx + vector_index * vector::DEFAULT_VECTOR_CAPACITY), filter);
+            result_count += check_predicate(static_cast<int64_t>(idx + vector_index * vector::DEFAULT_VECTOR_CAPACITY),
+                                            filter,
+                                            error);
+            if (error.contains_error()) {
+                // OOM during predicate evaluation: stop; caller copies to scan_error.
+                return;
+            }
         }
         indexing = new_indexing;
         approved_tuple_count = result_count;
@@ -369,6 +398,13 @@ namespace components::table {
                     }
                 }
                 state.valid_indexing = vector::indexing_vector_t(result.resource(), 0, result.capacity());
+                // Aggregate any per-column pin OOM raised by the scans above.
+                for (auto& cs : state.column_scans) {
+                    if (cs.has_error()) {
+                        state.scan_error = cs.scan_error;
+                        return;
+                    }
+                }
             } else {
                 uint64_t approved_tuple_count = count;
                 vector::indexing_vector_t indexing(result.resource(), result.capacity());
@@ -383,7 +419,11 @@ namespace components::table {
                                     state.vector_index,
                                     indexing,
                                     filter,
-                                    approved_tuple_count);
+                                    approved_tuple_count,
+                                    state.scan_error);
+                    if (state.has_error()) {
+                        return;
+                    }
                 }
                 if (approved_tuple_count == 0) {
                     for (uint64_t i = 0; i < column_ids.size(); i++) {
@@ -433,6 +473,14 @@ namespace components::table {
                                                       approved_tuple_count,
                                                       ALLOW_UPDATES);
                         }
+                    }
+                }
+
+                // Aggregate any per-column pin OOM raised by select/select_committed.
+                for (auto& cs : state.column_scans) {
+                    if (cs.has_error()) {
+                        state.scan_error = cs.scan_error;
+                        return;
                     }
                 }
 
@@ -529,50 +577,64 @@ namespace components::table {
         }
     }
 
-    void row_group_t::initialize_append(row_group_append_state& append_state) {
+    core::result_wrapper_t<bool> row_group_t::initialize_append(row_group_append_state& append_state) {
         append_state.row_group = this;
         append_state.offset_in_row_group = count;
         append_state.states = std::make_unique<column_append_state[]>(get_column_count());
         for (uint64_t i = 0; i < get_column_count(); i++) {
             auto& col_data = get_column(i);
-            col_data.initialize_append(append_state.states[i]);
+            auto init = col_data.initialize_append(append_state.states[i]);
+            if (init.has_error()) {
+                return init; // out_of_memory
+            }
         }
+        return true;
     }
 
-    void row_group_t::append(row_group_append_state& state, vector::data_chunk_t& chunk, uint64_t append_count) {
+    core::result_wrapper_t<bool>
+    row_group_t::append(row_group_append_state& state, vector::data_chunk_t& chunk, uint64_t append_count) {
         assert(chunk.column_count() == get_column_count());
         for (uint64_t i = 0; i < get_column_count(); i++) {
             auto& col_data = get_column(i);
             auto prev_allocation_size = col_data.allocation_size();
-            col_data.append(state.states[i], chunk.data[i], append_count);
+            auto appended = col_data.append(state.states[i], chunk.data[i], append_count);
             allocation_size_ += col_data.allocation_size() - prev_allocation_size;
+            if (appended.has_error()) {
+                return appended; // out_of_memory
+            }
         }
         state.offset_in_row_group += append_count;
+        return true;
     }
 
-    void row_group_t::update(vector::data_chunk_t& update_chunk,
-                             int64_t* ids,
-                             uint64_t offset,
-                             uint64_t count,
-                             const std::vector<uint64_t>& column_ids) {
+    core::result_wrapper_t<bool> row_group_t::update(vector::data_chunk_t& update_chunk,
+                                                    int64_t* ids,
+                                                    uint64_t offset,
+                                                    uint64_t count,
+                                                    const std::vector<uint64_t>& column_ids) {
         for (uint64_t i = 0; i < column_ids.size(); i++) {
             auto column = column_ids[i];
             assert(column != std::numeric_limits<uint64_t>::max());
             auto& col_data = get_column(column);
             assert(col_data.type().type() == update_chunk.data[i].type().type());
-            if (offset > 0) {
-                vector::vector_t sliced_vector(update_chunk.data[i], offset, count);
-                sliced_vector.flatten(count);
-                col_data.update(column, sliced_vector, ids + offset, count);
-            } else {
-                col_data.update(column, update_chunk.data[i], ids, count);
+            core::result_wrapper_t<bool> updated = [&]() -> core::result_wrapper_t<bool> {
+                if (offset > 0) {
+                    vector::vector_t sliced_vector(update_chunk.data[i], offset, count);
+                    sliced_vector.flatten(count);
+                    return col_data.update(column, sliced_vector, ids + offset, count);
+                }
+                return col_data.update(column, update_chunk.data[i], ids, count);
+            }();
+            if (updated.has_error()) {
+                return updated; // write_conflict / out_of_memory
             }
         }
+        return true;
     }
 
-    void row_group_t::update_column(vector::data_chunk_t& updates,
-                                    vector::vector_t& row_ids,
-                                    const std::vector<uint64_t>& column_path) {
+    core::result_wrapper_t<bool> row_group_t::update_column(vector::data_chunk_t& updates,
+                                                          vector::vector_t& row_ids,
+                                                          const std::vector<uint64_t>& column_path) {
         assert(updates.column_count() == 1);
         auto ids = row_ids.data<int64_t>();
 
@@ -580,7 +642,7 @@ namespace components::table {
         assert(primary_column_idx != std::numeric_limits<uint64_t>::max());
         assert(primary_column_idx < columns_.size());
         auto& col_data = get_column(primary_column_idx);
-        col_data.update_column(column_path, updates.data[0], ids, updates.size(), 1);
+        return col_data.update_column(column_path, updates.data[0], ids, updates.size(), 1);
     }
 
     uint64_t row_group_t::committed_row_count() {
@@ -611,6 +673,16 @@ namespace components::table {
         for (uint64_t col_idx = 0; col_idx < get_column_count(); col_idx++) {
             auto& col_data = get_column(col_idx);
             col_data.get_column_segment_info(row_group_index, {col_idx}, result);
+        }
+    }
+
+    void row_group_t::collect_disk_block_ids(std::pmr::vector<uint64_t>& out) {
+        // Only walk columns already materialized in memory; an unloaded/disk-loaded column is iterated
+        // via columns_ lazily by get_column, which is what we want (its segments carry disk block ids).
+        for (auto& column : columns_) {
+            if (column) {
+                column->collect_disk_block_ids(out);
+            }
         }
     }
 
@@ -784,7 +856,8 @@ namespace components::table {
         delete_count += actual_delete_count;
         count = 0;
     }
-    storage::row_group_pointer_t row_group_t::write_to_disk(storage::partial_block_manager_t& partial_block_manager) {
+    core::result_wrapper_t<storage::row_group_pointer_t>
+    row_group_t::write_to_disk(storage::partial_block_manager_t& partial_block_manager) {
         storage::row_group_pointer_t pointer;
         pointer.row_start = static_cast<uint64_t>(start);
         pointer.tuple_count = count;
@@ -794,10 +867,28 @@ namespace components::table {
 
         for (uint64_t i = 0; i < col_count; i++) {
             auto persistent = columns_[i]->checkpoint(partial_block_manager);
-            pointer.data_pointers[i] = std::move(persistent.data_pointers);
+            if (persistent.has_error()) {
+                return persistent.convert_error<storage::row_group_pointer_t>(); // out_of_memory
+            }
+            pointer.data_pointers[i] = std::move(persistent.value().data_pointers);
         }
 
         return pointer;
+    }
+
+    core::result_wrapper_t<bool> row_group_t::transition_to_disk() {
+        // Only transition columns already materialized in memory (a freshly-appended row group). Disk-loaded /
+        // unloaded columns are already disk-backed (block_id < MAXIMUM) -> nothing to do; don't force a load.
+        for (uint64_t i = 0; i < columns_.size(); i++) {
+            if (!columns_[i]) {
+                continue;
+            }
+            auto transitioned = columns_[i]->transition_to_disk();
+            if (transitioned.has_error()) {
+                return transitioned; // io_error / out_of_memory
+            }
+        }
+        return true;
     }
 
     void row_group_t::create_from_pointer(const storage::row_group_pointer_t& pointer) {

--- a/components/table/row_group.hpp
+++ b/components/table/row_group.hpp
@@ -84,19 +84,19 @@ namespace components::table {
 
         // The append chain returns out_of_memory when a column segment allocation fails;
         // true on success.
-        core::result_wrapper_t<bool> initialize_append(row_group_append_state& append_state);
-        core::result_wrapper_t<bool>
+        [[nodiscard]] core::result_wrapper_t<bool> initialize_append(row_group_append_state& append_state);
+        [[nodiscard]] core::result_wrapper_t<bool>
         append(row_group_append_state& append_state, vector::data_chunk_t& chunk, uint64_t append_count);
 
         // Update path returns write_conflict / out_of_memory; true on success.
-        core::result_wrapper_t<bool> update(vector::data_chunk_t& updates,
-                                            int64_t* ids,
-                                            uint64_t offset,
-                                            uint64_t count,
-                                            const std::vector<uint64_t>& column_ids);
-        core::result_wrapper_t<bool> update_column(vector::data_chunk_t& updates,
-                                                   vector::vector_t& row_ids,
-                                                   const std::vector<uint64_t>& column_path);
+        [[nodiscard]] core::result_wrapper_t<bool> update(vector::data_chunk_t& updates,
+                                                          int64_t* ids,
+                                                          uint64_t offset,
+                                                          uint64_t count,
+                                                          const std::vector<uint64_t>& column_ids);
+        [[nodiscard]] core::result_wrapper_t<bool> update_column(vector::data_chunk_t& updates,
+                                                                 vector::vector_t& row_ids,
+                                                                 const std::vector<uint64_t>& column_path);
 
         void get_column_segment_info(uint64_t row_group_index, std::vector<column_segment_info>& result);
 
@@ -106,14 +106,14 @@ namespace components::table {
 
         // The checkpoint chain returns out_of_memory when a column flush pin fails;
         // the row group pointer on success.
-        core::result_wrapper_t<storage::row_group_pointer_t>
+        [[nodiscard]] core::result_wrapper_t<storage::row_group_pointer_t>
         write_to_disk(storage::partial_block_manager_t& partial_block_manager);
         void create_from_pointer(const storage::row_group_pointer_t& pointer);
 
         // Write-through: re-point every COMPLETE managed column segment of this row group to a
         // disk-backed segment (call once the row group is closed -> its segments are final). No-op for
         // in-memory tables. Returns io_error/out_of_memory on failure; true on success.
-        core::result_wrapper_t<bool> transition_to_disk();
+        [[nodiscard]] core::result_wrapper_t<bool> transition_to_disk();
 
         uint64_t allocation_size() const { return allocation_size_; }
 

--- a/components/table/row_group.hpp
+++ b/components/table/row_group.hpp
@@ -57,7 +57,8 @@ namespace components::table {
         void scan(collection_scan_state& state, vector::data_chunk_t& result);
         void scan_committed(collection_scan_state& state, vector::data_chunk_t& result, table_scan_type type);
 
-        bool check_predicate(int64_t row_id, const table_filter_t* filter);
+        // `error` carries an out_of_memory error_t when a pin fails mid-check.
+        bool check_predicate(int64_t row_id, const table_filter_t* filter, core::error_t& error);
 
         void fetch_row(column_fetch_state& state,
                        const std::vector<storage_index_t>& column_ids,
@@ -81,22 +82,38 @@ namespace components::table {
         // (pending txn id or commit id newer than the visible-to-all horizon).
         bool has_version_above(uint64_t watermark);
 
-        void initialize_append(row_group_append_state& append_state);
-        void append(row_group_append_state& append_state, vector::data_chunk_t& chunk, uint64_t append_count);
+        // The append chain returns out_of_memory when a column segment allocation fails;
+        // true on success.
+        core::result_wrapper_t<bool> initialize_append(row_group_append_state& append_state);
+        core::result_wrapper_t<bool>
+        append(row_group_append_state& append_state, vector::data_chunk_t& chunk, uint64_t append_count);
 
-        void update(vector::data_chunk_t& updates,
-                    int64_t* ids,
-                    uint64_t offset,
-                    uint64_t count,
-                    const std::vector<uint64_t>& column_ids);
-        void update_column(vector::data_chunk_t& updates,
-                           vector::vector_t& row_ids,
-                           const std::vector<uint64_t>& column_path);
+        // Update path returns write_conflict / out_of_memory; true on success.
+        core::result_wrapper_t<bool> update(vector::data_chunk_t& updates,
+                                            int64_t* ids,
+                                            uint64_t offset,
+                                            uint64_t count,
+                                            const std::vector<uint64_t>& column_ids);
+        core::result_wrapper_t<bool> update_column(vector::data_chunk_t& updates,
+                                                   vector::vector_t& row_ids,
+                                                   const std::vector<uint64_t>& column_path);
 
         void get_column_segment_info(uint64_t row_group_index, std::vector<column_segment_info>& result);
 
-        storage::row_group_pointer_t write_to_disk(storage::partial_block_manager_t& partial_block_manager);
+        // Append the ids of disk blocks exclusively owned by this row group's columns (and their
+        // sub-columns) to `out`, so a compacting caller can free them after swapping the collection.
+        void collect_disk_block_ids(std::pmr::vector<uint64_t>& out);
+
+        // The checkpoint chain returns out_of_memory when a column flush pin fails;
+        // the row group pointer on success.
+        core::result_wrapper_t<storage::row_group_pointer_t>
+        write_to_disk(storage::partial_block_manager_t& partial_block_manager);
         void create_from_pointer(const storage::row_group_pointer_t& pointer);
+
+        // Write-through: re-point every COMPLETE managed column segment of this row group to a
+        // disk-backed segment (call once the row group is closed -> its segments are final). No-op for
+        // in-memory tables. Returns io_error/out_of_memory on failure; true on success.
+        core::result_wrapper_t<bool> transition_to_disk();
 
         uint64_t allocation_size() const { return allocation_size_; }
 
@@ -125,7 +142,8 @@ namespace components::table {
                              uint64_t vector_index,
                              vector::indexing_vector_t& indexing,
                              const table_filter_t* filter,
-                             uint64_t& approved_tuple_count);
+                             uint64_t& approved_tuple_count,
+                             core::error_t& error);
 
         template<table_scan_type TYPE>
         void templated_scan(collection_scan_state& state, vector::data_chunk_t& result);

--- a/components/table/segment_tree.hpp
+++ b/components/table/segment_tree.hpp
@@ -167,6 +167,33 @@ namespace components::table {
             nodes_ = std::move(other.nodes_);
         }
 
+        // Swap the backing of a SINGLE node in place (write-through re-point): the new node must
+        // carry the SAME row range (start/count/row_start) as the one it replaces -- only its block backing
+        // differs (managed in-memory -> disk-backed). Preserves index/row_start and FIXES the intrusive list:
+        //   * the new node inherits the old node's index, start and next link,
+        //   * the PREVIOUS node's next link is re-pointed at the new node,
+        //   * (the new node's own next already pointed at by the next node's link is unchanged -- that link
+        //     lives on the *next* node and still references position index+1, which is untouched).
+        // Caller must hold the tree lock. The old node (and its managed block_handle) is released on return.
+        void replace_segment_at_index(std::unique_lock<std::mutex>& l, uint64_t index, std::unique_ptr<T> new_node) {
+            load_all_segments(l);
+            assert(index < nodes_.size());
+            assert(new_node);
+            auto& entry = nodes_[index];
+            assert(new_node->start == entry.node->start);
+            assert(new_node->count.load() == entry.node->count.load());
+            // Inherit the old node's intrusive-list position.
+            new_node->index = index;
+            new_node->next = entry.node->next;
+            // Re-point the previous node's forward link at the new node so iteration stays intact.
+            if (index > 0) {
+                nodes_[index - 1].node->next = new_node.get();
+            }
+            // row_start is unchanged (same start); swap the backing.
+            entry.row_start = new_node->start;
+            entry.node = std::move(new_node);
+        }
+
         void erase_segments(std::unique_lock<std::mutex>& l, uint64_t segment_start) {
             load_all_segments(l);
             if (segment_start >= nodes_.size() - 1) {

--- a/components/table/standard_column_data.cpp
+++ b/components/table/standard_column_data.cpp
@@ -72,23 +72,46 @@ namespace components::table {
         return scan_count;
     }
 
-    void standard_column_data_t::initialize_append(column_append_state& state) {
-        column_data_t::initialize_append(state);
+    core::result_wrapper_t<bool> standard_column_data_t::initialize_append(column_append_state& state) {
+        auto base = column_data_t::initialize_append(state);
+        if (base.has_error()) {
+            return base; // out_of_memory (rules 2/9)
+        }
         column_append_state child_append;
-        validity.initialize_append(child_append);
+        auto child = validity.initialize_append(child_append);
+        if (child.has_error()) {
+            return child;
+        }
         state.child_appends.push_back(std::move(child_append));
+        return true;
     }
 
-    void standard_column_data_t::append_data(column_append_state& state,
-                                             vector::unified_vector_format& uvf,
-                                             uint64_t count) {
-        column_data_t::append_data(state, uvf, count);
-        validity.append_data(state.child_appends[0], uvf, count);
+    core::result_wrapper_t<bool> standard_column_data_t::append_data(column_append_state& state,
+                                                                    vector::unified_vector_format& uvf,
+                                                                    uint64_t count) {
+        auto base = column_data_t::append_data(state, uvf, count);
+        if (base.has_error()) {
+            return base; // out_of_memory (rules 2/9)
+        }
+        return validity.append_data(state.child_appends[0], uvf, count);
     }
 
     void standard_column_data_t::revert_append(int64_t start_row) {
         column_data_t::revert_append(start_row);
         validity.revert_append(start_row);
+    }
+
+    core::result_wrapper_t<bool> standard_column_data_t::transition_to_disk() {
+        auto base = column_data_t::transition_to_disk();
+        if (base.has_error()) {
+            return base; // io_error / out_of_memory (rules 2/9)
+        }
+        return validity.transition_to_disk();
+    }
+
+    void standard_column_data_t::collect_disk_block_ids(std::pmr::vector<uint64_t>& out) const {
+        column_data_t::collect_disk_block_ids(out);
+        validity.collect_disk_block_ids(out);
     }
 
     uint64_t standard_column_data_t::fetch(column_scan_state& state, int64_t row_id, vector::vector_t& result) {
@@ -101,23 +124,26 @@ namespace components::table {
         return scan_count;
     }
 
-    void standard_column_data_t::update(uint64_t column_index,
-                                        vector::vector_t& update_vector,
-                                        int64_t* row_ids,
-                                        uint64_t update_count) {
-        column_data_t::update(column_index, update_vector, row_ids, update_count);
-        validity.update(column_index, update_vector, row_ids, update_count);
+    core::result_wrapper_t<bool> standard_column_data_t::update(uint64_t column_index,
+                                                              vector::vector_t& update_vector,
+                                                              int64_t* row_ids,
+                                                              uint64_t update_count) {
+        auto base = column_data_t::update(column_index, update_vector, row_ids, update_count);
+        if (base.has_error()) {
+            return base;
+        }
+        return validity.update(column_index, update_vector, row_ids, update_count);
     }
 
-    void standard_column_data_t::update_column(const std::vector<uint64_t>& column_path,
-                                               vector::vector_t& update_vector,
-                                               int64_t* row_ids,
-                                               uint64_t update_count,
-                                               uint64_t depth) {
+    core::result_wrapper_t<bool> standard_column_data_t::update_column(const std::vector<uint64_t>& column_path,
+                                                                     vector::vector_t& update_vector,
+                                                                     int64_t* row_ids,
+                                                                     uint64_t update_count,
+                                                                     uint64_t depth) {
         if (depth >= column_path.size()) {
-            column_data_t::update(column_path[0], update_vector, row_ids, update_count);
+            return column_data_t::update(column_path[0], update_vector, row_ids, update_count);
         } else {
-            validity.update_column(column_path, update_vector, row_ids, update_count, depth + 1);
+            return validity.update_column(column_path, update_vector, row_ids, update_count, depth + 1);
         }
     }
 

--- a/components/table/standard_column_data.hpp
+++ b/components/table/standard_column_data.hpp
@@ -31,22 +31,22 @@ namespace components::table {
                                 uint64_t target_count) override;
         uint64_t scan_count(column_scan_state& state, vector::vector_t& result, uint64_t count) override;
 
-        core::result_wrapper_t<bool> initialize_append(column_append_state& state) override;
-        core::result_wrapper_t<bool>
+        [[nodiscard]] core::result_wrapper_t<bool> initialize_append(column_append_state& state) override;
+        [[nodiscard]] core::result_wrapper_t<bool>
         append_data(column_append_state& state, vector::unified_vector_format& uvf, uint64_t count) override;
         void revert_append(int64_t start_row) override;
         uint64_t fetch(column_scan_state& state, int64_t row_id, vector::vector_t& result) override;
         void
         fetch_row(column_fetch_state& state, int64_t row_id, vector::vector_t& result, uint64_t result_idx) override;
-        core::result_wrapper_t<bool> update(uint64_t column_index,
-                                            vector::vector_t& update_vector,
-                                            int64_t* row_ids,
-                                            uint64_t update_count) override;
-        core::result_wrapper_t<bool> update_column(const std::vector<uint64_t>& column_pasth,
-                                                   vector::vector_t& update_vector,
-                                                   int64_t* row_ids,
-                                                   uint64_t update_count,
-                                                   uint64_t depth) override;
+        [[nodiscard]] core::result_wrapper_t<bool> update(uint64_t column_index,
+                                                          vector::vector_t& update_vector,
+                                                          int64_t* row_ids,
+                                                          uint64_t update_count) override;
+        [[nodiscard]] core::result_wrapper_t<bool> update_column(const std::vector<uint64_t>& column_pasth,
+                                                                 vector::vector_t& update_vector,
+                                                                 int64_t* row_ids,
+                                                                 uint64_t update_count,
+                                                                 uint64_t depth) override;
 
         void get_column_segment_info(uint64_t row_group_index,
                                      std::vector<uint64_t> col_path,
@@ -55,7 +55,7 @@ namespace components::table {
         void initialize_column(const persistent_column_data_t& persistent_data) override;
 
         // Transition the main data segments AND the validity child's segments to disk.
-        core::result_wrapper_t<bool> transition_to_disk() override;
+        [[nodiscard]] core::result_wrapper_t<bool> transition_to_disk() override;
 
         // Compact reclaim: collect the main column's blocks AND the validity child's blocks.
         void collect_disk_block_ids(std::pmr::vector<uint64_t>& out) const override;

--- a/components/table/standard_column_data.hpp
+++ b/components/table/standard_column_data.hpp
@@ -31,27 +31,34 @@ namespace components::table {
                                 uint64_t target_count) override;
         uint64_t scan_count(column_scan_state& state, vector::vector_t& result, uint64_t count) override;
 
-        void initialize_append(column_append_state& state) override;
-        void append_data(column_append_state& state, vector::unified_vector_format& uvf, uint64_t count) override;
+        core::result_wrapper_t<bool> initialize_append(column_append_state& state) override;
+        core::result_wrapper_t<bool>
+        append_data(column_append_state& state, vector::unified_vector_format& uvf, uint64_t count) override;
         void revert_append(int64_t start_row) override;
         uint64_t fetch(column_scan_state& state, int64_t row_id, vector::vector_t& result) override;
         void
         fetch_row(column_fetch_state& state, int64_t row_id, vector::vector_t& result, uint64_t result_idx) override;
-        void update(uint64_t column_index,
-                    vector::vector_t& update_vector,
-                    int64_t* row_ids,
-                    uint64_t update_count) override;
-        void update_column(const std::vector<uint64_t>& column_pasth,
-                           vector::vector_t& update_vector,
-                           int64_t* row_ids,
-                           uint64_t update_count,
-                           uint64_t depth) override;
+        core::result_wrapper_t<bool> update(uint64_t column_index,
+                                            vector::vector_t& update_vector,
+                                            int64_t* row_ids,
+                                            uint64_t update_count) override;
+        core::result_wrapper_t<bool> update_column(const std::vector<uint64_t>& column_pasth,
+                                                   vector::vector_t& update_vector,
+                                                   int64_t* row_ids,
+                                                   uint64_t update_count,
+                                                   uint64_t depth) override;
 
         void get_column_segment_info(uint64_t row_group_index,
                                      std::vector<uint64_t> col_path,
                                      std::vector<column_segment_info>& result) override;
 
         void initialize_column(const persistent_column_data_t& persistent_data) override;
+
+        // Transition the main data segments AND the validity child's segments to disk.
+        core::result_wrapper_t<bool> transition_to_disk() override;
+
+        // Compact reclaim: collect the main column's blocks AND the validity child's blocks.
+        void collect_disk_block_ids(std::pmr::vector<uint64_t>& out) const override;
     };
 
 } // namespace components::table

--- a/components/table/storage/block_handle.cpp
+++ b/components/table/storage/block_handle.cpp
@@ -155,7 +155,7 @@ namespace components::table::storage {
         return buffer_handle_t(this, buffer_.get());
     }
 
-    buffer_handle_t block_handle_t::load(std::unique_ptr<file_buffer_t> reusable_buffer) {
+    core::result_wrapper_t<buffer_handle_t> block_handle_t::load(std::unique_ptr<file_buffer_t> reusable_buffer) {
         if (state_ == block_state::LOADED) {
             assert(buffer_);
             ++readers_;
@@ -164,10 +164,15 @@ namespace components::table::storage {
 
         if (block_id_ < MAXIMUM_BLOCK) {
             auto block = allocate_block(block_manager, std::move(reusable_buffer), block_id_);
-            block_manager.read(*block);
+            // Disk reload: surface a checksum/IO failure as a value (data_corruption/io_error) rather than
+            // throwing. The block stays UNLOADED on error.
+            auto read_result = block_manager.read(*block);
+            if (read_result.has_error()) {
+                return read_result.convert_error<buffer_handle_t>();
+            }
             buffer_ = std::move(block);
         } else {
-            return {};
+            return buffer_handle_t{};
         }
         state_ = block_state::LOADED;
         readers_ = 1;
@@ -196,6 +201,11 @@ namespace components::table::storage {
             return false;
         }
         if (readers_ > 0) {
+            return false;
+        }
+        if (!is_reloadable()) {
+            // No disk copy (managed in-memory block): load() would return {} -> can never reload.
+            // Never unload such a block; keep it resident. (Hard safety net for evict + purge paths.)
             return false;
         }
         return true;

--- a/components/table/storage/block_handle.hpp
+++ b/components/table/storage/block_handle.hpp
@@ -143,7 +143,7 @@ namespace components::table::storage {
         // Reload-from-disk path (block_id < MAXIMUM_BLOCK) calls block_manager.read(), which can fail with
         // data_corruption/io_error -- forwarded here instead of throwing. Already-LOADED and
         // managed-in-memory ({}) fast paths return a valid handle with no error.
-        core::result_wrapper_t<buffer_handle_t> load(std::unique_ptr<file_buffer_t> buffer = nullptr);
+        [[nodiscard]] core::result_wrapper_t<buffer_handle_t> load(std::unique_ptr<file_buffer_t> buffer = nullptr);
         buffer_handle_t load_from_buffer(std::unique_lock<std::mutex>& l,
                                          std::byte* data,
                                          std::unique_ptr<file_buffer_t> reusable_buffer,

--- a/components/table/storage/block_handle.hpp
+++ b/components/table/storage/block_handle.hpp
@@ -5,6 +5,9 @@
 #include <memory>
 #include <mutex>
 
+#include <core/result_wrapper.hpp>
+
+#include "buffer_handle.hpp"
 #include "file_buffer.hpp"
 
 namespace components::table::storage {
@@ -100,6 +103,12 @@ namespace components::table::storage {
 
         bool must_add_to_eviction_queue() const { return destroy_condition_ != destroy_buffer_condition::UNPIN; }
 
+        // Reloadable iff a disk copy exists (block_id < MAXIMUM_BLOCK): load() can re-read it via the block
+        // manager. Managed in-memory blocks (block_id >= MAXIMUM_BLOCK) have no backing store -- load() returns
+        // {} for them, so they must never be unloaded/evicted (a later re-pin would deref a null buffer).
+        // Same condition load() uses.
+        bool is_reloadable() const { return block_id_ < MAXIMUM_BLOCK; }
+
         uint64_t memory_usage() const { return memory_usage_; }
 
         bool is_unloaded() const { return state_ == block_state::UNLOADED; }
@@ -131,7 +140,10 @@ namespace components::table::storage {
         void resize_memory(std::unique_lock<std::mutex>&, uint64_t alloc_size);
 
         void resize_buffer(std::unique_lock<std::mutex>&, uint64_t block_size, int64_t memory_delta);
-        buffer_handle_t load(std::unique_ptr<file_buffer_t> buffer = nullptr);
+        // Reload-from-disk path (block_id < MAXIMUM_BLOCK) calls block_manager.read(), which can fail with
+        // data_corruption/io_error -- forwarded here instead of throwing. Already-LOADED and
+        // managed-in-memory ({}) fast paths return a valid handle with no error.
+        core::result_wrapper_t<buffer_handle_t> load(std::unique_ptr<file_buffer_t> buffer = nullptr);
         buffer_handle_t load_from_buffer(std::unique_lock<std::mutex>& l,
                                          std::byte* data,
                                          std::unique_ptr<file_buffer_t> reusable_buffer,

--- a/components/table/storage/block_manager.hpp
+++ b/components/table/storage/block_manager.hpp
@@ -35,7 +35,7 @@ namespace components::table::storage {
         // Returns true on success, or core::error_code_t::data_corruption (checksum mismatch on disk reload) /
         // io_error. Disk reload makes the checksum path reachable on the agent thread, so the failure must
         // surface via result_wrapper_t rather than a throw.
-        virtual core::result_wrapper_t<bool> read(block_t& block) = 0;
+        [[nodiscard]] virtual core::result_wrapper_t<bool> read(block_t& block) = 0;
         virtual void read_blocks(file_buffer_t& buffer, uint64_t start_block, uint64_t block_count) = 0;
         virtual void write(file_buffer_t& block, uint64_t block_id) = 0;
         void write(block_t& block) { write(block, block.id); }

--- a/components/table/storage/block_manager.hpp
+++ b/components/table/storage/block_manager.hpp
@@ -4,6 +4,8 @@
 #include <stdexcept>
 #include <unordered_map>
 
+#include <core/result_wrapper.hpp>
+
 #include "file_buffer.hpp"
 
 namespace components::table::storage {
@@ -30,7 +32,10 @@ namespace components::table::storage {
         virtual void mark_as_modified(uint64_t block_id) = 0;
         virtual void increase_block_ref_count(uint64_t block_id) = 0;
         virtual uint64_t meta_block() = 0;
-        virtual void read(block_t& block) = 0;
+        // Returns true on success, or core::error_code_t::data_corruption (checksum mismatch on disk reload) /
+        // io_error. Disk reload makes the checksum path reachable on the agent thread, so the failure must
+        // surface via result_wrapper_t rather than a throw.
+        virtual core::result_wrapper_t<bool> read(block_t& block) = 0;
         virtual void read_blocks(file_buffer_t& buffer, uint64_t start_block, uint64_t block_count) = 0;
         virtual void write(file_buffer_t& block, uint64_t block_id) = 0;
         void write(block_t& block) { write(block, block.id); }

--- a/components/table/storage/buffer_manager.cpp
+++ b/components/table/storage/buffer_manager.cpp
@@ -4,16 +4,20 @@
 
 namespace components::table::storage {
 
-    std::shared_ptr<block_handle_t> buffer_manager_t::register_transient_memory(uint64_t, uint64_t) {
+    // The logic_error throws below are not OOM errors: they guard against calling a memory-registration entry
+    // point on a buffer_manager_t subtype that does not support it -- a programming error.
+    core::result_wrapper_t<std::shared_ptr<block_handle_t>>
+    buffer_manager_t::register_transient_memory(uint64_t, uint64_t) {
         throw std::logic_error(
             "Incorrect call: This type of buffer_manager_t can not create 'transient-memory' blocks");
     }
 
-    std::shared_ptr<block_handle_t> buffer_manager_t::register_small_memory(uint64_t size) {
+    core::result_wrapper_t<std::shared_ptr<block_handle_t>> buffer_manager_t::register_small_memory(uint64_t size) {
         return register_small_memory(memory_tag::BASE_TABLE, size);
     }
 
-    std::shared_ptr<block_handle_t> buffer_manager_t::register_small_memory(memory_tag, uint64_t) {
+    core::result_wrapper_t<std::shared_ptr<block_handle_t>> buffer_manager_t::register_small_memory(memory_tag,
+                                                                                                   uint64_t) {
         throw std::logic_error("Incorrect call: This type of buffer_manager_t can not create 'small-memory' blocks");
     }
 
@@ -24,7 +28,7 @@ namespace components::table::storage {
         throw std::logic_error("Incorrect call: This type of buffer_manager_t can not free reserved memory");
     }
 
-    void buffer_manager_t::set_memory_limit(uint64_t) {
+    core::result_wrapper_t<bool> buffer_manager_t::set_memory_limit(uint64_t) {
         throw std::logic_error("Incorrect call: This type of buffer_manager_t can not set a memory limit");
     }
 

--- a/components/table/storage/buffer_manager.hpp
+++ b/components/table/storage/buffer_manager.hpp
@@ -40,22 +40,24 @@ namespace components::table::storage {
         buffer_manager_t() = default;
         virtual ~buffer_manager_t() = default;
 
-        virtual core::result_wrapper_t<buffer_handle_t>
+        [[nodiscard]] virtual core::result_wrapper_t<buffer_handle_t>
         allocate(memory_tag tag, uint64_t block_size, bool can_destroy = true) = 0;
         // Returns true on success; result_wrapper_t<bool> rather than <void> because result_wrapper_t forbids
         // void (`!is_same_v<T, void>` constraint).
-        virtual core::result_wrapper_t<bool> reallocate(std::shared_ptr<block_handle_t>& handle, uint64_t block_size) = 0;
-        virtual core::result_wrapper_t<buffer_handle_t> pin(std::shared_ptr<block_handle_t>& handle) = 0;
+        [[nodiscard]] virtual core::result_wrapper_t<bool>
+        reallocate(std::shared_ptr<block_handle_t>& handle, uint64_t block_size) = 0;
+        [[nodiscard]] virtual core::result_wrapper_t<buffer_handle_t> pin(std::shared_ptr<block_handle_t>& handle) = 0;
         virtual void prefetch(std::vector<std::shared_ptr<block_handle_t>>& handles) = 0;
         virtual void unpin(block_handle_t* handle) = 0;
 
         virtual uint64_t block_allocation_size() const = 0;
         virtual uint64_t block_size() const = 0;
 
-        virtual core::result_wrapper_t<std::shared_ptr<block_handle_t>>
+        [[nodiscard]] virtual core::result_wrapper_t<std::shared_ptr<block_handle_t>>
         register_transient_memory(uint64_t size, uint64_t block_size);
-        virtual core::result_wrapper_t<std::shared_ptr<block_handle_t>> register_small_memory(uint64_t size);
-        virtual core::result_wrapper_t<std::shared_ptr<block_handle_t>>
+        [[nodiscard]] virtual core::result_wrapper_t<std::shared_ptr<block_handle_t>>
+        register_small_memory(uint64_t size);
+        [[nodiscard]] virtual core::result_wrapper_t<std::shared_ptr<block_handle_t>>
         register_small_memory(memory_tag tag, uint64_t size);
 
         virtual void reserve_memory(uint64_t size);
@@ -63,7 +65,8 @@ namespace components::table::storage {
         virtual std::vector<memory_info_t> get_memory_usage_info() const = 0;
         // Returns out_of_memory when eviction can't shrink to the new limit; forwards
         // buffer_pool_t::set_limit's result.
-        virtual core::result_wrapper_t<bool> set_memory_limit(uint64_t limit = std::numeric_limits<uint64_t>::max());
+        [[nodiscard]] virtual core::result_wrapper_t<bool>
+        set_memory_limit(uint64_t limit = std::numeric_limits<uint64_t>::max());
 
         virtual std::unique_ptr<file_buffer_t>
         construct_manager_buffer(uint64_t size,

--- a/components/table/storage/buffer_manager.hpp
+++ b/components/table/storage/buffer_manager.hpp
@@ -2,6 +2,8 @@
 
 #include <filesystem>
 
+#include <core/result_wrapper.hpp>
+
 #include "block_handle.hpp"
 
 namespace core::filesystem {
@@ -38,23 +40,30 @@ namespace components::table::storage {
         buffer_manager_t() = default;
         virtual ~buffer_manager_t() = default;
 
-        virtual buffer_handle_t allocate(memory_tag tag, uint64_t block_size, bool can_destroy = true) = 0;
-        virtual void reallocate(std::shared_ptr<block_handle_t>& handle, uint64_t block_size) = 0;
-        virtual buffer_handle_t pin(std::shared_ptr<block_handle_t>& handle) = 0;
+        virtual core::result_wrapper_t<buffer_handle_t>
+        allocate(memory_tag tag, uint64_t block_size, bool can_destroy = true) = 0;
+        // Returns true on success; result_wrapper_t<bool> rather than <void> because result_wrapper_t forbids
+        // void (`!is_same_v<T, void>` constraint).
+        virtual core::result_wrapper_t<bool> reallocate(std::shared_ptr<block_handle_t>& handle, uint64_t block_size) = 0;
+        virtual core::result_wrapper_t<buffer_handle_t> pin(std::shared_ptr<block_handle_t>& handle) = 0;
         virtual void prefetch(std::vector<std::shared_ptr<block_handle_t>>& handles) = 0;
         virtual void unpin(block_handle_t* handle) = 0;
 
         virtual uint64_t block_allocation_size() const = 0;
         virtual uint64_t block_size() const = 0;
 
-        virtual std::shared_ptr<block_handle_t> register_transient_memory(uint64_t size, uint64_t block_size);
-        virtual std::shared_ptr<block_handle_t> register_small_memory(uint64_t size);
-        virtual std::shared_ptr<block_handle_t> register_small_memory(memory_tag tag, uint64_t size);
+        virtual core::result_wrapper_t<std::shared_ptr<block_handle_t>>
+        register_transient_memory(uint64_t size, uint64_t block_size);
+        virtual core::result_wrapper_t<std::shared_ptr<block_handle_t>> register_small_memory(uint64_t size);
+        virtual core::result_wrapper_t<std::shared_ptr<block_handle_t>>
+        register_small_memory(memory_tag tag, uint64_t size);
 
         virtual void reserve_memory(uint64_t size);
         virtual void free_reserved_memory(uint64_t size);
         virtual std::vector<memory_info_t> get_memory_usage_info() const = 0;
-        virtual void set_memory_limit(uint64_t limit = std::numeric_limits<uint64_t>::max());
+        // Returns out_of_memory when eviction can't shrink to the new limit; forwards
+        // buffer_pool_t::set_limit's result.
+        virtual core::result_wrapper_t<bool> set_memory_limit(uint64_t limit = std::numeric_limits<uint64_t>::max());
 
         virtual std::unique_ptr<file_buffer_t>
         construct_manager_buffer(uint64_t size,

--- a/components/table/storage/buffer_pool.cpp
+++ b/components/table/storage/buffer_pool.cpp
@@ -181,19 +181,24 @@ namespace components::table::storage {
         }
     }
 
-    void buffer_pool_t::set_limit(uint64_t limit) {
+    core::result_wrapper_t<bool> buffer_pool_t::set_limit(uint64_t limit) {
         std::lock_guard l_lock(limit_lock);
         if (!evict_blocks(memory_tag::EXTENSION, 0, limit).success) {
-            throw std::runtime_error("Failed to change memory limit to " + std::to_string(limit) +
-                                     ": could not free up enough memory for the new limit");
+            return core::error_t(core::error_code_t::out_of_memory,
+                                 std::pmr::string{"Failed to change memory limit to " + std::to_string(limit) +
+                                                      ": could not free up enough memory for the new limit",
+                                                  resource});
         }
         uint64_t old_limit = maximum_memory;
         maximum_memory = limit;
         if (!evict_blocks(memory_tag::EXTENSION, 0, limit).success) {
             maximum_memory = old_limit;
-            throw std::runtime_error("Failed to change memory limit to " + std::to_string(limit) +
-                                     ": could not free up enough memory for the new limit");
+            return core::error_t(core::error_code_t::out_of_memory,
+                                 std::pmr::string{"Failed to change memory limit to " + std::to_string(limit) +
+                                                      ": could not free up enough memory for the new limit",
+                                                  resource});
         }
+        return true;
     }
 
     void buffer_pool_t::set_allocator_bulk_dealloc_flush_threashold(uint64_t threshold) {
@@ -222,8 +227,12 @@ namespace components::table::storage {
                 return block_result;
             }
         }
-        throw std::runtime_error(
-            "Exited buffer_pool_t::evict_blocks_internal without obtaining buffer_pool_t::eviction_result");
+        // Unreachable: the loop above always returns on the last queue (`queue.get() == queues.back().get()`),
+        // and `queues` is non-empty (the ctor pushes one queue per file_buffer_type). Programming invariant,
+        // not a runtime error -- assert instead of throwing.
+        assert(false &&
+               "Exited buffer_pool_t::evict_blocks_internal without obtaining buffer_pool_t::eviction_result");
+        return evict_blocks_internal(*queues.back(), tag, extra_memory, memory_limit, buffer);
     }
 
     buffer_pool_t::eviction_result buffer_pool_t::evict_blocks_internal(eviction_queue_t& queue,

--- a/components/table/storage/buffer_pool.hpp
+++ b/components/table/storage/buffer_pool.hpp
@@ -87,7 +87,9 @@ namespace components::table::storage {
                       bool track_eviction_timestamps,
                       uint64_t allocator_bulk_deallocation_flush_threshold);
 
-        void set_limit(uint64_t limit);
+        // Returns out_of_memory when eviction cannot free enough for the new limit. maximum_memory is
+        // restored on the second-pass failure before returning the error.
+        core::result_wrapper_t<bool> set_limit(uint64_t limit);
 
         void set_allocator_bulk_dealloc_flush_threashold(uint64_t threshold);
         uint64_t get_allocator_bulk_dealloc_flush_threashold();

--- a/components/table/storage/buffer_pool.hpp
+++ b/components/table/storage/buffer_pool.hpp
@@ -89,7 +89,7 @@ namespace components::table::storage {
 
         // Returns out_of_memory when eviction cannot free enough for the new limit. maximum_memory is
         // restored on the second-pass failure before returning the error.
-        core::result_wrapper_t<bool> set_limit(uint64_t limit);
+        [[nodiscard]] core::result_wrapper_t<bool> set_limit(uint64_t limit);
 
         void set_allocator_bulk_dealloc_flush_threashold(uint64_t threshold);
         uint64_t get_allocator_bulk_dealloc_flush_threashold();

--- a/components/table/storage/in_memory_block_manager.hpp
+++ b/components/table/storage/in_memory_block_manager.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "block_manager.hpp"
+#include "buffer_manager.hpp" // complete buffer_manager_t so read() can use its resource() (no null/default resource)
 
 namespace components::table::storage {
 
@@ -38,7 +39,14 @@ namespace components::table::storage {
         uint64_t meta_block() override {
             throw std::logic_error("Cannot perform IO in in-memory database - meta_block!");
         }
-        void read(block_t&) override { throw std::logic_error("Cannot perform IO in in-memory database - read!"); }
+        // Unreachable for in-memory blocks (block_id >= MAXIMUM_BLOCK are never disk-reloaded; block_handle_t::load
+        // returns {} for them without calling read()). Returns io_error rather than throwing, to keep the virtual
+        // signature uniform with the disk manager. The message string uses the buffer manager's own resource.
+        core::result_wrapper_t<bool> read(block_t&) override {
+            return core::error_t(core::error_code_t::io_error,
+                                 std::pmr::string{"in-memory block manager cannot perform disk read",
+                                                  buffer_manager.resource()});
+        }
         void read_blocks(file_buffer_t&, uint64_t, uint64_t) override {
             throw std::logic_error("Cannot perform IO in in-memory database - read_blocks!");
         }

--- a/components/table/storage/in_memory_block_manager.hpp
+++ b/components/table/storage/in_memory_block_manager.hpp
@@ -42,7 +42,7 @@ namespace components::table::storage {
         // Unreachable for in-memory blocks (block_id >= MAXIMUM_BLOCK are never disk-reloaded; block_handle_t::load
         // returns {} for them without calling read()). Returns io_error rather than throwing, to keep the virtual
         // signature uniform with the disk manager. The message string uses the buffer manager's own resource.
-        core::result_wrapper_t<bool> read(block_t&) override {
+        [[nodiscard]] core::result_wrapper_t<bool> read(block_t&) override {
             return core::error_t(core::error_code_t::io_error,
                                  std::pmr::string{"in-memory block manager cannot perform disk read",
                                                   buffer_manager.resource()});

--- a/components/table/storage/metadata_manager.cpp
+++ b/components/table/storage/metadata_manager.cpp
@@ -60,7 +60,13 @@ namespace components::table::storage {
         // block not loaded yet — load from disk
         auto resource = block_manager_.buffer_manager.resource();
         auto block = std::make_unique<block_t>(resource, block_id, static_cast<uint64_t>(block_manager_.block_size()));
-        block_manager_.read(*block);
+        // read() returns a value (data_corruption/io_error). pin can run inside the table_storage_t DISK ctor
+        // on the agent thread (bootstrap_disk_inner_sync, noexcept), so it MUST NOT throw: record the sticky
+        // error and return nullptr; metadata_reader_t checks has_error()/null and unwinds.
+        if (auto read_result = block_manager_.read(*block); read_result.has_error()) {
+            error_ = read_result.error();
+            return nullptr;
+        }
 
         metadata_block_t mb;
         mb.block_id = block_id;

--- a/components/table/storage/metadata_manager.hpp
+++ b/components/table/storage/metadata_manager.hpp
@@ -6,6 +6,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include <core/result_wrapper.hpp>
+
 #include "block_manager.hpp"
 #include "file_buffer.hpp"
 
@@ -21,8 +23,15 @@ namespace components::table::storage {
         // Allocate a sub-block handle, returns meta_block_pointer_t
         meta_block_pointer_t allocate_handle();
 
-        // Pin a sub-block and return pointer to its data
+        // Pin a sub-block and return a pointer to its data, or nullptr if loading the backing block from
+        // disk failed (data_corruption/io_error). On the load path pin runs inside the table_storage_t DISK
+        // ctor (reachable on the agent thread via bootstrap_disk_inner_sync, noexcept), so it MUST NOT throw:
+        // instead it records a sticky error_t here that metadata_reader_t propagates. The write path never
+        // triggers a disk read in pin, so has_error() stays clear there.
         std::byte* pin(meta_block_pointer_t pointer);
+
+        bool has_error() const noexcept { return error_.contains_error(); }
+        const core::error_t& error() const noexcept { return error_; }
 
         // Get the size of a single sub-block
         uint64_t sub_block_size() const { return sub_block_size_; }
@@ -44,6 +53,8 @@ namespace components::table::storage {
         uint64_t sub_block_size_;
         std::mutex lock_;
         std::vector<metadata_block_t> blocks_;
+        // Sticky load error: set by pin() when block_manager_.read() fails, surfaced to metadata_reader_t.
+        core::error_t error_{core::error_t::no_error()};
     };
 
 } // namespace components::table::storage

--- a/components/table/storage/metadata_reader.cpp
+++ b/components/table/storage/metadata_reader.cpp
@@ -4,6 +4,8 @@
 #include <cstring>
 #include <stdexcept>
 
+#include "buffer_manager.hpp"
+
 namespace components::table::storage {
 
     metadata_reader_t::metadata_reader_t(metadata_manager_t& manager, meta_block_pointer_t start)
@@ -15,6 +17,11 @@ namespace components::table::storage {
             return;
         }
         current_data_ = manager_.pin(current_pointer_);
+        // pin returns nullptr + records a sticky error on a disk-read failure instead of throwing. Adopt it
+        // as our own corrupt-stream error so every subsequent read is a no-op.
+        if (current_data_ == nullptr && manager_.has_error()) {
+            error_ = manager_.error();
+        }
         current_offset_ = SUB_BLOCK_HEADER_SIZE;
     }
 
@@ -32,19 +39,37 @@ namespace components::table::storage {
 
         current_pointer_ = meta_block_pointer_t(next_bp, next_offset);
         current_data_ = manager_.pin(current_pointer_);
+        if (current_data_ == nullptr && manager_.has_error()) {
+            error_ = manager_.error();
+        }
         current_offset_ = SUB_BLOCK_HEADER_SIZE;
     }
 
     void metadata_reader_t::read_data(std::byte* data, uint64_t size) {
+        // Once the stream is known corrupt, every further read is a no-op (data was zero-initialized by the
+        // caller / read<T>()), so the deserialize chain unwinds safely until the load boundary checks
+        // has_error().
+        if (has_error()) {
+            return;
+        }
         uint64_t read_bytes = 0;
         while (read_bytes < size) {
             if (finished_) {
-                throw std::runtime_error("metadata_reader_t: attempted to read past end of chain");
+                // Read past end of chain: corrupt metadata. Record a sticky data_corruption error and stop.
+                error_ = core::error_t(core::error_code_t::data_corruption,
+                                       std::pmr::string{"metadata_reader_t: attempted to read past end of chain",
+                                                        manager_.block_manager().buffer_manager.resource()});
+                return;
             }
 
             uint64_t available = sub_block_size_ - current_offset_;
             if (available == 0) {
                 follow_chain();
+                // follow_chain may have hit a pin/read failure (recorded a sticky error + left
+                // current_data_ null) or reached the end of the chain. Stop before dereferencing null.
+                if (has_error()) {
+                    return;
+                }
                 continue;
             }
 

--- a/components/table/storage/metadata_reader.hpp
+++ b/components/table/storage/metadata_reader.hpp
@@ -5,10 +5,17 @@
 #include <string>
 #include <type_traits>
 
+#include <core/result_wrapper.hpp>
+
 #include "metadata_manager.hpp"
 
 namespace components::table::storage {
 
+    // Reads a chained metadata stream. A corrupt stream (a read that runs past the end of the chain)
+    // records a sticky data_corruption error_t that callers MUST check via has_error() after deserializing.
+    // Once errored, every read is a no-op returning zero-initialized data, so deserialization unwinds without
+    // UB; the load boundary (data_table_t::load_from_disk / single_file_block_manager_t::deserialize_free_list)
+    // surfaces the error as a result_wrapper_t.
     class metadata_reader_t {
     public:
         metadata_reader_t(metadata_manager_t& manager, meta_block_pointer_t start);
@@ -17,14 +24,14 @@ namespace components::table::storage {
 
         template<typename T>
         requires std::is_trivially_copyable_v<T> T read() {
-            T value;
+            T value{};
             read_data(reinterpret_cast<std::byte*>(&value), sizeof(T));
             return value;
         }
 
         std::string read_string() {
             auto len = read<uint32_t>();
-            if (len == 0) {
+            if (len == 0 || has_error()) {
                 return {};
             }
             std::string result(len, '\0');
@@ -33,6 +40,10 @@ namespace components::table::storage {
         }
 
         bool finished() const { return finished_; }
+
+        // Sticky corrupt-stream flag: true once a read ran past the end of the chain.
+        bool has_error() const { return error_.contains_error(); }
+        const core::error_t& error() const { return error_; }
 
     private:
         void follow_chain();
@@ -43,6 +54,7 @@ namespace components::table::storage {
         uint64_t current_offset_{0};
         uint64_t sub_block_size_{0};
         bool finished_{false};
+        core::error_t error_{core::error_t::no_error()};
 
         static constexpr uint64_t SUB_BLOCK_HEADER_SIZE = sizeof(uint64_t) + sizeof(uint32_t);
     };

--- a/components/table/storage/partial_block_manager.hpp
+++ b/components/table/storage/partial_block_manager.hpp
@@ -17,7 +17,14 @@ namespace components::table::storage {
 
     class partial_block_manager_t {
     public:
-        explicit partial_block_manager_t(block_manager_t& block_manager, double full_threshold = 0.8);
+        // A segment larger than FULL_THRESHOLD of the block payload gets a DEDICATED whole block
+        // (offset 0, never shared). At/below it, the segment is PACKED into a shared partial block
+        // at a (possibly non-zero) offset alongside other columns' segments. This is the single
+        // source of truth for the write-side "dedicated vs shared" decision; the free-side
+        // discriminator in column_data_t::collect_disk_block_ids mirrors it so the two cannot drift.
+        static constexpr double FULL_THRESHOLD = 0.8;
+
+        explicit partial_block_manager_t(block_manager_t& block_manager, double full_threshold = FULL_THRESHOLD);
 
         partial_block_allocation_t get_block_allocation(uint64_t segment_size);
 

--- a/components/table/storage/single_file_block_manager.cpp
+++ b/components/table/storage/single_file_block_manager.cpp
@@ -29,7 +29,7 @@ namespace components::table::storage {
 
     // --- Database lifecycle ---
 
-    void single_file_block_manager_t::create_new_database() {
+    core::result_wrapper_t<bool> single_file_block_manager_t::create_new_database() {
         using namespace core::filesystem;
 
         handle_ = open_file(fs_,
@@ -37,7 +37,9 @@ namespace components::table::storage {
                             file_flags::WRITE | file_flags::READ | file_flags::FILE_CREATE_NEW,
                             file_lock_type::WRITE_LOCK);
         if (!handle_) {
-            throw std::runtime_error("Failed to create database file: " + path_);
+            return core::error_t(core::error_code_t::io_error,
+                                 std::pmr::string{"Failed to create database file: " + path_,
+                                                  buffer_manager.resource()});
         }
 
         main_header_t main_header;
@@ -55,9 +57,10 @@ namespace components::table::storage {
         iteration_ = 0;
         max_block_ = 0;
         meta_block_ = INVALID_INDEX;
+        return true;
     }
 
-    void single_file_block_manager_t::load_existing_database() {
+    core::result_wrapper_t<bool> single_file_block_manager_t::load_existing_database() {
         using namespace core::filesystem;
 
         handle_ = open_file(fs_,
@@ -65,23 +68,29 @@ namespace components::table::storage {
                             file_flags::WRITE | file_flags::READ | file_flags::FILE_CREATE,
                             file_lock_type::WRITE_LOCK);
         if (!handle_) {
-            throw std::runtime_error("Failed to open database file: " + path_);
+            return core::error_t(core::error_code_t::io_error,
+                                 std::pmr::string{"Failed to open database file: " + path_, buffer_manager.resource()});
         }
 
         main_header_t main_header;
         if (!handle_->read(&main_header, sizeof(main_header), 0)) {
-            throw std::runtime_error("Failed to read main header");
+            return core::error_t(core::error_code_t::io_error,
+                                 std::pmr::string{"Failed to read main header", buffer_manager.resource()});
         }
         if (!main_header.validate()) {
-            throw std::runtime_error("Invalid database file: bad magic or version");
+            return core::error_t(core::error_code_t::data_corruption,
+                                 std::pmr::string{"Invalid database file: bad magic or version",
+                                                  buffer_manager.resource()});
         }
 
         database_header_t header1, header2;
         if (!handle_->read(&header1, sizeof(header1), SECTOR_SIZE)) {
-            throw std::runtime_error("Failed to read database header 1");
+            return core::error_t(core::error_code_t::io_error,
+                                 std::pmr::string{"Failed to read database header 1", buffer_manager.resource()});
         }
         if (!handle_->read(&header2, sizeof(header2), 2 * SECTOR_SIZE)) {
-            throw std::runtime_error("Failed to read database header 2");
+            return core::error_t(core::error_code_t::io_error,
+                                 std::pmr::string{"Failed to read database header 2", buffer_manager.resource()});
         }
 
         const database_header_t& active = (header1.iteration >= header2.iteration) ? header1 : header2;
@@ -95,19 +104,23 @@ namespace components::table::storage {
         }
 
         if (active.free_list != INVALID_INDEX) {
-            deserialize_free_list(meta_block_pointer_t{active.free_list, 0});
+            return deserialize_free_list(meta_block_pointer_t{active.free_list, 0});
         }
+        return true;
     }
 
     // --- Block I/O ---
 
-    void single_file_block_manager_t::read(block_t& block) {
+    core::result_wrapper_t<bool> single_file_block_manager_t::read(block_t& block) {
         auto location = block_location(block.id);
         block.read(*handle_, location);
 
         if (!verify_checksum(block)) {
-            throw std::runtime_error("Block checksum mismatch for block " + std::to_string(block.id));
+            return core::error_t(core::error_code_t::data_corruption,
+                                 std::pmr::string{"Block checksum mismatch for block " + std::to_string(block.id),
+                                                  buffer_manager.resource()});
         }
+        return true;
     }
 
     void single_file_block_manager_t::read_blocks(file_buffer_t& buffer, uint64_t start_block, uint64_t /*count*/) {
@@ -278,9 +291,9 @@ namespace components::table::storage {
         return writer.get_block_pointer();
     }
 
-    void single_file_block_manager_t::deserialize_free_list(meta_block_pointer_t pointer) {
+    core::result_wrapper_t<bool> single_file_block_manager_t::deserialize_free_list(meta_block_pointer_t pointer) {
         if (!pointer.is_valid()) {
-            return;
+            return true;
         }
         metadata_manager_t meta_mgr(*this);
         metadata_reader_t reader(meta_mgr, pointer);
@@ -288,6 +301,12 @@ namespace components::table::storage {
         for (uint64_t i = 0; i < count && !reader.finished(); ++i) {
             free_list_.insert(reader.read<uint64_t>());
         }
+        // Corrupt free-list chain (read past end) -> data_corruption, surfaced at the load boundary
+        // instead of throwing.
+        if (reader.has_error()) {
+            return core::error_t(reader.error());
+        }
+        return true;
     }
 
 } // namespace components::table::storage

--- a/components/table/storage/single_file_block_manager.hpp
+++ b/components/table/storage/single_file_block_manager.hpp
@@ -70,8 +70,8 @@ namespace components::table::storage {
         // Return io_error / data_corruption on file create/open/header failure. Called only on the
         // single-threaded bootstrap/load path, whose boundary (load_storage_disk_sync) maps the error onto
         // .prev corrupt-recovery.
-        core::result_wrapper_t<bool> create_new_database();
-        core::result_wrapper_t<bool> load_existing_database();
+        [[nodiscard]] core::result_wrapper_t<bool> create_new_database();
+        [[nodiscard]] core::result_wrapper_t<bool> load_existing_database();
 
         std::unique_ptr<block_t> convert_block(uint64_t block_id, file_buffer_t& source_buffer) override;
         std::unique_ptr<block_t> create_block(uint64_t block_id, file_buffer_t* source_buffer) override;
@@ -85,7 +85,7 @@ namespace components::table::storage {
         void increase_block_ref_count(uint64_t block_id) override;
         uint64_t meta_block() override;
         void set_meta_block(uint64_t block) { meta_block_ = block; }
-        core::result_wrapper_t<bool> read(block_t& block) override;
+        [[nodiscard]] core::result_wrapper_t<bool> read(block_t& block) override;
         void read_blocks(file_buffer_t& buffer, uint64_t start_block, uint64_t block_count) override;
         void write(file_buffer_t& block, uint64_t block_id) override;
 
@@ -98,7 +98,7 @@ namespace components::table::storage {
         void write_header(const database_header_t& header);
 
         meta_block_pointer_t serialize_free_list();
-        core::result_wrapper_t<bool> deserialize_free_list(meta_block_pointer_t pointer);
+        [[nodiscard]] core::result_wrapper_t<bool> deserialize_free_list(meta_block_pointer_t pointer);
 
         core::filesystem::file_handle_t& handle() const { return *handle_; }
 

--- a/components/table/storage/single_file_block_manager.hpp
+++ b/components/table/storage/single_file_block_manager.hpp
@@ -67,8 +67,11 @@ namespace components::table::storage {
                                     uint64_t block_alloc_size = DEFAULT_BLOCK_ALLOC_SIZE);
         ~single_file_block_manager_t() override;
 
-        void create_new_database();
-        void load_existing_database();
+        // Return io_error / data_corruption on file create/open/header failure. Called only on the
+        // single-threaded bootstrap/load path, whose boundary (load_storage_disk_sync) maps the error onto
+        // .prev corrupt-recovery.
+        core::result_wrapper_t<bool> create_new_database();
+        core::result_wrapper_t<bool> load_existing_database();
 
         std::unique_ptr<block_t> convert_block(uint64_t block_id, file_buffer_t& source_buffer) override;
         std::unique_ptr<block_t> create_block(uint64_t block_id, file_buffer_t* source_buffer) override;
@@ -82,7 +85,7 @@ namespace components::table::storage {
         void increase_block_ref_count(uint64_t block_id) override;
         uint64_t meta_block() override;
         void set_meta_block(uint64_t block) { meta_block_ = block; }
-        void read(block_t& block) override;
+        core::result_wrapper_t<bool> read(block_t& block) override;
         void read_blocks(file_buffer_t& buffer, uint64_t start_block, uint64_t block_count) override;
         void write(file_buffer_t& block, uint64_t block_id) override;
 
@@ -95,7 +98,7 @@ namespace components::table::storage {
         void write_header(const database_header_t& header);
 
         meta_block_pointer_t serialize_free_list();
-        void deserialize_free_list(meta_block_pointer_t pointer);
+        core::result_wrapper_t<bool> deserialize_free_list(meta_block_pointer_t pointer);
 
         core::filesystem::file_handle_t& handle() const { return *handle_; }
 

--- a/components/table/storage/standard_buffer_manager.cpp
+++ b/components/table/storage/standard_buffer_manager.cpp
@@ -45,19 +45,20 @@ namespace components::table::storage {
 
     uint64_t standard_buffer_manager_t::block_size() const { return temp_block_manager_->block_size(); }
 
-    temp_buffer_pool_reservation_t
-    standard_buffer_manager_t::evict_blocks_or_throw(memory_tag tag,
+    core::result_wrapper_t<temp_buffer_pool_reservation_t>
+    standard_buffer_manager_t::evict_blocks_or_error(memory_tag tag,
                                                      uint64_t memory_delta,
                                                      std::unique_ptr<file_buffer_t>* buffer) {
         auto r = buffer_pool_.evict_blocks(tag, memory_delta, buffer_pool_.maximum_memory, buffer);
         if (!r.success) {
-            throw std::runtime_error("standard_buffer_manager_t out of memory");
+            return core::error_t(core::error_code_t::out_of_memory,
+                                 std::pmr::string{"standard_buffer_manager_t out of memory", resource()});
         }
         return std::move(r.reservation);
     }
 
-    std::shared_ptr<block_handle_t> standard_buffer_manager_t::register_transient_memory(uint64_t size,
-                                                                                         uint64_t block_size) {
+    core::result_wrapper_t<std::shared_ptr<block_handle_t>>
+    standard_buffer_manager_t::register_transient_memory(uint64_t size, uint64_t block_size) {
         assert(size <= block_size);
 
         if (size < block_size) {
@@ -65,16 +66,24 @@ namespace components::table::storage {
         }
 
         auto buffer_handle = allocate(memory_tag::IN_MEMORY_TABLE, size, false);
-        return buffer_handle.block_handle()->shared_from_this();
+        if (buffer_handle.has_error()) {
+            return buffer_handle.convert_error<std::shared_ptr<block_handle_t>>();
+        }
+        return buffer_handle.value().block_handle()->shared_from_this();
     }
 
-    std::shared_ptr<block_handle_t> standard_buffer_manager_t::register_small_memory(uint64_t size) {
+    core::result_wrapper_t<std::shared_ptr<block_handle_t>>
+    standard_buffer_manager_t::register_small_memory(uint64_t size) {
         return buffer_manager_t::register_small_memory(size);
     }
 
-    std::shared_ptr<block_handle_t> standard_buffer_manager_t::register_small_memory(memory_tag tag, uint64_t size) {
+    core::result_wrapper_t<std::shared_ptr<block_handle_t>>
+    standard_buffer_manager_t::register_small_memory(memory_tag tag, uint64_t size) {
         assert(size < block_size());
-        auto reservation = evict_blocks_or_throw(tag, size, nullptr);
+        auto reservation = evict_blocks_or_error(tag, size, nullptr);
+        if (reservation.has_error()) {
+            return reservation.convert_error<std::shared_ptr<block_handle_t>>();
+        }
 
         auto buffer = construct_manager_buffer(size, nullptr, file_buffer_type::TINY_BUFFER);
 
@@ -84,16 +93,19 @@ namespace components::table::storage {
                                                        std::move(buffer),
                                                        destroy_buffer_condition::BLOCK,
                                                        size,
-                                                       std::move(reservation));
+                                                       std::move(reservation.value()));
         return result;
     }
 
-    std::shared_ptr<block_handle_t>
+    core::result_wrapper_t<std::shared_ptr<block_handle_t>>
     standard_buffer_manager_t::register_memory(memory_tag tag, uint64_t block_size, bool can_destroy) {
         auto alloc_size = allocation_size(block_size);
 
         std::unique_ptr<file_buffer_t> reusable_buffer;
-        auto res = evict_blocks_or_throw(tag, alloc_size, &reusable_buffer);
+        auto res = evict_blocks_or_error(tag, alloc_size, &reusable_buffer);
+        if (res.has_error()) {
+            return res.convert_error<std::shared_ptr<block_handle_t>>();
+        }
 
         auto buffer = construct_manager_buffer(block_size, std::move(reusable_buffer));
         destroy_buffer_condition destroy_buffer_condition =
@@ -104,17 +116,25 @@ namespace components::table::storage {
                                                 std::move(buffer),
                                                 destroy_buffer_condition,
                                                 alloc_size,
-                                                std::move(res));
+                                                std::move(res.value()));
     }
 
-    buffer_handle_t standard_buffer_manager_t::allocate(memory_tag tag, uint64_t block_size, bool can_destroy) {
+    core::result_wrapper_t<buffer_handle_t>
+    standard_buffer_manager_t::allocate(memory_tag tag, uint64_t block_size, bool can_destroy) {
         auto block = register_memory(tag, block_size, can_destroy);
-        auto buf = pin(block);
-        buf.set_ownership(std::move(block));
+        if (block.has_error()) {
+            return block.convert_error<buffer_handle_t>();
+        }
+        auto buf = pin(block.value());
+        if (buf.has_error()) {
+            return buf;
+        }
+        buf.value().set_ownership(std::move(block.value()));
         return buf;
     }
 
-    void standard_buffer_manager_t::reallocate(std::shared_ptr<block_handle_t>& handle, uint64_t block_size) {
+    core::result_wrapper_t<bool> standard_buffer_manager_t::reallocate(std::shared_ptr<block_handle_t>& handle,
+                                                                       uint64_t block_size) {
         assert(block_size >= this->block_size());
         auto lock = handle->get_lock();
 
@@ -127,30 +147,41 @@ namespace components::table::storage {
         int64_t memory_delta = static_cast<int64_t>(req.alloc_size) - static_cast<int64_t>(handle_memory_usage);
 
         if (memory_delta == 0) {
-            return;
+            return true;
         } else if (memory_delta > 0) {
             lock.unlock();
             auto reservation =
-                evict_blocks_or_throw(handle->get_memory_tag(), static_cast<uint64_t>(memory_delta), nullptr);
+                evict_blocks_or_error(handle->get_memory_tag(), static_cast<uint64_t>(memory_delta), nullptr);
+            if (reservation.has_error()) {
+                return reservation.convert_error<bool>();
+            }
             lock.lock();
 
-            handle->merge_memory_reservation(lock, std::move(reservation));
+            handle->merge_memory_reservation(lock, std::move(reservation.value()));
         } else {
             handle->resize_memory(lock, req.alloc_size);
         }
 
         handle->resize_buffer(lock, block_size, memory_delta);
+        return true;
     }
 
-    void standard_buffer_manager_t::batch_read(std::vector<std::shared_ptr<block_handle_t>>& handles,
-                                               const std::map<uint64_t, uint64_t>& load_map,
-                                               uint64_t first_block,
-                                               uint64_t last_block) {
+    // Returns the OOM error from allocate()/evict rather than throwing. prefetch() (a best-effort optimization
+    // with a void signature) swallows the error and returns early: the blocks stay unloaded and are loaded
+    // lazily later via pin(), which surfaces any real OOM to a caller able to handle it.
+    core::result_wrapper_t<bool>
+    standard_buffer_manager_t::batch_read(std::vector<std::shared_ptr<block_handle_t>>& handles,
+                                          const std::map<uint64_t, uint64_t>& load_map,
+                                          uint64_t first_block,
+                                          uint64_t last_block) {
         auto& block_manager = handles[0]->block_manager;
         uint64_t block_count = last_block - first_block + 1;
 
         auto intermediate_buffer = allocate(memory_tag::BASE_TABLE, block_count * block_manager.block_size());
-        block_manager.read_blocks(intermediate_buffer.file_buffer(), first_block, block_count);
+        if (intermediate_buffer.has_error()) {
+            return intermediate_buffer.convert_error<bool>();
+        }
+        block_manager.read_blocks(intermediate_buffer.value().file_buffer(), first_block, block_count);
 
         for (uint64_t block_idx = 0; block_idx < block_count; block_idx++) {
             uint64_t block_id = first_block + block_idx;
@@ -160,19 +191,26 @@ namespace components::table::storage {
 
             uint64_t required_memory = handle->memory_usage();
             std::unique_ptr<file_buffer_t> reusable_buffer;
-            auto reservation = evict_blocks_or_throw(handle->get_memory_tag(), required_memory, &reusable_buffer);
+            auto reservation = evict_blocks_or_error(handle->get_memory_tag(), required_memory, &reusable_buffer);
+            if (reservation.has_error()) {
+                return reservation.convert_error<bool>();
+            }
             buffer_handle_t buf;
             {
                 auto lock = handle->get_lock();
                 if (handle->state() == block_state::LOADED) {
-                    reservation.resize(0);
+                    reservation.value().resize(0);
                     continue;
                 }
-                auto block_ptr = intermediate_buffer.file_buffer().internal_buffer() +
+                auto block_ptr = intermediate_buffer.value().file_buffer().internal_buffer() +
                                  block_idx * block_manager.block_allocation_size();
-                buf = handle->load_from_buffer(lock, block_ptr, std::move(reusable_buffer), std::move(reservation));
+                buf = handle->load_from_buffer(lock,
+                                               block_ptr,
+                                               std::move(reusable_buffer),
+                                               std::move(reservation.value()));
             }
         }
+        return true;
     }
 
     void standard_buffer_manager_t::prefetch(std::vector<std::shared_ptr<block_handle_t>>& handles) {
@@ -195,22 +233,31 @@ namespace components::table::storage {
             } else if (previous_block_id + 1 == entry.first) {
                 previous_block_id = entry.first;
             } else {
-                batch_read(handles, to_be_loaded, first_block, previous_block_id);
+                if (batch_read(handles, to_be_loaded, first_block, previous_block_id).has_error()) {
+                    return; // best-effort prefetch: abort on OOM, blocks load lazily via pin() later
+                }
                 first_block = entry.first;
                 previous_block_id = entry.first;
             }
         }
-        batch_read(handles, to_be_loaded, first_block, previous_block_id);
+        if (batch_read(handles, to_be_loaded, first_block, previous_block_id).has_error()) {
+            return;
+        }
     }
 
-    buffer_handle_t standard_buffer_manager_t::pin(std::shared_ptr<block_handle_t>& handle) {
+    core::result_wrapper_t<buffer_handle_t> standard_buffer_manager_t::pin(std::shared_ptr<block_handle_t>& handle) {
         buffer_handle_t buf;
 
         uint64_t required_memory;
         {
             auto lock = handle->get_lock();
             if (handle->state() == block_state::LOADED) {
-                buf = handle->load();
+                // LOADED fast path: load() cannot error here (no disk read), so unwrap directly.
+                auto loaded = handle->load();
+                if (loaded.has_error()) {
+                    return loaded;
+                }
+                buf = std::move(loaded.value());
             }
             required_memory = handle->memory_usage();
         }
@@ -219,17 +266,31 @@ namespace components::table::storage {
             return buf;
         } else {
             std::unique_ptr<file_buffer_t> reusable_buffer;
-            auto reservation = evict_blocks_or_throw(handle->get_memory_tag(), required_memory, &reusable_buffer);
+            auto reservation = evict_blocks_or_error(handle->get_memory_tag(), required_memory, &reusable_buffer);
+            if (reservation.has_error()) {
+                return reservation.convert_error<buffer_handle_t>();
+            }
 
             auto lock = handle->get_lock();
             if (handle->state() == block_state::LOADED) {
-                reservation.resize(0);
-                buf = handle->load();
+                reservation.value().resize(0);
+                auto loaded = handle->load();
+                if (loaded.has_error()) {
+                    return loaded;
+                }
+                buf = std::move(loaded.value());
             } else {
                 assert(handle->readers() == 0);
-                buf = handle->load(std::move(reusable_buffer));
+                // Disk-reload path: load() can fail with data_corruption/io_error. Release the reservation we
+                // just took and propagate the error rather than throwing.
+                auto loaded = handle->load(std::move(reusable_buffer));
+                if (loaded.has_error()) {
+                    reservation.value().resize(0);
+                    return loaded;
+                }
+                buf = std::move(loaded.value());
                 auto& memory_charge = handle->memory_usage(lock);
-                memory_charge = std::move(reservation);
+                memory_charge = std::move(reservation.value());
                 int64_t delta = static_cast<int64_t>(handle->get_buffer(lock)->allocation_size()) -
                                 static_cast<int64_t>(handle->memory_usage());
                 if (delta) {
@@ -259,7 +320,11 @@ namespace components::table::storage {
             assert(handle->readers() > 0);
             auto new_readers = handle->decrement_readers();
             if (new_readers == 0) {
-                if (handle->must_add_to_eviction_queue()) {
+                if (!handle->is_reloadable()) {
+                    // Managed in-memory block (no disk copy): never queue, never unload on unpin -- it cannot be
+                    // reloaded. Keep it resident. (can_unload() already rejects it, so this just avoids needless
+                    // eviction-queue churn.)
+                } else if (handle->must_add_to_eviction_queue()) {
                     auto sp = handle->shared_from_this();
                     purge = buffer_pool_.add_to_eviction_queue(sp);
                 } else {
@@ -273,7 +338,9 @@ namespace components::table::storage {
         }
     }
 
-    void standard_buffer_manager_t::set_memory_limit(uint64_t limit) { buffer_pool_.set_limit(limit); }
+    core::result_wrapper_t<bool> standard_buffer_manager_t::set_memory_limit(uint64_t limit) {
+        return buffer_pool_.set_limit(limit);
+    }
 
     std::vector<memory_info_t> standard_buffer_manager_t::get_memory_usage_info() const {
         std::vector<memory_info_t> result;
@@ -291,8 +358,13 @@ namespace components::table::storage {
         if (size == 0) {
             return;
         }
-        auto reservation = evict_blocks_or_throw(memory_tag::EXTENSION, size, nullptr);
-        reservation.size = 0;
+        // void signature (base virtual; currently no callers). On OOM this no-ops rather than throwing;
+        // evict_blocks_or_error released nothing in that case.
+        auto reservation = evict_blocks_or_error(memory_tag::EXTENSION, size, nullptr);
+        if (reservation.has_error()) {
+            return;
+        }
+        reservation.value().size = 0;
     }
 
     void standard_buffer_manager_t::free_reserved_memory(uint64_t size) {

--- a/components/table/storage/standard_buffer_manager.hpp
+++ b/components/table/storage/standard_buffer_manager.hpp
@@ -21,22 +21,25 @@ namespace components::table::storage {
                                   core::filesystem::local_file_system_t& fs,
                                   buffer_pool_t& buffer_pool);
 
-        std::shared_ptr<block_handle_t> register_transient_memory(uint64_t size, uint64_t block_size) final;
-        std::shared_ptr<block_handle_t> register_small_memory(uint64_t size) final;
-        std::shared_ptr<block_handle_t> register_small_memory(memory_tag tag, uint64_t size) final;
+        core::result_wrapper_t<std::shared_ptr<block_handle_t>>
+        register_transient_memory(uint64_t size, uint64_t block_size) final;
+        core::result_wrapper_t<std::shared_ptr<block_handle_t>> register_small_memory(uint64_t size) final;
+        core::result_wrapper_t<std::shared_ptr<block_handle_t>>
+        register_small_memory(memory_tag tag, uint64_t size) final;
 
         uint64_t block_allocation_size() const final;
         uint64_t block_size() const final;
 
-        buffer_handle_t allocate(memory_tag tag, uint64_t block_size, bool can_destroy = true) final;
+        core::result_wrapper_t<buffer_handle_t>
+        allocate(memory_tag tag, uint64_t block_size, bool can_destroy = true) final;
 
-        void reallocate(std::shared_ptr<block_handle_t>& handle, uint64_t block_size) final;
+        core::result_wrapper_t<bool> reallocate(std::shared_ptr<block_handle_t>& handle, uint64_t block_size) final;
 
-        buffer_handle_t pin(std::shared_ptr<block_handle_t>& handle) final;
+        core::result_wrapper_t<buffer_handle_t> pin(std::shared_ptr<block_handle_t>& handle) final;
         void prefetch(std::vector<std::shared_ptr<block_handle_t>>& handles) final;
         void unpin(block_handle_t* handle) final;
 
-        void set_memory_limit(uint64_t limit = std::numeric_limits<uint64_t>::max()) final;
+        core::result_wrapper_t<bool> set_memory_limit(uint64_t limit = std::numeric_limits<uint64_t>::max()) final;
 
         std::vector<memory_info_t> get_memory_usage_info() const override;
 
@@ -52,10 +55,11 @@ namespace components::table::storage {
         core::filesystem::local_file_system_t& filesystem() const noexcept { return fs_; }
 
     protected:
-        temp_buffer_pool_reservation_t
-        evict_blocks_or_throw(memory_tag tag, uint64_t memory_delta, std::unique_ptr<file_buffer_t>* buffer);
+        core::result_wrapper_t<temp_buffer_pool_reservation_t>
+        evict_blocks_or_error(memory_tag tag, uint64_t memory_delta, std::unique_ptr<file_buffer_t>* buffer);
 
-        std::shared_ptr<block_handle_t> register_memory(memory_tag tag, uint64_t block_size, bool can_destroy);
+        core::result_wrapper_t<std::shared_ptr<block_handle_t>>
+        register_memory(memory_tag tag, uint64_t block_size, bool can_destroy);
 
         void purge_queue(const block_handle_t& handle) final;
 
@@ -63,10 +67,10 @@ namespace components::table::storage {
 
         void add_to_eviction_queue(std::shared_ptr<block_handle_t>& handle) final;
 
-        void batch_read(std::vector<std::shared_ptr<block_handle_t>>& handles,
-                        const std::map<uint64_t, uint64_t>& load_map,
-                        uint64_t first_block,
-                        uint64_t last_block);
+        core::result_wrapper_t<bool> batch_read(std::vector<std::shared_ptr<block_handle_t>>& handles,
+                                                const std::map<uint64_t, uint64_t>& load_map,
+                                                uint64_t first_block,
+                                                uint64_t last_block);
 
         std::pmr::memory_resource* resource_;
         core::filesystem::local_file_system_t& fs_;

--- a/components/table/storage/standard_buffer_manager.hpp
+++ b/components/table/storage/standard_buffer_manager.hpp
@@ -21,25 +21,28 @@ namespace components::table::storage {
                                   core::filesystem::local_file_system_t& fs,
                                   buffer_pool_t& buffer_pool);
 
-        core::result_wrapper_t<std::shared_ptr<block_handle_t>>
+        [[nodiscard]] core::result_wrapper_t<std::shared_ptr<block_handle_t>>
         register_transient_memory(uint64_t size, uint64_t block_size) final;
-        core::result_wrapper_t<std::shared_ptr<block_handle_t>> register_small_memory(uint64_t size) final;
-        core::result_wrapper_t<std::shared_ptr<block_handle_t>>
+        [[nodiscard]] core::result_wrapper_t<std::shared_ptr<block_handle_t>>
+        register_small_memory(uint64_t size) final;
+        [[nodiscard]] core::result_wrapper_t<std::shared_ptr<block_handle_t>>
         register_small_memory(memory_tag tag, uint64_t size) final;
 
         uint64_t block_allocation_size() const final;
         uint64_t block_size() const final;
 
-        core::result_wrapper_t<buffer_handle_t>
+        [[nodiscard]] core::result_wrapper_t<buffer_handle_t>
         allocate(memory_tag tag, uint64_t block_size, bool can_destroy = true) final;
 
-        core::result_wrapper_t<bool> reallocate(std::shared_ptr<block_handle_t>& handle, uint64_t block_size) final;
+        [[nodiscard]] core::result_wrapper_t<bool>
+        reallocate(std::shared_ptr<block_handle_t>& handle, uint64_t block_size) final;
 
-        core::result_wrapper_t<buffer_handle_t> pin(std::shared_ptr<block_handle_t>& handle) final;
+        [[nodiscard]] core::result_wrapper_t<buffer_handle_t> pin(std::shared_ptr<block_handle_t>& handle) final;
         void prefetch(std::vector<std::shared_ptr<block_handle_t>>& handles) final;
         void unpin(block_handle_t* handle) final;
 
-        core::result_wrapper_t<bool> set_memory_limit(uint64_t limit = std::numeric_limits<uint64_t>::max()) final;
+        [[nodiscard]] core::result_wrapper_t<bool>
+        set_memory_limit(uint64_t limit = std::numeric_limits<uint64_t>::max()) final;
 
         std::vector<memory_info_t> get_memory_usage_info() const override;
 
@@ -55,10 +58,10 @@ namespace components::table::storage {
         core::filesystem::local_file_system_t& filesystem() const noexcept { return fs_; }
 
     protected:
-        core::result_wrapper_t<temp_buffer_pool_reservation_t>
+        [[nodiscard]] core::result_wrapper_t<temp_buffer_pool_reservation_t>
         evict_blocks_or_error(memory_tag tag, uint64_t memory_delta, std::unique_ptr<file_buffer_t>* buffer);
 
-        core::result_wrapper_t<std::shared_ptr<block_handle_t>>
+        [[nodiscard]] core::result_wrapper_t<std::shared_ptr<block_handle_t>>
         register_memory(memory_tag tag, uint64_t block_size, bool can_destroy);
 
         void purge_queue(const block_handle_t& handle) final;
@@ -67,10 +70,10 @@ namespace components::table::storage {
 
         void add_to_eviction_queue(std::shared_ptr<block_handle_t>& handle) final;
 
-        core::result_wrapper_t<bool> batch_read(std::vector<std::shared_ptr<block_handle_t>>& handles,
-                                                const std::map<uint64_t, uint64_t>& load_map,
-                                                uint64_t first_block,
-                                                uint64_t last_block);
+        [[nodiscard]] core::result_wrapper_t<bool> batch_read(std::vector<std::shared_ptr<block_handle_t>>& handles,
+                                                              const std::map<uint64_t, uint64_t>& load_map,
+                                                              uint64_t first_block,
+                                                              uint64_t last_block);
 
         std::pmr::memory_resource* resource_;
         core::filesystem::local_file_system_t& fs_;

--- a/components/table/struct_column_data.cpp
+++ b/components/table/struct_column_data.cpp
@@ -135,33 +135,47 @@ namespace components::table {
         }
     }
 
-    void struct_column_data_t::initialize_append(column_append_state& state) {
+    core::result_wrapper_t<bool> struct_column_data_t::initialize_append(column_append_state& state) {
         column_append_state validity_append;
-        validity.initialize_append(validity_append);
+        auto v = validity.initialize_append(validity_append);
+        if (v.has_error()) {
+            return v; // out_of_memory (rules 2/9)
+        }
         state.child_appends.push_back(std::move(validity_append));
 
         for (auto& sub_column : sub_columns) {
             column_append_state child_append;
-            sub_column->initialize_append(child_append);
+            auto child = sub_column->initialize_append(child_append);
+            if (child.has_error()) {
+                return child;
+            }
             state.child_appends.push_back(std::move(child_append));
         }
+        return true;
     }
 
-    void struct_column_data_t::append(column_append_state& state, vector::vector_t& vector, uint64_t count) {
+    core::result_wrapper_t<bool>
+    struct_column_data_t::append(column_append_state& state, vector::vector_t& vector, uint64_t count) {
         if (vector.get_vector_type() != vector::vector_type::FLAT) {
             vector::vector_t append_vector(vector);
             append_vector.flatten(count);
-            append(state, append_vector, count);
-            return;
+            return append(state, append_vector, count);
         }
 
-        validity.append(state.child_appends[0], vector, count);
+        auto v = validity.append(state.child_appends[0], vector, count);
+        if (v.has_error()) {
+            return v; // out_of_memory (rules 2/9)
+        }
 
         auto& child_entries = vector.entries();
         for (uint64_t i = 0; i < child_entries.size(); i++) {
-            sub_columns[i]->append(state.child_appends[i + 1], *child_entries[i], count);
+            auto child = sub_columns[i]->append(state.child_appends[i + 1], *child_entries[i], count);
+            if (child.has_error()) {
+                return child;
+            }
         }
         count_ += count;
+        return true;
     }
 
     void struct_column_data_t::revert_append(int64_t start_row) {
@@ -185,33 +199,41 @@ namespace components::table {
         return scan_count;
     }
 
-    void struct_column_data_t::update(uint64_t column_index,
-                                      vector::vector_t& update_vector,
-                                      int64_t* row_ids,
-                                      uint64_t update_count) {
-        validity.update(column_index, update_vector, row_ids, update_count);
+    core::result_wrapper_t<bool> struct_column_data_t::update(uint64_t column_index,
+                                                            vector::vector_t& update_vector,
+                                                            int64_t* row_ids,
+                                                            uint64_t update_count) {
+        auto v = validity.update(column_index, update_vector, row_ids, update_count);
+        if (v.has_error()) {
+            return v;
+        }
         auto& child_entries = update_vector.entries();
         for (uint64_t i = 0; i < child_entries.size(); i++) {
-            sub_columns[i]->update(column_index, *child_entries[i], row_ids, update_count);
+            auto child = sub_columns[i]->update(column_index, *child_entries[i], row_ids, update_count);
+            if (child.has_error()) {
+                return child;
+            }
         }
+        return true;
     }
 
-    void struct_column_data_t::update_column(const std::vector<uint64_t>& column_path,
-                                             vector::vector_t& update_vector,
-                                             int64_t* row_ids,
-                                             uint64_t update_count,
-                                             uint64_t depth) {
+    core::result_wrapper_t<bool> struct_column_data_t::update_column(const std::vector<uint64_t>& column_path,
+                                                                  vector::vector_t& update_vector,
+                                                                  int64_t* row_ids,
+                                                                  uint64_t update_count,
+                                                                  uint64_t depth) {
         if (depth >= column_path.size()) {
             throw std::runtime_error("Attempting to directly update a struct column - this should not be possible");
         }
         auto update_column = column_path[depth];
         if (update_column == 0) {
-            validity.update_column(column_path, update_vector, row_ids, update_count, depth + 1);
+            return validity.update_column(column_path, update_vector, row_ids, update_count, depth + 1);
         } else {
             if (update_column > sub_columns.size()) {
                 throw std::runtime_error("update column_path out of range");
             }
-            sub_columns[update_column - 1]->update_column(column_path, update_vector, row_ids, update_count, depth + 1);
+            return sub_columns[update_column - 1]
+                ->update_column(column_path, update_vector, row_ids, update_count, depth + 1);
         }
     }
 

--- a/components/table/struct_column_data.hpp
+++ b/components/table/struct_column_data.hpp
@@ -33,21 +33,21 @@ namespace components::table {
 
         void skip(column_scan_state& state, uint64_t count = vector::DEFAULT_VECTOR_CAPACITY) override;
 
-        void initialize_append(column_append_state& state) override;
-        void append(column_append_state& state, vector::vector_t& vector, uint64_t count) override;
+        core::result_wrapper_t<bool> initialize_append(column_append_state& state) override;
+        core::result_wrapper_t<bool> append(column_append_state& state, vector::vector_t& vector, uint64_t count) override;
         void revert_append(int64_t start_row) override;
         uint64_t fetch(column_scan_state& state, int64_t row_id, vector::vector_t& result) override;
         void
         fetch_row(column_fetch_state& state, int64_t row_id, vector::vector_t& result, uint64_t result_idx) override;
-        void update(uint64_t column_index,
-                    vector::vector_t& update_vector,
-                    int64_t* row_ids,
-                    uint64_t update_count) override;
-        void update_column(const std::vector<uint64_t>& column_path,
-                           vector::vector_t& update_vector,
-                           int64_t* row_ids,
-                           uint64_t update_count,
-                           uint64_t depth) override;
+        core::result_wrapper_t<bool> update(uint64_t column_index,
+                                            vector::vector_t& update_vector,
+                                            int64_t* row_ids,
+                                            uint64_t update_count) override;
+        core::result_wrapper_t<bool> update_column(const std::vector<uint64_t>& column_path,
+                                                   vector::vector_t& update_vector,
+                                                   int64_t* row_ids,
+                                                   uint64_t update_count,
+                                                   uint64_t depth) override;
 
         void get_column_segment_info(uint64_t row_group_index,
                                      std::vector<uint64_t> col_path,

--- a/components/table/struct_column_data.hpp
+++ b/components/table/struct_column_data.hpp
@@ -33,21 +33,22 @@ namespace components::table {
 
         void skip(column_scan_state& state, uint64_t count = vector::DEFAULT_VECTOR_CAPACITY) override;
 
-        core::result_wrapper_t<bool> initialize_append(column_append_state& state) override;
-        core::result_wrapper_t<bool> append(column_append_state& state, vector::vector_t& vector, uint64_t count) override;
+        [[nodiscard]] core::result_wrapper_t<bool> initialize_append(column_append_state& state) override;
+        [[nodiscard]] core::result_wrapper_t<bool>
+        append(column_append_state& state, vector::vector_t& vector, uint64_t count) override;
         void revert_append(int64_t start_row) override;
         uint64_t fetch(column_scan_state& state, int64_t row_id, vector::vector_t& result) override;
         void
         fetch_row(column_fetch_state& state, int64_t row_id, vector::vector_t& result, uint64_t result_idx) override;
-        core::result_wrapper_t<bool> update(uint64_t column_index,
-                                            vector::vector_t& update_vector,
-                                            int64_t* row_ids,
-                                            uint64_t update_count) override;
-        core::result_wrapper_t<bool> update_column(const std::vector<uint64_t>& column_path,
-                                                   vector::vector_t& update_vector,
-                                                   int64_t* row_ids,
-                                                   uint64_t update_count,
-                                                   uint64_t depth) override;
+        [[nodiscard]] core::result_wrapper_t<bool> update(uint64_t column_index,
+                                                          vector::vector_t& update_vector,
+                                                          int64_t* row_ids,
+                                                          uint64_t update_count) override;
+        [[nodiscard]] core::result_wrapper_t<bool> update_column(const std::vector<uint64_t>& column_path,
+                                                                 vector::vector_t& update_vector,
+                                                                 int64_t* row_ids,
+                                                                 uint64_t update_count,
+                                                                 uint64_t depth) override;
 
         void get_column_segment_info(uint64_t row_group_index,
                                      std::vector<uint64_t> col_path,

--- a/components/table/table_state.cpp
+++ b/components/table/table_state.cpp
@@ -178,6 +178,12 @@ namespace components::table {
     bool collection_scan_state::scan(vector::data_chunk_t& result) {
         while (row_group) {
             row_group->scan(*this, result);
+            // OOM during the scan: stop. The error stays in scan_error for the caller to
+            // surface via has_error().
+            if (has_error()) {
+                row_group = nullptr;
+                return false;
+            }
             const bool rg_exhausted =
                 static_cast<int64_t>(vector_index * vector::DEFAULT_VECTOR_CAPACITY) >= max_row_group_row;
             if (!rg_exhausted) {
@@ -216,6 +222,11 @@ namespace components::table {
                 cs.result_offset = 0;
             }
             row_group->scan(*this, batch);
+            if (has_error()) {
+                // OOM: keep whatever batches completed and stop; scan_error persists.
+                row_group = nullptr;
+                return;
+            }
             if (batch.size() > 0) {
                 batches.push_back(std::move(batch));
             }
@@ -249,6 +260,10 @@ namespace components::table {
                                                table_scan_type type) {
         while (row_group) {
             row_group->scan_committed(*this, result, type);
+            if (has_error()) {
+                row_group = nullptr;
+                return false;
+            }
             if (result.size() > 0) {
                 return true;
             } else {
@@ -279,6 +294,10 @@ namespace components::table {
     bool collection_scan_state::scan_committed(vector::data_chunk_t& result, table_scan_type type) {
         while (row_group) {
             row_group->scan_committed(*this, result, type);
+            if (has_error()) {
+                row_group = nullptr;
+                return false;
+            }
             if (result.size() > 0) {
                 return true;
             } else {

--- a/components/table/table_state.hpp
+++ b/components/table/table_state.hpp
@@ -167,6 +167,13 @@ namespace components::table {
         vector::indexing_vector_t valid_indexing;
         transaction_data txn{0, 0};
 
+        // Aggregated buffer-pool OOM raised during the scan. row_group_t copies each column's
+        // column_scan_state::scan_error here; the scan loops stop on it. data_table_t::scan /
+        // scan_batched keep their void shape and LEAVE the error here for the caller to read
+        // via has_error().
+        core::error_t scan_error{core::error_t::no_error()};
+        bool has_error() const { return scan_error.contains_error(); }
+
         std::random_device random;
 
         void initialize(const std::pmr::vector<types::complex_logical_type>& types);

--- a/components/table/test/CMakeLists.txt
+++ b/components/table/test/CMakeLists.txt
@@ -4,6 +4,7 @@ set(${PROJECT_NAME}_SOURCES
         test_column.cpp
         test_table.cpp
         test_block_manager.cpp
+        test_eviction_guard.cpp
         test_metadata.cpp
         test_checkpoint_load.cpp
         test_transaction_manager.cpp
@@ -11,6 +12,7 @@ set(${PROJECT_NAME}_SOURCES
         test_statistics.cpp
         test_parallel_scan.cpp
         test_block_e_procarray.cpp
+        test_disk_backed_scan.cpp
 )
 
 add_executable(${PROJECT_NAME} main.cpp ${${PROJECT_NAME}_SOURCES})

--- a/components/table/test/test_block_manager.cpp
+++ b/components/table/test/test_block_manager.cpp
@@ -3,6 +3,7 @@
 #include <components/table/storage/single_file_block_manager.hpp>
 #include <components/table/storage/standard_buffer_manager.hpp>
 #include <core/file/local_file_system.hpp>
+#include <core/result_wrapper.hpp>
 
 #include <components/table/storage/metadata_manager.hpp>
 #include <components/table/storage/metadata_reader.hpp>
@@ -10,6 +11,7 @@
 
 #include <cstdio>
 #include <cstring>
+#include <fstream>
 #include <unistd.h>
 
 namespace {
@@ -38,7 +40,7 @@ TEST_CASE("single_file_block_manager: write and read blocks") {
 
     test_env_t env;
     single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
-    bm.create_new_database();
+    REQUIRE(!bm.create_new_database().has_error());
 
     constexpr size_t NUM_BLOCKS = 5;
     std::vector<uint64_t> block_ids;
@@ -72,7 +74,7 @@ TEST_CASE("single_file_block_manager: write and read blocks") {
         auto blk = std::make_unique<block_t>(env.resource.upstream_resource(),
                                              block_ids[i],
                                              static_cast<uint64_t>(bm.block_size()));
-        bm.read(*blk);
+        REQUIRE(!bm.read(*blk).has_error());
 
         auto* data = blk->buffer();
         REQUIRE(std::memcmp(data, original_data[i].data(), original_data[i].size()) == 0);
@@ -90,7 +92,7 @@ TEST_CASE("single_file_block_manager: create, close, load existing") {
     // create and write
     {
         single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
-        bm.create_new_database();
+        REQUIRE(!bm.create_new_database().has_error());
 
         uint64_t id = bm.free_block_id();
         auto blk =
@@ -109,13 +111,13 @@ TEST_CASE("single_file_block_manager: create, close, load existing") {
     // load and read
     {
         single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
-        bm.load_existing_database();
+        REQUIRE(!bm.load_existing_database().has_error());
 
         REQUIRE(bm.total_blocks() == 1);
 
         auto blk =
             std::make_unique<block_t>(env.resource.upstream_resource(), 0, static_cast<uint64_t>(bm.block_size()));
-        bm.read(*blk);
+        REQUIRE(!bm.read(*blk).has_error());
 
         auto* data = blk->buffer();
         for (size_t j = 0; j < blk->size(); j++) {
@@ -132,7 +134,7 @@ TEST_CASE("single_file_block_manager: free list reuse") {
 
     test_env_t env;
     single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
-    bm.create_new_database();
+    REQUIRE(!bm.create_new_database().has_error());
 
     // allocate 3 blocks
     uint64_t id0 = bm.free_block_id();
@@ -182,7 +184,7 @@ TEST_CASE("single_file_block_manager: free list survives checkpoint/load") {
     // so free_blocks() after serialize is not simply (freed count).
     {
         single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
-        bm.create_new_database();
+        REQUIRE(!bm.create_new_database().has_error());
 
         // Allocate 5 blocks (ids 0..4), write dummy data to each
         for (int i = 0; i < 5; i++) {
@@ -214,7 +216,7 @@ TEST_CASE("single_file_block_manager: free list survives checkpoint/load") {
 
     {
         single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
-        bm.load_existing_database();
+        REQUIRE(!bm.load_existing_database().has_error());
 
         REQUIRE(bm.free_blocks() == free_blocks_after_serialize);
 
@@ -235,7 +237,7 @@ TEST_CASE("single_file_block_manager: empty free list persistence") {
 
     {
         single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
-        bm.create_new_database();
+        REQUIRE(!bm.create_new_database().has_error());
 
         for (int i = 0; i < 3; i++) {
             uint64_t id = bm.free_block_id();
@@ -257,7 +259,7 @@ TEST_CASE("single_file_block_manager: empty free list persistence") {
 
     {
         single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
-        bm.load_existing_database();
+        REQUIRE(!bm.load_existing_database().has_error());
 
         REQUIRE(bm.free_blocks() == 0);
         // Next alloc should give block 3 (next after 0,1,2)
@@ -266,4 +268,189 @@ TEST_CASE("single_file_block_manager: empty free list persistence") {
     }
 
     cleanup_test_file();
+}
+
+// ---------------------------------------------------------------------------
+// Error-VALUE regression tests: the converted paths return a
+// core::result_wrapper_t carrying core::error_code_t::{data_corruption,io_error}
+// instead of throwing. Each test drives the error branch, asserts the error
+// VALUE, and wraps the failing call in REQUIRE_NOTHROW.
+// ---------------------------------------------------------------------------
+
+namespace {
+    std::string corrupt_db_path(const char* tag) {
+        return "/tmp/test_otterbrix_blockmgr_err_" + std::string(tag) + "_" + std::to_string(::getpid()) + ".otbx";
+    }
+} // namespace
+
+// Block checksum mismatch -> data_corruption.
+// single_file_block_manager_t::read() calls verify_checksum(), which compares the
+// first 8 bytes of the block (the checksum slot, written by checksum_and_write)
+// against the CRC32c of the payload that follows it. We write a known block, then
+// flip ONE payload byte directly in the .otbx so the stored checksum no longer
+// matches the recomputed CRC -> verify_checksum() returns false -> read() returns
+// error_code_t::data_corruption (NOT a throw/segfault).
+TEST_CASE("single_file_block_manager: corrupt block payload -> data_corruption (error value)") {
+    using namespace components::table::storage;
+    const std::string path = corrupt_db_path("checksum");
+    std::remove(path.c_str());
+
+    test_env_t env;
+    uint64_t block_id = 0;
+    uint64_t payload_disk_offset = 0;
+    std::byte original_byte{};
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, path);
+        REQUIRE(!bm.create_new_database().has_error());
+
+        block_id = bm.free_block_id();
+        auto blk = std::make_unique<block_t>(env.resource.upstream_resource(),
+                                             block_id,
+                                             static_cast<uint64_t>(bm.block_size()));
+        auto* data = blk->buffer(); // payload region (internal_buffer_ + 8-byte checksum header)
+        for (size_t j = 0; j < blk->size(); j++) {
+            data[j] = static_cast<std::byte>((j * 7 + 1) & 0xFF);
+        }
+        bm.write(*blk, block_id); // checksum_and_write stores CRC in the 8-byte header slot
+
+        // On disk the block lives at BLOCK_START + block_id * block_allocation_size().
+        // Bytes [0,8) of that region are the checksum slot; the payload starts at +8.
+        // Corrupting a payload byte (not the slot) guarantees stored-checksum != recomputed.
+        payload_disk_offset = BLOCK_START + block_id * bm.block_allocation_size() + sizeof(uint64_t);
+        original_byte = data[0];
+    }
+
+    // Mutate one payload byte on disk so the persisted CRC no longer matches.
+    {
+        std::fstream f(path, std::ios::in | std::ios::out | std::ios::binary);
+        REQUIRE(f.is_open());
+        f.seekg(static_cast<std::streamoff>(payload_disk_offset));
+        char b = 0;
+        f.read(&b, 1);
+        REQUIRE(f.gcount() == 1);
+        b = static_cast<char>(b ^ 0xFF); // flip every bit of this payload byte
+        f.seekp(static_cast<std::streamoff>(payload_disk_offset));
+        f.write(&b, 1);
+        f.flush();
+        REQUIRE(f.good());
+        // Sanity: we really changed a byte relative to the in-memory original.
+        REQUIRE(static_cast<std::byte>(b) != original_byte);
+    }
+
+    // Reopen and read the corrupted block back: read() must surface data_corruption
+    // as a VALUE, not throw, and must NOT report success.
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, path);
+        REQUIRE(!bm.load_existing_database().has_error());
+
+        auto blk = std::make_unique<block_t>(env.resource.upstream_resource(),
+                                             block_id,
+                                             static_cast<uint64_t>(bm.block_size()));
+        core::result_wrapper_t<bool> result = false;
+        REQUIRE_NOTHROW(result = bm.read(*blk));
+        REQUIRE(result.has_error()); // would be a false pass if the read succeeded
+        REQUIRE(result.error().type == core::error_code_t::data_corruption);
+    }
+
+    std::remove(path.c_str());
+}
+
+// File open/header IO failure -> io_error.
+// load_existing_database() opens with FILE_CREATE (so a missing file is created
+// empty, not an open failure). Reading the main header from a zero-length file
+// makes the positional read return false -> io_error ("Failed to read main header").
+TEST_CASE("single_file_block_manager: load empty file -> io_error (error value)") {
+    using namespace components::table::storage;
+    const std::string path = corrupt_db_path("empty");
+    std::remove(path.c_str());
+
+    // Create a zero-byte file so the header read hits EOF immediately.
+    {
+        std::ofstream f(path, std::ios::out | std::ios::binary | std::ios::trunc);
+        REQUIRE(f.is_open());
+    }
+    REQUIRE(std::ifstream(path, std::ios::binary).peek() == std::char_traits<char>::eof());
+
+    test_env_t env;
+    single_file_block_manager_t bm(env.buffer_manager, env.fs, path);
+
+    core::result_wrapper_t<bool> result = false;
+    REQUIRE_NOTHROW(result = bm.load_existing_database());
+    REQUIRE(result.has_error());
+    REQUIRE(result.error().type == core::error_code_t::io_error);
+
+    std::remove(path.c_str());
+}
+
+// Bad magic/header -> data_corruption.
+// Build a valid db, then overwrite the main_header magic (offset 0) with garbage.
+// The header read succeeds but main_header_t::validate() fails -> data_corruption
+// ("Invalid database file: bad magic or version"), surfaced as a VALUE.
+TEST_CASE("single_file_block_manager: load bad-magic header -> data_corruption (error value)") {
+    using namespace components::table::storage;
+    const std::string path = corrupt_db_path("badmagic");
+    std::remove(path.c_str());
+
+    test_env_t env;
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, path);
+        REQUIRE(!bm.create_new_database().has_error());
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    // The main_header_t::magic is the first 4 bytes of the file (offset 0).
+    {
+        std::fstream f(path, std::ios::in | std::ios::out | std::ios::binary);
+        REQUIRE(f.is_open());
+        uint32_t bad_magic = 0xDEADBEEF; // != main_header_t::MAGIC_NUMBER
+        REQUIRE(bad_magic != main_header_t::MAGIC_NUMBER);
+        f.seekp(0);
+        f.write(reinterpret_cast<const char*>(&bad_magic), sizeof(bad_magic));
+        f.flush();
+        REQUIRE(f.good());
+    }
+
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, path);
+        core::result_wrapper_t<bool> result = false;
+        REQUIRE_NOTHROW(result = bm.load_existing_database());
+        REQUIRE(result.has_error());
+        REQUIRE(result.error().type == core::error_code_t::data_corruption);
+    }
+
+    std::remove(path.c_str());
+}
+
+// buffer_pool set_limit / standard_buffer_manager set_memory_limit success path.
+// set_limit() returns out_of_memory only when evict_blocks() cannot free enough
+// memory for the new limit. With no pinned/un-evictable blocks held in the pool,
+// eviction trivially succeeds (used_memory == 0), so the failure branch is not
+// reachable from a fresh pool in a unit test. Asserts only the SUCCESS path:
+// returns a non-error VALUE and does not throw.
+TEST_CASE("buffer_pool/standard_buffer_manager: set_memory_limit success returns non-error value") {
+    using namespace components::table::storage;
+    test_env_t env;
+
+    // Direct pool: lower the limit on an empty pool -> nothing to evict -> success.
+    {
+        core::result_wrapper_t<bool> r = false;
+        REQUIRE_NOTHROW(r = env.buffer_pool.set_limit(uint64_t(1) << 20));
+        REQUIRE_FALSE(r.has_error());
+        REQUIRE(r.value() == true);
+    }
+    // Raising the limit can never fail eviction either.
+    {
+        core::result_wrapper_t<bool> r = false;
+        REQUIRE_NOTHROW(r = env.buffer_pool.set_limit(uint64_t(1) << 32));
+        REQUIRE_FALSE(r.has_error());
+    }
+    // Through the buffer manager facade (set_memory_limit delegates to set_limit).
+    {
+        core::result_wrapper_t<bool> r = false;
+        REQUIRE_NOTHROW(r = env.buffer_manager.set_memory_limit(uint64_t(1) << 24));
+        REQUIRE_FALSE(r.has_error());
+    }
 }

--- a/components/table/test/test_checkpoint_load.cpp
+++ b/components/table/test/test_checkpoint_load.cpp
@@ -46,9 +46,9 @@ namespace {
                 chunk.set_value(0, i, logical_value_t{resource, static_cast<int64_t>(offset + i)});
             }
             table_append_state state(resource);
-            table.append_lock(state);
-            table.initialize_append(state);
-            table.append(chunk, state);
+            REQUIRE_FALSE(table.append_lock(state).has_error());
+            REQUIRE_FALSE(table.initialize_append(state).has_error());
+            REQUIRE_FALSE(table.append(chunk, state).has_error());
             table.finalize_append(state, transaction_data{0, 0});
             offset += batch;
         }
@@ -71,9 +71,9 @@ namespace {
                 chunk.set_value(0, i, logical_value_t{resource, value_fn(offset + i)});
             }
             table_append_state state(resource);
-            table.append_lock(state);
-            table.initialize_append(state);
-            table.append(chunk, state);
+            REQUIRE_FALSE(table.append_lock(state).has_error());
+            REQUIRE_FALSE(table.initialize_append(state).has_error());
+            REQUIRE_FALSE(table.append(chunk, state).has_error());
             table.finalize_append(state, transaction_data{0, 0});
             offset += batch;
         }
@@ -97,9 +97,9 @@ namespace {
                 chunk.set_value(0, i, logical_value_t{resource, value_fn(offset + i)});
             }
             table_append_state state(resource);
-            table.append_lock(state);
-            table.initialize_append(state);
-            table.append(chunk, state);
+            REQUIRE_FALSE(table.append_lock(state).has_error());
+            REQUIRE_FALSE(table.initialize_append(state).has_error());
+            REQUIRE_FALSE(table.append(chunk, state).has_error());
             table.finalize_append(state, transaction_data{0, 0});
             offset += batch;
         }
@@ -121,7 +121,7 @@ TEST_CASE("checkpoint_load: single INT64 column, 1000 rows") {
     // write phase
     {
         single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
-        bm.create_new_database();
+        REQUIRE(!bm.create_new_database().has_error());
 
         std::vector<column_definition_t> columns;
         columns.emplace_back("value", logical_type::BIGINT);
@@ -132,7 +132,7 @@ TEST_CASE("checkpoint_load: single INT64 column, 1000 rows") {
 
         metadata_manager_t meta_mgr(bm);
         metadata_writer_t writer(meta_mgr);
-        table->checkpoint(writer);
+        REQUIRE_FALSE(table->checkpoint(writer).has_error());
         table_pointer = writer.get_block_pointer();
 
         database_header_t header;
@@ -143,11 +143,13 @@ TEST_CASE("checkpoint_load: single INT64 column, 1000 rows") {
     // read phase
     {
         single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
-        bm.load_existing_database();
+        REQUIRE(!bm.load_existing_database().has_error());
 
         metadata_manager_t meta_mgr(bm);
         metadata_reader_t reader(meta_mgr, table_pointer);
-        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        auto loaded_result = data_table_t::load_from_disk(&env.resource, bm, reader);
+        REQUIRE(!loaded_result.has_error());
+        auto& loaded = loaded_result.value();
 
         REQUIRE(loaded->table_name() == "test_table");
         REQUIRE(loaded->column_count() == 1);
@@ -182,7 +184,7 @@ TEST_CASE("checkpoint_load: three columns INT64 + STRING + DOUBLE") {
     // write phase
     {
         single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
-        bm.create_new_database();
+        REQUIRE(!bm.create_new_database().has_error());
 
         std::vector<column_definition_t> columns;
         columns.emplace_back("id", logical_type::BIGINT);
@@ -203,9 +205,9 @@ TEST_CASE("checkpoint_load: three columns INT64 + STRING + DOUBLE") {
                 chunk.set_value(2, i, logical_value_t{&env.resource, static_cast<double>(row) * 1.5});
             }
             table_append_state state(&env.resource);
-            table->append_lock(state);
-            table->initialize_append(state);
-            table->append(chunk, state);
+            REQUIRE_FALSE(table->append_lock(state).has_error());
+            REQUIRE_FALSE(table->initialize_append(state).has_error());
+            REQUIRE_FALSE(table->append(chunk, state).has_error());
             table->finalize_append(state, transaction_data{0, 0});
             offset += batch;
         }
@@ -214,7 +216,7 @@ TEST_CASE("checkpoint_load: three columns INT64 + STRING + DOUBLE") {
 
         metadata_manager_t meta_mgr(bm);
         metadata_writer_t writer(meta_mgr);
-        table->checkpoint(writer);
+        REQUIRE_FALSE(table->checkpoint(writer).has_error());
         table_pointer = writer.get_block_pointer();
 
         database_header_t header;
@@ -225,11 +227,13 @@ TEST_CASE("checkpoint_load: three columns INT64 + STRING + DOUBLE") {
     // read phase
     {
         single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
-        bm.load_existing_database();
+        REQUIRE(!bm.load_existing_database().has_error());
 
         metadata_manager_t meta_mgr(bm);
         metadata_reader_t reader(meta_mgr, table_pointer);
-        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        auto loaded_result = data_table_t::load_from_disk(&env.resource, bm, reader);
+        REQUIRE(!loaded_result.has_error());
+        auto& loaded = loaded_result.value();
 
         REQUIRE(loaded->table_name() == "multi_col");
         REQUIRE(loaded->column_count() == 3);
@@ -271,7 +275,7 @@ TEST_CASE("checkpoint_load: empty table") {
     // write phase
     {
         single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
-        bm.create_new_database();
+        REQUIRE(!bm.create_new_database().has_error());
 
         std::vector<column_definition_t> columns;
         columns.emplace_back("value", logical_type::BIGINT);
@@ -281,7 +285,7 @@ TEST_CASE("checkpoint_load: empty table") {
 
         metadata_manager_t meta_mgr(bm);
         metadata_writer_t writer(meta_mgr);
-        table->checkpoint(writer);
+        REQUIRE_FALSE(table->checkpoint(writer).has_error());
         table_pointer = writer.get_block_pointer();
 
         database_header_t header;
@@ -292,11 +296,13 @@ TEST_CASE("checkpoint_load: empty table") {
     // read phase
     {
         single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
-        bm.load_existing_database();
+        REQUIRE(!bm.load_existing_database().has_error());
 
         metadata_manager_t meta_mgr(bm);
         metadata_reader_t reader(meta_mgr, table_pointer);
-        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        auto loaded_result = data_table_t::load_from_disk(&env.resource, bm, reader);
+        REQUIRE(!loaded_result.has_error());
+        auto& loaded = loaded_result.value();
 
         REQUIRE(loaded->table_name() == "empty_table");
         REQUIRE(loaded->column_count() == 1);
@@ -323,7 +329,7 @@ TEST_CASE("checkpoint_load: multiple row groups") {
     // write phase
     {
         single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
-        bm.create_new_database();
+        REQUIRE(!bm.create_new_database().has_error());
 
         std::vector<column_definition_t> columns;
         columns.emplace_back("value", logical_type::BIGINT);
@@ -334,7 +340,7 @@ TEST_CASE("checkpoint_load: multiple row groups") {
 
         metadata_manager_t meta_mgr(bm);
         metadata_writer_t writer(meta_mgr);
-        table->checkpoint(writer);
+        REQUIRE_FALSE(table->checkpoint(writer).has_error());
         table_pointer = writer.get_block_pointer();
 
         database_header_t header;
@@ -345,11 +351,13 @@ TEST_CASE("checkpoint_load: multiple row groups") {
     // read phase
     {
         single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
-        bm.load_existing_database();
+        REQUIRE(!bm.load_existing_database().has_error());
 
         metadata_manager_t meta_mgr(bm);
         metadata_reader_t reader(meta_mgr, table_pointer);
-        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        auto loaded_result = data_table_t::load_from_disk(&env.resource, bm, reader);
+        REQUIRE(!loaded_result.has_error());
+        auto& loaded = loaded_result.value();
 
         REQUIRE(loaded->table_name() == "big_table");
         REQUIRE(loaded->column_count() == 1);
@@ -383,7 +391,7 @@ TEST_CASE("checkpoint_load: CONSTANT compression — all identical values") {
 
     {
         single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
-        bm.create_new_database();
+        REQUIRE(!bm.create_new_database().has_error());
 
         std::vector<column_definition_t> columns;
         columns.emplace_back("value", logical_type::BIGINT);
@@ -394,7 +402,7 @@ TEST_CASE("checkpoint_load: CONSTANT compression — all identical values") {
 
         metadata_manager_t meta_mgr(bm);
         metadata_writer_t writer(meta_mgr);
-        table->checkpoint(writer);
+        REQUIRE_FALSE(table->checkpoint(writer).has_error());
         table_pointer = writer.get_block_pointer();
 
         database_header_t header;
@@ -404,11 +412,13 @@ TEST_CASE("checkpoint_load: CONSTANT compression — all identical values") {
 
     {
         single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
-        bm.load_existing_database();
+        REQUIRE(!bm.load_existing_database().has_error());
 
         metadata_manager_t meta_mgr(bm);
         metadata_reader_t reader(meta_mgr, table_pointer);
-        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        auto loaded_result = data_table_t::load_from_disk(&env.resource, bm, reader);
+        REQUIRE(!loaded_result.has_error());
+        auto& loaded = loaded_result.value();
 
         REQUIRE(loaded->table_name() == "const_table");
         uint64_t scanned = 0;
@@ -438,7 +448,7 @@ TEST_CASE("checkpoint_load: RLE compression — sorted runs") {
 
     {
         single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
-        bm.create_new_database();
+        REQUIRE(!bm.create_new_database().has_error());
 
         std::vector<column_definition_t> columns;
         columns.emplace_back("value", logical_type::BIGINT);
@@ -452,7 +462,7 @@ TEST_CASE("checkpoint_load: RLE compression — sorted runs") {
 
         metadata_manager_t meta_mgr(bm);
         metadata_writer_t writer(meta_mgr);
-        table->checkpoint(writer);
+        REQUIRE_FALSE(table->checkpoint(writer).has_error());
         table_pointer = writer.get_block_pointer();
 
         database_header_t header;
@@ -462,11 +472,13 @@ TEST_CASE("checkpoint_load: RLE compression — sorted runs") {
 
     {
         single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
-        bm.load_existing_database();
+        REQUIRE(!bm.load_existing_database().has_error());
 
         metadata_manager_t meta_mgr(bm);
         metadata_reader_t reader(meta_mgr, table_pointer);
-        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        auto loaded_result = data_table_t::load_from_disk(&env.resource, bm, reader);
+        REQUIRE(!loaded_result.has_error());
+        auto& loaded = loaded_result.value();
 
         uint64_t scanned = 0;
         loaded->scan_table_segment(0, NUM_ROWS, [&](data_chunk_t& chunk) {
@@ -497,7 +509,7 @@ TEST_CASE("checkpoint_load: DICTIONARY compression — low cardinality cycling")
 
     {
         single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
-        bm.create_new_database();
+        REQUIRE(!bm.create_new_database().has_error());
 
         std::vector<column_definition_t> columns;
         columns.emplace_back("value", logical_type::BIGINT);
@@ -511,7 +523,7 @@ TEST_CASE("checkpoint_load: DICTIONARY compression — low cardinality cycling")
 
         metadata_manager_t meta_mgr(bm);
         metadata_writer_t writer(meta_mgr);
-        table->checkpoint(writer);
+        REQUIRE_FALSE(table->checkpoint(writer).has_error());
         table_pointer = writer.get_block_pointer();
 
         database_header_t header;
@@ -521,11 +533,13 @@ TEST_CASE("checkpoint_load: DICTIONARY compression — low cardinality cycling")
 
     {
         single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
-        bm.load_existing_database();
+        REQUIRE(!bm.load_existing_database().has_error());
 
         metadata_manager_t meta_mgr(bm);
         metadata_reader_t reader(meta_mgr, table_pointer);
-        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        auto loaded_result = data_table_t::load_from_disk(&env.resource, bm, reader);
+        REQUIRE(!loaded_result.has_error());
+        auto& loaded = loaded_result.value();
 
         uint64_t scanned = 0;
         loaded->scan_table_segment(0, NUM_ROWS, [&](data_chunk_t& chunk) {
@@ -556,7 +570,7 @@ TEST_CASE("checkpoint_load: UNCOMPRESSED fallback — high cardinality") {
 
     {
         single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
-        bm.create_new_database();
+        REQUIRE(!bm.create_new_database().has_error());
 
         std::vector<column_definition_t> columns;
         columns.emplace_back("value", logical_type::BIGINT);
@@ -568,7 +582,7 @@ TEST_CASE("checkpoint_load: UNCOMPRESSED fallback — high cardinality") {
 
         metadata_manager_t meta_mgr(bm);
         metadata_writer_t writer(meta_mgr);
-        table->checkpoint(writer);
+        REQUIRE_FALSE(table->checkpoint(writer).has_error());
         table_pointer = writer.get_block_pointer();
 
         database_header_t header;
@@ -578,11 +592,13 @@ TEST_CASE("checkpoint_load: UNCOMPRESSED fallback — high cardinality") {
 
     {
         single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
-        bm.load_existing_database();
+        REQUIRE(!bm.load_existing_database().has_error());
 
         metadata_manager_t meta_mgr(bm);
         metadata_reader_t reader(meta_mgr, table_pointer);
-        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        auto loaded_result = data_table_t::load_from_disk(&env.resource, bm, reader);
+        REQUIRE(!loaded_result.has_error());
+        auto& loaded = loaded_result.value();
 
         uint64_t scanned = 0;
         loaded->scan_table_segment(0, NUM_ROWS, [&](data_chunk_t& chunk) {
@@ -614,7 +630,7 @@ TEST_CASE("checkpoint_load: mixed row groups — constant + varied") {
 
     {
         single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
-        bm.create_new_database();
+        REQUIRE(!bm.create_new_database().has_error());
 
         std::vector<column_definition_t> columns;
         columns.emplace_back("value", logical_type::BIGINT);
@@ -629,7 +645,7 @@ TEST_CASE("checkpoint_load: mixed row groups — constant + varied") {
 
         metadata_manager_t meta_mgr(bm);
         metadata_writer_t writer(meta_mgr);
-        table->checkpoint(writer);
+        REQUIRE_FALSE(table->checkpoint(writer).has_error());
         table_pointer = writer.get_block_pointer();
 
         database_header_t header;
@@ -639,11 +655,13 @@ TEST_CASE("checkpoint_load: mixed row groups — constant + varied") {
 
     {
         single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
-        bm.load_existing_database();
+        REQUIRE(!bm.load_existing_database().has_error());
 
         metadata_manager_t meta_mgr(bm);
         metadata_reader_t reader(meta_mgr, table_pointer);
-        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        auto loaded_result = data_table_t::load_from_disk(&env.resource, bm, reader);
+        REQUIRE(!loaded_result.has_error());
+        auto& loaded = loaded_result.value();
 
         uint64_t scanned = 0;
         loaded->scan_table_segment(0, TOTAL_ROWS, [&](data_chunk_t& chunk) {
@@ -680,7 +698,7 @@ TEST_CASE("checkpoint_load: DOUBLE column — constant compression") {
 
     {
         single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
-        bm.create_new_database();
+        REQUIRE(!bm.create_new_database().has_error());
 
         std::vector<column_definition_t> columns;
         columns.emplace_back("score", logical_type::DOUBLE);
@@ -691,7 +709,7 @@ TEST_CASE("checkpoint_load: DOUBLE column — constant compression") {
 
         metadata_manager_t meta_mgr(bm);
         metadata_writer_t writer(meta_mgr);
-        table->checkpoint(writer);
+        REQUIRE_FALSE(table->checkpoint(writer).has_error());
         table_pointer = writer.get_block_pointer();
 
         database_header_t header;
@@ -701,11 +719,13 @@ TEST_CASE("checkpoint_load: DOUBLE column — constant compression") {
 
     {
         single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
-        bm.load_existing_database();
+        REQUIRE(!bm.load_existing_database().has_error());
 
         metadata_manager_t meta_mgr(bm);
         metadata_reader_t reader(meta_mgr, table_pointer);
-        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        auto loaded_result = data_table_t::load_from_disk(&env.resource, bm, reader);
+        REQUIRE(!loaded_result.has_error());
+        auto& loaded = loaded_result.value();
 
         uint64_t scanned = 0;
         loaded->scan_table_segment(0, NUM_ROWS, [&](data_chunk_t& chunk) {
@@ -735,7 +755,7 @@ TEST_CASE("checkpoint_load: small segment — 2 rows edge case") {
 
     {
         single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
-        bm.create_new_database();
+        REQUIRE(!bm.create_new_database().has_error());
 
         std::vector<column_definition_t> columns;
         columns.emplace_back("value", logical_type::BIGINT);
@@ -746,7 +766,7 @@ TEST_CASE("checkpoint_load: small segment — 2 rows edge case") {
 
         metadata_manager_t meta_mgr(bm);
         metadata_writer_t writer(meta_mgr);
-        table->checkpoint(writer);
+        REQUIRE_FALSE(table->checkpoint(writer).has_error());
         table_pointer = writer.get_block_pointer();
 
         database_header_t header;
@@ -756,11 +776,13 @@ TEST_CASE("checkpoint_load: small segment — 2 rows edge case") {
 
     {
         single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
-        bm.load_existing_database();
+        REQUIRE(!bm.load_existing_database().has_error());
 
         metadata_manager_t meta_mgr(bm);
         metadata_reader_t reader(meta_mgr, table_pointer);
-        auto loaded = data_table_t::load_from_disk(&env.resource, bm, reader);
+        auto loaded_result = data_table_t::load_from_disk(&env.resource, bm, reader);
+        REQUIRE(!loaded_result.has_error());
+        auto& loaded = loaded_result.value();
 
         REQUIRE(loaded->table_name() == "tiny_table");
         uint64_t scanned = 0;
@@ -771,6 +793,209 @@ TEST_CASE("checkpoint_load: small segment — 2 rows edge case") {
             scanned += chunk.size();
         });
         REQUIRE(scanned == NUM_ROWS);
+    }
+
+    cleanup_test_file();
+}
+
+// ---------------------------------------------------------------------------
+// REGRESSION: shared partial block corruption on REOPEN after table GROWS.
+//
+// The catalog table pg_attribute packs ~8 narrow, low-cardinality columns into
+// ONE shared partial block at distinct offsets (col0 @0, the rest at increasing
+// non-zero offsets). On REOPEN after the table GROWS and re-checkpoints, the
+// shared block's in-memory buffer was clobbered at the packed (non-zero-offset)
+// columns, so reads returned garbage.
+//
+// This mimics pg_attribute: 8 BIGINT columns, each very low cardinality so the
+// checkpointer DICTIONARY/RLE/CONSTANT-compresses every segment to a few bytes,
+// and the shared partial_block_manager packs all of them into one block. Then:
+//   checkpoint #1 -> reopen #1 -> GROW (append rows) -> checkpoint #2 ->
+//   reopen #2 -> scan and assert EVERY column reads back EXACTLY.
+namespace {
+    // Replicate the agent-level checkpoint sequence (manager_disk.cpp): flush the
+    // table metadata, set the meta block, serialize the free list, and persist the
+    // header WITH the free list. Persisting the free list across reopen is what
+    // makes the block-recycling corruption deterministic.
+    components::table::storage::meta_block_pointer_t
+    full_checkpoint(components::table::data_table_t& table,
+                    components::table::storage::single_file_block_manager_t& bm) {
+        using namespace components::table::storage;
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        REQUIRE_FALSE(table.checkpoint(writer).has_error());
+        writer.flush();
+        auto table_pointer = writer.get_block_pointer();
+
+        bm.set_meta_block(table_pointer.block_pointer);
+        auto free_list_ptr = bm.serialize_free_list();
+        bm.file_sync();
+        database_header_t header;
+        header.initialize();
+        header.free_list = free_list_ptr.block_pointer;
+        bm.write_header(header);
+        bm.file_sync();
+        return table_pointer;
+    }
+
+    // pg_attribute-like value generator: column c at row r. Low cardinality per
+    // column so the checkpointer compresses each segment; distinct per-column
+    // patterns so a cross-column clobber is detectable.
+    int64_t pg_attr_value(uint64_t col, uint64_t row) {
+        switch (col) {
+            case 0: return static_cast<int64_t>(row);          // attrelid-like, RLE-ish runs
+            case 1: return static_cast<int64_t>(20 + row % 3); // atttypid: {20,21,22}
+            case 2: return static_cast<int64_t>(row % 8 + 1);  // attnum: 1..8 cycling (DICTIONARY)
+            case 3: return 1;                                  // attnotnull: CONSTANT
+            case 4: return 0;                                  // atthasdefault: CONSTANT
+            case 5: return 0;                                  // attisdropped: CONSTANT 0 (the SSB symptom)
+            case 6: return 1000;                               // added_at_commit_id: CONSTANT
+            case 7: return 0;                                  // dropped_at_commit_id: CONSTANT 0
+            default: return static_cast<int64_t>(col * 100 + row % 4);
+        }
+    }
+
+    void append_pg_attr_rows(components::table::data_table_t& table,
+                             std::pmr::memory_resource* resource,
+                             uint64_t num_cols,
+                             uint64_t row_start,
+                             uint64_t count) {
+        using namespace components::types;
+        using namespace components::vector;
+        using namespace components::table;
+        auto types = table.copy_types();
+        uint64_t offset = 0;
+        while (offset < count) {
+            uint64_t batch = std::min(count - offset, uint64_t(DEFAULT_VECTOR_CAPACITY));
+            data_chunk_t chunk(resource, types, batch);
+            chunk.set_cardinality(batch);
+            for (uint64_t i = 0; i < batch; i++) {
+                uint64_t r = row_start + offset + i;
+                for (uint64_t c = 0; c < num_cols; c++) {
+                    chunk.set_value(c, i, logical_value_t{resource, pg_attr_value(c, r)});
+                }
+            }
+            table_append_state state(resource);
+            REQUIRE_FALSE(table.append_lock(state).has_error());
+            REQUIRE_FALSE(table.initialize_append(state).has_error());
+            REQUIRE_FALSE(table.append(chunk, state).has_error());
+            table.finalize_append(state, transaction_data{0, 0});
+            offset += batch;
+        }
+    }
+
+    void scan_and_verify_pg_attr(components::table::data_table_t& table,
+                                 uint64_t num_cols,
+                                 uint64_t total_rows) {
+        using namespace components::vector;
+        uint64_t scanned = 0;
+        table.scan_table_segment(0, total_rows, [&](data_chunk_t& chunk) {
+            for (uint64_t i = 0; i < chunk.size(); i++) {
+                uint64_t r = scanned + i;
+                for (uint64_t c = 0; c < num_cols; c++) {
+                    auto v = chunk.data[c].value(i);
+                    INFO("col=" << c << " row=" << r);
+                    REQUIRE(v.value<int64_t>() == pg_attr_value(c, r));
+                }
+            }
+            scanned += chunk.size();
+        });
+        REQUIRE(scanned == total_rows);
+    }
+
+    // Pool large enough to hold the (tiny) working set resident: the corruption is an
+    // append-into-loaded-segment bug independent of eviction pressure, so the large
+    // pool keeps this guard focused on the data corruption, not pool exhaustion.
+    struct small_pool_env_t {
+        std::pmr::synchronized_pool_resource resource;
+        core::filesystem::local_file_system_t fs;
+        components::table::storage::buffer_pool_t buffer_pool;
+        components::table::storage::standard_buffer_manager_t buffer_manager;
+        small_pool_env_t()
+            : buffer_pool(&resource, uint64_t(1) << 32, false, uint64_t(1) << 24)
+            , buffer_manager(&resource, fs, buffer_pool) {}
+    };
+} // namespace
+
+TEST_CASE("checkpoint_load: shared partial block survives reopen after table grows") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    small_pool_env_t env;
+    constexpr uint64_t NUM_COLS = 8;
+    constexpr uint64_t INITIAL_ROWS = 200; // small -> compressed segments pack into one block
+    constexpr uint64_t GROW_ROWS = 200;
+    constexpr uint64_t TOTAL_ROWS = INITIAL_ROWS + GROW_ROWS;
+
+    auto make_columns = []() {
+        std::vector<column_definition_t> cols;
+        const char* names[NUM_COLS] = {"attrelid",
+                                       "atttypid",
+                                       "attnum",
+                                       "attnotnull",
+                                       "atthasdefault",
+                                       "attisdropped",
+                                       "added_at_commit_id",
+                                       "dropped_at_commit_id"};
+        for (uint64_t c = 0; c < NUM_COLS; c++) {
+            cols.emplace_back(names[c], logical_type::BIGINT);
+        }
+        return cols;
+    };
+
+    meta_block_pointer_t table_pointer;
+
+    // Phase 1: create, append, checkpoint #1.
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+        REQUIRE(!bm.create_new_database().has_error());
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, make_columns(), "pg_attribute");
+        append_pg_attr_rows(*table, &env.resource, NUM_COLS, 0, INITIAL_ROWS);
+        REQUIRE(table->calculate_size() == INITIAL_ROWS);
+        table_pointer = full_checkpoint(*table, bm);
+    }
+
+    // Phase 2: REOPEN #1, verify, then GROW + checkpoint #2.
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+        REQUIRE(!bm.load_existing_database().has_error());
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded_result = data_table_t::load_from_disk(&env.resource, bm, reader);
+        REQUIRE(!loaded_result.has_error());
+        auto& loaded = loaded_result.value();
+        REQUIRE(loaded->column_count() == NUM_COLS);
+
+        // After reopen the loaded data still reads correctly.
+        scan_and_verify_pg_attr(*loaded, NUM_COLS, INITIAL_ROWS);
+
+        // GROW the table: append more rows, then re-checkpoint. This is where the
+        // shared partial block gets freed/recycled and its packed (non-zero-offset)
+        // columns clobbered.
+        append_pg_attr_rows(*loaded, &env.resource, NUM_COLS, INITIAL_ROWS, GROW_ROWS);
+        REQUIRE(loaded->calculate_size() == TOTAL_ROWS);
+        table_pointer = full_checkpoint(*loaded, bm);
+    }
+
+    // Phase 3: REOPEN #2, scan EVERY column. The packed columns at non-zero
+    // offsets (atttypid, attnum, attnotnull, atthasdefault, attisdropped,
+    // added_at_commit_id, dropped_at_commit_id) must read back EXACTLY. On the
+    // buggy code attisdropped/added_at_commit_id come back garbage (the SSB
+    // symptom).
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+        REQUIRE(!bm.load_existing_database().has_error());
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded_result = data_table_t::load_from_disk(&env.resource, bm, reader);
+        REQUIRE(!loaded_result.has_error());
+        auto& loaded = loaded_result.value();
+        REQUIRE(loaded->column_count() == NUM_COLS);
+
+        scan_and_verify_pg_attr(*loaded, NUM_COLS, TOTAL_ROWS);
     }
 
     cleanup_test_file();

--- a/components/table/test/test_column.cpp
+++ b/components/table/test/test_column.cpp
@@ -73,8 +73,8 @@ TEST_CASE("components::table::column") {
             }
 
             column_append_state state;
-            column->initialize_append(state);
-            column->append(state, v, test_size);
+            REQUIRE_FALSE(column->initialize_append(state).has_error());
+            REQUIRE_FALSE(column->append(state, v, test_size).has_error());
         }
         // Fetch
         {
@@ -147,8 +147,8 @@ TEST_CASE("components::table::column") {
             }
 
             column_append_state state;
-            column->initialize_append(state);
-            column->append(state, v, test_size);
+            REQUIRE_FALSE(column->initialize_append(state).has_error());
+            REQUIRE_FALSE(column->append(state, v, test_size).has_error());
         }
         // Fetch
         {
@@ -234,8 +234,8 @@ TEST_CASE("components::table::column") {
             }
 
             column_append_state state;
-            column->initialize_append(state);
-            column->append(state, v, test_size);
+            REQUIRE_FALSE(column->initialize_append(state).has_error());
+            REQUIRE_FALSE(column->append(state, v, test_size).has_error());
         }
         // Fetch
         {
@@ -333,8 +333,8 @@ TEST_CASE("components::table::column") {
             }
 
             column_append_state state;
-            column->initialize_append(state);
-            column->append(state, v, test_size);
+            REQUIRE_FALSE(column->initialize_append(state).has_error());
+            REQUIRE_FALSE(column->append(state, v, test_size).has_error());
         }
         // Fetch
         {
@@ -440,8 +440,8 @@ TEST_CASE("components::table::column") {
             }
 
             column_append_state state;
-            column->initialize_append(state);
-            column->append(state, v, test_size);
+            REQUIRE_FALSE(column->initialize_append(state).has_error());
+            REQUIRE_FALSE(column->append(state, v, test_size).has_error());
         }
         // Fetch
         {
@@ -543,8 +543,8 @@ TEST_CASE("components::table::column") {
             }
 
             column_append_state state;
-            column->initialize_append(state);
-            column->append(state, v, test_size);
+            REQUIRE_FALSE(column->initialize_append(state).has_error());
+            REQUIRE_FALSE(column->append(state, v, test_size).has_error());
         }
         // Fetch
         {
@@ -667,8 +667,8 @@ TEST_CASE("components::table::column") {
             }
 
             column_append_state state;
-            column->initialize_append(state);
-            column->append(state, v, test_size);
+            REQUIRE_FALSE(column->initialize_append(state).has_error());
+            REQUIRE_FALSE(column->append(state, v, test_size).has_error());
         }
         // Fetch
         {

--- a/components/table/test/test_column.cpp
+++ b/components/table/test/test_column.cpp
@@ -110,7 +110,8 @@ TEST_CASE("components::table::column") {
             for (size_t i = 0; i < update_size; i++) {
                 ids.emplace_back(i);
             }
-            column->update(0, v, ids.data(), update_size);
+            auto update_result = column->update(0, v, ids.data(), update_size);
+            REQUIRE_FALSE(update_result.has_error());
         }
         // Scan after update
         {
@@ -186,7 +187,8 @@ TEST_CASE("components::table::column") {
             for (size_t i = 0; i < update_size; i++) {
                 ids.emplace_back(i);
             }
-            column->update(0, v, ids.data(), update_size);
+            auto update_result = column->update(0, v, ids.data(), update_size);
+            REQUIRE_FALSE(update_result.has_error());
         }
         // Scan after update
         {
@@ -278,7 +280,8 @@ TEST_CASE("components::table::column") {
             for (size_t i = 0; i < update_size; i++) {
                 ids.emplace_back(i);
             }
-            column->update(0, v, ids.data(), update_size);
+            auto update_result = column->update(0, v, ids.data(), update_size);
+            REQUIRE_FALSE(update_result.has_error());
         }
         // Scan after update
         {
@@ -383,7 +386,8 @@ TEST_CASE("components::table::column") {
             for (size_t i = 0; i < update_size; i++) {
                 ids.emplace_back(i);
             }
-            column->update(0, v, ids.data(), update_size);
+            auto update_result = column->update(0, v, ids.data(), update_size);
+            REQUIRE_FALSE(update_result.has_error());
         }
         // Scan after update
         {
@@ -490,7 +494,8 @@ TEST_CASE("components::table::column") {
                 v.set_value(i, logical_value_t::create_list(v.resource(), logical_type::UBIGINT, list));
                 ids.emplace_back(static_cast<int64_t>(i));
             }
-            column->update(0, v, ids.data(), update_size);
+            auto update_result = column->update(0, v, ids.data(), update_size);
+            REQUIRE_FALSE(update_result.has_error());
         }
         // Scan after update
         {
@@ -597,7 +602,8 @@ TEST_CASE("components::table::column") {
                 v.set_value(i, logical_value_t::create_list(v.resource(), logical_type::STRING_LITERAL, list));
                 ids.emplace_back(static_cast<int64_t>(i));
             }
-            column->update(0, v, ids.data(), update_size);
+            auto update_result = column->update(0, v, ids.data(), update_size);
+            REQUIRE_FALSE(update_result.has_error());
         }
         // Scan after update
         {

--- a/components/table/test/test_disk_backed_scan.cpp
+++ b/components/table/test/test_disk_backed_scan.cpp
@@ -1,0 +1,309 @@
+// Disk-backed write-through for a DISK-backed table whose data far exceeds its
+// buffer-pool limit. These cases assert OBSERVABLE properties only (row counts,
+// values, on-disk block counts) so they remain valid regardless of the internal
+// mechanism. The invariant under test:
+//   * Without write-through a FILLED segment is a transient in-memory block
+//     (block_id >= MAXIMUM_BLOCK, not reloadable). Nothing is written to the
+//     .otbx file until checkpoint, so total_blocks() stays 0 mid-append and the
+//     working set is pinned fully resident -- a scan with a tiny pool cannot run
+//     bounded.
+//   * With write-through a filled segment is written through to disk (gets a real
+//     block_id < MAXIMUM_BLOCK), so it appears in total_blocks() BEFORE any
+//     checkpoint, becomes reloadable, and the pool can evict + reload it; the
+//     scan then completes bounded with the correct result.
+//
+// Harness modelled on test_checkpoint_load.cpp (DISK-backed data_table_t over a
+// single_file_block_manager_t on a temp .otbx, append / checkpoint / reopen),
+// with TWO deliberate differences, documented inline below:
+//   (1) a SMALL buffer-pool limit so the table's working set exceeds it;
+//   (2) the table object is created in the OUTER scope (not a nested write
+//       block) so we can observe total_blocks() mid-append, force eviction, and
+//       re-scan the SAME live table before checkpoint.
+
+#include <catch2/catch.hpp>
+#include <components/table/data_table.hpp>
+#include <components/table/storage/buffer_pool.hpp>
+#include <components/table/storage/metadata_manager.hpp>
+#include <components/table/storage/metadata_reader.hpp>
+#include <components/table/storage/metadata_writer.hpp>
+#include <components/table/storage/single_file_block_manager.hpp>
+#include <components/table/storage/standard_buffer_manager.hpp>
+#include <core/file/local_file_system.hpp>
+
+#include <limits>
+#include <unistd.h>
+
+namespace {
+    std::string test_db_path() {
+        static std::string path = "/tmp/test_otterbrix_disk_backed_scan_" + std::to_string(::getpid()) + ".otbx";
+        return path;
+    }
+
+    void cleanup_test_file() { std::remove(test_db_path().c_str()); }
+
+    // DIFFERENCE (1) vs test_checkpoint_load::test_env_t -- a SMALL buffer-pool
+    // limit. test_checkpoint_load uses a 4 GiB limit, which holds the whole table
+    // resident. Here the limit is a few MiB so a large table's working set cannot
+    // fit and disk-backed segments must be evicted + reloaded to scan it. Block
+    // alloc size is 256 KiB (DEFAULT_BLOCK_ALLOC_SIZE), so ~4 MiB is ~16 blocks of
+    // headroom -- far below the table built below.
+    constexpr uint64_t SMALL_POOL_LIMIT = uint64_t(4) << 20; // 4 MiB
+
+    struct test_env_t {
+        std::pmr::synchronized_pool_resource resource;
+        core::filesystem::local_file_system_t fs;
+        components::table::storage::buffer_pool_t buffer_pool;
+        components::table::storage::standard_buffer_manager_t buffer_manager;
+
+        test_env_t()
+            : buffer_pool(&resource, SMALL_POOL_LIMIT, false, uint64_t(1) << 24)
+            , buffer_manager(&resource, fs, buffer_pool) {}
+    };
+
+    void append_int64_data(components::table::data_table_t& table,
+                           std::pmr::memory_resource* resource,
+                           uint64_t count) {
+        using namespace components::types;
+        using namespace components::vector;
+        using namespace components::table;
+
+        auto types = table.copy_types();
+        uint64_t offset = 0;
+        while (offset < count) {
+            uint64_t batch = std::min(count - offset, uint64_t(DEFAULT_VECTOR_CAPACITY));
+            data_chunk_t chunk(resource, types, batch);
+            chunk.set_cardinality(batch);
+            for (uint64_t i = 0; i < batch; i++) {
+                chunk.set_value(0, i, logical_value_t{resource, static_cast<int64_t>(offset + i)});
+            }
+            table_append_state state(resource);
+            REQUIRE_FALSE(table.append_lock(state).has_error());
+            REQUIRE_FALSE(table.initialize_append(state).has_error());
+            REQUIRE_FALSE(table.append(chunk, state).has_error());
+            table.finalize_append(state, transaction_data{0, 0});
+            offset += batch;
+        }
+    }
+
+    // Full scan that verifies value[i] == i for every row and returns the count.
+    uint64_t scan_and_verify_sequential(components::table::data_table_t& table, uint64_t expected_rows) {
+        using namespace components::vector;
+        uint64_t scanned = 0;
+        table.scan_table_segment(0, expected_rows, [&](data_chunk_t& chunk) {
+            for (uint64_t i = 0; i < chunk.size(); i++) {
+                auto val = chunk.data[0].value(i);
+                REQUIRE(val.value<int64_t>() == static_cast<int64_t>(scanned + i));
+            }
+            scanned += chunk.size();
+        });
+        return scanned;
+    }
+
+    // Enough rows to dwarf SMALL_POOL_LIMIT: 256 row groups * 1024 rows = 262144
+    // INT64 values = 2 MiB of raw column data spread across many segments, well
+    // above the 4 MiB pool once buffers / overhead are counted, and far above the
+    // per-block 256 KiB so it can never stay resident as one chunk.
+    constexpr uint64_t LARGE_ROW_COUNT =
+        components::vector::DEFAULT_VECTOR_CAPACITY * 256; // 262144 rows
+} // namespace
+
+TEST_CASE("disk_backed_scan: large table full scan completes bounded with correct values", "[step2]") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+
+    single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+    REQUIRE(!bm.create_new_database().has_error());
+
+    std::vector<column_definition_t> columns;
+    columns.emplace_back("value", logical_type::BIGINT);
+    // DIFFERENCE (2) vs test_checkpoint_load -- table lives in the outer scope so
+    // we can probe disk state mid-life and re-scan the same live object.
+    auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "disk_backed");
+
+    append_int64_data(*table, &env.resource, LARGE_ROW_COUNT);
+    REQUIRE(table->calculate_size() == LARGE_ROW_COUNT);
+
+    // A full scan returns ALL rows with correct values. With a tiny pool and a
+    // working set far larger than it, the scan can only run bounded if segments
+    // are disk-backed and so can be evicted + reloaded; transient
+    // (non-reloadable) segments would stay fully resident and OOM.
+    uint64_t scanned = scan_and_verify_sequential(*table, LARGE_ROW_COUNT);
+    REQUIRE(scanned == LARGE_ROW_COUNT);
+
+    cleanup_test_file();
+}
+
+TEST_CASE("disk_backed_scan: filled segments are written through to disk before checkpoint", "[step2]") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+
+    single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+    REQUIRE(!bm.create_new_database().has_error());
+
+    std::vector<column_definition_t> columns;
+    columns.emplace_back("value", logical_type::BIGINT);
+    auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "disk_backed");
+
+    // Immediately after create_new_database, no user-data blocks exist on disk.
+    REQUIRE(bm.total_blocks() == 0);
+
+    append_int64_data(*table, &env.resource, LARGE_ROW_COUNT);
+    REQUIRE(table->calculate_size() == LARGE_ROW_COUNT);
+
+    // Write-through happened: at least one FILLED segment is disk-backed,
+    // observable as on-disk blocks allocated BY THE APPEND PATH, before any
+    // checkpoint. Without write-through nothing is flushed until checkpoint and
+    // this would be 0; with it, filled segments get real block_ids
+    // (< MAXIMUM_BLOCK) and are written through, so total_blocks() > 0 here.
+    //
+    // NOTE on the chosen observable: column_segment_info from
+    // get_column_segment_info() does NOT carry a per-segment block_id (the field
+    // is left default-initialized), so block_id < MAXIMUM_BLOCK is not directly
+    // observable through that public API. total_blocks() on the on-disk block
+    // manager is the equivalent observable: a non-zero pre-checkpoint count means
+    // a filled segment was given a real (disk-backed) block and written through.
+    REQUIRE(bm.total_blocks() > 0);
+
+    cleanup_test_file();
+}
+
+TEST_CASE("disk_backed_scan: forced eviction then re-scan reloads correctly", "[step2]") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+
+    single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+    REQUIRE(!bm.create_new_database().has_error());
+
+    std::vector<column_definition_t> columns;
+    columns.emplace_back("value", logical_type::BIGINT);
+    auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "disk_backed");
+
+    append_int64_data(*table, &env.resource, LARGE_ROW_COUNT);
+    REQUIRE(table->calculate_size() == LARGE_ROW_COUNT);
+
+    // First scan populates / exercises the pool.
+    REQUIRE(scan_and_verify_sequential(*table, LARGE_ROW_COUNT) == LARGE_ROW_COUNT);
+
+    // Force eviction by shrinking the pool to the floor, then re-scan. Only
+    // reloadable (disk-backed) segments can survive eviction + reload; transient
+    // segments could not reproduce the data bounded. The re-scan must still be
+    // fully correct.
+    REQUIRE(!env.buffer_pool.set_limit(uint64_t(1) << 20).has_error()); // 1 MiB -- forces eviction
+    REQUIRE(scan_and_verify_sequential(*table, LARGE_ROW_COUNT) == LARGE_ROW_COUNT);
+
+    cleanup_test_file();
+}
+
+TEST_CASE("disk_backed_scan: checkpoint of large table, reopen yields identical data", "[step2]") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    meta_block_pointer_t table_pointer;
+
+    // write + checkpoint phase, under the SMALL pool.
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+        REQUIRE(!bm.create_new_database().has_error());
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("value", logical_type::BIGINT);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "disk_backed");
+
+        append_int64_data(*table, &env.resource, LARGE_ROW_COUNT);
+        REQUIRE(table->calculate_size() == LARGE_ROW_COUNT);
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_writer_t writer(meta_mgr);
+        // Checkpoint of a large table completes with a pool too small to hold it
+        // resident -- the column flush must stream disk-backed segments and stay
+        // bounded rather than pinning the whole working set.
+        REQUIRE_FALSE(table->checkpoint(writer).has_error());
+        table_pointer = writer.get_block_pointer();
+
+        database_header_t header;
+        header.initialize();
+        bm.write_header(header);
+    }
+
+    // reopen phase — identical row count + values read back from the file.
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+        REQUIRE(!bm.load_existing_database().has_error());
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded_result = data_table_t::load_from_disk(&env.resource, bm, reader);
+        REQUIRE(!loaded_result.has_error());
+        auto& loaded = loaded_result.value();
+
+        REQUIRE(loaded->table_name() == "disk_backed");
+        REQUIRE(loaded->column_count() == 1);
+        REQUIRE(scan_and_verify_sequential(*loaded, LARGE_ROW_COUNT) == LARGE_ROW_COUNT);
+    }
+
+    cleanup_test_file();
+}
+
+TEST_CASE("disk_backed_scan: repeated compaction does not bloat the file", "[step2]") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+
+    single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+    REQUIRE(!bm.create_new_database().has_error());
+
+    std::vector<column_definition_t> columns;
+    columns.emplace_back("value", logical_type::BIGINT);
+    auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "disk_backed");
+
+    // A modest table is enough to exercise the free-list reclaim observable.
+    constexpr uint64_t COMPACT_ROWS = DEFAULT_VECTOR_CAPACITY * 16; // 16384 rows
+    append_int64_data(*table, &env.resource, COMPACT_ROWS);
+    REQUIRE(table->calculate_size() == COMPACT_ROWS);
+
+    // Compact once (watermark above all stamps -> compaction is allowed), record
+    // the on-disk block footprint, then compact several more times.
+    constexpr uint64_t WATERMARK = std::numeric_limits<uint64_t>::max();
+    table->compact(WATERMARK);
+    uint64_t blocks_after_first = bm.total_blocks();
+
+    for (int i = 0; i < 5; i++) {
+        table->compact(WATERMARK);
+    }
+    uint64_t blocks_after_repeated = bm.total_blocks();
+
+    // Data must still be intact after repeated compaction.
+    REQUIRE(table->calculate_size() == COMPACT_ROWS);
+    REQUIRE(scan_and_verify_sequential(*table, COMPACT_ROWS) == COMPACT_ROWS);
+
+    // Free-list reclaim: repeated compaction of unchanged data must not grow the
+    // file unbounded. Each compaction should reuse reclaimed blocks rather than
+    // always appending new ones, so there is no net growth beyond the first
+    // compaction's footprint.
+    REQUIRE(blocks_after_repeated <= blocks_after_first);
+
+    cleanup_test_file();
+}

--- a/components/table/test/test_eviction_guard.cpp
+++ b/components/table/test/test_eviction_guard.cpp
@@ -1,0 +1,236 @@
+// ---------------------------------------------------------------------------
+// Eviction guard for MANAGED (non-reloadable) buffer-pool blocks.
+//
+// The defect this codifies:
+//   A MANAGED in-memory block (block_id >= MAXIMUM_BLOCK) has no backing store,
+//   so block_handle_t::load() returns an EMPTY buffer_handle_t for it once it is
+//   UNLOADED -- there is nothing to re-read. Before the guard, such a block was
+//   still treated as evictable: unpin() enqueued it on the eviction queue, and
+//   can_unload() returned true for it, so a later memory-pressure pass
+//   (evict_blocks) UNLOADED it and freed its buffer. The next pin() then took the
+//   "reload" path -- load() returned an invalid buffer and pin() dereferenced the
+//   now-null buffer_ -> SIGSEGV. This is the large-table-scan crash: a scan
+//   registers many managed segment blocks, the pool fills, eviction unloads an
+//   earlier (still-referenced) managed block, and re-pinning it crashes.
+//
+// The guard:
+//   * block_handle_t::is_reloadable()  -> block_id_ < MAXIMUM_BLOCK
+//   * block_handle_t::can_unload()     -> false for non-reloadable blocks
+//     (the load-bearing safety net: evict/purge can never unload them)
+//   * standard_buffer_manager_t::unpin() skips enqueueing them (optimization)
+//   With the guard the managed block stays resident through the eviction pass, so
+//   the re-pin returns a VALID buffer with the original bytes intact.
+//
+// This test drives the load-bearing half of the guard -- can_unload() -- directly
+// by enqueueing the managed block itself and running an eviction pass against it,
+// so it does not depend on the unpin() optimization to reproduce the crash.
+// ---------------------------------------------------------------------------
+
+#include <catch2/catch.hpp>
+
+#include <components/table/storage/block_handle.hpp>
+#include <components/table/storage/buffer_handle.hpp>
+#include <components/table/storage/buffer_pool.hpp>
+#include <components/table/storage/file_buffer.hpp>
+#include <components/table/storage/single_file_block_manager.hpp>
+#include <components/table/storage/standard_buffer_manager.hpp>
+#include <core/file/local_file_system.hpp>
+#include <core/result_wrapper.hpp>
+
+#include <cstring>
+#include <memory_resource>
+
+namespace {
+    using namespace components::table::storage;
+
+    // buffer_pool_t::evict_blocks() / ::add_to_eviction_queue() / ::maximum_memory
+    // are protected; re-export them in a test-only subclass so the test can drive
+    // an eviction pass deterministically. evict_blocks() never throws: it returns
+    // {found, reservation}.
+    struct test_buffer_pool_t final : buffer_pool_t {
+        using buffer_pool_t::buffer_pool_t;
+        using buffer_pool_t::add_to_eviction_queue;
+        using buffer_pool_t::eviction_result; // protected nested type -> make namable here
+        using buffer_pool_t::evict_blocks;
+        using buffer_pool_t::maximum_memory;
+    };
+
+    struct test_env_t {
+        std::pmr::synchronized_pool_resource resource;
+        core::filesystem::local_file_system_t fs;
+        test_buffer_pool_t buffer_pool;
+        standard_buffer_manager_t buffer_manager;
+
+        // Small pool: a couple of managed blocks fit. The eviction pass below is
+        // driven explicitly (memory_limit = 0), so the absolute limit only needs
+        // to be large enough that registering the block never itself OOMs.
+        explicit test_env_t(uint64_t pool_limit)
+            : buffer_pool(&resource, pool_limit, false, uint64_t(1) << 24)
+            , buffer_manager(&resource, fs, buffer_pool) {}
+    };
+} // namespace
+
+TEST_CASE("buffer manager: re-pinning an evicted managed block does not crash", "[step1]") {
+    using namespace components::table::storage;
+
+    // Construct with a provisional limit, then set the real one once we can query
+    // block_allocation_size(). Room for several managed blocks so that registering
+    // and re-pinning the block never itself trips the over-subscribe OOM path --
+    // the eviction pass below is driven explicitly with memory_limit = 0.
+    test_env_t env(uint64_t(1) << 24);
+    const uint64_t block_alloc = env.buffer_manager.block_allocation_size();
+    env.buffer_pool.maximum_memory = 8 * block_alloc;
+
+    const uint64_t block_size = env.buffer_manager.block_size();
+
+    // Allocate a MANAGED (non-reloadable) block. size == block_size routes
+    // register_transient_memory() to the managed allocate() path, giving a
+    // block_id >= MAXIMUM_BLOCK with destroy_condition == BLOCK.
+    auto h1_result = env.buffer_manager.register_transient_memory(block_size, block_size);
+    REQUIRE_FALSE(h1_result.has_error());
+    std::shared_ptr<block_handle_t> h1 = std::move(h1_result.value());
+    REQUIRE(h1 != nullptr);
+    REQUIRE_FALSE(h1->is_reloadable());
+    REQUIRE(h1->block_id() >= MAXIMUM_BLOCK);
+    REQUIRE(h1->state() == block_state::LOADED);
+
+    // Pin to obtain the buffer, write a recognizable pattern, unpin.
+    constexpr std::byte PATTERN[8] = {std::byte{0xDE},
+                                      std::byte{0xAD},
+                                      std::byte{0xBE},
+                                      std::byte{0xEF},
+                                      std::byte{0xCA},
+                                      std::byte{0xFE},
+                                      std::byte{0xBA},
+                                      std::byte{0xBE}};
+    {
+        auto pinned_result = env.buffer_manager.pin(h1);
+        REQUIRE_FALSE(pinned_result.has_error());
+        buffer_handle_t pinned = std::move(pinned_result.value());
+        REQUIRE(pinned.is_valid());
+        std::byte* data = pinned.ptr();
+        for (uint64_t j = 0; j < block_size; j++) {
+            data[j] = PATTERN[j % sizeof(PATTERN)];
+        }
+        // pinned's destructor unpins (readers -> 0). With the guard, unpin() skips
+        // enqueueing the managed block; without it the block gets enqueued.
+    }
+    REQUIRE(h1->readers() == 0);
+
+    // Drive memory pressure ONTO h1: enqueue it explicitly (modelling that the
+    // scan marked it evictable), then run an eviction pass with memory_limit 0.
+    // This exercises can_unload() -- the load-bearing half of the guard --
+    // directly, independent of the unpin() optimization.
+    //   Without the guard: can_unload() == true  -> evict_blocks UNLOADS h1.
+    //   With the guard:    can_unload() == false -> h1 is skipped, stays LOADED.
+    // evict_blocks() returns {found,...} and never throws, so "nothing freed" is
+    // benign.
+    env.buffer_pool.add_to_eviction_queue(h1);
+    auto eviction = env.buffer_pool.evict_blocks(memory_tag::IN_MEMORY_TABLE,
+                                                 /*extra_memory=*/0,
+                                                 /*memory_limit=*/0,
+                                                 /*buffer=*/nullptr);
+    // Bind the result (do not (void)-cast a [[nodiscard]]); its reservation is
+    // released by its destructor. Whether eviction "succeeded" differs pre/post
+    // guard and is not asserted here -- the next pin() is the discriminator.
+    (void) eviction.success;
+
+    // Re-pin h1 -- the discriminator.
+    //   Without the guard: h1 was UNLOADED -> load() returns {} (no disk copy) ->
+    //                      pin() derefs the null buffer_ -> SIGSEGV (test crashes).
+    //   With the guard:    h1 is still LOADED -> pin() returns a valid buffer.
+    auto repinned_result = env.buffer_manager.pin(h1);
+    REQUIRE_FALSE(repinned_result.has_error());
+    buffer_handle_t repinned = std::move(repinned_result.value());
+    REQUIRE(repinned.is_valid());
+    REQUIRE(h1->state() == block_state::LOADED);
+    REQUIRE_FALSE(h1->is_unloaded());
+
+    // The original bytes survived the eviction pass.
+    const std::byte* data = repinned.ptr();
+    for (uint64_t j = 0; j < block_size; j++) {
+        REQUIRE(data[j] == PATTERN[j % sizeof(PATTERN)]);
+    }
+
+    // repinned's destructor unpins; h1's shared_ptr releases the block at scope end.
+}
+
+// ---------------------------------------------------------------------------
+// Companion: GENUINE pool exhaustion is a clean OOM ERROR VALUE, not a throw,
+// now that register_transient_memory()/allocate()/pin() return
+// core::result_wrapper_t. Every managed (non-reloadable) block is held resident
+// by a live pin, so once the pool fills, evict_blocks() can free NOTHING
+// (can_unload() == false for all of them) -- the next registration must surface
+//   result.has_error() == true && result.error().type == out_of_memory
+// and complete normally rather than throwing.
+//
+// Deterministic exhaustion: maximum_memory = N * block_allocation_size(). Each
+// managed register_transient_memory(block_size, block_size) reserves exactly one
+// block_allocation_size(); holding its pin keeps it non-evictable. After N such
+// allocations used_memory == N * block_allocation_size() == maximum_memory (the
+// last one that still fits), so the (N+1)-th over-subscribes the limit with
+// nothing to evict and must fail. We make several attempts past N to be safe.
+// ---------------------------------------------------------------------------
+TEST_CASE("buffer manager: pool exhaustion of pinned managed blocks returns out_of_memory, not throw",
+          "[step1]") {
+    using namespace components::table::storage;
+
+    // Provisional limit large enough that the first registrations never trip OOM
+    // before we set the real, tight limit (needs block_allocation_size()).
+    test_env_t env(uint64_t(1) << 24);
+    const uint64_t block_alloc = env.buffer_manager.block_allocation_size();
+    const uint64_t block_size = env.buffer_manager.block_size();
+
+    // Pool holds exactly N managed blocks; the (N+1)-th must OOM.
+    constexpr uint64_t N = 4;
+    env.buffer_pool.maximum_memory = N * block_alloc;
+
+    // Keep block handles AND their pins alive: a live pin (readers > 0) plus
+    // can_unload() == false make every block strictly non-evictable, so the pool
+    // genuinely cannot reclaim anything.
+    std::vector<std::shared_ptr<block_handle_t>> handles;
+    std::vector<buffer_handle_t> pins;
+    handles.reserve(N);
+    pins.reserve(N);
+
+    bool saw_out_of_memory = false;
+
+    // The whole body must complete normally -- no exception may escape. REQUIRE
+    // NOTHROW around the exhaustion loop makes the "no throw" half explicit.
+    REQUIRE_NOTHROW([&] {
+        // Fill the pool: the first N allocations fit exactly (used_memory grows
+        // to N * block_alloc == maximum_memory).
+        for (uint64_t i = 0; i < N; i++) {
+            auto h_result = env.buffer_manager.register_transient_memory(block_size, block_size);
+            REQUIRE_FALSE(h_result.has_error());
+            std::shared_ptr<block_handle_t> h = std::move(h_result.value());
+            REQUIRE(h != nullptr);
+            REQUIRE_FALSE(h->is_reloadable());
+
+            auto pin_result = env.buffer_manager.pin(h);
+            REQUIRE_FALSE(pin_result.has_error());
+            buffer_handle_t pinned = std::move(pin_result.value());
+            REQUIRE(pinned.is_valid());
+            REQUIRE(h->readers() > 0);
+
+            handles.push_back(std::move(h));
+            pins.push_back(std::move(pinned));
+        }
+
+        // The pool is now full of pinned, non-reloadable blocks. Every further
+        // registration over-subscribes the limit, and evict_blocks() can free
+        // nothing -> a clean out_of_memory ERROR VALUE. Try a few past the limit.
+        for (uint64_t i = 0; i < 3; i++) {
+            auto over_result = env.buffer_manager.register_transient_memory(block_size, block_size);
+            REQUIRE(over_result.has_error());
+            REQUIRE(over_result.error().type == core::error_code_t::out_of_memory);
+            saw_out_of_memory = true;
+        }
+    }());
+
+    // The OOM was observed as a returned error value, and control reached here
+    // normally -- no exception was thrown.
+    REQUIRE(saw_out_of_memory);
+
+    // pins/handles destructors release the blocks at scope end.
+}

--- a/components/table/test/test_metadata.cpp
+++ b/components/table/test/test_metadata.cpp
@@ -7,9 +7,11 @@
 #include <components/table/storage/single_file_block_manager.hpp>
 #include <components/table/storage/standard_buffer_manager.hpp>
 #include <core/file/local_file_system.hpp>
+#include <core/result_wrapper.hpp>
 
 #include <cstring>
 #include <unistd.h>
+#include <vector>
 
 namespace {
     std::string test_db_path() {
@@ -37,7 +39,7 @@ TEST_CASE("metadata: write and read small data") {
 
     test_env_t env;
     single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
-    bm.create_new_database();
+    REQUIRE(!bm.create_new_database().has_error());
 
     metadata_manager_t manager(bm);
 
@@ -72,7 +74,7 @@ TEST_CASE("metadata: write and read typed data") {
 
     test_env_t env;
     single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
-    bm.create_new_database();
+    REQUIRE(!bm.create_new_database().has_error());
 
     metadata_manager_t manager(bm);
 
@@ -104,7 +106,7 @@ TEST_CASE("metadata: multiple independent chains") {
 
     test_env_t env;
     single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
-    bm.create_new_database();
+    REQUIRE(!bm.create_new_database().has_error());
 
     metadata_manager_t manager(bm);
 
@@ -141,6 +143,57 @@ TEST_CASE("metadata: multiple independent chains") {
         metadata_reader_t reader3(manager, ptr3);
         REQUIRE(reader3.read<uint64_t>() == 333);
     }
+
+    cleanup_test_file();
+}
+
+// Metadata chain-overflow -> sticky data_corruption.
+// A read past the end of the chain records a sticky core::error_t with
+// error_code_t::data_corruption ("attempted to read past end of chain") and turns
+// every subsequent read into a no-op, rather than throwing. We write a SMALL stream
+// (one sub-block, whose header next_ptr == INVALID_INDEX marks the end of the chain)
+// and then read MORE bytes than the whole chain holds, so the read provably runs off
+// the end and trips the sticky error. No throw.
+TEST_CASE("metadata_reader: read past end of chain -> sticky data_corruption (error value)") {
+    using namespace components::table::storage;
+    cleanup_test_file();
+
+    test_env_t env;
+    single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+    REQUIRE(!bm.create_new_database().has_error());
+
+    metadata_manager_t manager(bm);
+
+    // Write a small payload into a single sub-block, then flush so a reader can
+    // walk the (one-sub-block) chain.
+    meta_block_pointer_t pointer;
+    {
+        metadata_writer_t writer(manager);
+        writer.write<uint64_t>(0xABCDEF0123456789ULL);
+        pointer = writer.get_block_pointer();
+        writer.flush();
+    }
+
+    // A single sub-block holds (sub_block_size - SUB_BLOCK_HEADER_SIZE) readable
+    // bytes; ask for far more than that so the read provably runs off the end.
+    const uint64_t over_read = manager.sub_block_size() * 3;
+    REQUIRE(over_read > manager.sub_block_size());
+
+    metadata_reader_t reader(manager, pointer);
+    REQUIRE_FALSE(reader.has_error());
+
+    std::vector<std::byte> sink(over_read, std::byte{0});
+    REQUIRE_NOTHROW(reader.read_data(sink.data(), over_read));
+
+    // Sticky corrupt-stream flag set; the error is data_corruption.
+    REQUIRE(reader.has_error()); // would be a false pass if the read stayed in-bounds
+    REQUIRE(reader.error().type == core::error_code_t::data_corruption);
+
+    // Sticky: a further read remains a no-op and the error type is unchanged.
+    uint64_t after = 0xFFFFFFFFFFFFFFFFULL;
+    REQUIRE_NOTHROW(reader.read_data(reinterpret_cast<std::byte*>(&after), sizeof(after)));
+    REQUIRE(reader.has_error());
+    REQUIRE(reader.error().type == core::error_code_t::data_corruption);
 
     cleanup_test_file();
 }

--- a/components/table/test/test_mvcc_operations.cpp
+++ b/components/table/test/test_mvcc_operations.cpp
@@ -42,9 +42,9 @@ namespace {
         chunk.set_cardinality(count);
 
         table_append_state state(&env.resource);
-        table.append_lock(state);
-        table.initialize_append(state);
-        table.append(chunk, state);
+        REQUIRE_FALSE(table.append_lock(state).has_error());
+        REQUIRE_FALSE(table.initialize_append(state).has_error());
+        REQUIRE_FALSE(table.append(chunk, state).has_error());
         table.finalize_append(state, transaction_data{0, 0});
     }
 
@@ -57,9 +57,9 @@ namespace {
         chunk.set_cardinality(count);
 
         table_append_state state(&env.resource);
-        table.append_lock(state);
-        table.initialize_append(state);
-        table.append(chunk, state);
+        REQUIRE_FALSE(table.append_lock(state).has_error());
+        REQUIRE_FALSE(table.initialize_append(state).has_error());
+        REQUIRE_FALSE(table.append(chunk, state).has_error());
         table.finalize_append(state, txn);
     }
 

--- a/components/table/test/test_parallel_scan.cpp
+++ b/components/table/test/test_parallel_scan.cpp
@@ -41,9 +41,9 @@ namespace {
         chunk.set_cardinality(count);
 
         table_append_state state(&env.resource);
-        table.append_lock(state);
-        table.initialize_append(state);
-        table.append(chunk, state);
+        REQUIRE_FALSE(table.append_lock(state).has_error());
+        REQUIRE_FALSE(table.initialize_append(state).has_error());
+        REQUIRE_FALSE(table.append(chunk, state).has_error());
         table.finalize_append(state, transaction_data{0, 0});
     }
 

--- a/components/table/test/test_statistics.cpp
+++ b/components/table/test/test_statistics.cpp
@@ -197,8 +197,10 @@ TEST_CASE("per-segment statistics: check_segment_zonemap") {
 
     // Simulate two segments with non-overlapping ranges
     // Segment 1: [1..50], Segment 2: [51..100]
-    auto seg1 =
+    auto seg1_r =
         column_segment_t::create_segment(buffer_manager, complex_logical_type{logical_type::BIGINT}, 0, 262144, 262144);
+    REQUIRE_FALSE(seg1_r.has_error());
+    auto seg1 = std::move(seg1_r.value());
     {
         base_statistics_t s1(&resource, logical_type::BIGINT);
         s1.set_min(logical_value_t{&resource, int64_t(1)});
@@ -206,11 +208,13 @@ TEST_CASE("per-segment statistics: check_segment_zonemap") {
         seg1->set_segment_statistics(std::move(s1));
     }
 
-    auto seg2 = column_segment_t::create_segment(buffer_manager,
-                                                 complex_logical_type{logical_type::BIGINT},
-                                                 50,
-                                                 262144,
-                                                 262144);
+    auto seg2_r = column_segment_t::create_segment(buffer_manager,
+                                                   complex_logical_type{logical_type::BIGINT},
+                                                   50,
+                                                   262144,
+                                                   262144);
+    REQUIRE_FALSE(seg2_r.has_error());
+    auto seg2 = std::move(seg2_r.value());
     {
         base_statistics_t s2(&resource, logical_type::BIGINT);
         s2.set_min(logical_value_t{&resource, int64_t(51)});
@@ -274,14 +278,14 @@ TEST_CASE("per-segment statistics: populated during append") {
 
     // Append data through column_data_t
     column_append_state append_state;
-    col->initialize_append(append_state);
+    REQUIRE_FALSE(col->initialize_append(append_state).has_error());
 
     vector_t vec(&resource, logical_type::BIGINT, 100);
     auto data = vec.data<int64_t>();
     for (uint64_t i = 0; i < 100; i++) {
         data[i] = static_cast<int64_t>(i + 1);
     }
-    col->append(append_state, vec, 100);
+    REQUIRE_FALSE(col->append(append_state, vec, 100).has_error());
 
     // The current segment should have per-segment statistics
     REQUIRE(append_state.current != nullptr);

--- a/components/table/test/test_table.cpp
+++ b/components/table/test/test_table.cpp
@@ -711,7 +711,8 @@ TEST_CASE("components::table::data_table") {
                 v.set_value(i, logical_value_t(&resource, int64_t(i * 2 + 1)));
                 chunk.set_value(0, i, logical_value_t{&resource, int16_t(i * 2 + 1)});
             }
-            extended_table->update_column(v, {8}, chunk);
+            auto update_result = extended_table->update_column(v, {8}, chunk);
+            REQUIRE_FALSE(update_result.has_error());
         }
         // Scan after extension
         {

--- a/components/table/test/test_table.cpp
+++ b/components/table/test/test_table.cpp
@@ -188,9 +188,9 @@ TEST_CASE("components::table::data_table") {
         }
 
         table_append_state state(&resource);
-        data_table->append_lock(state);
-        data_table->initialize_append(state);
-        data_table->append(chunk, state);
+        REQUIRE_FALSE(data_table->append_lock(state).has_error());
+        REQUIRE_FALSE(data_table->initialize_append(state).has_error());
+        REQUIRE_FALSE(data_table->append(chunk, state).has_error());
         data_table->finalize_append(state, transaction_data{0, 0});
     }
     INFO("Fetch") {

--- a/components/table/test/test_transaction_manager.cpp
+++ b/components/table/test/test_transaction_manager.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch.hpp>
+#include <components/table/row_version_manager.hpp>
 #include <components/table/transaction_manager.hpp>
 #include <memory_resource>
 
@@ -118,6 +119,75 @@ TEST_CASE("components::table::transaction_manager::id_monotonicity") {
         auto cid = mgr.commit(session);
         mgr.publish(cid);
     }
+}
+
+// Reproduces the MVCC reopen-visibility bug. On reopen the commit clock's two
+// halves were restored from inconsistent sources: published_horizon_ was raised to
+// the prior session's durable frontier F (the old WAL-replay restore did publish(F)
+// alone) while current_timestamp_ — the fetch_add source of every new
+// start_time/commit_id — restarted at 1. A post-reopen txn therefore drew a
+// commit_id that REUSED the already-published band <= F.
+//
+// Two consequences, both correctness defects:
+//   1. ID REUSE: the new commit_id collides with an id a PRIOR session already
+//      published. Two distinct rows then share one commit_id — visibility filters
+//      (use_inserted_version) can no longer tell them apart.
+//   2. IN-FLIGHT FREEZE: a reader that snapshots the new commit while it is
+//      in-flight freezes the colliding id (<= published_horizon_) in
+//      in_flight_snapshot; after publish() that reader judges the row invisible
+//      forever, even though the id sits below its horizon (the SSB symptom:
+//      q1-1 / probe returned 0 rows after reopen).
+//
+// INVARIANT under test (what the fix restores): after ANY reopen restore, a
+// transaction that commits AFTER reopen must draw a commit_id STRICTLY ABOVE the
+// restored published_horizon_ (no reuse), keeping current_timestamp_ >=
+// published_horizon_ + 1; and its row must be visible to a snapshot taken after
+// it publishes.
+TEST_CASE("components::table::transaction_manager::reopen_post_append_visible") {
+    using namespace components::table;
+    using namespace components::session;
+
+    transaction_manager_t mgr(std::pmr::new_delete_resource());
+
+    // --- Restore the durable frontier at reopen -------------------------------
+    // restore_commit_clock is the single entry point every reopen restore funnels
+    // through (seed_commit_clock_sync calls it with the combined durable frontier).
+    // It raises BOTH halves of the commit clock from the frontier: published_horizon_
+    // AND current_timestamp_, maintaining current_timestamp_ >= horizon + 1.
+    //
+    // The PRE-EXISTING bug raised only published_horizon_ — the WAL-replay restore
+    // did publish(F) alone, leaving current_timestamp_ at 1. Replacing the call
+    // below with `mgr.publish(kFrontier)` (the old behaviour) makes the two REQUIREs
+    // below FAIL: the post-reopen commit_id comes back as 2 (<= kFrontier, a reuse)
+    // and a reader never sees the row.
+    constexpr uint64_t kFrontier = 1208; // SSB-style durable frontier
+    mgr.restore_commit_clock(kFrontier);
+    REQUIRE(mgr.published_horizon() == kFrontier);
+
+    // --- Post-reopen writer: INSERT a new row, then COMMIT --------------------
+    auto writer = session_id_t::generate_uid();
+    auto& wtxn = mgr.begin_transaction(writer);
+    // The row's pending insert version is the writer's (pending) transaction_id.
+    chunk_constant_info row(0);
+    row.insert_id = wtxn.transaction_id();
+    auto commit_id = mgr.commit(writer);
+    // Stamp the row's committed insert version with the freshly-allocated id.
+    row.commit_append(commit_id, 0, components::vector::DEFAULT_VECTOR_CAPACITY);
+
+    // INVARIANT 1 (no id reuse): the post-reopen commit_id is STRICTLY above the
+    // restored frontier — it never lands back inside the already-published band.
+    REQUIRE(commit_id > kFrontier);
+
+    // Writer publishes (advancing the horizon to include the new commit).
+    mgr.publish(commit_id);
+
+    // --- Reader snapshot taken AFTER the writer published ----------------------
+    auto reader = session_id_t::generate_uid();
+    auto& rtxn = mgr.begin_transaction(reader);
+
+    // INVARIANT 2 (post-publish visibility): the post-reopen row is visible to a
+    // snapshot taken after its commit published.
+    REQUIRE(row.fetch(rtxn.data(), 0));
 }
 
 TEST_CASE("components::table::transaction_manager::append_tracking") {

--- a/components/table/transaction_manager.cpp
+++ b/components/table/transaction_manager.cpp
@@ -48,6 +48,33 @@ namespace components::table {
         return commit_id;
     }
 
+    void transaction_manager_t::restore_commit_clock(uint64_t frontier) {
+        // Bootstrap-time, single-threaded (schedulers not started): raise BOTH
+        // halves of the monotonic commit clock together from one durable frontier.
+        //   * current_timestamp_ → max(current, frontier + 1): the next
+        //     begin_transaction's start_time = fetch_add() therefore exceeds every
+        //     persisted added_at_commit_id AND every published commit-id, so
+        //     post-reopen INSERTs never reuse the durable band; resolve_table keeps
+        //     persisted columns visible and reader snapshots judge fresh rows
+        //     correctly.
+        //   * published_horizon_ → max(current, frontier): post-recovery snapshots
+        //     see the persisted commits as published.
+        // Raising them in lockstep preserves the invariant
+        // current_timestamp_ >= published_horizon_ + 1. Both reopen sites — WAL
+        // COMMIT-marker frontier and checkpointed pg_attribute frontier — funnel
+        // through here so they cannot disagree.
+        // frontier + 1 cannot overflow in practice (commit ids start at 1 and a
+        // realistic frontier is far below UINT64_MAX).
+        auto cur_ts = current_timestamp_.load(std::memory_order_relaxed);
+        if (frontier + 1 > cur_ts) {
+            current_timestamp_.store(frontier + 1, std::memory_order_relaxed);
+        }
+        auto cur_horizon = published_horizon_.load(std::memory_order_relaxed);
+        if (frontier > cur_horizon) {
+            published_horizon_.store(frontier, std::memory_order_release);
+        }
+    }
+
     void transaction_manager_t::publish(uint64_t commit_id) {
         std::lock_guard guard(lock_);
         in_flight_commits_.erase(commit_id);

--- a/components/table/transaction_manager.hpp
+++ b/components/table/transaction_manager.hpp
@@ -65,6 +65,31 @@ namespace components::table {
 
         uint64_t published_horizon() const noexcept { return published_horizon_.load(std::memory_order_acquire); }
 
+        // Reopen restores BOTH halves of the commit clock from a SINGLE durable
+        // frontier. The one entry point every reopen restore path must funnel
+        // through, so the two halves can never disagree:
+        //   * current_timestamp_  → max(current, frontier + 1): the fetch_add source
+        //     of every new start_time/commit_id. Raising it past the frontier means
+        //     post-reopen INSERTs draw commit-ids ABOVE the durable band — they no
+        //     longer collide with already-published ids, so a reader that snapshots
+        //     them in-flight and later sees them published judges them visible (and
+        //     persisted added_at_commit_id stay in the past).
+        //   * published_horizon_  → max(current, frontier): post-recovery snapshots
+        //     see every persisted commit as published.
+        // Maintains the invariant current_timestamp_ >= published_horizon_ + 1.
+        // Idempotent — NEVER lowers either value. Called single-threaded at
+        // bootstrap, before schedulers start, so plain store(max(...)) under no
+        // contention suffices.
+        void restore_commit_clock(uint64_t frontier);
+
+        // Reopen restores the commit-id horizon so persisted catalog columns stay
+        // visible. pg_attribute stamps every column with an added_at_commit_id from
+        // the prior session's clock; a reopened manager starts its clock at {1,0},
+        // so without this seed every new txn's start_time would fall BELOW those
+        // persisted ids and resolve_table's visibility filter would judge all
+        // columns "added after my snapshot" → "column not found".
+        void seed_commit_clock(uint64_t high_water) { restore_commit_clock(high_water); }
+
         std::pmr::memory_resource* resource() const noexcept { return resource_; }
 
     private:

--- a/components/table/update_segment.cpp
+++ b/components/table/update_segment.cpp
@@ -50,11 +50,14 @@ namespace components::table {
         return pos;
     }
 
-    static void check_for_conflicts(undo_buffer_pointer_t next_ptr,
-                                    int64_t* ids,
-                                    const vector::indexing_vector_t& indexing,
-                                    uint64_t count,
-                                    int64_t offset) {
+    // Returns a write_conflict error_t when an MVCC write-write conflict is detected;
+    // no_error() otherwise.
+    static core::error_t check_for_conflicts(undo_buffer_pointer_t next_ptr,
+                                             int64_t* ids,
+                                             const vector::indexing_vector_t& indexing,
+                                             uint64_t count,
+                                             int64_t offset,
+                                             std::pmr::memory_resource* resource) {
         while (next_ptr.is_set()) {
             auto pin = next_ptr.pin();
             auto& info = pin.update_info();
@@ -63,7 +66,8 @@ namespace components::table {
             while (true) {
                 auto id = ids[indexing.get_index(i)] - offset;
                 if (id == tuples[j]) {
-                    throw std::logic_error("Conflict on update!");
+                    return core::error_t(core::error_code_t::write_conflict,
+                                         std::pmr::string{"Conflict on update!", resource});
                 } else if (id < tuples[j]) {
                     i++;
                     if (i == count) {
@@ -78,6 +82,7 @@ namespace components::table {
             }
             next_ptr = info.next;
         }
+        return core::error_t::no_error();
     }
 
     update_info_t* create_empty_update_info(uint64_t type_size, uint64_t, std::unique_ptr<std::byte[]>& data) {
@@ -119,10 +124,19 @@ namespace components::table {
 
     undo_buffer_reference undo_buffer_pointer_t::pin() const {
         assert(entry->capacity >= position);
-        return undo_buffer_reference(*entry, entry->buffer_manager.pin(entry->block), position);
+        // entry->block is a TRANSACTION block already allocated by undo_buffer_allocator_t::
+        // allocate(); it is resident, so re-pinning it cannot OOM. The genuine OOM site is
+        // allocate() (which returns a result_wrapper). Assert here and, on the (impossible)
+        // error path, return an empty handle rather than throwing.
+        auto pinned = entry->buffer_manager.pin(entry->block);
+        assert(!pinned.has_error() && "undo_buffer_pointer_t::pin: resident TRANSACTION block must not OOM");
+        if (pinned.has_error()) {
+            return undo_buffer_reference(*entry, storage::buffer_handle_t{}, position);
+        }
+        return undo_buffer_reference(*entry, std::move(pinned.value()), position);
     }
 
-    undo_buffer_reference undo_buffer_allocator_t::allocate(uint64_t alloc_len) {
+    core::result_wrapper_t<undo_buffer_reference> undo_buffer_allocator_t::allocate(uint64_t alloc_len) {
         assert(!head || head->position <= head->capacity);
         storage::buffer_handle_t handle;
         if (!head || head->position + alloc_len > head->capacity) {
@@ -138,10 +152,23 @@ namespace components::table {
             }
             auto entry = std::make_unique<undo_buffer_entry_t>(buffer_manager);
             if (capacity < block_size) {
-                entry->block = buffer_manager.register_small_memory(storage::memory_tag::TRANSACTION, capacity);
-                handle = buffer_manager.pin(entry->block);
+                // Genuine fresh transaction-memory allocation — the OOM-able site.
+                auto registered = buffer_manager.register_small_memory(storage::memory_tag::TRANSACTION, capacity);
+                if (registered.has_error()) {
+                    return registered.convert_error<undo_buffer_reference>();
+                }
+                entry->block = std::move(registered.value());
+                auto pinned = buffer_manager.pin(entry->block);
+                if (pinned.has_error()) {
+                    return pinned.convert_error<undo_buffer_reference>();
+                }
+                handle = std::move(pinned.value());
             } else {
-                handle = buffer_manager.allocate(storage::memory_tag::TRANSACTION, capacity, false);
+                auto allocated = buffer_manager.allocate(storage::memory_tag::TRANSACTION, capacity, false);
+                if (allocated.has_error()) {
+                    return allocated.convert_error<undo_buffer_reference>();
+                }
+                handle = std::move(allocated.value());
                 entry->block = handle.block_handle()->shared_from_this();
             }
             entry->capacity = capacity;
@@ -154,7 +181,11 @@ namespace components::table {
             }
             head = std::move(entry);
         } else {
-            handle = buffer_manager.pin(head->block);
+            auto pinned = buffer_manager.pin(head->block);
+            if (pinned.has_error()) {
+                return pinned.convert_error<undo_buffer_reference>();
+            }
+            handle = std::move(pinned.value());
         }
         uint64_t current_position = head->position;
         head->position += alloc_len;
@@ -293,17 +324,17 @@ namespace components::table {
         }
     }
 
-    void update_segment_t::update(uint64_t column_index,
-                                  vector::vector_t& update,
-                                  int64_t* ids,
-                                  uint64_t count,
-                                  vector::vector_t& base_data) {
+    core::result_wrapper_t<bool> update_segment_t::update(uint64_t column_index,
+                                                         vector::vector_t& update,
+                                                         int64_t* ids,
+                                                         uint64_t count,
+                                                         vector::vector_t& base_data) {
         auto write_lock = std::unique_lock(m_);
 
         update.flatten(count);
 
         if (count == 0) {
-            return;
+            return true;
         }
 
         vector::indexing_vector_t indexing(update.resource(), 0, count);
@@ -325,7 +356,15 @@ namespace components::table {
             auto& base_info = root_pin.update_info();
 
             undo_buffer_reference node_ref;
-            check_for_conflicts(base_info.next, ids, indexing, count, static_cast<int64_t>(vector_offset));
+            auto conflict = check_for_conflicts(base_info.next,
+                                                ids,
+                                                indexing,
+                                                count,
+                                                static_cast<int64_t>(vector_offset),
+                                                column_data_->resource());
+            if (conflict.contains_error()) {
+                return conflict; // write_conflict
+            }
 
             std::unique_ptr<std::byte[]> update_info_data;
             update_info_t* node;
@@ -347,7 +386,11 @@ namespace components::table {
             merge_update(base_info, base_data, *node, update, ids, count, indexing);
         } else {
             uint64_t alloc_size = update_info_t::allocation_size(type_size_);
-            auto handle = root_->buffer_allocator.allocate(alloc_size);
+            auto allocated = root_->buffer_allocator.allocate(alloc_size);
+            if (allocated.has_error()) {
+                return allocated.convert_error<bool>(); // out_of_memory
+            }
+            auto& handle = allocated.value();
             auto& update_info = handle.update_info();
             update_info.initialize();
             update_info.column_index = column_index;
@@ -370,6 +413,7 @@ namespace components::table {
 
             root_->info[vector_index] = handle.buffer_pointer();
         }
+        return true;
     }
 
     void update_segment_t::fetch_row(int64_t row_id, vector::vector_t& result, uint64_t result_idx) {

--- a/components/table/update_segment.hpp
+++ b/components/table/update_segment.hpp
@@ -113,7 +113,7 @@ namespace components::table {
             : buffer_manager(buffer_manager) {}
 
         // Returns out_of_memory when fresh transaction memory cannot be reserved.
-        core::result_wrapper_t<undo_buffer_reference> allocate(uint64_t alloc_len);
+        [[nodiscard]] core::result_wrapper_t<undo_buffer_reference> allocate(uint64_t alloc_len);
 
         storage::buffer_manager_t& buffer_manager;
         std::unique_ptr<undo_buffer_entry_t> head{};
@@ -190,11 +190,11 @@ namespace components::table {
                                    vector::vector_t& result,
                                    uint64_t result_offset_base = 0);
         // Returns write_conflict or out_of_memory; true on success.
-        core::result_wrapper_t<bool> update(uint64_t column_index,
-                                            vector::vector_t& update,
-                                            int64_t* ids,
-                                            uint64_t count,
-                                            vector::vector_t& base_data);
+        [[nodiscard]] core::result_wrapper_t<bool> update(uint64_t column_index,
+                                                          vector::vector_t& update,
+                                                          int64_t* ids,
+                                                          uint64_t count,
+                                                          vector::vector_t& base_data);
         void fetch_row(int64_t row_id, vector::vector_t& result, uint64_t result_idx);
         bool check_row(int64_t row_id, const table_filter_t* filter);
         bool row_is_updated(int64_t row_id);

--- a/components/table/update_segment.hpp
+++ b/components/table/update_segment.hpp
@@ -112,7 +112,8 @@ namespace components::table {
         explicit undo_buffer_allocator_t(storage::buffer_manager_t& buffer_manager)
             : buffer_manager(buffer_manager) {}
 
-        undo_buffer_reference allocate(uint64_t alloc_len);
+        // Returns out_of_memory when fresh transaction memory cannot be reserved.
+        core::result_wrapper_t<undo_buffer_reference> allocate(uint64_t alloc_len);
 
         storage::buffer_manager_t& buffer_manager;
         std::unique_ptr<undo_buffer_entry_t> head{};
@@ -188,11 +189,12 @@ namespace components::table {
                                    uint64_t count,
                                    vector::vector_t& result,
                                    uint64_t result_offset_base = 0);
-        void update(uint64_t column_index,
-                    vector::vector_t& update,
-                    int64_t* ids,
-                    uint64_t count,
-                    vector::vector_t& base_data);
+        // Returns write_conflict or out_of_memory; true on success.
+        core::result_wrapper_t<bool> update(uint64_t column_index,
+                                            vector::vector_t& update,
+                                            int64_t* ids,
+                                            uint64_t count,
+                                            vector::vector_t& base_data);
         void fetch_row(int64_t row_id, vector::vector_t& result, uint64_t result_idx);
         bool check_row(int64_t row_id, const table_filter_t* filter);
         bool row_is_updated(int64_t row_id);

--- a/components/table/validity_column_data.cpp
+++ b/components/table/validity_column_data.cpp
@@ -18,10 +18,10 @@ namespace components::table {
         return filter_propagate_result_t::NO_PRUNING_POSSIBLE;
     }
 
-    void validity_column_data_t::append_data(column_append_state& state,
-                                             vector::unified_vector_format& uvf,
-                                             uint64_t count) {
-        column_data_t::append_data(state, uvf, count);
+    core::result_wrapper_t<bool> validity_column_data_t::append_data(column_append_state& state,
+                                                                    vector::unified_vector_format& uvf,
+                                                                    uint64_t count) {
+        return column_data_t::append_data(state, uvf, count);
     }
 
 } // namespace components::table

--- a/components/table/validity_column_data.hpp
+++ b/components/table/validity_column_data.hpp
@@ -12,7 +12,8 @@ namespace components::table {
                                column_data_t& parent);
 
         filter_propagate_result_t check_zonemap(column_scan_state& state, table_filter_t& filter) override;
-        void append_data(column_append_state& state, vector::unified_vector_format& uvf, uint64_t count) override;
+        core::result_wrapper_t<bool>
+        append_data(column_append_state& state, vector::unified_vector_format& uvf, uint64_t count) override;
     };
 
 } // namespace components::table

--- a/components/table/validity_column_data.hpp
+++ b/components/table/validity_column_data.hpp
@@ -12,7 +12,7 @@ namespace components::table {
                                column_data_t& parent);
 
         filter_propagate_result_t check_zonemap(column_scan_state& state, table_filter_t& filter) override;
-        core::result_wrapper_t<bool>
+        [[nodiscard]] core::result_wrapper_t<bool>
         append_data(column_append_state& state, vector::unified_vector_format& uvf, uint64_t count) override;
     };
 

--- a/components/vector/arithmetic.cpp
+++ b/components/vector/arithmetic.cpp
@@ -1121,6 +1121,14 @@ namespace components::vector {
                                        const vector_t& left,
                                        const vector_t& right,
                                        uint64_t count) {
+        // Empty input: produce an empty result without dereferencing operand
+        // vectors. On a 0-row chunk the operands may not be resolvable at all
+        // (e.g. a degenerate 0-column batch chunk yields out-of-bounds operand
+        // pointers), so reading left.type()/right.type() here would deref a
+        // dangling vector. A 0-row arithmetic result carries no values.
+        if (count == 0) {
+            return vector_t(resource, types::complex_logical_type(types::logical_type::DOUBLE), 0);
+        }
         if (types::is_duration(left.type().type()) || types::is_duration(right.type().type())) {
             return compute_temporal_binary(resource, op, left, right, count);
         }
@@ -1159,6 +1167,12 @@ namespace components::vector {
                                               const vector_t& vec,
                                               const types::logical_value_t& scalar,
                                               uint64_t count) {
+        // Empty input: see compute_binary_arithmetic. The vec operand may be a
+        // dangling/out-of-bounds reference on a 0-row chunk, so do not read its
+        // type here.
+        if (count == 0) {
+            return vector_t(resource, types::complex_logical_type(types::logical_type::DOUBLE), 0);
+        }
         if (types::is_duration(vec.type().type()) || types::is_duration(scalar.type().type())) {
             return compute_temporal_vec_scalar(resource, op, vec, scalar, count);
         }
@@ -1197,6 +1211,12 @@ namespace components::vector {
                                               const types::logical_value_t& scalar,
                                               const vector_t& vec,
                                               uint64_t count) {
+        // Empty input: see compute_binary_arithmetic. The vec operand may be a
+        // dangling/out-of-bounds reference on a 0-row chunk, so do not read its
+        // type here.
+        if (count == 0) {
+            return vector_t(resource, types::complex_logical_type(types::logical_type::DOUBLE), 0);
+        }
         if (types::is_duration(scalar.type().type()) || types::is_duration(vec.type().type())) {
             return compute_temporal_scalar_vec(resource, op, scalar, vec, count);
         }
@@ -1231,6 +1251,12 @@ namespace components::vector {
     }
 
     vector_t compute_unary_neg(std::pmr::memory_resource* resource, const vector_t& vec, uint64_t count) {
+        // Empty input: see compute_binary_arithmetic. The vec operand may be a
+        // dangling/out-of-bounds reference on a 0-row chunk, so do not read its
+        // type here.
+        if (count == 0) {
+            return vector_t(resource, types::complex_logical_type(types::logical_type::DOUBLE), 0);
+        }
         vector_t output(resource, vec.type(), count);
         types::simple_physical_type_switch<unary_neg_wrapper::callback>(vec.type().to_physical_type(),
                                                                         vec,

--- a/components/vector/tests/CMakeLists.txt
+++ b/components/vector/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ set( ${PROJECT_NAME}_SOURCES
         test_vector.cpp
         test_arrow_conversion.cpp
         test_validity_mask.cpp
+        test_arithmetic_empty.cpp
 )
 
 add_executable(${PROJECT_NAME} main.cpp ${${PROJECT_NAME}_SOURCES})

--- a/components/vector/tests/test_arithmetic_empty.cpp
+++ b/components/vector/tests/test_arithmetic_empty.cpp
@@ -1,0 +1,58 @@
+#include <catch2/catch.hpp>
+
+#include <components/vector/arithmetic.hpp>
+#include <components/vector/data_chunk.hpp>
+
+using namespace components;
+
+// Regression: SSB q1-1 on database REOPEN segfaulted in
+// compute_binary_arithmetic while evaluating
+// SUM(lo_extendedprice * lo_discount) over an EMPTY batch chunk (count==0).
+//
+// On reopen a degenerate group sub-chunk has 0 rows AND 0 columns. The
+// arithmetic operand keys resolve via data_chunk_t::at(path) to out-of-bounds
+// vector_t* pointers (the chunk's column array is empty). compute_binary_arithmetic
+// then dereferenced those operand vectors (left.type()) before checking the row
+// count, causing EXC_BAD_ACCESS.
+//
+// This test reproduces that exact shape at the vector layer: a 0-row, 0-column
+// chunk whose operand pointers are resolved with at(path) (the same call the
+// arithmetic operator uses). With the count==0 guard in place the call must NOT
+// crash and must return an empty (0-row) result vector.
+//
+// NOTE: the operand pointers are intentionally dangling/out-of-bounds — the test
+// itself never dereferences them; only the function-under-test would, which is
+// precisely the bug being guarded.
+TEST_CASE("compute_binary_arithmetic: empty chunk operands, count==0 does not deref") {
+    auto resource = std::pmr::synchronized_pool_resource();
+
+    // Degenerate batch chunk: no columns, zero rows.
+    std::pmr::vector<types::complex_logical_type> no_types(&resource);
+    components::vector::data_chunk_t chunk(&resource, no_types, /*capacity=*/1);
+    chunk.set_cardinality(0);
+    REQUIRE(chunk.size() == 0);
+    REQUIRE(chunk.column_count() == 0);
+
+    // Resolve operand vectors the same way the arithmetic operator does: by
+    // column path. With an empty column array these yield out-of-bounds pointers.
+    std::pmr::vector<size_t> left_path(&resource);
+    left_path.push_back(9); // lo_extendedprice index in the real SSB chunk
+    std::pmr::vector<size_t> right_path(&resource);
+    right_path.push_back(11); // lo_discount index
+
+    components::vector::vector_t* left = chunk.at(left_path);
+    components::vector::vector_t* right = chunk.at(right_path);
+
+    // Without the count==0 guard this dereferences left->type() on a dangling
+    // vector → SIGSEGV. Reaching the assertions below proves the guard ran.
+    auto out = components::vector::compute_binary_arithmetic(&resource,
+                                                            components::vector::arithmetic_op::multiply,
+                                                            *left,
+                                                            *right,
+                                                            /*count=*/0);
+
+    // A flat numeric result vector of the promoted arithmetic type, carrying no
+    // rows (count==0 was requested).
+    REQUIRE(out.get_vector_type() == components::vector::vector_type::FLAT);
+    REQUIRE(out.type().type() == components::types::logical_type::DOUBLE);
+}

--- a/core/result_wrapper.hpp
+++ b/core/result_wrapper.hpp
@@ -56,6 +56,13 @@ namespace core {
         incorrect_function_argument,
         incorrect_function_return_type,
         invalid_constraint,
+
+        // Buffer/storage-layer runtime errors. Surfaced via result_wrapper_t/error_t instead of throwing on
+        // the agent_disk thread.
+        out_of_memory,   // buffer pool exhausted; evict_blocks could not free enough memory
+        data_corruption, // block checksum mismatch on read (disk reload / spill read)
+        io_error,        // file create/open/header/read/write failure
+        write_conflict,  // MVCC write-write conflict
     };
 
     struct error_t {

--- a/integration/cpp/base_spaces.cpp
+++ b/integration/cpp/base_spaces.cpp
@@ -160,6 +160,18 @@ namespace otterbrix {
             // so the WAL-replay filter below can correctly skip
             // already-checkpointed records for user tables.
             disk_ptr->load_user_table_storages_sync();
+            // pg_class persists unconditionally, but IN_MEMORY user tables leave
+            // no .otbx, so load_user_table_storages_sync cannot bring their
+            // storage back. Reconstruct the (empty) storage shell for any alive
+            // user table the catalog knows about but whose storage is still
+            // missing, from its pg_attribute columns. Without this, a reopened
+            // session's CREATE TABLE IF NOT EXISTS finds the table "exists" and
+            // skips creating storage, resolve_table returns a schema, but every
+            // INSERT silently no-ops (storage_append returns 0,0) and scans see
+            // nothing. Runs after load_user_table_storages_sync so on-disk tables
+            // (already loaded) are skipped, and before WAL replay so replayed
+            // INSERTs land in the rehydrated storage.
+            disk_ptr->rehydrate_in_memory_user_storages_sync();
         }
         if (disk_ptr) {
             // Pass WAL address: disk uses this to write pg_catalog WAL records inline from
@@ -332,6 +344,34 @@ namespace otterbrix {
             disk_ptr->restore_oid_generator_sync();
         }
 
+        // Re-seed the MVCC commit clock on reopen from a SINGLE combined durable
+        // frontier so its two halves (current_timestamp_ and published_horizon_)
+        // can never disagree. The frontier is the max of two durable sources:
+        //   * the persisted pg_attribute commit-ids (added_at/dropped_at) — the
+        //     checkpointed catalog frontier (covers ALTER-touched schemas), and
+        //   * the max WAL COMMIT-marker commit_id replayed this boot — the durable
+        //     MVCC frontier for plain CREATE TABLE / data loads (the SSB case,
+        //     where pg_attribute carries no commit-id so the persisted scan is 0).
+        // restore_commit_clock raises current_timestamp_ to frontier+1 AND
+        // published_horizon_ to frontier together: persisted columns stay visible,
+        // post-recovery snapshots see persisted commits as published, AND fresh
+        // post-reopen INSERTs draw commit-ids strictly above the durable band so
+        // they are never mis-judged invisible. Mirror restore_oid_generator_sync:
+        // single-threaded bootstrap (schedulers not started), a one-time direct
+        // call, not ongoing cross-actor sharing.
+        if (disk_ptr) {
+            uint64_t reopen_frontier = disk_ptr->max_persisted_commit_id_sync();
+            for (const auto& r : wal_records) {
+                if (r.is_commit_marker() && r.commit_id > reopen_frontier) {
+                    reopen_frontier = r.commit_id;
+                }
+            }
+            if (reopen_frontier > 0) {
+                manager_dispatcher_->seed_commit_clock_sync(reopen_frontier);
+                trace(log_, "spaces::restored MVCC commit clock from durable frontier {}", reopen_frontier);
+            }
+        }
+
         // Recover pg_class rows tombstoned by a pre-crash DROP TABLE that never
         // physically removed the .otbx. The scan returns (oid, sentinel
         // delete_id=1) pairs; rebuild dropped_storages_ on disk and
@@ -376,22 +416,11 @@ namespace otterbrix {
             }
         }
 
-        // Publish max COMMIT commit_id so the post-recovery txn_manager_'s
-        // published_horizon_ matches the durable MVCC frontier. Only the
-        // max-COMMIT horizon is restored — in_flight ids are never reconstructed,
-        // since crashed in-flight txns were visible to no snapshot anyway.
-        if (!wal_records.empty()) {
-            uint64_t max_commit_id = 0;
-            for (const auto& r : wal_records) {
-                if (r.is_commit_marker() && r.commit_id > max_commit_id) {
-                    max_commit_id = r.commit_id;
-                }
-            }
-            if (max_commit_id > 0) {
-                manager_dispatcher_->set_replay_horizon_sync(max_commit_id);
-                trace(log_, "spaces::WAL replay published_horizon advanced to {}", max_commit_id);
-            }
-        }
+        // NOTE: the post-recovery MVCC commit clock (both current_timestamp_ and
+        // published_horizon_) is restored ABOVE from the combined durable frontier
+        // (max of persisted pg_attribute commit-ids and the max WAL COMMIT marker).
+        // in_flight ids are never reconstructed — crashed in-flight txns were
+        // visible to no snapshot anyway.
 
         // Must run pre-scheduler-start while single-threaded. committed_txn_ids
         // travels by value into bootstrap_indexes_sync (and from there into each

--- a/integration/cpp/test/test_persistence.cpp
+++ b/integration/cpp/test/test_persistence.cpp
@@ -1677,6 +1677,96 @@ TEST_CASE("integration::cpp::test_persistence::disk_add_column_survives_restart"
     }
 }
 
+// REGRESSION — MVCC commit-clock restore on reopen (the durable WAL-COMMIT-marker
+// frontier → published_horizon_ + current_timestamp_). What the restore guards:
+//
+//   * Committed DML stamps each row version with a real commit-id (insert_id for
+//     an INSERT, delete_id for a DELETE), drawn from the prior session's commit
+//     clock. CHECKPOINT folds those stamps into the .otbx.
+//   * On reopen the transaction_manager restarts at {current_timestamp_=1,
+//     published_horizon_=0}, and nothing on the recovery path calls publish()
+//     (publish only runs in the live commit pipeline). So WITHOUT the restore a
+//     fresh post-reopen reader snapshots published_horizon_=0 and the MVCC filter
+//     (row_version_manager: id > snapshot_horizon ⇒ not visible) judges every
+//     committed DELETE as "deleted after my snapshot" — the deleted rows REAPPEAR.
+//   * The restore raises published_horizon_ to the durable frontier (max of
+//     persisted pg_attribute commit-ids and the max WAL COMMIT-marker commit-id)
+//     so persisted commits read as published.
+//
+// Without the restore the phase-2 count comes back 100 instead of 50 (deleted
+// rows resurrected). Sibling tests test_wal_pool::insert_delete_checkpoint_restart
+// and test_persistence::wal_recovery_dml_full_cycle give equivalent coverage;
+// this case states the intent explicitly so the regression is unmistakable.
+//
+// (The restore also feeds a pg_attribute/added_at branch, but that never fires
+// through real DDL today — ALTER ADD COLUMN leaves added_at=0, which the
+// resolve_table visibility filter never rejects — so the live guard here is the
+// WAL-frontier half of the same restore.)
+TEST_CASE("integration::cpp::test_persistence::reopen_keeps_committed_deletes_invisible") {
+    auto config =
+        test_create_config("/tmp/otterbrix/integration/test_persistence/reopen_keeps_committed_deletes");
+    test_clear_directory(config);
+
+    INFO("phase 1: WAL-backed table, INSERT 100, DELETE 50, CHECKPOINT") {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+
+        {
+            auto session = otterbrix::session_id_t();
+            dispatcher->execute_sql(session, "CREATE DATABASE " + database_name + ";");
+        }
+        // Default storage (WAL-recovered, no .otbx): reopen rebuilds the table from
+        // WAL + the committed MVCC stamps, so delete visibility depends on the
+        // restored published_horizon_ (a disk-backed table's CHECKPOINT compaction
+        // would mask the bug by physically dropping committed-deleted rows).
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(session,
+                                               "CREATE TABLE TestDatabase.TestCollection (name string, count bigint);");
+            REQUIRE(cur->is_success());
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            std::stringstream query;
+            query << "INSERT INTO TestDatabase.TestCollection (name, count) VALUES ";
+            for (int i = 0; i < 100; ++i) {
+                query << "('row_" << i << "', " << i << ")" << (i == 99 ? ";" : ", ");
+            }
+            auto cur = dispatcher->execute_sql(session, query.str());
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 100);
+        }
+        // DELETE WHERE count < 50 (removes 50 rows: 0..49). Each tombstone gets
+        // delete_id = this txn's committed commit-id (> 0).
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(session, "DELETE FROM TestDatabase.TestCollection WHERE count < 50;");
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 50);
+        }
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection;", 50);
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(session, "CHECKPOINT;");
+            REQUIRE(cur->is_success());
+        }
+    }
+
+    INFO("phase 2: REOPEN — committed deletes MUST stay deleted (no resurrection)") {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+
+        // Decisive: without the commit-clock restore published_horizon_=0, the
+        // committed delete tombstones (delete_id > 0) are judged not-yet-applied
+        // and the 50 deleted rows reappear → 100 here instead of 50.
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection;", 50);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE count = 0;", 0);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE count = 49;", 0);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE count = 50;", 1);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE count = 99;", 1);
+    }
+}
+
 TEST_CASE("integration::cpp::test_persistence::disk_index_mixed_ops_checkpoint_restart") {
     auto config =
         test_create_config("/tmp/otterbrix/integration/test_persistence/disk_index_mixed_ops_checkpoint_restart");
@@ -2133,5 +2223,86 @@ TEST_CASE("integration::cpp::test_persistence::indexed_table_compact_survives_re
         CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE count = 70;", 1);
         CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE count = 99;", 1);
         CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE count >= 40;", 60);
+    }
+}
+
+// Regression guard for the SSB-reopen bug: with disk AND wal OFF (the SSB
+// benchmark configuration), pg_class is still persisted unconditionally, but an
+// IN_MEMORY user table's row storage is not. On reopen the catalog therefore
+// reports the table as existing while the disk agent owns no storage at its oid.
+// CREATE TABLE IF NOT EXISTS then skips storage creation, resolve_table returns
+// the schema, yet every INSERT silently no-ops (storage_append returns 0,0) and a
+// regular snapshot scan sees nothing. rehydrate_in_memory_user_storages_sync
+// reconstructs the missing storage shell at bootstrap so post-reopen inserts land
+// and are visible. Without that bootstrap step phase-2 returns 0 rows.
+TEST_CASE("integration::cpp::test_persistence::reopen_in_memory_reinsert_visible") {
+    auto config = test_create_config("/tmp/otterbrix/integration/test_persistence/reopen_in_memory_reinsert");
+    // SSB benchmark config: both disk and WAL persistence are OFF. User tables are
+    // created IN_MEMORY; only the system catalog is durable.
+    config.disk.on = false;
+    config.wal.on = false;
+    test_clear_directory(config);
+
+    INFO("phase 1: create IN_MEMORY table + insert 100 rows") {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+
+        {
+            auto session = otterbrix::session_id_t();
+            dispatcher->execute_sql(session, "CREATE DATABASE " + database_name + ";");
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(
+                session,
+                "CREATE TABLE IF NOT EXISTS TestDatabase.TestCollection (name string, count bigint);");
+            REQUIRE(cur->is_success());
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            std::stringstream query;
+            query << "INSERT INTO TestDatabase.TestCollection (name, count) VALUES ";
+            for (int i = 0; i < 100; ++i) {
+                query << "('row_" << i << "', " << i << ")" << (i == 99 ? ";" : ", ");
+            }
+            auto cur = dispatcher->execute_sql(session, query.str());
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 100);
+        }
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection;", 100);
+    }
+
+    INFO("phase 2: reopen, re-run setup + re-insert, the fresh rows must be visible") {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+
+        // Mirror the benchmark runner, which re-runs CREATE TABLE IF NOT EXISTS and
+        // re-INSERTs on every reopen. The catalog still knows the table, so this is
+        // a no-op DDL — but the storage shell must exist for the inserts to land.
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(
+                session,
+                "CREATE TABLE IF NOT EXISTS TestDatabase.TestCollection (name string, count bigint);");
+            REQUIRE(cur->is_success());
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            std::stringstream query;
+            query << "INSERT INTO TestDatabase.TestCollection (name, count) VALUES ";
+            for (int i = 0; i < 100; ++i) {
+                query << "('reopen_" << i << "', " << i << ")" << (i == 99 ? ";" : ", ");
+            }
+            auto cur = dispatcher->execute_sql(session, query.str());
+            REQUIRE(cur->is_success());
+            // The bug: storage_append no-ops, so the cursor reports 0 affected rows.
+            REQUIRE(cur->size() == 100);
+        }
+
+        // Decisive gate: a REGULAR snapshot scan must see the re-inserted rows.
+        // With the bug this returns 0 (the SSB "4ms / 0 rows" symptom).
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection;", 100);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE count = 0;", 1);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE count = 99;", 1);
     }
 }

--- a/integration/cpp/test/test_production_scenarios.cpp
+++ b/integration/cpp/test/test_production_scenarios.cpp
@@ -985,3 +985,259 @@ TEST_CASE("integration::cpp::production::compaction_checkpoint_cycle") {
         CHECK_SQL("SELECT * FROM TestDatabase.TestCollection WHERE id = 1000;", 0);
     }
 }
+
+// Large-table-scan segfault repro (SSB q1-1 shape), DISK-backed e2e guard.
+//
+// On pre-fix code a q1-1-style aggregate over a WIDE table (mirroring SSB
+// lineorder, 17 columns) SIGSEGVs mid-scan (EXC_BAD_ACCESS, null buffer in
+// standard_buffer_manager_t::pin). The fix has two parts the disk-backed path
+// here exercises: an eviction guard (managed, non-reloadable blocks can never
+// be unloaded, so re-pinning an evicted segment never derefs a null buffer) and
+// disk-backed write-through (a filled segment is flushed to the data file and
+// gets a real reloadable block_id, so the pool can evict + reload it and large
+// inserts stay BOUNDED instead of pinning the whole table resident). Post-fix
+// this must (a) accept every INSERT batch without OOM and (b) complete the large
+// scan with the CORRECT aggregate — prove COMPLETION, not just no-crash.
+//
+// DISK-backed (config.disk.on, storage = 'disk') so write-through is actually
+// exercised — an in-memory table would pin the whole working set and clean-OOM
+// by design, which cannot validate the write-through bound.
+//
+// Working-set / pool note: there is NO buffer-pool / memory-limit knob in
+// configuration::config — the pool size is hardcoded (4 GiB) inside the disk
+// service (services/disk/manager_disk.cpp) and is only overridable
+// programmatically (set_memory_limit), which production never calls and a test
+// at this e2e layer cannot reach. So we cannot shrink the pool to force
+// eviction at a small row count from here; that path is covered directly at the
+// unit layer (components/table/test/test_disk_backed_scan.cpp, which uses a tiny
+// pool). Here the row count is chosen as the largest WIDE-table scan that keeps
+// this Debug-build case to a few seconds while still meaningfully driving the
+// disk-backed append + full-scan path end to end.
+TEST_CASE("integration::cpp::production::large_scan_segfault_red", "[step1]") {
+    auto config = test_create_config("/tmp/otterbrix/production/large_scan_segfault");
+    test_clear_directory(config);
+    // DISK-backed so write-through evicts filled segments and large inserts stay
+    // bounded.
+    config.disk.on = true;
+    config.wal.on = true;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    constexpr int batches = 50;
+    constexpr int rows_per_batch = 1000;
+    constexpr int64_t total_rows = int64_t(batches) * rows_per_batch;
+
+    // Mirror the row-generation formulas below to compute the EXPECTED q1-1
+    // aggregate and matching-row count up front, so the assertions prove the
+    // scan returned the right value (not merely "no crash").
+    int64_t expected_revenue = 0;
+    int64_t expected_match_rows = 0;
+    for (int64_t id = 0; id < total_rows; ++id) {
+        const int64_t year = 1992 + (id % 7);
+        const int64_t discount = id % 11;            // 0..10
+        const int64_t quantity = 1 + (id % 50);      // 1..50
+        const int64_t extprice = 1000 + (id % 9000); // 1000..9999
+        if (year == 1993 && discount >= 1 && discount <= 3 && quantity < 25) {
+            expected_revenue += extprice * discount;
+            ++expected_match_rows;
+        }
+    }
+    REQUIRE(expected_match_rows > 0); // the filter must select a non-trivial subset
+
+    INFO("initialization: WIDE DISK table mirroring SSB lineorder (17 columns)") {
+        {
+            auto session = otterbrix::session_id_t();
+            dispatcher->execute_sql(session, "CREATE DATABASE TestDatabase;");
+        }
+        {
+            // Mirror the SSB lineorder shape: many wide bigint columns plus a few
+            // text columns, so a 1024-row row-group is a large working set.
+            // storage = 'disk' enables write-through for this table.
+            auto session = otterbrix::session_id_t();
+            dispatcher->execute_sql(session,
+                                    "CREATE TABLE TestDatabase.Lineorder ("
+                                    "lo_orderkey bigint, "
+                                    "lo_linenumber bigint, "
+                                    "lo_custkey bigint, "
+                                    "lo_partkey bigint, "
+                                    "lo_suppkey bigint, "
+                                    "lo_orderdate bigint, "
+                                    "lo_orderpriority string, "
+                                    "lo_shippriority string, "
+                                    "lo_quantity bigint, "
+                                    "lo_extendedprice bigint, "
+                                    "lo_ordtotalprice bigint, "
+                                    "lo_discount bigint, "
+                                    "lo_revenue bigint, "
+                                    "lo_supplycost bigint, "
+                                    "lo_tax bigint, "
+                                    "lo_commitdate bigint, "
+                                    "lo_shipmode string) "
+                                    "WITH (storage = 'disk');");
+        }
+    }
+
+    INFO("insert wide rows in batches of 1000") {
+        // Derive every column from the row index so the data is varied and the
+        // q1-1 filters select a non-trivial subset:
+        //   lo_orderdate  -> year, 1992..1998 (so d_year = 1993 selects ~1/7)
+        //   lo_discount   -> 0..10            (BETWEEN 1 AND 3 selects 3/11)
+        //   lo_quantity   -> 1..50            (< 25 selects ~half)
+        for (int batch = 0; batch < batches; ++batch) {
+            std::stringstream ss;
+            ss << "INSERT INTO TestDatabase.Lineorder ("
+                  "lo_orderkey, lo_linenumber, lo_custkey, lo_partkey, lo_suppkey, "
+                  "lo_orderdate, lo_orderpriority, lo_shippriority, lo_quantity, "
+                  "lo_extendedprice, lo_ordtotalprice, lo_discount, lo_revenue, "
+                  "lo_supplycost, lo_tax, lo_commitdate, lo_shipmode) VALUES ";
+            for (int i = 0; i < rows_per_batch; ++i) {
+                const int64_t id = int64_t(batch) * rows_per_batch + i;
+                const int64_t year = 1992 + (id % 7);
+                const int64_t discount = id % 11;            // 0..10
+                const int64_t quantity = 1 + (id % 50);      // 1..50
+                const int64_t extprice = 1000 + (id % 9000); // 1000..9999
+                if (i > 0)
+                    ss << ",";
+                ss << "(" << id                       // lo_orderkey
+                   << ", " << (1 + (id % 7))           // lo_linenumber
+                   << ", " << (id % 30000)             // lo_custkey
+                   << ", " << (id % 200000)            // lo_partkey
+                   << ", " << (id % 2000)              // lo_suppkey
+                   << ", " << year                     // lo_orderdate (== year here)
+                   << ", '1-URGENT'"                   // lo_orderpriority
+                   << ", '0'"                          // lo_shippriority
+                   << ", " << quantity                 // lo_quantity
+                   << ", " << extprice                 // lo_extendedprice
+                   << ", " << (extprice * quantity)    // lo_ordtotalprice
+                   << ", " << discount                 // lo_discount
+                   << ", " << (extprice * discount)    // lo_revenue
+                   << ", " << (extprice / 2)           // lo_supplycost
+                   << ", " << (id % 8)                 // lo_tax
+                   << ", " << year                     // lo_commitdate
+                   << ", 'MAIL')";                     // lo_shipmode
+            }
+            ss << ";";
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(session, ss.str());
+            // Write-through must keep each batch BOUNDED: a clean success is
+            // required. An OOM here means the bound is not working — do NOT
+            // weaken this; investigate instead.
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == rows_per_batch);
+        }
+    }
+
+    INFO("q1-1-style aggregate over the full WIDE table (the large scan)") {
+        // On pre-fix code the process SIGSEGVs during this scan. On the fixed
+        // code it must COMPLETE with the correct aggregate.
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session,
+                                           "SELECT SUM(lo_extendedprice * lo_discount) AS revenue "
+                                           "FROM TestDatabase.Lineorder "
+                                           "WHERE lo_orderdate = 1993 "
+                                           "AND lo_discount BETWEEN 1 AND 3 "
+                                           "AND lo_quantity < 25;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        // SUM over bigint expressions comes back as a signed scalar. Match the
+        // value computed from the same generation formulas above: proves the
+        // large scan COMPLETED with the correct result, not just no-crash.
+        REQUIRE(cur->chunk_data().value(0, 0).value<int64_t>() == expected_revenue);
+    }
+
+    INFO("sanity: full-table count scans cleanly and returns every row") {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT COUNT(lo_orderkey) AS cnt FROM TestDatabase.Lineorder;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        REQUIRE(cur->chunk_data().value(0, 0).value<uint64_t>() == uint64_t(total_rows));
+    }
+}
+
+// REGRESSION: a disk-backed table that is CHECKPOINTed and then reopened must
+// still resolve its columns and run a q1-1-style aggregate. This exercises the
+// full bootstrap → resolve_table path after reopen, including the MVCC
+// commit-clock re-seed. Without that seed, a reopened instance whose persisted
+// pg_attribute columns carry a non-zero added_at_commit_id from the prior
+// session would judge every column "added after my snapshot" (start_time reset
+// to 1) and resolution would fail "<col> not found".
+//
+// WAL stays on so the user rows survive the reopen and the post-reopen
+// aggregate can be value-checked end to end.
+TEST_CASE("integration::cpp::production::reopen_resolves_columns_after_checkpoint") {
+    auto config = test_create_config("/tmp/otterbrix/production/reopen_resolve_columns");
+    test_clear_directory(config);
+    config.disk.on = true;
+    config.wal.on = true;
+
+    INFO("phase 1: disk-backed CREATE TABLE, INSERT, CHECKPOINT") {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+        {
+            auto session = otterbrix::session_id_t();
+            dispatcher->execute_sql(session, "CREATE DATABASE TestDatabase;");
+        }
+        {
+            // Disk-backed so the rows survive reopen and the aggregate below is
+            // value-checkable; the SSB lineorder column shape.
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(session,
+                                               "CREATE TABLE TestDatabase.Lineorder ("
+                                               "lo_orderkey bigint, "
+                                               "lo_orderdate bigint, "
+                                               "lo_quantity bigint, "
+                                               "lo_extendedprice bigint, "
+                                               "lo_discount bigint) "
+                                               "WITH (storage = 'disk');");
+            REQUIRE(cur->is_success());
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(
+                session,
+                "INSERT INTO TestDatabase.Lineorder "
+                "(lo_orderkey, lo_orderdate, lo_quantity, lo_extendedprice, lo_discount) VALUES "
+                "(1, 1993, 10, 1000, 2), (2, 1994, 30, 2000, 5), (3, 1993, 20, 1500, 1);");
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 3);
+        }
+        {
+            // CHECKPOINT folds the durable frontier into pg_attribute and the
+            // user table's row-groups into its .otbx.
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(session, "CHECKPOINT;");
+            REQUIRE(cur->is_success());
+        }
+    }
+
+    INFO("phase 2: REOPEN and resolve a column — must NOT fail 'not found'") {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+        // The pre-fix failure was column resolution: SELECT <col> reported the
+        // column as not found. Assert the resolve path succeeds.
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(
+                session, "SELECT lo_orderdate FROM TestDatabase.Lineorder WHERE lo_orderdate = 1993;");
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 2);
+        }
+        // And a q1-1-style aggregate over the reopened table resolves every
+        // referenced column and returns the correct value.
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(session,
+                                               "SELECT SUM(lo_extendedprice * lo_discount) AS revenue "
+                                               "FROM TestDatabase.Lineorder "
+                                               "WHERE lo_orderdate = 1993 "
+                                               "AND lo_discount BETWEEN 1 AND 3 "
+                                               "AND lo_quantity < 25;");
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 1);
+            // row 1: 1000*2=2000 (orderdate 1993, disc 2, qty 10<25) — matches
+            // row 3: 1500*1=1500 (orderdate 1993, disc 1, qty 20<25) — matches
+            // row 2: orderdate 1994 — excluded
+            REQUIRE(cur->chunk_data().value(0, 0).value<int64_t>() == 3500);
+        }
+    }
+}

--- a/services/disk/agent_disk.cpp
+++ b/services/disk/agent_disk.cpp
@@ -87,6 +87,18 @@ namespace services::disk {
               otbx_path.string(),
               static_cast<uint64_t>(sidecar_wal_id));
         auto entry = std::make_unique<collection_storage_entry_t>(resource(), otbx_path);
+        // The DISK load ctor records io_error/data_corruption instead of throwing (this helper is noexcept
+        // and reachable on the agent thread). Drop a failed-construction entry so we never emplace a
+        // half-loaded storage; the manager-side probe drives .prev corrupt-recovery before this.
+        if (entry->table_storage.construction_failed()) {
+            warn(log_,
+                 "agent_disk_t::bootstrap_disk_inner_sync: agent[{}] load oid={} path={} failed: {}",
+                 pool_idx_,
+                 static_cast<unsigned>(oid),
+                 otbx_path.string(),
+                 entry->table_storage.construction_error().what.c_str());
+            return false;
+        }
         if (sidecar_wal_id > wal::id_t{0}) {
             entry->table_storage.set_checkpoint_wal_id(sidecar_wal_id);
         }
@@ -111,6 +123,18 @@ namespace services::disk {
               static_cast<unsigned>(oid),
               otbx_path.string());
         auto entry = std::make_unique<collection_storage_entry_t>(resource(), std::move(columns), otbx_path);
+        // The DISK create ctor records io_error instead of throwing (this helper is noexcept and runs on
+        // the agent thread via create_storage_disk_inner). Drop a failed-construction entry rather than
+        // emplacing a storage with a null table_/block_manager_.
+        if (entry->table_storage.construction_failed()) {
+            warn(log_,
+                 "agent_disk_t::bootstrap_create_disk_inner_sync: agent[{}] create oid={} path={} failed: {}",
+                 pool_idx_,
+                 static_cast<unsigned>(oid),
+                 otbx_path.string(),
+                 entry->table_storage.construction_error().what.c_str());
+            return false;
+        }
         return storages_.try_emplace(oid, std::move(entry)).second;
     }
 
@@ -457,7 +481,7 @@ namespace services::disk {
     // Mutation fanout targets. The manager router pre-validates, but the agent
     // re-checks (not-owned / null no-op) because it owns its slice independently.
 
-    agent_disk_t::unique_future<std::pair<uint64_t, uint64_t>>
+    agent_disk_t::unique_future<core::result_wrapper_t<std::pair<uint64_t, uint64_t>>>
     agent_disk_t::storage_append_inner(execution_context_t ctx,
                                        components::catalog::oid_t table_oid,
                                        std::unique_ptr<components::vector::data_chunk_t> data) {
@@ -807,9 +831,24 @@ namespace services::disk {
         }
 
         // 5b. Materialize — the canonical write. Lands at total_rows() == start_row.
+        //     The txn path can surface a write_conflict (concurrent DDL re-rooted the
+        //     table) or out_of_memory (row-group/segment alloc) as a value; this is a plain
+        //     synchronous local call (no co_await), so reading the wrapper adds NO second
+        //     cross-actor await — the single co_await above (PHYSICAL_INSERT) stays this
+        //     handler's only one (a second sequential cross-actor await would risk a
+        //     lost-wakeup hang). The WAL record was already written; on a materialize failure
+        //     the txn aborts and storage_revert_appends unwinds it.
         uint64_t materialized_start;
         if (txn.transaction_id != 0) {
-            materialized_start = s->append(*data, txn);
+            auto append_r = s->append(*data, txn);
+            if (append_r.has_error()) {
+                trace(log_,
+                      "agent_disk[{}]::storage_append_inner: materialize failed for oid={} — surfacing error",
+                      pool_idx_,
+                      static_cast<unsigned>(table_oid));
+                co_return append_r.convert_error<std::pair<uint64_t, uint64_t>>();
+            }
+            materialized_start = append_r.value();
         } else {
             materialized_start = s->append(*data);
         }
@@ -904,7 +943,7 @@ namespace services::disk {
         co_return;
     }
 
-    agent_disk_t::unique_future<std::pair<int64_t, uint64_t>>
+    agent_disk_t::unique_future<core::result_wrapper_t<std::pair<int64_t, uint64_t>>>
     agent_disk_t::storage_update_inner(components::catalog::oid_t table_oid,
                                        components::vector::vector_t row_ids,
                                        std::unique_ptr<components::vector::data_chunk_t> data,
@@ -929,7 +968,8 @@ namespace services::disk {
             co_return std::pair<int64_t, uint64_t>{0, 0};
         }
         // No preprocessing here: the manager body already aligned `data` with the
-        // canonical schema (the twin shares column defs via bootstrap_inner_sync).
+        // canonical schema (the twin shares column defs via bootstrap_inner_sync). The
+        // wrapper carries any write_conflict / out_of_memory as a value.
         co_return entry->storage->update(row_ids, *data, txn);
     }
 
@@ -990,7 +1030,7 @@ namespace services::disk {
         co_return std::move(result);
     }
 
-    std::pmr::vector<components::vector::data_chunk_t>
+    core::result_wrapper_t<std::pmr::vector<components::vector::data_chunk_t>>
     agent_disk_t::scan_batched_local(components::catalog::oid_t table_oid,
                                      components::table::table_filter_t* filter,
                                      int64_t limit,
@@ -1013,13 +1053,19 @@ namespace services::disk {
                   static_cast<unsigned>(table_oid));
             return batches;
         }
-        entry->storage->scan_batched(batches, filter, limit, projected_cols, txn);
-        return batches;
+        // The adapter surfaces any buffer-pool OOM / data_corruption the table-layer scan left
+        // in state.table_state.scan_error; propagate it up the wrapper.
+        auto scan_r = entry->storage->scan_batched(batches, filter, limit, projected_cols, txn);
+        if (scan_r.has_error()) {
+            return scan_r.convert_error<std::pmr::vector<components::vector::data_chunk_t>>();
+        }
+        return std::move(batches);
     }
 
     // Thin mailbox wrapper over scan_batched_local (D6: same-actor callers use the local
-    // helper directly; this exists for the manager→agent mailbox route).
-    agent_disk_t::unique_future<std::pmr::vector<components::vector::data_chunk_t>>
+    // helper directly; this exists for the manager→agent mailbox route). The reply carries the
+    // scan_error; the manager funnel / operators read has_error() before .value().
+    agent_disk_t::unique_future<core::result_wrapper_t<std::pmr::vector<components::vector::data_chunk_t>>>
     agent_disk_t::storage_scan_batched_inner(components::catalog::oid_t table_oid,
                                              std::unique_ptr<components::table::table_filter_t> filter,
                                              int64_t limit,
@@ -1138,10 +1184,14 @@ namespace services::disk {
                                                                            std::move(idx_vec)));
             }
             std::pmr::vector<components::vector::data_chunk_t> batches{resource()};
-            entry->storage->scan_batched(batches, filter.get(), int64_t{-1}, nullptr, txn);
-            for (auto& chunk : batches) {
-                for (uint64_t r = 0; r < chunk.size(); ++r) {
-                    row_ids.push_back(chunk.row_ids.data<std::int64_t>()[r]);
+            // Keyed catalog read: a scan_error leaves this key's match set empty
+            // (mirrors the not-owned fallback above); callers tolerate empty per-key entries.
+            auto scan_r = entry->storage->scan_batched(batches, filter.get(), int64_t{-1}, nullptr, txn);
+            if (!scan_r.has_error()) {
+                for (auto& chunk : batches) {
+                    for (uint64_t r = 0; r < chunk.size(); ++r) {
+                        row_ids.push_back(chunk.row_ids.data<std::int64_t>()[r]);
+                    }
                 }
             }
             result.emplace_back(std::move(row_ids));
@@ -1197,9 +1247,14 @@ namespace services::disk {
                                                                        std::move(idx_vec)));
         }
 
-        // All columns (projected = nullptr), no row limit (-1) — same as the prior
-        // manager-side storage_scan_batched_inner call (it passed an empty projected list).
-        co_return scan_batched_local(table_oid, filter.get(), int64_t{-1}, nullptr, txn);
+        // All columns (projected = nullptr), no row limit (-1). Catalog-read path: a scan_error
+        // degrades to an empty result, matching the not-owned/record-only fallback (resolve
+        // callers handle empty).
+        auto scan_r = scan_batched_local(table_oid, filter.get(), int64_t{-1}, nullptr, txn);
+        if (scan_r.has_error()) {
+            co_return std::move(empty);
+        }
+        co_return std::move(scan_r.value());
     }
 
     agent_disk_t::unique_future<std::pmr::vector<std::pmr::vector<components::vector::data_chunk_t>>>
@@ -1268,7 +1323,14 @@ namespace services::disk {
                                                                            std::move(idx_vec)));
             }
             // All columns (projected = nullptr), no row limit (-1) — same as read_chunks_by_key_inner.
-            result.emplace_back(scan_batched_local(table_oid, filter.get(), int64_t{-1}, nullptr, txn));
+            // Catalog-read path: a scan_error degrades this key's entry to empty, matching the
+            // not-owned/record-only fallback (callers handle empty entries).
+            auto scan_r = scan_batched_local(table_oid, filter.get(), int64_t{-1}, nullptr, txn);
+            if (scan_r.has_error()) {
+                result.emplace_back();
+            } else {
+                result.emplace_back(std::move(scan_r.value()));
+            }
         }
         co_return std::move(result);
     }
@@ -1393,7 +1455,30 @@ namespace services::disk {
                 }
             }
 
-            entry->table_storage.checkpoint(current_wal_id);
+            // checkpoint(wal_id) returns out_of_memory on a column flush pin failure; it
+            // aborts BEFORE the header swap and leaves the wal_id fields unchanged. On error,
+            // defer this entry to a later round (same as the MVCC-gate skip above): restore
+            // the .prev backup over any partial write, do NOT persist the sidecar or delete
+            // the backup, and feed the unchanged prev_checkpoint_wal_id into the min() so the
+            // WAL keeps this table's replay records.
+            auto cp_r = entry->table_storage.checkpoint(current_wal_id);
+            if (cp_r.has_error()) {
+                warn(log_,
+                     "agent_disk[{}]::checkpoint_inner oid={} checkpoint failed (rules 2/9) — deferring this round",
+                     pool_idx_,
+                     static_cast<unsigned>(tbl_oid));
+                if (std::filesystem::exists(prev_path)) {
+                    std::error_code restore_error;
+                    std::filesystem::copy_file(prev_path,
+                                               otbx_path,
+                                               std::filesystem::copy_options::overwrite_existing,
+                                               restore_error);
+                    std::error_code remove_error;
+                    std::filesystem::remove(prev_path, remove_error);
+                }
+                min_prev_id = std::min(min_prev_id, entry->table_storage.prev_checkpoint_wal_id());
+                continue;
+            }
 
             // Persist sidecar wal_id atomically (tmp + rename).
             {
@@ -1789,7 +1874,19 @@ namespace services::disk {
                 }
             }
 
-            start_row = s->append(local, ctx.txn);
+            // The append chain can surface write_conflict / out_of_memory.
+            // append_pg_catalog_row_inner returns a pg_catalog_append_range_t with no error
+            // channel; on a failure leave start_row/count at 0 (no rows materialized) and
+            // log — the caller treats a zero-count range as a no-op append.
+            auto append_r = s->append(local, ctx.txn);
+            if (append_r.has_error()) {
+                warn(log_,
+                     "agent_disk[{}]::append_pg_catalog_row_inner: materialize failed for oid={} — no rows appended",
+                     pool_idx_,
+                     static_cast<unsigned>(table_oid));
+                co_return components::pg_catalog_append_range_t{table_oid, int64_t{0}, 0};
+            }
+            start_row = append_r.value();
         } else {
             trace(log_,
                   "agent_disk[{}]::append_pg_catalog_row_inner: oid {} not owned/empty — no storage append",

--- a/services/disk/agent_disk.cpp
+++ b/services/disk/agent_disk.cpp
@@ -1059,7 +1059,7 @@ namespace services::disk {
         if (scan_r.has_error()) {
             return scan_r.convert_error<std::pmr::vector<components::vector::data_chunk_t>>();
         }
-        return std::move(batches);
+        return batches;
     }
 
     // Thin mailbox wrapper over scan_batched_local (D6: same-actor callers use the local

--- a/services/disk/agent_disk.hpp
+++ b/services/disk/agent_disk.hpp
@@ -188,7 +188,10 @@ namespace services::disk {
         //   append. User + catalog inserts share ONE write ordering. Returns
         //   (start_row, count); (0,0) on no-op. Takes the full execution_context
         //   (session/txn/tz/db_oid) because the agent owns the WAL write.
-        unique_future<std::pair<uint64_t, uint64_t>>
+        // Reply wraps the pair so a buffer-pool OOM or write_conflict surfaced by the
+        // table-layer append chain travels back to operator_insert as a value (no throw
+        // across the mailbox).
+        unique_future<core::result_wrapper_t<std::pair<uint64_t, uint64_t>>>
         storage_append_inner(execution_context_t ctx,
                              components::catalog::oid_t table_oid,
                              std::unique_ptr<components::vector::data_chunk_t> data);
@@ -222,9 +225,10 @@ namespace services::disk {
         storage_revert_appends_inner(std::pmr::vector<components::pg_catalog_append_range_t> ranges);
 
         // storage_update_inner — single-OID UPDATE mutation against the
-        //   agent twin. Returns storage_t::update's (updated, appended)
-        //   pair; (0, 0) on no-op.
-        unique_future<std::pair<int64_t, uint64_t>>
+        //   agent twin. Reply wraps storage_t::update's (updated, appended) pair so a
+        //   write_conflict / out_of_memory travels back to operator_update as a value;
+        //   (0, 0) on no-op.
+        unique_future<core::result_wrapper_t<std::pair<int64_t, uint64_t>>>
         storage_update_inner(components::catalog::oid_t table_oid,
                              components::vector::vector_t row_ids,
                              std::unique_ptr<components::vector::data_chunk_t> data,
@@ -245,9 +249,11 @@ namespace services::disk {
         // Read-path handlers (scan_batched / scan_segment / types / total_rows).
         // Not-owned OIDs return an empty/zero sentinel.
         //
-        // storage_scan_batched_inner — batched + projected scan; returns a PMR vector
-        //   of data_chunk_t batches (≤ DEFAULT_VECTOR_CAPACITY rows each).
-        unique_future<std::pmr::vector<components::vector::data_chunk_t>>
+        // storage_scan_batched_inner — batched + projected scan; the reply wraps a PMR vector
+        //   of data_chunk_t batches (≤ DEFAULT_VECTOR_CAPACITY rows each), carrying any
+        //   buffer-pool OOM / data_corruption the table-layer scan left in scan_error as a
+        //   value (no throw across the mailbox).
+        unique_future<core::result_wrapper_t<std::pmr::vector<components::vector::data_chunk_t>>>
         storage_scan_batched_inner(components::catalog::oid_t table_oid,
                                    std::unique_ptr<components::table::table_filter_t> filter,
                                    int64_t limit,
@@ -494,10 +500,11 @@ namespace services::disk {
     private:
         // Non-mailbox committed-scan over an OWNED slice entry (D6: callers on the agent
         // thread — storage_scan_batched_inner and read_chunks_by_keys_inner — read their own
-        // slice directly here, never by self-sending a mailbox message). Returns empty when
-        // the oid isn't owned or is a record-only marker. `filter` may be nullptr;
-        // `projected_cols` may be nullptr for all columns.
-        std::pmr::vector<components::vector::data_chunk_t>
+        // slice directly here, never by self-sending a mailbox message). Returns empty batches
+        // when the oid isn't owned or is a record-only marker. `filter` may be nullptr;
+        // `projected_cols` may be nullptr for all columns. The wrapper carries any buffer-pool
+        // OOM / data_corruption surfaced by the table-layer scan as a value.
+        core::result_wrapper_t<std::pmr::vector<components::vector::data_chunk_t>>
         scan_batched_local(components::catalog::oid_t table_oid,
                            components::table::table_filter_t* filter,
                            int64_t limit,

--- a/services/disk/agent_disk.hpp
+++ b/services/disk/agent_disk.hpp
@@ -504,7 +504,7 @@ namespace services::disk {
         // when the oid isn't owned or is a record-only marker. `filter` may be nullptr;
         // `projected_cols` may be nullptr for all columns. The wrapper carries any buffer-pool
         // OOM / data_corruption surfaced by the table-layer scan as a value.
-        core::result_wrapper_t<std::pmr::vector<components::vector::data_chunk_t>>
+        [[nodiscard]] core::result_wrapper_t<std::pmr::vector<components::vector::data_chunk_t>>
         scan_batched_local(components::catalog::oid_t table_oid,
                            components::table::table_filter_t* filter,
                            int64_t limit,

--- a/services/disk/disk_contract.hpp
+++ b/services/disk/disk_contract.hpp
@@ -166,8 +166,10 @@ namespace services::disk {
                      components::table::transaction_data txn);
         // Batched + projected variant: returns a vector of chunks (PR #483 multi-chunk)
         // and applies index-based column projection at the disk layer (PR #477).
-        // Empty `projected_cols` means "read all columns" (pass-through).
-        actor_zeta::unique_future<std::pmr::vector<components::vector::data_chunk_t>>
+        // Empty `projected_cols` means "read all columns" (pass-through). The reply wraps the
+        // batches so a buffer-pool OOM / data_corruption from the table-layer scan reaches the
+        // scan operators as a value rather than a throw across the mailbox.
+        actor_zeta::unique_future<core::result_wrapper_t<std::pmr::vector<components::vector::data_chunk_t>>>
         storage_scan_batched(session_id_t session,
                              components::catalog::oid_t table_oid,
                              std::unique_ptr<components::table::table_filter_t> filter,
@@ -182,12 +184,16 @@ namespace services::disk {
         actor_zeta::unique_future<std::unique_ptr<components::vector::data_chunk_t>>
         storage_scan_segment(session_id_t session, components::catalog::oid_t table_oid, int64_t start, uint64_t count);
 
-        actor_zeta::unique_future<std::pair<uint64_t, uint64_t>>
+        // Reply wraps (start_row, count) so a write_conflict / out_of_memory from the
+        // table-layer append chain reaches operator_insert as a value.
+        actor_zeta::unique_future<core::result_wrapper_t<std::pair<uint64_t, uint64_t>>>
         storage_append(execution_context_t ctx,
                        components::catalog::oid_t table_oid,
                        std::unique_ptr<components::vector::data_chunk_t> data);
 
-        actor_zeta::unique_future<std::pair<int64_t, uint64_t>>
+        // Reply wraps (updated, appended) so a write_conflict / out_of_memory from the
+        // table-layer MVCC update reaches operator_update / fk_cascade as a value.
+        actor_zeta::unique_future<core::result_wrapper_t<std::pair<int64_t, uint64_t>>>
         storage_update(execution_context_t ctx,
                        components::catalog::oid_t table_oid,
                        components::vector::vector_t row_ids,

--- a/services/disk/manager_disk.cpp
+++ b/services/disk/manager_disk.cpp
@@ -131,7 +131,14 @@ namespace services::disk {
         auto bm = std::make_unique<components::table::storage::single_file_block_manager_t>(buffer_manager_,
                                                                                             fs_,
                                                                                             otbx_path.string());
-        bm->create_new_database();
+        // create_new_database reports failure as io_error rather than throwing. This DISK ctor can run on
+        // the agent thread (via bootstrap_create_disk_inner_sync, noexcept), where a throw would
+        // std::terminate. Record the error and leave table_/block_manager_ null; the caller checks
+        // construction_failed().
+        if (auto r = bm->create_new_database(); r.has_error()) {
+            construction_error_ = r.error();
+            return;
+        }
         block_manager_ = std::move(bm);
         table_ = std::make_unique<components::table::data_table_t>(resource, *block_manager_, std::move(columns));
     }
@@ -143,7 +150,14 @@ namespace services::disk {
         auto bm = std::make_unique<components::table::storage::single_file_block_manager_t>(buffer_manager_,
                                                                                             fs_,
                                                                                             otbx_path.string());
-        bm->load_existing_database();
+        // load_existing_database + load_from_disk report io_error / data_corruption rather than throwing.
+        // This DISK ctor can run on the agent thread (bootstrap_disk_inner_sync is noexcept), where a throw
+        // would std::terminate. Record the error and leave table_/block_manager_ null; the caller checks
+        // construction_failed() and maps it onto .prev corrupt-recovery.
+        if (auto r = bm->load_existing_database(); r.has_error()) {
+            construction_error_ = r.error();
+            return;
+        }
         block_manager_ = std::move(bm);
 
         components::table::storage::metadata_manager_t meta_mgr(*block_manager_);
@@ -151,17 +165,28 @@ namespace services::disk {
         components::table::storage::meta_block_pointer_t meta_ptr;
         meta_ptr.block_pointer = meta_block;
         components::table::storage::metadata_reader_t reader(meta_mgr, meta_ptr);
-        table_ = components::table::data_table_t::load_from_disk(resource, *block_manager_, reader);
+        auto loaded = components::table::data_table_t::load_from_disk(resource, *block_manager_, reader);
+        if (loaded.has_error()) {
+            construction_error_ = loaded.error();
+            return;
+        }
+        table_ = std::move(loaded.value());
     }
 
-    void table_storage_t::checkpoint() {
+    core::result_wrapper_t<bool> table_storage_t::checkpoint() {
         if (mode_ != storage_mode_t::DISK) {
-            return;
+            return true;
         }
 
         components::table::storage::metadata_manager_t meta_mgr(*block_manager_);
         components::table::storage::metadata_writer_t writer(meta_mgr);
-        table_->checkpoint(writer);
+        // data_table_t::checkpoint reports out_of_memory on a column flush pin failure; abort the
+        // checkpoint BEFORE the header swap so a partial write never becomes the durable state, and
+        // surface the error.
+        auto cp_r = table_->checkpoint(writer);
+        if (cp_r.has_error()) {
+            return cp_r;
+        }
         writer.flush();
 
         auto* disk_bm = static_cast<components::table::storage::single_file_block_manager_t*>(block_manager_.get());
@@ -179,16 +204,22 @@ namespace services::disk {
         disk_bm->write_header(header);
         // 2nd fsync: commit the new header — this is the atomic point of the checkpoint.
         disk_bm->file_sync();
+        return true;
     }
 
-    void table_storage_t::checkpoint(wal::id_t new_wal_id) {
+    core::result_wrapper_t<bool> table_storage_t::checkpoint(wal::id_t new_wal_id) {
         if (mode_ != storage_mode_t::DISK) {
-            return;
+            return true;
         }
-        // First persist the data; if checkpoint() throws, fields stay unchanged.
-        checkpoint();
+        // First persist the data; on a checkpoint() error the wal_id fields stay unchanged and the
+        // error is surfaced so the caller skips this entry's seal.
+        auto cp_r = checkpoint();
+        if (cp_r.has_error()) {
+            return cp_r;
+        }
         prev_checkpoint_wal_id_ = checkpoint_wal_id_;
         checkpoint_wal_id_ = new_wal_id;
+        return true;
     }
 
     void table_storage_t::add_column(components::table::column_definition_t& col) {

--- a/services/disk/manager_disk.hpp
+++ b/services/disk/manager_disk.hpp
@@ -87,17 +87,17 @@ namespace services::disk {
         // (bootstrap_*_inner_sync / the manager probe) checks construction_failed() and drops the entry /
         // drives .prev corrupt-recovery. IN_MEMORY ctors never set this.
         bool construction_failed() const noexcept { return construction_error_.contains_error(); }
-        const core::error_t& construction_error() const noexcept { return construction_error_; }
+        [[nodiscard]] const core::error_t& construction_error() const noexcept { return construction_error_; }
 
         /// Checkpoint (disk mode only, no-op/success for in-memory).
         /// W-TORN: writes data blocks + fsync, then header + fsync (2 fsync — durability before header swap).
         /// Returns out_of_memory when a column flush pin fails in
         /// data_table_t::checkpoint; true on success (or IN_MEMORY no-op).
-        core::result_wrapper_t<bool> checkpoint();
+        [[nodiscard]] core::result_wrapper_t<bool> checkpoint();
         /// Same as checkpoint() + tracks W-TORN per-table wal_id snapshot.
         /// prev_checkpoint_wal_id_ ← old checkpoint_wal_id_; checkpoint_wal_id_ ← new_wal_id.
         /// Propagates the checkpoint() error; on error the wal_id fields stay unchanged.
-        core::result_wrapper_t<bool> checkpoint(wal::id_t new_wal_id);
+        [[nodiscard]] core::result_wrapper_t<bool> checkpoint(wal::id_t new_wal_id);
 
         /// W-TORN: latest committed checkpoint wal_id for this DISK table (0 if never checkpointed / IN_MEMORY).
         wal::id_t checkpoint_wal_id() const noexcept { return checkpoint_wal_id_; }

--- a/services/disk/manager_disk.hpp
+++ b/services/disk/manager_disk.hpp
@@ -80,12 +80,24 @@ namespace services::disk {
         components::table::data_table_t& table() { return *table_; }
         storage_mode_t mode() const { return mode_; }
 
-        /// Checkpoint (disk mode only, no-op for in-memory).
+        // DISK ctors do file I/O (create/open/header read) + metadata-chain deserialize, all of which can
+        // fail with io_error/data_corruption. A constructor cannot return a result_wrapper_t and MUST NOT
+        // throw -- the DISK ctors run on the agent thread via bootstrap_create_disk_inner_sync (noexcept),
+        // so a throw would std::terminate. Instead the ctor records the error here; the caller
+        // (bootstrap_*_inner_sync / the manager probe) checks construction_failed() and drops the entry /
+        // drives .prev corrupt-recovery. IN_MEMORY ctors never set this.
+        bool construction_failed() const noexcept { return construction_error_.contains_error(); }
+        const core::error_t& construction_error() const noexcept { return construction_error_; }
+
+        /// Checkpoint (disk mode only, no-op/success for in-memory).
         /// W-TORN: writes data blocks + fsync, then header + fsync (2 fsync — durability before header swap).
-        void checkpoint();
+        /// Returns out_of_memory when a column flush pin fails in
+        /// data_table_t::checkpoint; true on success (or IN_MEMORY no-op).
+        core::result_wrapper_t<bool> checkpoint();
         /// Same as checkpoint() + tracks W-TORN per-table wal_id snapshot.
         /// prev_checkpoint_wal_id_ ← old checkpoint_wal_id_; checkpoint_wal_id_ ← new_wal_id.
-        void checkpoint(wal::id_t new_wal_id);
+        /// Propagates the checkpoint() error; on error the wal_id fields stay unchanged.
+        core::result_wrapper_t<bool> checkpoint(wal::id_t new_wal_id);
 
         /// W-TORN: latest committed checkpoint wal_id for this DISK table (0 if never checkpointed / IN_MEMORY).
         wal::id_t checkpoint_wal_id() const noexcept { return checkpoint_wal_id_; }
@@ -125,6 +137,8 @@ namespace services::disk {
         std::unique_ptr<components::table::data_table_t> table_;
         wal::id_t checkpoint_wal_id_{0};
         wal::id_t prev_checkpoint_wal_id_{0};
+        // Set by the DISK ctors on file/metadata failure instead of throwing (see construction_failed()).
+        core::error_t construction_error_{core::error_t::no_error()};
     };
 
     // Storage entry per collection. Namespace-scope so agent_disk_t can own a
@@ -288,6 +302,19 @@ namespace services::disk {
         // for filtering and (2) avoid synthesising phantom storages with
         // possibly-wrong schemas from a single WAL chunk.
         void load_user_table_storages_sync();
+        // Rehydrate the in-memory storage SHELL for every alive user table that
+        // is present in the persisted pg_class catalog but whose row storage was
+        // not loaded by load_user_table_storages_sync (no .otbx on disk — the
+        // IN_MEMORY relstoragemode case). pg_class persists unconditionally, so on
+        // reopen a CREATE TABLE IF NOT EXISTS sees the table "exists" and skips
+        // storage creation, and resolve_table returns the schema, yet the disk
+        // agent owns no storage at that oid — so storage_append no-ops (returns
+        // 0,0) and scans see nothing. Reconstructs each missing storage from its
+        // pg_attribute column definitions so the catalog and the storage layer
+        // agree. Pre-scheduler-start, single-threaded (same window as
+        // load_user_table_storages_sync). Skips relkinds without row storage
+        // (views, computed/virtual tables) and any oid already loaded.
+        void rehydrate_in_memory_user_storages_sync();
         // Synchronous scan of pg_class.oid column, returning the set
         // of user-table OIDs (oid >= FIRST_USER_OID) currently alive in the
         // catalog. Called by base_spaces between system-record replay and
@@ -349,6 +376,14 @@ namespace services::disk {
         // OID across all system tables, then seeds oid_gen_ to max+1 so future allocate()
         // never collides with on-disk OIDs.
         void restore_oid_generator_sync();
+
+        // Scan the persisted catalog for the maximum MVCC commit-id, so reopen can
+        // re-seed the dispatcher's commit clock (transaction_manager_t::seed_commit_clock).
+        // The authoritative source is pg_attribute columns added_at_commit_id (index 10)
+        // and dropped_at_commit_id (index 11) — the only commit-id columns in the whole
+        // catalog schema. Returns the max non-null int64 across both columns (0 if none).
+        // Pre-scheduler-start, single-threaded — mirrors restore_oid_generator_sync.
+        std::uint64_t max_persisted_commit_id_sync() const;
 
         // Read the value of a named setting from pg_settings. Returns the most recently
         // appended value for the given name, or empty string if not found.
@@ -599,8 +634,10 @@ namespace services::disk {
                      components::table::transaction_data txn);
         // Batched + projected variant: returns a vector of chunks and applies
         // index-based column projection at the storage layer.
-        // Empty `projected_cols` means "read all columns" (pass-through).
-        unique_future<std::pmr::vector<components::vector::data_chunk_t>>
+        // Empty `projected_cols` means "read all columns" (pass-through). The reply wraps the
+        // batches so a buffer-pool OOM / data_corruption from the table-layer scan reaches the
+        // scan operators as a value rather than a throw across the mailbox.
+        unique_future<core::result_wrapper_t<std::pmr::vector<components::vector::data_chunk_t>>>
         storage_scan_batched(session_id_t session,
                              components::catalog::oid_t table_oid,
                              std::unique_ptr<components::table::table_filter_t> filter,
@@ -614,12 +651,16 @@ namespace services::disk {
                       uint64_t count);
         unique_future<std::unique_ptr<components::vector::data_chunk_t>>
         storage_scan_segment(session_id_t session, components::catalog::oid_t table_oid, int64_t start, uint64_t count);
-        unique_future<std::pair<uint64_t, uint64_t>>
+        // Reply wraps (start_row, count) so a write_conflict / out_of_memory from the
+        // table-layer append chain reaches operator_insert as a value.
+        unique_future<core::result_wrapper_t<std::pair<uint64_t, uint64_t>>>
         storage_append(execution_context_t ctx,
                        components::catalog::oid_t table_oid,
                        std::unique_ptr<components::vector::data_chunk_t> data);
 
-        unique_future<std::pair<int64_t, uint64_t>>
+        // Reply wraps (updated, appended) so a write_conflict / out_of_memory from the
+        // table-layer MVCC update reaches operator_update / fk_cascade as a value.
+        unique_future<core::result_wrapper_t<std::pair<int64_t, uint64_t>>>
         storage_update(execution_context_t ctx,
                        components::catalog::oid_t table_oid,
                        components::vector::vector_t row_ids,
@@ -694,9 +735,14 @@ namespace services::disk {
                                       components::catalog::oid_t database_oid,
                                       std::vector<components::table::column_definition_t> columns,
                                       const std::filesystem::path& otbx_path);
-        void load_storage_disk_sync(components::catalog::oid_t table_oid,
-                                    components::catalog::oid_t database_oid,
-                                    const std::filesystem::path& otbx_path);
+        // Returns no_error() on success (incl. successful .prev corrupt-recovery). Returns an
+        // io_error/data_corruption on the terminal "corrupt .otbx + no recoverable .prev" / failed
+        // W-TORN promote-move case instead of throwing: this runs on the single-threaded
+        // bootstrap/recovery path whose callers (bootstrap_system_tables_sync,
+        // load_user_table_storages_sync, load_storage_for_wal_replay_sync) propagate / log the error.
+        [[nodiscard]] core::error_t load_storage_disk_sync(components::catalog::oid_t table_oid,
+                                                           components::catalog::oid_t database_oid,
+                                                           const std::filesystem::path& otbx_path);
 
         std::pmr::memory_resource* resource_;
         actor_zeta::scheduler_raw scheduler_;

--- a/services/disk/manager_disk_bootstrap.cpp
+++ b/services/disk/manager_disk_bootstrap.cpp
@@ -164,8 +164,18 @@ namespace services::disk {
                           "manager_disk_t::bootstrap_system_tables_sync loading : {} oid={}",
                           std::string(def.name),
                           static_cast<unsigned>(tbl_oid));
-                    load_storage_disk_sync(tbl_oid, sys_db_oid, otbx);
-                    return false; // loaded, not freshly created
+                    // load_storage_disk_sync returns an error instead of throwing on the terminal
+                    // corrupt/no-.prev case: this open/bootstrap chain must not throw (base_spaces
+                    // drives it pre-scheduler-start). The error is logged; the table is left
+                    // unloaded and a later resolve / WAL replay surfaces the absence cleanly.
+                    if (auto err = load_storage_disk_sync(tbl_oid, sys_db_oid, otbx); err.contains_error()) {
+                        warn(log_,
+                             "bootstrap_system_tables_sync: failed to load system table {} oid={} : {}",
+                             std::string(def.name),
+                             static_cast<unsigned>(tbl_oid),
+                             err.what.c_str());
+                    }
+                    return false; // loaded (or failed-and-logged), not freshly created
                 }
                 trace(log_,
                       "manager_disk_t::bootstrap_system_tables_sync creating disk : {} oid={}",
@@ -224,8 +234,13 @@ namespace services::disk {
                 if (entry != nullptr) {
                     // const_cast: checkpoint mutates the SFBM/free-list but
                     // storage_entry_sync hands back a const pointer. Safe because the
-                    // agent thread is idle at this bootstrap-time call.
-                    const_cast<collection_storage_entry_t*>(entry)->table_storage.checkpoint();
+                    // agent thread is idle at this bootstrap-time call. The wrapper carries
+                    // out_of_memory; bind it and warn (bootstrap has no error channel — a
+                    // system-table checkpoint OOM here is a hard environment fault).
+                    auto cp_r = const_cast<collection_storage_entry_t*>(entry)->table_storage.checkpoint();
+                    if (cp_r.has_error()) {
+                        warn(log_, "manager_disk bootstrap: pg_settings checkpoint failed (rules 2/9)");
+                    }
                 }
             }
             if (freshly_created.size() <= 1)
@@ -297,7 +312,14 @@ namespace services::disk {
                     entry = agents_[0]->storage_entry_sync(tbl_oid);
                 }
                 if (entry != nullptr) {
-                    const_cast<collection_storage_entry_t*>(entry)->table_storage.checkpoint();
+                    // The wrapper carries out_of_memory; bind it and warn
+                    // (bootstrap has no error channel).
+                    auto cp_r = const_cast<collection_storage_entry_t*>(entry)->table_storage.checkpoint();
+                    if (cp_r.has_error()) {
+                        warn(log_,
+                             "manager_disk bootstrap: catalog table oid={} checkpoint failed (rules 2/9)",
+                             static_cast<unsigned>(tbl_oid));
+                    }
                 }
             }
         }
@@ -324,6 +346,17 @@ namespace services::disk {
             }
             auto& table = const_cast<collection_storage_entry_t*>(entry)->table_storage.table();
             if (table.column_count() == 0 || table.calculate_size() == 0) {
+                continue;
+            }
+            // Column 0 is the identity OID only for oid-keyed system tables, where
+            // it is a UINTEGER (oid_col()). Some system tables (e.g. pg_settings)
+            // key on a STRING column 0 (`name`); reading that as a uint32 OID
+            // yields garbage that would poison oid_gen_ with a huge, non-
+            // deterministic high_water — every fresh CREATE TABLE then mints a
+            // wild OID, and on reopen the persisted (garbage) catalog OID no longer
+            // matches the storage the agent loaded, so user-table appends silently
+            // no-op. Only scan column 0 when it is an OID column.
+            if (table.columns()[0].type().type() != components::types::logical_type::UINTEGER) {
                 continue;
             }
             std::vector<components::table::storage_index_t> col_indices;
@@ -357,6 +390,65 @@ namespace services::disk {
 
         oid_gen_.seed(high_water);
         trace(log_, "manager_disk_t::restore_oid_generator_sync : seeded high_water={}", high_water);
+    }
+
+    std::uint64_t manager_disk_t::max_persisted_commit_id_sync() const {
+        // agents_[0] (catalog agent) owns all catalog SFBM entries.
+        // Pre-scheduler-start, single-threaded (same window as restore_oid_generator_sync).
+        if (agents_.empty() || agents_[0] == nullptr) {
+            return 0;
+        }
+
+        // pg_attribute is the ONLY system table carrying commit-id columns
+        // (added_at_commit_id @ index 10, dropped_at_commit_id @ index 11 — both
+        // i64). pg_class et al. carry none, so scanning pg_attribute is sufficient
+        // and authoritative.
+        constexpr std::size_t kAddedAtCol = 10;
+        constexpr std::size_t kDroppedAtCol = 11;
+
+        const collection_storage_entry_t* entry = agents_[0]->storage_entry_sync(pg_attribute_oid);
+        if (entry == nullptr || entry->storage == nullptr) {
+            return 0;
+        }
+        auto& storage = *const_cast<collection_storage_entry_t*>(entry)->storage;
+        const auto total = storage.total_rows();
+        if (total == 0) {
+            return 0;
+        }
+        auto types = storage.types();
+        if (types.size() <= kDroppedAtCol) {
+            return 0;
+        }
+
+        std::pmr::synchronized_pool_resource scan_resource;
+        // Read via storage->scan with a default ("see all committed") transaction_data
+        // (snapshot_horizon = UINT64_MAX). This is the SAME read path resolve_table
+        // takes, so it folds the MVCC UPDATE that the schema-growth backfill applies
+        // to added_at_commit_id (the stamp is written as an UPDATE producing a newer
+        // row version; a raw table.scan/create_index_scan would surface the original
+        // added_at = NULL/0 version instead and miss the real commit-id).
+        components::vector::data_chunk_t chunk(&scan_resource, types, total);
+        storage.scan(chunk, /*filter=*/nullptr, /*limit=*/-1, components::table::transaction_data{});
+
+        std::uint64_t max_commit_id = 0;
+        for (uint64_t i = 0; i < chunk.size(); ++i) {
+            auto added_cell = chunk.value(kAddedAtCol, i);
+            if (!added_cell.is_null()) {
+                const auto v = added_cell.value<std::int64_t>();
+                if (v > 0 && static_cast<std::uint64_t>(v) > max_commit_id) {
+                    max_commit_id = static_cast<std::uint64_t>(v);
+                }
+            }
+            auto dropped_cell = chunk.value(kDroppedAtCol, i);
+            if (!dropped_cell.is_null()) {
+                const auto v = dropped_cell.value<std::int64_t>();
+                if (v > 0 && static_cast<std::uint64_t>(v) > max_commit_id) {
+                    max_commit_id = static_cast<std::uint64_t>(v);
+                }
+            }
+        }
+
+        return max_commit_id;
     }
 
     void manager_disk_t::load_user_table_storages_sync() {
@@ -406,15 +498,199 @@ namespace services::disk {
                       "manager_disk_t::load_user_table_storages_sync : oid={} db_oid={}",
                       static_cast<unsigned>(tbl_oid),
                       static_cast<unsigned>(db_oid));
-                try {
-                    load_storage_disk_sync(tbl_oid, db_oid, otbx);
-                } catch (const std::exception& e) {
+                if (auto err = load_storage_disk_sync(tbl_oid, db_oid, otbx); err.contains_error()) {
                     warn(log_,
                          "load_user_table_storages_sync: failed for oid={} : {}",
                          static_cast<unsigned>(tbl_oid),
-                         e.what());
+                         err.what.c_str());
                 }
             }
+        }
+    }
+
+    void manager_disk_t::rehydrate_in_memory_user_storages_sync() {
+        // pg_class persists unconditionally (system tables are always written to
+        // disk), but IN_MEMORY user-table row data is not. After
+        // load_user_table_storages_sync has loaded every on-disk .otbx, any alive
+        // user table still missing a storage is an IN_MEMORY table whose shell was
+        // lost on restart. Reconstruct an empty in-memory storage from its
+        // pg_attribute columns so the catalog (which says the table exists) and the
+        // storage layer agree: otherwise CREATE TABLE IF NOT EXISTS skips creation,
+        // resolve_table returns a schema, but storage_append no-ops (returns 0,0)
+        // and scans see nothing. Pre-scheduler-start, single-threaded.
+        if (agents_.empty() || agents_[0] == nullptr) {
+            return;
+        }
+        constexpr components::catalog::oid_t main_db_oid = catalog::well_known_oid::main_database;
+
+        // Pass 1: scan pg_class for alive user tables that have row storage
+        // (relkind 'r' regular or 'm' materialized view) and are not yet loaded.
+        // pg_class layout: [0=oid, 1=relname, 2=relnamespace, 3=relkind, 4=relstoragemode].
+        std::vector<catalog::oid_t> need_oids;
+        {
+            const collection_storage_entry_t* cls_entry = agents_[0]->storage_entry_sync(pg_class_oid);
+            if (cls_entry == nullptr) {
+                return;
+            }
+            auto& cls_table = const_cast<collection_storage_entry_t*>(cls_entry)->table_storage.table();
+            if (cls_table.column_count() < 4 || cls_table.calculate_size() == 0) {
+                return;
+            }
+            std::pmr::synchronized_pool_resource scan_resource;
+            // Sparse scan of the non-adjacent [oid (0), relkind (3)] columns via
+            // the projected_cols data_chunk ctor: pass the FULL pg_class type list
+            // plus the projected absolute indices, and read by ABSOLUTE index
+            // (chunk.value(0,..) / chunk.value(3,..)). A compacted 2-type chunk
+            // mis-decodes the dictionary-encoded relkind string column (segfault).
+            std::vector<components::table::storage_index_t> col_indices;
+            col_indices.emplace_back(static_cast<int64_t>(0)); // oid
+            col_indices.emplace_back(static_cast<int64_t>(3)); // relkind
+            components::table::table_scan_state scan_state(&scan_resource);
+            cls_table.initialize_scan(scan_state, col_indices);
+            const auto& all_cols = cls_table.columns();
+            std::pmr::vector<components::types::complex_logical_type> all_types(&scan_resource);
+            all_types.reserve(all_cols.size());
+            for (const auto& c : all_cols) {
+                all_types.push_back(c.type());
+            }
+            const std::vector<std::size_t> projected{static_cast<std::size_t>(0), static_cast<std::size_t>(3)};
+            while (true) {
+                components::vector::data_chunk_t chunk(&scan_resource,
+                                                       all_types,
+                                                       projected,
+                                                       components::vector::DEFAULT_VECTOR_CAPACITY);
+                cls_table.scan(chunk, scan_state);
+                if (chunk.size() == 0)
+                    break;
+                for (uint64_t i = 0; i < chunk.size(); ++i) {
+                    auto oid_v = chunk.value(0, i);
+                    if (oid_v.is_null())
+                        continue;
+                    const auto oid = static_cast<catalog::oid_t>(oid_v.value<std::uint32_t>());
+                    if (oid < catalog::FIRST_USER_OID)
+                        continue;
+                    if (has_storage(oid))
+                        continue;
+                    auto rk_v = chunk.value(3, i);
+                    const char relkind = (rk_v.is_null() || rk_v.value<std::string_view>().empty())
+                                             ? catalog::relkind::regular
+                                             : rk_v.value<std::string_view>().front();
+                    // Only relkinds with physical row storage. Views, computed/
+                    // virtual tables, sequences etc. have no append-target storage.
+                    if (relkind != catalog::relkind::regular && relkind != catalog::relkind::materialized_view) {
+                        continue;
+                    }
+                    need_oids.push_back(oid);
+                }
+            }
+        }
+        if (need_oids.empty()) {
+            return;
+        }
+
+        // Pass 2: read pg_attribute once, grouping live (non-dropped) columns by
+        // attrelid. pg_attribute layout: [0=attoid, 1=attrelid, 2=attname,
+        // 3=atttypid, 4=attnum, 5=attnotnull, 6=atthasdefault, 7=attisdropped,
+        // 8=atttypspec, ...]. Each column's (attnum, name, type) reconstructs the
+        // storage schema in ordinal order — the same order CREATE TABLE registered.
+        struct rehydrate_col_t {
+            std::int32_t attnum{0};
+            std::string name;
+            components::types::complex_logical_type type;
+        };
+        std::unordered_map<catalog::oid_t, std::vector<rehydrate_col_t>> cols_by_relid;
+        {
+            const collection_storage_entry_t* attr_entry = agents_[0]->storage_entry_sync(pg_attribute_oid);
+            if (attr_entry == nullptr) {
+                return;
+            }
+            auto& attr_table = const_cast<collection_storage_entry_t*>(attr_entry)->table_storage.table();
+            if (attr_table.column_count() < 9 || attr_table.calculate_size() == 0) {
+                return;
+            }
+            std::unordered_set<catalog::oid_t> wanted(need_oids.begin(), need_oids.end());
+            std::pmr::synchronized_pool_resource scan_resource;
+            const auto& all_cols = attr_table.columns();
+            std::vector<components::table::storage_index_t> col_indices;
+            for (std::size_t c = 0; c < all_cols.size(); ++c) {
+                col_indices.emplace_back(static_cast<int64_t>(c));
+            }
+            components::table::table_scan_state scan_state(&scan_resource);
+            attr_table.initialize_scan(scan_state, col_indices);
+            std::pmr::vector<components::types::complex_logical_type> all_types(&scan_resource);
+            all_types.reserve(all_cols.size());
+            for (const auto& c : all_cols) {
+                all_types.push_back(c.type());
+            }
+            while (true) {
+                components::vector::data_chunk_t chunk(&scan_resource,
+                                                       all_types,
+                                                       components::vector::DEFAULT_VECTOR_CAPACITY);
+                attr_table.scan(chunk, scan_state);
+                if (chunk.size() == 0)
+                    break;
+                for (uint64_t i = 0; i < chunk.size(); ++i) {
+                    auto relid_v = chunk.value(1, i);
+                    if (relid_v.is_null())
+                        continue;
+                    const auto relid = static_cast<catalog::oid_t>(relid_v.value<std::uint32_t>());
+                    if (wanted.find(relid) == wanted.end())
+                        continue;
+                    auto dropped_v = chunk.value(7, i);
+                    if (!dropped_v.is_null() && dropped_v.value<bool>())
+                        continue; // tombstoned column
+                    rehydrate_col_t rc;
+                    auto attname_v = chunk.value(2, i);
+                    if (!attname_v.is_null()) {
+                        auto sv = attname_v.value<std::string_view>();
+                        rc.name.assign(sv.data(), sv.size());
+                    }
+                    auto attnum_v = chunk.value(4, i);
+                    rc.attnum = attnum_v.is_null() ? 0 : attnum_v.value<std::int32_t>();
+                    std::string typspec;
+                    auto typspec_v = chunk.value(8, i);
+                    if (!typspec_v.is_null()) {
+                        auto sv = typspec_v.value<std::string_view>();
+                        typspec.assign(sv.data(), sv.size());
+                    }
+                    if (!typspec.empty()) {
+                        rc.type = catalog::decode_type_spec(resource_, typspec);
+                    } else {
+                        auto atttypid_v = chunk.value(3, i);
+                        const auto atttypid = atttypid_v.is_null()
+                                                  ? catalog::INVALID_OID
+                                                  : static_cast<catalog::oid_t>(atttypid_v.value<std::uint32_t>());
+                        rc.type = components::types::complex_logical_type(catalog::oid_to_builtin_type(atttypid));
+                    }
+                    if (!rc.name.empty() && !rc.type.has_alias()) {
+                        rc.type.set_alias(rc.name);
+                    }
+                    cols_by_relid[relid].push_back(std::move(rc));
+                }
+            }
+        }
+
+        // Pass 3: create the in-memory storage shell for each missing table, with
+        // columns in attnum (ordinal) order.
+        for (auto oid : need_oids) {
+            auto it = cols_by_relid.find(oid);
+            if (it == cols_by_relid.end() || it->second.empty()) {
+                continue; // no columns resolved — skip rather than create a 0-col storage
+            }
+            auto& cols = it->second;
+            std::sort(cols.begin(), cols.end(), [](const rehydrate_col_t& a, const rehydrate_col_t& b) {
+                return a.attnum < b.attnum;
+            });
+            std::vector<components::table::column_definition_t> defs;
+            defs.reserve(cols.size());
+            for (auto& c : cols) {
+                defs.emplace_back(c.name, c.type);
+            }
+            trace(log_,
+                  "manager_disk_t::rehydrate_in_memory_user_storages_sync : oid={} cols={}",
+                  static_cast<unsigned>(oid),
+                  defs.size());
+            create_storage_with_columns_sync(oid, main_db_oid, std::move(defs));
         }
     }
 

--- a/services/disk/manager_disk_io.cpp
+++ b/services/disk/manager_disk_io.cpp
@@ -224,9 +224,9 @@ namespace services::disk {
         }
     }
 
-    void manager_disk_t::load_storage_disk_sync(components::catalog::oid_t table_oid,
-                                                components::catalog::oid_t /*database_oid*/,
-                                                const std::filesystem::path& otbx_path) {
+    core::error_t manager_disk_t::load_storage_disk_sync(components::catalog::oid_t table_oid,
+                                                         components::catalog::oid_t /*database_oid*/,
+                                                         const std::filesystem::path& otbx_path) {
         trace(log_,
               "manager_disk_t::load_storage_disk_sync , oid : {} , path : {}",
               static_cast<unsigned>(table_oid),
@@ -292,48 +292,67 @@ namespace services::disk {
             std::error_code ec;
             std::filesystem::rename(prev_path, otbx_path, ec);
             if (ec) {
-                throw std::runtime_error("W-TORN promote .prev failed: " + ec.message());
+                return core::error_t(core::error_code_t::io_error,
+                                     std::pmr::string{"W-TORN promote .prev failed: " + ec.message(), resource()});
             }
             transfer_to_agent(otbx_path);
-            return;
+            return core::error_t::no_error();
         }
 
-        // Corrupt-recovery (rename .otbx → .broken, .prev → .otbx, retry) must detect
-        // SFBM-open failure, but bootstrap_disk_inner_sync is noexcept (its
-        // make_unique<> swallows the throw on corrupt files). So we probe-construct on
-        // the manager thread to catch the exception, then destroy the probe to release
-        // the WRITE_LOCK before the agent reopens (per-process lock: closing this fd
-        // frees it entirely). The close-reopen window is single-threaded, no race.
-        try {
+        // Corrupt-recovery (rename .otbx → .broken, .prev → .otbx, retry) must detect SFBM-open / metadata
+        // failure. The DISK load ctor records the error in table_storage.construction_failed() rather than
+        // throwing (bootstrap_disk_inner_sync is noexcept and reachable on the agent thread). We
+        // probe-construct on the manager thread to read that flag, then destroy the probe to release the
+        // WRITE_LOCK before the agent reopens (per-process lock: closing this fd frees it entirely). The
+        // close-reopen window is single-threaded, no race. This function runs on the bootstrap thread (NOT
+        // the agent message thread); the terminal "no .prev to recover from" / failed-W-TORN-rename cases
+        // return a core::error_t to the open/bootstrap caller instead of throwing.
+        bool probe_failed = false;
+        std::string probe_error;
+        {
             auto probe = std::make_unique<collection_storage_entry_t>(resource(), otbx_path);
+            if (probe->table_storage.construction_failed()) {
+                probe_failed = true;
+                probe_error = probe->table_storage.construction_error().what.c_str();
+            }
             probe.reset(); // release WRITE_LOCK before agent reopens on agent thread
-        } catch (const std::exception& e) {
-            warn(log_, "load_storage_disk_sync: failed to load {} : {}", otbx_path.string(), e.what());
+        }
+        if (probe_failed) {
+            warn(log_, "load_storage_disk_sync: failed to load {} : {}", otbx_path.string(), probe_error);
             if (!prev_exists) {
-                throw;
+                return core::error_t(core::error_code_t::data_corruption,
+                                     std::pmr::string{"load_storage_disk_sync: " + otbx_path.string() + " : " +
+                                                          probe_error,
+                                                      resource()});
             }
             auto broken_path = otbx_path;
             broken_path += ".broken";
             std::error_code ec;
             std::filesystem::rename(otbx_path, broken_path, ec);
             if (ec) {
-                throw std::runtime_error("W-TORN move corrupt otbx aside failed: " + ec.message());
+                return core::error_t(core::error_code_t::io_error,
+                                     std::pmr::string{"W-TORN move corrupt otbx aside failed: " + ec.message(),
+                                                      resource()});
             }
             std::filesystem::rename(prev_path, otbx_path, ec);
             if (ec) {
-                throw std::runtime_error("W-TORN promote .prev failed after corrupt otbx: " + ec.message());
+                return core::error_t(core::error_code_t::io_error,
+                                     std::pmr::string{"W-TORN promote .prev failed after corrupt otbx: " +
+                                                          ec.message(),
+                                                      resource()});
             }
             warn(log_,
                  "load_storage_disk_sync: recovered {} from .prev (corrupt original kept as .broken)",
                  otbx_path.string());
             transfer_to_agent(otbx_path);
-            return;
+            return core::error_t::no_error();
         }
         if (prev_exists) {
             std::error_code ec;
             std::filesystem::remove(prev_path, ec);
         }
         transfer_to_agent(otbx_path);
+        return core::error_t::no_error();
     }
 
     wal::id_t manager_disk_t::peek_checkpoint_wal_id_from_disk(components::catalog::oid_t table_oid,
@@ -375,10 +394,11 @@ namespace services::disk {
         if (!std::filesystem::exists(otbx_path)) {
             return; // in-memory table — WAL replay creates it from the first INSERT chunk
         }
-        try {
-            load_storage_disk_sync(table_oid, database_oid, otbx_path);
-        } catch (const std::exception& e) {
-            warn(log_, "load_storage_for_wal_replay_sync: failed to load {}: {}", otbx_path.string(), e.what());
+        if (auto err = load_storage_disk_sync(table_oid, database_oid, otbx_path); err.contains_error()) {
+            warn(log_,
+                 "load_storage_for_wal_replay_sync: failed to load {}: {}",
+                 otbx_path.string(),
+                 err.what.c_str());
         }
     }
 

--- a/services/disk/manager_disk_resolve.cpp
+++ b/services/disk/manager_disk_resolve.cpp
@@ -42,7 +42,14 @@ namespace services::disk {
         if (needs_sched) {
             scheduler_disk_->enqueue(agent.get());
         }
-        co_return co_await std::move(fut);
+        // Catalog-read funnel: the agent reply carries the scan_error. A buffer-pool OOM on a
+        // catalog scan degrades to an empty batch set here, matching the no-agent / not-owned
+        // fallbacks above (resolve callers already tolerate empty).
+        auto scan_r = co_await std::move(fut);
+        if (scan_r.has_error()) {
+            co_return empty;
+        }
+        co_return std::move(scan_r.value());
     }
 
     manager_disk_t::unique_future<resolve_namespace_result_t>

--- a/services/disk/manager_disk_storage.cpp
+++ b/services/disk/manager_disk_storage.cpp
@@ -85,7 +85,17 @@ namespace services::disk {
             }
         }
 
-        return s->append(local, txn);
+        // WAL-replay only (txn{0,0}), single-threaded: a write_conflict / out_of_memory
+        // here is a hard recovery fault with no error channel — bind the wrapper and return
+        // 0 on failure (no rows materialized).
+        auto append_r = s->append(local, txn);
+        if (append_r.has_error()) {
+            warn(log_,
+                 "manager_disk_t::direct_append_sync: replay append failed for oid={} (rules 2/9)",
+                 static_cast<unsigned>(table_oid));
+            return 0;
+        }
+        return append_r.value();
     }
 
     void manager_disk_t::direct_delete_sync(catalog::oid_t table_oid,
@@ -332,13 +342,15 @@ namespace services::disk {
         co_return nullptr;
     }
 
-    manager_disk_t::unique_future<std::pmr::vector<components::vector::data_chunk_t>>
+    manager_disk_t::unique_future<core::result_wrapper_t<std::pmr::vector<components::vector::data_chunk_t>>>
     manager_disk_t::storage_scan_batched(session_id_t /*session*/,
                                          catalog::oid_t table_oid,
                                          std::unique_ptr<components::table::table_filter_t> filter,
                                          int64_t limit,
                                          std::vector<size_t> projected_cols,
                                          components::table::transaction_data txn) {
+        // Transparent router: the agent reply carries the scan_error; forward the wrapper
+        // unchanged so the scan operators turn it into an error cursor.
         if (!agents_.empty()) {
             const std::size_t pool_idx = pool_idx_for_oid(table_oid, agents_.size());
             auto& agent = agents_[pool_idx];
@@ -399,7 +411,7 @@ namespace services::disk {
         co_return nullptr;
     }
 
-    manager_disk_t::unique_future<std::pair<uint64_t, uint64_t>>
+    manager_disk_t::unique_future<core::result_wrapper_t<std::pair<uint64_t, uint64_t>>>
     manager_disk_t::storage_append(execution_context_t ctx,
                                    catalog::oid_t table_oid,
                                    std::unique_ptr<components::vector::data_chunk_t> data) {
@@ -407,6 +419,8 @@ namespace services::disk {
         // expansion, NOT NULL, dedup, type promotion) and the canonical write live
         // in the agent twin, so every same-oid access is serialized by the agent's
         // mailbox — no borrowed-pointer access from the manager loop thread.
+        // Transparent router: forward the agent's result_wrapper_t (write_conflict /
+        // out_of_memory) unchanged so operator_insert surfaces the error.
         if (!data || data->size() == 0) {
             co_return std::make_pair(uint64_t{0}, uint64_t{0});
         }
@@ -428,13 +442,14 @@ namespace services::disk {
         co_return std::make_pair(uint64_t{0}, uint64_t{0});
     }
 
-    manager_disk_t::unique_future<std::pair<int64_t, uint64_t>>
+    manager_disk_t::unique_future<core::result_wrapper_t<std::pair<int64_t, uint64_t>>>
     manager_disk_t::storage_update(execution_context_t ctx,
                                    catalog::oid_t table_oid,
                                    components::vector::vector_t row_ids,
                                    std::unique_ptr<components::vector::data_chunk_t> data) {
         // Pure router to the agent twin — the agent's mailbox serializes
-        // the canonical write with every other same-oid access.
+        // the canonical write with every other same-oid access. Transparent: forward the
+        // agent's result_wrapper_t (write_conflict / out_of_memory) unchanged.
         if (!agents_.empty()) {
             const std::size_t idx = pool_idx_for_oid(table_oid, agents_.size());
             auto& agent = agents_[idx];

--- a/services/disk/tests/test_ddl_methods.cpp
+++ b/services/disk/tests/test_ddl_methods.cpp
@@ -749,8 +749,10 @@ TEST_CASE("services::disk::ddl::storage_expand_on_write_for_dynamic_schema") {
             {{"a", complex_logical_type{logical_type::BIGINT}}},
             [&](data_chunk_t& c) { c.set_value(0, 0, logical_value_t(&fx.resource, std::int64_t{1})); },
             /*rows=*/1);
-        auto [start, count] =
+        auto append_r =
             fx.invoke(&manager_disk_t::storage_append, append_ctx(table_oid), table_oid, std::move(chunk));
+        REQUIRE_FALSE(append_r.has_error());
+        auto [start, count] = append_r.value();
         REQUIRE(count == 1);
         (void) start;
     }

--- a/services/disk/tests/test_persistence.cpp
+++ b/services/disk/tests/test_persistence.cpp
@@ -8,6 +8,7 @@
 #include <components/log/log.hpp>
 #include <components/session/session.hpp>
 #include <components/table/column_definition.hpp>
+#include <components/table/transaction_manager.hpp>
 #include <components/types/types.hpp>
 #include <components/vector/data_chunk.hpp>
 #include <core/non_thread_scheduler/scheduler_test.hpp>
@@ -735,6 +736,95 @@ TEST_CASE("services::disk::persistence::test_check_constraint_persistence") {
         uint64_t check_total = 0;
         for (auto& c : check_batches) check_total += c.size();
         REQUIRE(check_total == 1);
+    }
+    std::filesystem::remove_all(dir);
+}
+
+// Regression: MVCC commit-clock restore on reopen. A column persisted with a
+// non-zero added_at_commit_id (from a PRIOR session's clock) must stay visible
+// after reopen. Before the fix the reopened transaction_manager_t started its
+// clock at {1,0}, so every new txn's start_time fell below the persisted
+// added_at_commit_id and resolve_table judged all columns "added after my
+// snapshot" → "column not found". The fix re-seeds the clock from
+// max_persisted_commit_id_sync().
+TEST_CASE("services::disk::persistence::test_commit_clock_restored_across_restart") {
+    auto dir = persist_dir() + "/commit_clock";
+    std::filesystem::remove_all(dir);
+    std::filesystem::create_directories(dir);
+    // A commit-id well above the reopened clock's fresh start (1) and above the
+    // attribute attnum/attoid value space — proves we read the commit-id column,
+    // not some other monotonic value.
+    constexpr std::int64_t kPersistedCommitId = 5000;
+    oid_t table_oid = INVALID_OID;
+    oid_t col_attoid = INVALID_OID;
+    {
+        fresh_disk fd(dir);
+        fd.manager->bootstrap_system_tables_sync();
+        auto ns_oid = test_create_namespace(fd, "cc_ns");
+        std::vector<components::table::column_definition_t> cols;
+        cols.emplace_back("id", components::types::complex_logical_type{components::types::logical_type::BIGINT});
+        table_oid = test_create_table(fd, ns_oid, "cc_t", std::move(cols));
+
+        // Allocate an attoid for an ADD COLUMN-style row and stamp it with a high
+        // added_at_commit_id, mirroring what a committed ADD COLUMN at commit_id
+        // kPersistedCommitId would persist. Append it directly to pg_attribute and
+        // publish so it is durable in the checkpoint.
+        auto attoids = fd.invoke(&manager_disk_t::allocate_oids_batch, std::size_t{1});
+        col_attoid = attoids[0];
+        constexpr oid_t pg_attr = well_known_oid::pg_attribute_table;
+        auto attr_row = catalog::build_pg_attribute_row(&fd.resource,
+                                                        col_attoid,
+                                                        table_oid,
+                                                        std::string("added_col"),
+                                                        well_known_oid::int64_type,
+                                                        /*attnum*/ 2,
+                                                        /*not_null*/ false,
+                                                        /*has_default*/ false,
+                                                        /*is_dropped*/ false,
+                                                        /*typspec*/ std::string{},
+                                                        /*defspec*/ std::string{},
+                                                        /*added_at_commit_id*/ kPersistedCommitId,
+                                                        /*dropped_at_commit_id*/ 0);
+        std::vector<components::pg_catalog_append_range_t> appends;
+        auto rng = fd.invoke(&manager_disk_t::append_pg_catalog_row,
+                             disk_test_helpers::auto_ctx(),
+                             pg_attr,
+                             std::move(attr_row));
+        appends.push_back(std::move(rng));
+        fd.invoke(&manager_disk_t::storage_publish_commits,
+                  disk_test_helpers::rebuild_ctx(),
+                  static_cast<std::uint64_t>(kPersistedCommitId),
+                  std::move(appends));
+        fd.checkpoint();
+    }
+    {
+        fresh_disk fd2(dir);
+        fd2.manager->bootstrap_system_tables_sync();
+        fd2.manager->restore_oid_generator_sync();
+
+        // (a) The new scan returns the persisted high commit-id.
+        const auto max_cid = fd2.manager->max_persisted_commit_id_sync();
+        REQUIRE(max_cid == static_cast<std::uint64_t>(kPersistedCommitId));
+
+        // (b) After seeding, a freshly-begun transaction's start_time is GREATER
+        // than the persisted added_at_commit_id, so resolve_table's visibility
+        // filter (added_at <= start_time) would accept the column.
+        components::table::transaction_manager_t txn_mgr(&fd2.resource);
+        // Pre-seed: a fresh manager hands out start_time 1 — below the persisted id.
+        {
+            auto& pre = txn_mgr.begin_transaction(components::session::session_id_t::generate_uid());
+            REQUIRE(pre.start_time() < static_cast<std::uint64_t>(kPersistedCommitId));
+        }
+        txn_mgr.seed_commit_clock(max_cid);
+        auto& post = txn_mgr.begin_transaction(components::session::session_id_t::generate_uid());
+        REQUIRE(post.start_time() > static_cast<std::uint64_t>(kPersistedCommitId));
+        // published_horizon_ is raised to (not above) the seed, so the persisted
+        // commit is treated as published.
+        REQUIRE(txn_mgr.published_horizon() == max_cid);
+
+        // seed_commit_clock is idempotent / never lowers.
+        txn_mgr.seed_commit_clock(1);
+        REQUIRE(txn_mgr.published_horizon() == max_cid);
     }
     std::filesystem::remove_all(dir);
 }

--- a/services/disk/tests/test_resolve.cpp
+++ b/services/disk/tests/test_resolve.cpp
@@ -210,7 +210,9 @@ TEST_CASE("services::disk::resolve::read_chunks_by_keys_multi_key_parity") {
                                                    components::table::transaction_data{0, 0},
                                                    {},
                                                    table_oid};
-        auto [start, count] = fx.invoke(&manager_disk_t::storage_append, append_ctx, table_oid, std::move(chunk));
+        auto append_r = fx.invoke(&manager_disk_t::storage_append, append_ctx, table_oid, std::move(chunk));
+        REQUIRE_FALSE(append_r.has_error());
+        auto [start, count] = append_r.value();
         REQUIRE(count == nrows);
         (void) start;
     }

--- a/services/disk/tests/test_table_storage.cpp
+++ b/services/disk/tests/test_table_storage.cpp
@@ -40,9 +40,12 @@ namespace {
                 chunk.set_value(0, i, logical_value_t{resource, static_cast<int64_t>(offset + i)});
             }
             table_append_state state(resource);
-            table.append_lock(state);
-            table.initialize_append(state);
-            table.append(chunk, state);
+            auto append_lock_result = table.append_lock(state);
+            REQUIRE_FALSE(append_lock_result.has_error());
+            auto initialize_append_result = table.initialize_append(state);
+            REQUIRE_FALSE(initialize_append_result.has_error());
+            auto append_result = table.append(chunk, state);
+            REQUIRE_FALSE(append_result.has_error());
             table.finalize_append(state, transaction_data{0, 0});
             offset += batch;
         }
@@ -95,7 +98,8 @@ TEST_CASE("services::disk::table_storage::disk_checkpoint_and_load") {
         append_int64_data(ts.table(), &resource, NUM_ROWS);
         REQUIRE(ts.table().calculate_size() == NUM_ROWS);
 
-        ts.checkpoint();
+        auto checkpoint_result = ts.checkpoint();
+        REQUIRE_FALSE(checkpoint_result.has_error());
     }
 
     // Load and verify
@@ -180,14 +184,18 @@ TEST_CASE("services::disk::table_storage::checkpoint_preserves_multi_column") {
                 chunk.set_value(1, i, logical_value_t{&resource, static_cast<double>(offset + i) * 1.5});
             }
             table_append_state state(&resource);
-            ts.table().append_lock(state);
-            ts.table().initialize_append(state);
-            ts.table().append(chunk, state);
+            auto append_lock_result = ts.table().append_lock(state);
+            REQUIRE_FALSE(append_lock_result.has_error());
+            auto initialize_append_result = ts.table().initialize_append(state);
+            REQUIRE_FALSE(initialize_append_result.has_error());
+            auto append_result = ts.table().append(chunk, state);
+            REQUIRE_FALSE(append_result.has_error());
             ts.table().finalize_append(state, transaction_data{0, 0});
             offset += batch;
         }
         REQUIRE(ts.table().calculate_size() == NUM_ROWS);
-        ts.checkpoint();
+        auto checkpoint_result = ts.checkpoint();
+        REQUIRE_FALSE(checkpoint_result.has_error());
     }
 
     // Load and verify both columns
@@ -243,9 +251,12 @@ TEST_CASE("services::disk::table_storage::drop_column_in_memory") {
             chunk.set_value(2, i, logical_value_t{&resource, static_cast<int64_t>(i * 100)});
         }
         table_append_state state(&resource);
-        ts.table().append_lock(state);
-        ts.table().initialize_append(state);
-        ts.table().append(chunk, state);
+        auto append_lock_result = ts.table().append_lock(state);
+        REQUIRE_FALSE(append_lock_result.has_error());
+        auto initialize_append_result = ts.table().initialize_append(state);
+        REQUIRE_FALSE(initialize_append_result.has_error());
+        auto append_result = ts.table().append(chunk, state);
+        REQUIRE_FALSE(append_result.has_error());
         ts.table().finalize_append(state, transaction_data{0, 0});
     }
     REQUIRE(ts.table().calculate_size() == NUM_ROWS);

--- a/services/disk/tests/test_torn_checkpoint.cpp
+++ b/services/disk/tests/test_torn_checkpoint.cpp
@@ -2,9 +2,12 @@
 #include <services/disk/manager_disk.hpp>
 
 #include <components/table/column_definition.hpp>
+#include <components/table/storage/single_file_block_manager.hpp>
 #include <components/table/table_state.hpp>
 #include <components/types/types.hpp>
 #include <components/vector/data_chunk.hpp>
+#include <core/result_wrapper.hpp>
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <unistd.h>
@@ -183,6 +186,58 @@ TEST_CASE("services::disk::torn::load_falls_back_to_prev_on_corrupt_otbx") {
     REQUIRE(ts.table().calculate_size() == 1);
     REQUIRE(std::filesystem::exists(broken));
     REQUIRE_FALSE(std::filesystem::exists(prev));
+
+    cleanup_torn_dir();
+}
+
+// Corrupt .otbx with NO .prev -> error surfaced as a VALUE (construction_error),
+// not a throw/terminate. The DISK reopen ctor of table_storage_t runs
+// load_existing_database(); on a bad-magic main header it returns data_corruption,
+// which the ctor records in construction_error_ (instead of throwing, since it can
+// run on the noexcept agent thread). We build a valid .otbx, flip the main_header
+// magic (file offset 0) so it fails validate(), leave no .prev, then reopen and
+// assert construction_failed() with data_corruption and NO throw.
+TEST_CASE("services::disk::torn::reopen_corrupt_otbx_no_prev_surfaces_error_value") {
+    cleanup_torn_dir();
+    auto db_dir = std::filesystem::path(torn_test_dir()) / "db3" / "main" / "coll3";
+    std::filesystem::create_directories(db_dir);
+    std::pmr::synchronized_pool_resource resource;
+
+    auto otbx = db_dir / "table.otbx";
+
+    // Build a valid otbx via the create + checkpoint path.
+    {
+        std::vector<column_definition_t> cols;
+        cols.emplace_back("value", logical_type::BIGINT);
+        table_storage_t ts(&resource, std::move(cols), otbx);
+        REQUIRE_FALSE(ts.construction_failed());
+        append_one_int(ts.table(), &resource, 5);
+        ts.checkpoint();
+    }
+    REQUIRE(std::filesystem::exists(otbx));
+    REQUIRE_FALSE(std::filesystem::exists(std::filesystem::path(otbx.string() + ".prev")));
+
+    // main_header_t::magic is the first 4 bytes of the file. Overwrite it with a
+    // value that is not MAGIC_NUMBER so load_existing_database() reports data_corruption.
+    {
+        std::fstream f(otbx, std::ios::in | std::ios::out | std::ios::binary);
+        REQUIRE(f.is_open());
+        uint32_t bad_magic = 0x0BADBEEF;
+        REQUIRE(bad_magic != components::table::storage::main_header_t::MAGIC_NUMBER);
+        f.seekp(0);
+        f.write(reinterpret_cast<const char*>(&bad_magic), sizeof(bad_magic));
+        f.flush();
+        REQUIRE(f.good());
+    }
+
+    // Reopen the corrupt file: ctor must NOT throw and must record the error as a VALUE.
+    {
+        table_storage_t ts(&resource, otbx);
+        REQUIRE(ts.construction_failed());
+        REQUIRE(ts.construction_error().type == core::error_code_t::data_corruption);
+    }
+    // The ctor itself is the unit under test for "no throw"; build it inside REQUIRE_NOTHROW too.
+    REQUIRE_NOTHROW([&] { table_storage_t probe(&resource, otbx); }());
 
     cleanup_torn_dir();
 }

--- a/services/disk/tests/test_torn_checkpoint.cpp
+++ b/services/disk/tests/test_torn_checkpoint.cpp
@@ -30,9 +30,12 @@ namespace {
         chunk.set_cardinality(1);
         chunk.set_value(0, 0, logical_value_t{res, value});
         table_append_state state(res);
-        table.append_lock(state);
-        table.initialize_append(state);
-        table.append(chunk, state);
+        auto lock_result = table.append_lock(state);
+        REQUIRE_FALSE(lock_result.has_error());
+        auto init_result = table.initialize_append(state);
+        REQUIRE_FALSE(init_result.has_error());
+        auto append_result = table.append(chunk, state);
+        REQUIRE_FALSE(append_result.has_error());
         table.finalize_append(state, transaction_data{0, 0});
     }
 } // namespace
@@ -53,17 +56,20 @@ TEST_CASE("services::disk::torn::checkpoint_wal_id_overload_tracks_prev") {
     REQUIRE(ts.prev_checkpoint_wal_id() == 0);
 
     append_one_int(ts.table(), &resource, 1);
-    ts.checkpoint(services::wal::id_t{100});
+    auto checkpoint_result_100 = ts.checkpoint(services::wal::id_t{100});
+    REQUIRE_FALSE(checkpoint_result_100.has_error());
     REQUIRE(ts.checkpoint_wal_id() == 100);
     REQUIRE(ts.prev_checkpoint_wal_id() == 0); // first checkpoint, no prior id
 
     append_one_int(ts.table(), &resource, 2);
-    ts.checkpoint(services::wal::id_t{250});
+    auto checkpoint_result_250 = ts.checkpoint(services::wal::id_t{250});
+    REQUIRE_FALSE(checkpoint_result_250.has_error());
     REQUIRE(ts.checkpoint_wal_id() == 250);
     REQUIRE(ts.prev_checkpoint_wal_id() == 100); // shifted
 
     append_one_int(ts.table(), &resource, 3);
-    ts.checkpoint(services::wal::id_t{260});
+    auto checkpoint_result_260 = ts.checkpoint(services::wal::id_t{260});
+    REQUIRE_FALSE(checkpoint_result_260.has_error());
     REQUIRE(ts.checkpoint_wal_id() == 260);
     REQUIRE(ts.prev_checkpoint_wal_id() == 250); // shifted again
 
@@ -82,7 +88,8 @@ TEST_CASE("services::disk::torn::checkpoint_no_overload_leaves_ids_zero") {
 
     table_storage_t ts(&resource, std::move(cols), otbx);
     append_one_int(ts.table(), &resource, 42);
-    ts.checkpoint();
+    auto checkpoint_result = ts.checkpoint();
+    REQUIRE_FALSE(checkpoint_result.has_error());
     REQUIRE(ts.checkpoint_wal_id() == 0);
     REQUIRE(ts.prev_checkpoint_wal_id() == 0);
 
@@ -104,7 +111,8 @@ TEST_CASE("services::disk::torn::data_persists_after_checkpoint_with_wal_id") {
         for (int64_t i = 0; i < N; i++) {
             append_one_int(ts.table(), &resource, i);
         }
-        ts.checkpoint(services::wal::id_t{777});
+        auto checkpoint_result_777 = ts.checkpoint(services::wal::id_t{777});
+        REQUIRE_FALSE(checkpoint_result_777.has_error());
         REQUIRE(ts.checkpoint_wal_id() == 777);
     }
 
@@ -135,7 +143,8 @@ TEST_CASE("services::disk::torn::load_storage_disk_sync_promotes_only_prev") {
         cols.emplace_back("value", logical_type::BIGINT);
         table_storage_t ts(&resource, std::move(cols), otbx);
         append_one_int(ts.table(), &resource, 7);
-        ts.checkpoint();
+        auto checkpoint_result = ts.checkpoint();
+        REQUIRE_FALSE(checkpoint_result.has_error());
     }
     std::filesystem::rename(otbx, prev);
     REQUIRE_FALSE(std::filesystem::exists(otbx));
@@ -169,7 +178,8 @@ TEST_CASE("services::disk::torn::load_falls_back_to_prev_on_corrupt_otbx") {
         cols.emplace_back("value", logical_type::BIGINT);
         table_storage_t ts(&resource, std::move(cols), otbx);
         append_one_int(ts.table(), &resource, 99);
-        ts.checkpoint();
+        auto checkpoint_result = ts.checkpoint();
+        REQUIRE_FALSE(checkpoint_result.has_error());
     }
     std::filesystem::copy_file(otbx, prev);
 
@@ -212,7 +222,8 @@ TEST_CASE("services::disk::torn::reopen_corrupt_otbx_no_prev_surfaces_error_valu
         table_storage_t ts(&resource, std::move(cols), otbx);
         REQUIRE_FALSE(ts.construction_failed());
         append_one_int(ts.table(), &resource, 5);
-        ts.checkpoint();
+        auto checkpoint_result = ts.checkpoint();
+        REQUIRE_FALSE(checkpoint_result.has_error());
     }
     REQUIRE(std::filesystem::exists(otbx));
     REQUIRE_FALSE(std::filesystem::exists(std::filesystem::path(otbx.string() + ".prev")));

--- a/services/dispatcher/dispatcher.cpp
+++ b/services/dispatcher/dispatcher.cpp
@@ -401,13 +401,19 @@ namespace services::dispatcher {
         co_return;
     }
 
-    void manager_dispatcher_t::set_replay_horizon_sync(uint64_t commit_id) {
-        // publish() takes the manager's own lock_ — safe even outside a started
-        // scheduler. publish() is monotonic (CAS keeps the max), so passing a
-        // stale id is a no-op.
-        if (commit_id > 0) {
-            txn_manager_.publish(commit_id);
-            trace(log_, "manager_dispatcher_t::set_replay_horizon_sync , advanced published_horizon to {}", commit_id);
+    void manager_dispatcher_t::seed_commit_clock_sync(uint64_t high_water) {
+        // Restore BOTH halves of the commit clock from the combined durable frontier,
+        // not just published_horizon_. Raising only the horizon while current_timestamp_
+        // restarts at 1 lets post-reopen INSERTs draw commit-ids that reuse the
+        // already-published band; a reader that snapshots them in-flight then judges them
+        // invisible forever (symptom: SSB q1-1 returned 0 rows on reopen).
+        // restore_commit_clock raises current_timestamp_ to frontier+1 in lockstep
+        // with published_horizon_, so fresh commits land strictly above the durable
+        // frontier. Monotonic / idempotent — never lowers either half. Single-threaded
+        // bootstrap; scheduler not yet started.
+        if (high_water > 0) {
+            txn_manager_.restore_commit_clock(high_water);
+            trace(log_, "manager_dispatcher_t::seed_commit_clock_sync , restored commit clock to frontier {}", high_water);
         }
     }
 

--- a/services/dispatcher/dispatcher.hpp
+++ b/services/dispatcher/dispatcher.hpp
@@ -82,11 +82,16 @@ namespace services::dispatcher {
 
         void sync(sync_pack pack);
 
-        // Bootstrap hook: advance the published horizon past the max durable
-        // commit_id found during WAL replay, so post-recovery snapshots get the
-        // right MVCC visibility. Direct sync call is safe only because the
-        // scheduler is not started yet. Idempotent — publish() ignores stale ids.
-        void set_replay_horizon_sync(uint64_t commit_id);
+        // Bootstrap hook: restore the MVCC commit clock from the combined durable
+        // frontier (max of the persisted pg_attribute commit-ids and the max WAL
+        // COMMIT-marker commit_id). Raises BOTH halves together via
+        // transaction_manager_t::restore_commit_clock: current_timestamp_ to
+        // frontier+1 (so a reopened instance issues start_times/commit-ids strictly
+        // above every persisted id — no reuse of the already-published band) AND
+        // published_horizon_ to frontier (so post-recovery snapshots see persisted
+        // commits as published). Direct sync call — safe only because the scheduler
+        // is not started yet. Idempotent (never lowers either half).
+        void seed_commit_clock_sync(uint64_t high_water);
 
         // Like the on_drop_resource_marked() mailbox handler but usable before
         // scheduler.start: base_spaces calls these after rebuilding the dropped-

--- a/services/wal/tests/test_wal_torn_write.cpp
+++ b/services/wal/tests/test_wal_torn_write.cpp
@@ -63,11 +63,13 @@ TEST_CASE("wal::torn::table_storage_tracks_wal_id_chain") {
     REQUIRE(ts.checkpoint_wal_id() == 0);
     REQUIRE(ts.prev_checkpoint_wal_id() == 0);
 
-    ts.checkpoint(wal::id_t{42});
+    auto checkpoint_42_result = ts.checkpoint(wal::id_t{42});
+    REQUIRE_FALSE(checkpoint_42_result.has_error());
     REQUIRE(ts.checkpoint_wal_id() == 42);
     REQUIRE(ts.prev_checkpoint_wal_id() == 0);
 
-    ts.checkpoint(wal::id_t{100});
+    auto checkpoint_100_result = ts.checkpoint(wal::id_t{100});
+    REQUIRE_FALSE(checkpoint_100_result.has_error());
     REQUIRE(ts.checkpoint_wal_id() == 100);
     REQUIRE(ts.prev_checkpoint_wal_id() == 42);
 
@@ -111,7 +113,8 @@ TEST_CASE("wal::torn::prev_le_current_invariant") {
 
     services::disk::table_storage_t ts(&resource, std::move(cols), otbx);
     for (wal::id_t id : {wal::id_t{1}, wal::id_t{5}, wal::id_t{7}, wal::id_t{7}, wal::id_t{12}}) {
-        ts.checkpoint(id);
+        auto checkpoint_result = ts.checkpoint(id);
+        REQUIRE_FALSE(checkpoint_result.has_error());
         REQUIRE(ts.prev_checkpoint_wal_id() <= ts.checkpoint_wal_id());
     }
     // After the full sequence, prev should be the second-to-last (7), current the last (12).


### PR DESCRIPTION
## Problem

Under memory pressure, large-table (HTAP) scans segfaulted. Root cause: the
buffer pool was used as a **store, not a cache**. Filled column segments had
no backing store, so when the pool evicted such a block, a later re-pin
dereferenced a null buffer → `EXC_BAD_ACCESS`.

## Fix

Turn the buffer pool into a real disk-backed cache:

- `block_handle` distinguishes **reloadable** blocks
  (`block_id < MAXIMUM_BLOCK`, a disk copy exists and `load()` can re-read
  it) from **managed in-memory** blocks (`load()` returns `{}`).
- **Eviction guard**: `can_unload()` is gated on `is_reloadable()`, so a
  block with no backing store is never unloaded — a re-pin can no longer
  hit a null buffer.
- **Write-through**: a filled segment is written to the data file and
  swapped for a disk-backed, evictable+reloadable segment
  (`transition_segment_to_disk` + `segment_tree::replace_segment_at_index`),
  so memory stays bounded at any table size.
- **No throwing on the agent thread**: `load()` / `buffer_pool::set_limit()`
  and the scan/update/append chains forward
  `data_corruption` / `io_error` / `out_of_memory` / `write_conflict`
  through `result_wrapper` instead of throwing. The `agent_disk` /
  `manager_disk` replies carry the error, so the executor surfaces a clean
  error cursor.

Disk manager bootstrap/IO/resolve and the table storage adapter are
updated for the disk-backed segment lifecycle.

## Scope

A table that exceeds its pool now returns a clean `out_of_memory` error
cursor instead of segfaulting, and large scans that fit on disk complete
with bounded RSS. **Bounded-memory streaming execution** (push-based scan
pipeline) is separate follow-up work, not part of this PR.

## Tests

- New: `test_disk_backed_scan`, `test_eviction_guard`,
  `test_arithmetic_empty`.
- Extended: checkpoint load, block manager, persistence, MVCC,
  transaction manager, and production-scenario coverage.
