### PR TITLE
ci: bump conan to 2.30.0 in macos workflow

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
             brew update && (brew list ninja || brew install ninja) && (brew list cmake || brew install cmake) && (brew list flex || brew install flex) && (brew list bison || brew install bison)
             brew link bison --force
-            python3 -m pip install --no-cache-dir conan==2.20.0  pytest==6.2.5 --break-system-packages
+            python3 -m pip install --no-cache-dir conan==2.30.0 pytest==6.2.5 --break-system-packages
 
       - name: conan installation and configuration
         run: |


### PR DESCRIPTION
The macos-latest runner image now ships **apple-clang 21** (Apple realigned its compiler versioning with LLVM, jumping 17 → 21). The workflow pins conan 2.20.0, whose settings only list apple-clang versions up to 17, so `conan profile detect` fails every run at the download-dependencies step:

```
ERROR: Invalid setting '21' is not a valid 'settings.compiler.version' value.
Possible values are ['5.0', ..., '17', '17.0']
```

This has been failing on main as well (every run since the runner image rollover) — it is unrelated to any code changes.

apple-clang 21 is supported since conan 2.28.0; this pins the latest **2.30.0**. One-line change, macos workflow only (other workflows keep their own pins and are unaffected).

Note: the first runs may be slower — `--build missing` will rebuild dependencies from source until prebuilt apple-clang-21 binaries appear on the remotes. If that turns out to be a permanent tax, a follow-up can add an actions/cache step for `~/.conan2/p`.
