### PR TITLE
SSB join performance: comma-join → hash, batched materialization, build-side selection, disk pushdown

### DIFF
--- a/benchmark/runner/CMakeLists.txt
+++ b/benchmark/runner/CMakeLists.txt
@@ -22,3 +22,7 @@ target_link_libraries(
         ${PROJECT_NAME} PRIVATE
         cpp_otterbrix
 )
+
+if (DEV_MODE)
+    add_subdirectory(test)
+endif()

--- a/benchmark/runner/benchmark.hpp
+++ b/benchmark/runner/benchmark.hpp
@@ -87,7 +87,7 @@ public:
     virtual std::string verify(benchmark_state_t& /*state*/) { return ""; }
 
     // Only SQL benchmarks have a setup phase to skip; the default is a no-op so the
-    // runner can request it uniformly without a dynamic_cast (rule 14).
+    // runner can request it uniformly without a dynamic_cast.
     virtual void set_disable_setup(bool /*disable*/) {}
 
     virtual uint64_t nruns() const { return 5; }

--- a/benchmark/runner/benchmark.hpp
+++ b/benchmark/runner/benchmark.hpp
@@ -86,6 +86,10 @@ public:
     virtual void cleanup(benchmark_state_t& /*state*/) {}
     virtual std::string verify(benchmark_state_t& /*state*/) { return ""; }
 
+    // Only SQL benchmarks have a setup phase to skip; the default is a no-op so the
+    // runner can request it uniformly without a dynamic_cast (rule 14).
+    virtual void set_disable_setup(bool /*disable*/) {}
+
     virtual uint64_t nruns() const { return 5; }
     virtual uint64_t timeout_seconds() const { return 30; }
 };

--- a/benchmark/runner/benchmark_runner.cpp
+++ b/benchmark/runner/benchmark_runner.cpp
@@ -1,12 +1,14 @@
 #include "benchmark_runner.hpp"
 
 #include <chrono>
+#include <filesystem>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <map>
 #include <regex>
 #include <set>
+#include <system_error>
 
 #include <components/configuration/configuration.hpp>
 #include <integration/cpp/base_spaces.hpp>
@@ -316,6 +318,19 @@ benchmark_result_t benchmark_runner_t::run_single(benchmark_t& bench, const benc
     }
 
     try {
+        // Fresh persisted state per benchmark. Every disk instance points at the
+        // same current_path()/"disk" (+ "/wal") — see benchmark_instance_t::make_config
+        // — so without a reset each load() re-runs CREATE TABLE IF NOT EXISTS and
+        // appends its @load_csv rows onto the previously persisted table, doubling
+        // row counts across benchmarks (60k -> 120k -> 180k ...). Clear the persisted
+        // dirs before opening the instance. Best-effort (error_code, no throw): a
+        // missing dir is not an error, and the fresh instance recreates them.
+        if (config.disk_on && !config.skip_load) {
+            std::error_code ec;
+            std::filesystem::remove_all(std::filesystem::current_path() / "disk", ec);
+            std::filesystem::remove_all(std::filesystem::current_path() / "wal", ec);
+        }
+
         benchmark_instance_t instance(config);
         benchmark_state_t state;
         state.dispatcher = instance.dispatcher();

--- a/benchmark/runner/benchmark_runner.cpp
+++ b/benchmark/runner/benchmark_runner.cpp
@@ -202,9 +202,7 @@ void benchmark_runner_t::run(const benchmark_configuration_t& config) {
     for (auto& b : benchmarks_) {
         if (matches_filter(*b, config)) {
             if (config.no_setup) {
-                if (auto* sql = dynamic_cast<sql_benchmark_t*>(b.get())) {
-                    sql->set_disable_setup(true);
-                }
+                b->set_disable_setup(true);
             }
             filtered.push_back(b.get());
         }

--- a/benchmark/runner/sql_benchmark.hpp
+++ b/benchmark/runner/sql_benchmark.hpp
@@ -25,7 +25,7 @@ public:
 
     void load(benchmark_state_t& state) override;
     void run(benchmark_state_t& state) override;
-    void set_disable_setup(bool disable) { disable_setup_ = disable; }
+    void set_disable_setup(bool disable) override { disable_setup_ = disable; }
 
     static std::vector<std::unique_ptr<sql_benchmark_t>>
     load_from_file(const std::filesystem::path& path, const std::filesystem::path& base_dir);

--- a/benchmark/runner/test/CMakeLists.txt
+++ b/benchmark/runner/test/CMakeLists.txt
@@ -1,0 +1,35 @@
+set(project benchmark_runner_test)
+
+cmake_policy(SET CMP0048 NEW)
+PROJECT(${project} VERSION "${CMAKE_PROJECT_VERSION}" LANGUAGES CXX)
+
+add_definitions(-DDEV_MODE)
+
+# Compile the runner sources under test alongside the test TU (the runner is an
+# executable, not a library, so there is nothing to link against). main.cpp is
+# deliberately excluded — Catch provides main via CATCH_CONFIG_MAIN.
+set(${PROJECT_NAME}_SOURCES
+        test_benchmark_reset.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../benchmark_runner.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../interpreted_benchmark.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../sql_benchmark.cpp
+)
+
+message(STATUS "PROJECT_NAME = ${PROJECT_NAME}")
+
+add_executable(${PROJECT_NAME} ${${PROJECT_NAME}_SOURCES})
+
+target_include_directories(${PROJECT_NAME} PRIVATE
+        ${CMAKE_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/..
+)
+
+target_link_libraries(
+        ${PROJECT_NAME} PRIVATE
+        cpp_otterbrix
+        Catch2::Catch2
+)
+
+include(CTest)
+include(Catch)
+catch_discover_tests(${PROJECT_NAME} PROPERTIES TIMEOUT 600)

--- a/benchmark/runner/test/test_benchmark_reset.cpp
+++ b/benchmark/runner/test/test_benchmark_reset.cpp
@@ -1,4 +1,4 @@
-// Regression test for the benchmark-runner disk-reset (Stage 0).
+// Regression test for the benchmark-runner disk-reset.
 //
 // The runner points every disk instance at the same current_path()/"disk"
 // (+ "/wal") directory. Each benchmark's load() does CREATE TABLE IF NOT EXISTS
@@ -8,10 +8,10 @@
 // disk/wal dirs before opening each instance.
 //
 // This test drives the real public runner path (run() -> run_single) with a
-// tiny self-contained benchmark loaded twice. RED without the reset: the second
+// tiny self-contained benchmark loaded twice. Without the reset: the second
 // run re-loads onto the first run's 3 persisted rows -> 6 rows -> the
 // @expected_rows=3 check fails -> the result CSV's verified column is FAIL.
-// GREEN with the reset: the second run starts empty -> 3 rows -> both OK.
+// With the reset: the second run starts empty -> 3 rows -> both OK.
 
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>

--- a/benchmark/runner/test/test_benchmark_reset.cpp
+++ b/benchmark/runner/test/test_benchmark_reset.cpp
@@ -1,0 +1,115 @@
+// Regression test for the benchmark-runner disk-reset (Stage 0).
+//
+// The runner points every disk instance at the same current_path()/"disk"
+// (+ "/wal") directory. Each benchmark's load() does CREATE TABLE IF NOT EXISTS
+// followed by an appending @load_csv, so before the fix a second run over a
+// persisted disk re-loaded the CSV and doubled the row count (this is the k^2
+// harness bug: 60k -> 120k -> 180k ...). run_single now removes the persisted
+// disk/wal dirs before opening each instance.
+//
+// This test drives the real public runner path (run() -> run_single) with a
+// tiny self-contained benchmark loaded twice. RED without the reset: the second
+// run re-loads onto the first run's 3 persisted rows -> 6 rows -> the
+// @expected_rows=3 check fails -> the result CSV's verified column is FAIL.
+// GREEN with the reset: the second run starts empty -> 3 rows -> both OK.
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
+#include "benchmark_configuration.hpp"
+#include "benchmark_runner.hpp"
+#include "sql_benchmark.hpp"
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <system_error>
+
+using namespace otterbrix::benchmark;
+
+TEST_CASE("benchmark::runner::disk_reset_prevents_accumulation") {
+    namespace fs = std::filesystem;
+
+    const auto cwd = fs::current_path();
+    const auto disk_dir = cwd / "disk";
+    const auto wal_dir = cwd / "wal";
+    const auto bench_dir = cwd / "reset_bench_tmp";
+
+    // Clean slate: the runner's disk/wal live under current_path(), so pre-clean
+    // them (and any leftover fixture) so the FIRST load starts from an empty
+    // table irrespective of prior process state. This pre-clean is the test's own
+    // hygiene — the second load is where the runner's reset is exercised.
+    std::error_code ec;
+    fs::remove_all(disk_dir, ec);
+    fs::remove_all(wal_dir, ec);
+    fs::remove_all(bench_dir, ec);
+    fs::create_directories(bench_dir);
+
+    // 3-row pipe-delimited CSV (matches the @load_csv default delimiter).
+    {
+        std::ofstream csv(bench_dir / "data.csv");
+        csv << "id|val\n"
+               "1|10\n"
+               "2|20\n"
+               "3|30\n";
+    }
+    // _setup.sql: declare the CSV load and create the table.
+    {
+        std::ofstream setup(bench_dir / "_setup.sql");
+        setup << "-- @database resetdb\n"
+                 "-- @load_csv data.csv items |\n"
+                 "CREATE TABLE IF NOT EXISTS items (id bigint, val bigint);\n";
+    }
+    // q.sql: the benchmark query. Its row count equals the single-load table
+    // size, so accumulation trips the @expected_rows check.
+    const auto query_path = bench_dir / "q.sql";
+    {
+        std::ofstream q(query_path);
+        q << "-- @expected_rows 3\n"
+             "SELECT id, val FROM items;\n";
+    }
+
+    benchmark_configuration_t config;
+    config.disk_on = true;
+    config.nruns = 1;
+    const auto csv_out = (bench_dir / "result.csv").string();
+    config.output_file = csv_out;
+
+    // Register the SAME benchmark twice: run() drives run_single once per entry.
+    // The 2nd run_single opens the disk the 1st persisted — without the reset it
+    // re-loads and the table doubles (3 -> 6), tripping @expected_rows.
+    benchmark_runner_t runner;
+    runner.load_single_benchmark(query_path);
+    runner.load_single_benchmark(query_path);
+
+    runner.run(config);
+
+    // The verified column (last field) of the result CSV must be OK for BOTH
+    // runs. Without the reset the 2nd run reports FAIL (6 rows != expected 3).
+    std::ifstream result(csv_out);
+    REQUIRE(result.is_open());
+    std::string line;
+    std::getline(result, line); // header
+    size_t data_rows = 0;
+    size_t fails = 0;
+    while (std::getline(result, line)) {
+        if (line.empty()) {
+            continue;
+        }
+        ++data_rows;
+        if (line.find(",FAIL") != std::string::npos) {
+            ++fails;
+        }
+    }
+    result.close();
+
+    // Cleanup regardless of outcome.
+    fs::remove_all(disk_dir, ec);
+    fs::remove_all(wal_dir, ec);
+    fs::remove_all(bench_dir, ec);
+
+    REQUIRE(data_rows == 2);
+    INFO("Both benchmark runs must verify OK; a FAIL means the disk was not reset "
+         "and rows accumulated across loads (3 -> 6).");
+    REQUIRE(fails == 0);
+}

--- a/components/compute/function.cpp
+++ b/components/compute/function.cpp
@@ -1,5 +1,7 @@
 #include "function.hpp"
 
+#include <core/pmr.hpp>
+
 #include <optional>
 
 using namespace components::vector;
@@ -281,7 +283,7 @@ namespace components::compute {
     std::unique_ptr<function> vector_function::get_copy(std::pmr::memory_resource* resource) const {
         auto result = std::make_unique<vector_function>(name_, arity_, doc_, kernel_slots_);
         for (const auto& kernel : kernels_) {
-            (void) result->add_kernel(resource, kernel);
+            [[maybe_unused]] auto add_res = result->add_kernel(resource, kernel);
         }
         return result;
     }
@@ -299,7 +301,7 @@ namespace components::compute {
     std::unique_ptr<function> aggregate_function::get_copy(std::pmr::memory_resource* resource) const {
         auto result = std::make_unique<aggregate_function>(name_, arity_, doc_, kernel_slots_, mergeable_);
         for (const auto& kernel : kernels_) {
-            (void) result->add_kernel(resource, kernel);
+            [[maybe_unused]] auto add_res = result->add_kernel(resource, kernel);
         }
         return result;
     }
@@ -312,7 +314,7 @@ namespace components::compute {
     std::unique_ptr<function> row_function::get_copy(std::pmr::memory_resource* resource) const {
         auto result = std::make_unique<row_function>(name_, arity_, doc_, kernel_slots_);
         for (const auto& kernel : kernels_) {
-            (void) result->add_kernel(resource, kernel);
+            [[maybe_unused]] auto add_res = result->add_kernel(resource, kernel);
         }
         return result;
     }
@@ -325,7 +327,7 @@ namespace components::compute {
     std::unique_ptr<function> expand_function::get_copy(std::pmr::memory_resource* resource) const {
         auto result = std::make_unique<expand_function>(name_, arity_, doc_, kernel_slots_);
         for (const auto& kernel : kernels_) {
-            (void) result->add_kernel(resource, kernel);
+            [[maybe_unused]] auto add_res = result->add_kernel(resource, kernel);
         }
         return result;
     }
@@ -337,9 +339,22 @@ namespace components::compute {
     std::once_flag function_registry_t::init_flag_;
     std::unique_ptr<function_registry_t> function_registry_t::default_registry_;
 
+    namespace {
+        // Backing resource for the process-wide default function registry. The default
+        // registry is a lazily-created singleton torn down during static destruction, so
+        // its resource must outlive that teardown; a never-destroyed heap resource
+        // (reachable from this static pointer, hence not a leak under LSan) guarantees it
+        // without std::pmr::get_default_resource() (rule 14), using the sanctioned
+        // core::pmr::otterbrix_resource (rule 20).
+        std::pmr::memory_resource* default_registry_resource() {
+            static core::pmr::otterbrix_resource* resource = new core::pmr::otterbrix_resource();
+            return resource;
+        }
+    } // namespace
+
     function_registry_t* function_registry_t::get_default() {
         std::call_once(init_flag_, []() {
-            default_registry_ = std::make_unique<function_registry_t>(std::pmr::get_default_resource());
+            default_registry_ = std::make_unique<function_registry_t>(default_registry_resource());
             default_registry_->register_builtin_functions();
         });
         return default_registry_.get();
@@ -348,8 +363,8 @@ namespace components::compute {
     void function_registry_t::reset_default() {
         // Ensure init_flag_ has fired (so get_default() won't later overwrite our
         // fresh instance), then replace with a clean builtins-only registry.
-        (void) get_default();
-        default_registry_ = std::make_unique<function_registry_t>(std::pmr::get_default_resource());
+        [[maybe_unused]] auto* fired = get_default();
+        default_registry_ = std::make_unique<function_registry_t>(default_registry_resource());
         default_registry_->register_builtin_functions();
     }
 

--- a/components/compute/function.cpp
+++ b/components/compute/function.cpp
@@ -344,8 +344,8 @@ namespace components::compute {
         // registry is a lazily-created singleton torn down during static destruction, so
         // its resource must outlive that teardown; a never-destroyed heap resource
         // (reachable from this static pointer, hence not a leak under LSan) guarantees it
-        // without std::pmr::get_default_resource() (rule 14), using the sanctioned
-        // core::pmr::otterbrix_resource (rule 20).
+        // without relying on std::pmr::get_default_resource(), using
+        // core::pmr::otterbrix_resource.
         std::pmr::memory_resource* default_registry_resource() {
             static core::pmr::otterbrix_resource* resource = new core::pmr::otterbrix_resource();
             return resource;

--- a/components/expressions/compare_expression.cpp
+++ b/components/expressions/compare_expression.cpp
@@ -113,6 +113,18 @@ namespace components::expressions {
         return new compare_expression_t(resource, type, nullptr, nullptr);
     }
 
+    bool is_key(const param_storage& param) noexcept { return std::holds_alternative<key_t>(param); }
+
+    const key_t& as_key(const param_storage& param) { return std::get<key_t>(param); }
+
+    key_t& as_key(param_storage& param) { return std::get<key_t>(param); }
+
+    bool is_expr(const param_storage& param) noexcept { return std::holds_alternative<expression_ptr>(param); }
+
+    const expression_ptr& as_expr(const param_storage& param) { return std::get<expression_ptr>(param); }
+
+    expression_ptr& as_expr(param_storage& param) { return std::get<expression_ptr>(param); }
+
     compare_type get_compare_type(const std::string& key) {
         if (key.empty()) {
             return compare_type::invalid;

--- a/components/expressions/compare_expression.hpp
+++ b/components/expressions/compare_expression.hpp
@@ -65,8 +65,7 @@ namespace components::expressions {
     compare_type get_compare_type(const std::string& key);
 
     // Encapsulated access to the `key_t` alternative of `param_storage` (a
-    // std::variant type alias — rule 14). These are the ONLY sanctioned readers of
-    // that variant in NEW code: callers name is_key/as_key instead of
+    // std::variant type alias). New code names is_key/as_key instead of
     // std::holds_alternative/std::get<key_t>, so no new site names std::variant.
     // as_key must be guarded by is_key (it delegates to std::get, which throws on a
     // mismatched alternative).
@@ -76,7 +75,7 @@ namespace components::expressions {
 
     // Same encapsulation for the nested-expression alternative of `param_storage` (a
     // compare/scalar/function operand that is itself an expression). New code reads it
-    // via is_expr/as_expr instead of std::holds_alternative/std::get (rule 14).
+    // via is_expr/as_expr instead of std::holds_alternative/std::get.
     // as_expr must be guarded by is_expr (it delegates to std::get, which throws on a
     // mismatched alternative).
     bool is_expr(const param_storage& param) noexcept;

--- a/components/expressions/compare_expression.hpp
+++ b/components/expressions/compare_expression.hpp
@@ -64,4 +64,23 @@ namespace components::expressions {
     bool is_union_compare_condition(compare_type type);
     compare_type get_compare_type(const std::string& key);
 
+    // Encapsulated access to the `key_t` alternative of `param_storage` (a
+    // std::variant type alias — rule 14). These are the ONLY sanctioned readers of
+    // that variant in NEW code: callers name is_key/as_key instead of
+    // std::holds_alternative/std::get<key_t>, so no new site names std::variant.
+    // as_key must be guarded by is_key (it delegates to std::get, which throws on a
+    // mismatched alternative).
+    bool is_key(const param_storage& param) noexcept;
+    const key_t& as_key(const param_storage& param);
+    key_t& as_key(param_storage& param);
+
+    // Same encapsulation for the nested-expression alternative of `param_storage` (a
+    // compare/scalar/function operand that is itself an expression). New code reads it
+    // via is_expr/as_expr instead of std::holds_alternative/std::get (rule 14).
+    // as_expr must be guarded by is_expr (it delegates to std::get, which throws on a
+    // mismatched alternative).
+    bool is_expr(const param_storage& param) noexcept;
+    const expression_ptr& as_expr(const param_storage& param);
+    expression_ptr& as_expr(param_storage& param);
+
 } // namespace components::expressions

--- a/components/physical_plan/operators/join_utils.hpp
+++ b/components/physical_plan/operators/join_utils.hpp
@@ -2,9 +2,11 @@
 
 #include <components/physical_plan/operators/operator_data.hpp>
 #include <components/vector/data_chunk.hpp>
+#include <components/vector/indexing_vector.hpp>
 #include <components/vector/vector_operations.hpp>
 
 #include <algorithm>
+#include <unordered_map>
 #include <vector>
 
 // Shared building blocks for the join operators. operator_join_t (nested-loop,
@@ -22,39 +24,86 @@ namespace components::operators::join_detail {
 
     // Computes the joined output schema and the per-side column→output-slot maps.
     //
-    // PostgreSQL-style: left columns map 1:1 to the first slots, then every right
-    // column is appended in its own slot. Duplicate (same-aliased) columns across
-    // the two sides stay addressable via their table qualifier; USING/NATURAL
-    // column-merging is resolved at the logical layer (validate_logical_plan.cpp),
-    // not here.
+    // The output schema is assembled in LOGICAL [left, right] order regardless of
+    // which physical input the operator materialized as its build side:
+    //   * `left_front`  is the operator's PROBE (physical left) front chunk.
+    //   * `right_front` is the operator's BUILD (physical right) front chunk.
+    //   * `swapped == false` — probe is logical-left, build is logical-right:
+    //       output = [probe cols 0..Lw, build cols Lw..Lw+Bw].
+    //   * `swapped == true`  — build is logical-left, probe is logical-right (the
+    //       build-side-selection heuristic moved the smaller/logical-left table into
+    //       the physical build slot): output = [build cols 0..Bw, probe cols Bw..Bw+Lw].
+    // `indices_left`/`indices_right` stay pure source→slot maps: indices_left[c] is
+    // the output slot for probe column c, indices_right[c] for build column c. The
+    // join_builder gathers each source column into its slot, so it never needs to
+    // know the orientation — only these maps change.
     //
-    // `res_types` is (re)filled starting from the left front-chunk types.
+    // The width invariant (Lw + Bw == total output cols) holds by construction from
+    // the same front chunks, so it is never guarded on the hot path.
+    //
+    // Duplicate (same-aliased) columns across the two sides stay addressable via
+    // their table qualifier; USING/NATURAL column-merging is resolved at the logical
+    // layer (validate_logical_plan.cpp), not here.
     inline void compute_join_layout(const vector::data_chunk_t& left_front,
                                     const vector::data_chunk_t& right_front,
+                                    bool swapped,
                                     std::pmr::vector<types::complex_logical_type>& res_types,
                                     std::vector<size_t>& indices_left,
                                     std::vector<size_t>& indices_right) {
-        res_types = left_front.types();
-        auto right_types = right_front.types();
-        size_t left_col_count = left_front.column_count();
-        size_t right_col_count = right_front.column_count();
+        auto left_types = left_front.types();   // probe types
+        auto right_types = right_front.types(); // build types
+        const size_t left_col_count = left_front.column_count();
+        const size_t right_col_count = right_front.column_count();
 
         indices_left.clear();
         indices_right.clear();
         indices_left.reserve(left_col_count);
         indices_right.reserve(right_col_count);
-        for (size_t i = 0; i < left_col_count; ++i) {
-            indices_left.emplace_back(i);
-        }
-        for (size_t i = 0; i < right_col_count; ++i) {
-            indices_right.emplace_back(left_col_count + i);
-            res_types.push_back(right_types[i]);
+
+        if (!swapped) {
+            // Probe == logical-left, build == logical-right.
+            res_types = left_types;
+            for (size_t i = 0; i < left_col_count; ++i) {
+                indices_left.emplace_back(i);
+            }
+            for (size_t i = 0; i < right_col_count; ++i) {
+                indices_right.emplace_back(left_col_count + i);
+                res_types.push_back(right_types[i]);
+            }
+        } else {
+            // Build == logical-left, probe == logical-right.
+            res_types = right_types;
+            for (size_t i = 0; i < right_col_count; ++i) {
+                indices_right.emplace_back(i);
+            }
+            for (size_t i = 0; i < left_col_count; ++i) {
+                indices_left.emplace_back(right_col_count + i);
+                res_types.push_back(left_types[i]);
+            }
         }
     }
 
     // Streams join output into a chunks_vector_t where every chunk is
-    // ≤ DEFAULT_VECTOR_CAPACITY (1024) rows. Emits rows one at a time via
-    // vector_ops::copy and flushes on each full chunk.
+    // ≤ DEFAULT_VECTOR_CAPACITY (1024) rows.
+    //
+    // Rather than materialize one cell at a time (which allocated a length-(li+1)
+    // indexing sequence per cell), the builder BUFFERS the matched source-row
+    // indices and flushes each full output chunk with ONE indexed vector_ops::copy
+    // (a gather) per (source-chunk, column). The probe (left) side is single-source
+    // per builder, so it is one gather per left column over the whole chunk; the
+    // build (right) side may span several chunks, so output rows are REORDERED
+    // grouped by their build chunk — one gather per (build-chunk, right column).
+    //
+    // Consequence: the operator's emit ROW order is UNSPECIFIED (downstream
+    // sorts/groups absorb it). COLUMN identity stays logical [left, right] — that is
+    // an orthogonal axis fixed by compute_join_layout / the indices_* maps.
+    //
+    // A single builder is used in exactly one of two modes, matching the callers:
+    //   * probe mode  — emit_matched / emit_left_only: every buffered row has a valid
+    //     left (probe) source; right source is a build chunk (matched) or NULL (left-only).
+    //   * drain mode  — emit_right_only only: every row's left source is NULL, right
+    //     source is a build chunk.
+    // NULL-padding therefore routes to the LOGICAL side via the same source→slot maps.
     class join_builder {
     public:
         join_builder(std::pmr::memory_resource* resource,
@@ -67,42 +116,144 @@ namespace components::operators::join_detail {
             , indices_left_(indices_left)
             , indices_right_(indices_right)
             , out_chunks_(out_chunks)
-            , cur_(resource, out_types, vector::DEFAULT_VECTOR_CAPACITY) {}
+            , cur_(resource, out_types, vector::DEFAULT_VECTOR_CAPACITY)
+            , buf_left_rows_(resource)
+            , buf_right_chunks_(resource)
+            , buf_right_rows_(resource) {}
 
         void flush() {
-            if (filled_ == 0) {
+            const uint64_t n = filled_;
+            if (n == 0) {
                 return;
             }
-            cur_.set_cardinality(filled_);
+
+            // --- Group buffered rows by their build (right) chunk pointer. A NULL
+            // right chunk (left-only rows) forms its own group. Rows are emitted into
+            // the output grouped by chunk so each right-column gather targets a
+            // contiguous range from a single source chunk. ---
+            std::pmr::unordered_map<const vector::data_chunk_t*, uint32_t> group_id{resource_};
+            std::pmr::vector<const vector::data_chunk_t*> group_chunk{resource_};
+            std::pmr::vector<uint32_t> entry_group{resource_};
+            entry_group.reserve(n);
+            for (uint64_t k = 0; k < n; ++k) {
+                const auto* rc = buf_right_chunks_[k];
+                auto it = group_id.find(rc);
+                uint32_t g;
+                if (it == group_id.end()) {
+                    g = static_cast<uint32_t>(group_chunk.size());
+                    group_id.emplace(rc, g);
+                    group_chunk.push_back(rc);
+                } else {
+                    g = it->second;
+                }
+                entry_group.push_back(g);
+            }
+            const uint32_t group_count = static_cast<uint32_t>(group_chunk.size());
+
+            // Counting sort into `order` (output slot → buffer entry index), grouped
+            // by build chunk. group_start[g] is the first output slot of group g.
+            std::pmr::vector<uint64_t> group_start{resource_};
+            group_start.assign(group_count + 1, 0);
+            for (uint64_t k = 0; k < n; ++k) {
+                ++group_start[entry_group[k] + 1];
+            }
+            for (uint32_t g = 0; g < group_count; ++g) {
+                group_start[g + 1] += group_start[g];
+            }
+            std::pmr::vector<uint64_t> order{resource_};
+            order.assign(n, 0);
+            std::pmr::vector<uint64_t> cursor{resource_};
+            cursor.assign(group_start.begin(), group_start.end());
+            for (uint64_t k = 0; k < n; ++k) {
+                order[cursor[entry_group[k]]++] = k;
+            }
+
+            // --- Left (probe) columns. Single source, so one gather over [0, n). ---
+            if (left_chunk_ != nullptr) {
+                vector::indexing_vector_t idx(resource_, n);
+                for (uint64_t out = 0; out < n; ++out) {
+                    idx.set_index(out, buf_left_rows_[order[out]]);
+                }
+                for (size_t c = 0; c < left_chunk_->column_count(); ++c) {
+                    if (is_placeholder(left_chunk_->data[c])) {
+                        continue;
+                    }
+                    vector::vector_ops::copy(left_chunk_->data[c], cur_.data[indices_left_[c]], idx, n, 0, 0, n);
+                }
+            } else {
+                // Drain mode: every row is right-only → NULL-pad all left columns.
+                for (size_t c = 0; c < indices_left_.size(); ++c) {
+                    for (uint64_t out = 0; out < n; ++out) {
+                        cur_.data[indices_left_[c]].validity().set_invalid(out);
+                    }
+                }
+            }
+
+            // --- Right (build) columns, one gather per (build-chunk, column). ---
+            for (uint32_t g = 0; g < group_count; ++g) {
+                const auto* rc = group_chunk[g];
+                const uint64_t s = group_start[g];
+                const uint64_t e = group_start[g + 1];
+                const uint64_t count = e - s;
+                if (count == 0) {
+                    continue;
+                }
+                if (rc == nullptr) {
+                    // left-only rows → NULL-pad all right columns over the range.
+                    for (size_t c = 0; c < indices_right_.size(); ++c) {
+                        for (uint64_t out = s; out < e; ++out) {
+                            cur_.data[indices_right_[c]].validity().set_invalid(out);
+                        }
+                    }
+                } else {
+                    vector::indexing_vector_t idx(resource_, count);
+                    for (uint64_t i = 0; i < count; ++i) {
+                        idx.set_index(i, buf_right_rows_[order[s + i]]);
+                    }
+                    for (size_t c = 0; c < rc->column_count(); ++c) {
+                        if (is_placeholder(rc->data[c])) {
+                            continue;
+                        }
+                        vector::vector_ops::copy(rc->data[c], cur_.data[indices_right_[c]], idx, count, 0, s, count);
+                    }
+                }
+            }
+
+            cur_.set_cardinality(n);
             out_chunks_.emplace_back(std::move(cur_));
             cur_ = vector::data_chunk_t(resource_, out_types_, vector::DEFAULT_VECTOR_CAPACITY);
             filled_ = 0;
+            left_chunk_ = nullptr;
+            buf_left_rows_.clear();
+            buf_right_chunks_.clear();
+            buf_right_rows_.clear();
         }
 
         void emit_matched(const vector::data_chunk_t& L, uint64_t li, const vector::data_chunk_t& R, uint64_t rj) {
             ensure_space();
-            copy_left_row(L, li);
-            copy_right_row(R, rj);
+            left_chunk_ = &L;
+            buf_left_rows_.push_back(li);
+            buf_right_chunks_.push_back(&R);
+            buf_right_rows_.push_back(rj);
             ++filled_;
         }
 
         // L row with NULLs on all right-side output columns.
         void emit_left_only(const vector::data_chunk_t& L, uint64_t li) {
             ensure_space();
-            copy_left_row(L, li);
-            for (size_t c = 0; c < indices_right_.size(); ++c) {
-                cur_.data[indices_right_[c]].validity().set_invalid(filled_);
-            }
+            left_chunk_ = &L;
+            buf_left_rows_.push_back(li);
+            buf_right_chunks_.push_back(nullptr);
+            buf_right_rows_.push_back(0);
             ++filled_;
         }
 
         // R row with NULLs on all left-side output columns.
         void emit_right_only(const vector::data_chunk_t& R, uint64_t rj) {
             ensure_space();
-            copy_right_row(R, rj);
-            for (size_t c = 0; c < indices_left_.size(); ++c) {
-                cur_.data[indices_left_[c]].validity().set_invalid(filled_);
-            }
+            buf_left_rows_.push_back(0);
+            buf_right_chunks_.push_back(&R);
+            buf_right_rows_.push_back(rj);
             ++filled_;
         }
 
@@ -113,22 +264,6 @@ namespace components::operators::join_detail {
             }
         }
 
-        void copy_left_row(const vector::data_chunk_t& L, uint64_t li) {
-            for (size_t c = 0; c < L.column_count(); ++c) {
-                if (is_placeholder(L.data[c]))
-                    continue;
-                vector::vector_ops::copy(L.data[c], cur_.data[indices_left_[c]], li + 1, li, filled_);
-            }
-        }
-
-        void copy_right_row(const vector::data_chunk_t& R, uint64_t rj) {
-            for (size_t c = 0; c < R.column_count(); ++c) {
-                if (is_placeholder(R.data[c]))
-                    continue;
-                vector::vector_ops::copy(R.data[c], cur_.data[indices_right_[c]], rj + 1, rj, filled_);
-            }
-        }
-
         std::pmr::memory_resource* resource_;
         const std::pmr::vector<types::complex_logical_type>& out_types_;
         const std::vector<size_t>& indices_left_;
@@ -136,6 +271,14 @@ namespace components::operators::join_detail {
         chunks_vector_t& out_chunks_;
         vector::data_chunk_t cur_;
         uint64_t filled_ = 0;
+
+        // Buffered source-row indices for the current (not-yet-flushed) output chunk.
+        // `left_chunk_` is the single probe source (nullptr in drain mode); a NULL
+        // entry in `buf_right_chunks_` marks a left-only row (NULL right side).
+        const vector::data_chunk_t* left_chunk_ = nullptr;
+        std::pmr::vector<uint64_t> buf_left_rows_;
+        std::pmr::vector<const vector::data_chunk_t*> buf_right_chunks_;
+        std::pmr::vector<uint64_t> buf_right_rows_;
     };
 
 } // namespace components::operators::join_detail

--- a/components/physical_plan/operators/join_utils.hpp
+++ b/components/physical_plan/operators/join_utils.hpp
@@ -281,4 +281,97 @@ namespace components::operators::join_detail {
         std::pmr::vector<uint64_t> buf_right_rows_;
     };
 
+    // Eager join output builder for operators whose BUILD (right) side is NOT
+    // materialized once for the whole probe but REGENERATED per outer row — namely
+    // operator_lateral_join_t, which re-runs its inner sub-plan for every outer row.
+    //
+    // The lazy join_builder above buffers raw (left_chunk, right_chunk) POINTERS and
+    // gathers them at flush(). That is sound ONLY when (i) a single probe chunk feeds
+    // the whole build and (ii) every build chunk outlives flush(). LATERAL breaks
+    // BOTH invariants: the outer input spans several persistent chunks (so a single
+    // overwritten left_chunk_ would mix rows across a flush window), and each inner
+    // result is destroyed at the end of its outer-row iteration (so a buffered right
+    // pointer would dangle by the post-loop flush → heap-use-after-free). This builder
+    // instead COPIES each row's left+right cells into the current output chunk at emit
+    // time, while both sources are still alive and correctly identified — no pointer
+    // buffering, so neither invariant is needed.
+    //
+    // Row/column semantics match join_builder: logical [left, right] output layout via
+    // the indices_* source→slot maps, NULL-padding the absent side for emit_left_only.
+    // It is a distinct strategy for a distinct operator — the two builders never share
+    // an instance or a flush path (no runtime lazy/eager toggle).
+    class eager_join_builder {
+    public:
+        eager_join_builder(std::pmr::memory_resource* resource,
+                           const std::pmr::vector<types::complex_logical_type>& out_types,
+                           const std::vector<size_t>& indices_left,
+                           const std::vector<size_t>& indices_right,
+                           chunks_vector_t& out_chunks)
+            : resource_(resource)
+            , out_types_(out_types)
+            , indices_left_(indices_left)
+            , indices_right_(indices_right)
+            , out_chunks_(out_chunks)
+            , cur_(resource, out_types, vector::DEFAULT_VECTOR_CAPACITY)
+            , idx1_(resource, uint64_t{1}) {}
+
+        // Matched (L row li) × (R row rj): copy both source rows into the output now.
+        void emit_matched(const vector::data_chunk_t& L, uint64_t li, const vector::data_chunk_t& R, uint64_t rj) {
+            copy_row_(L, li, indices_left_);
+            copy_row_(R, rj, indices_right_);
+            advance_();
+        }
+
+        // L row li with NULLs on all right-side output columns.
+        void emit_left_only(const vector::data_chunk_t& L, uint64_t li) {
+            copy_row_(L, li, indices_left_);
+            null_side_(indices_right_);
+            advance_();
+        }
+
+        void flush() {
+            if (filled_ == 0) {
+                return;
+            }
+            cur_.set_cardinality(filled_);
+            out_chunks_.emplace_back(std::move(cur_));
+            cur_ = vector::data_chunk_t(resource_, out_types_, vector::DEFAULT_VECTOR_CAPACITY);
+            filled_ = 0;
+        }
+
+    private:
+        // Gather source row `srow` into output row `filled_` via the side's source→slot map.
+        void copy_row_(const vector::data_chunk_t& src, uint64_t srow, const std::vector<size_t>& slots) {
+            idx1_.set_index(0, srow);
+            const size_t cols = src.column_count();
+            for (size_t c = 0; c < cols; ++c) {
+                if (is_placeholder(src.data[c])) {
+                    continue;
+                }
+                vector::vector_ops::copy(src.data[c], cur_.data[slots[c]], idx1_, 1, 0, filled_, 1);
+            }
+        }
+
+        void null_side_(const std::vector<size_t>& slots) {
+            for (size_t c = 0; c < slots.size(); ++c) {
+                cur_.data[slots[c]].validity().set_invalid(filled_);
+            }
+        }
+
+        void advance_() {
+            if (++filled_ == vector::DEFAULT_VECTOR_CAPACITY) {
+                flush();
+            }
+        }
+
+        std::pmr::memory_resource* resource_;
+        const std::pmr::vector<types::complex_logical_type>& out_types_;
+        const std::vector<size_t>& indices_left_;
+        const std::vector<size_t>& indices_right_;
+        chunks_vector_t& out_chunks_;
+        vector::data_chunk_t cur_;
+        vector::indexing_vector_t idx1_;
+        uint64_t filled_ = 0;
+    };
+
 } // namespace components::operators::join_detail

--- a/components/physical_plan/operators/operator_hash_join.cpp
+++ b/components/physical_plan/operators/operator_hash_join.cpp
@@ -187,7 +187,7 @@ namespace components::operators {
     core::error_t operator_hash_join_t::push(pipeline::context_t*, vector::data_chunk_t&& input, chunks_vector_t& out) {
         // Degenerate build side → emit nothing. This covers a truly absent right_
         // AND a build side that materialized ZERO chunks: a single-table filter
-        // pushed BELOW the join (Stage 3) can empty the build scan, and a disk scan
+        // pushed BELOW the join can empty the build scan, and a disk scan
         // over no rows yields an operator_data_t whose chunks() is empty (not one
         // empty chunk). Either way there is no build schema to lay out and, for an
         // inner/right-probe join, no build rows to match — so compute_join_layout

--- a/components/physical_plan/operators/operator_hash_join.cpp
+++ b/components/physical_plan/operators/operator_hash_join.cpp
@@ -64,9 +64,11 @@ namespace components::operators {
                                                log_t log,
                                                type join_type,
                                                size_t left_col,
-                                               size_t right_col)
+                                               size_t right_col,
+                                               bool swapped)
         : read_only_operator_t(resource, std::move(log), operator_type::hash_join)
-        , join_type_(join_type) {
+        , join_type_(join_type)
+        , swapped_(swapped) {
         // Single-column equi-key today (the optimizer stamps one eq(left,right));
         // stored as one-element lists so the build/probe path is arity-agnostic.
         probe_key_cols_.push_back(static_cast<uint64_t>(left_col));
@@ -183,11 +185,19 @@ namespace components::operators {
     }
 
     core::error_t operator_hash_join_t::push(pipeline::context_t*, vector::data_chunk_t&& input, chunks_vector_t& out) {
-        // The build (right) side is materialized by a separate sub-plan before the
-        // first push and always holds at least one (possibly empty) chunk. A truly
-        // absent right_ is a degenerate plan: emit nothing (no left layout to
-        // pad against, no build rows to preserve).
-        if (!right_ || !right_->output()) {
+        // Degenerate build side → emit nothing. This covers a truly absent right_
+        // AND a build side that materialized ZERO chunks: a single-table filter
+        // pushed BELOW the join (Stage 3) can empty the build scan, and a disk scan
+        // over no rows yields an operator_data_t whose chunks() is empty (not one
+        // empty chunk). Either way there is no build schema to lay out and, for an
+        // inner/right-probe join, no build rows to match — so compute_join_layout
+        // must never be handed a missing front chunk (dereferencing
+        // build_chunks.front() on an empty vector is UB: a null data_chunk_t whose
+        // types() faulted under -O2). Left NULL-padding is not preserved for this
+        // degenerate shape, matching the long-standing absent-right behavior;
+        // pushdown never pushes a filter onto an outer join's optional side, so an
+        // emptied build here is always an inner join with genuinely zero matches.
+        if (!right_ || !right_->output() || right_->output()->chunks().empty()) {
             index_built_ = true;
             return core::error_t::no_error();
         }
@@ -195,10 +205,14 @@ namespace components::operators {
         // Build the index + derive the output layout once, lazily.
         if (!index_built_) {
             const auto& build_chunks = right_->output()->chunks();
-            // operator_data_t always holds at least one (possibly empty) chunk.
-            assert(!build_chunks.empty());
+            // Non-empty by the degenerate-build guard above.
             res_types_ = std::pmr::vector<types::complex_logical_type>{resource_};
-            join_detail::compute_join_layout(input, build_chunks.front(), res_types_, indices_left_, indices_right_);
+            join_detail::compute_join_layout(input,
+                                             build_chunks.front(),
+                                             swapped_,
+                                             res_types_,
+                                             indices_left_,
+                                             indices_right_);
             build_index_();
             index_built_ = true;
         }

--- a/components/physical_plan/operators/operator_hash_join.hpp
+++ b/components/physical_plan/operators/operator_hash_join.hpp
@@ -51,11 +51,19 @@ namespace components::operators {
     public:
         using type = logical_plan::join_type;
 
+        // `swapped` records that the build-side-selection heuristic moved the
+        // LOGICAL-left table into the physical build (right_) slot (so left_col /
+        // right_col are the probe/build key columns after that swap). It is passed
+        // through to compute_join_layout so the output is re-assembled in logical
+        // [left, right] order. Defaulted so the (still unswapped) call sites and the
+        // nested-loop lowering compile unchanged; the build-side heuristic (Stage 2b)
+        // sets it. INNER-only — an outer join is never swapped.
         operator_hash_join_t(std::pmr::memory_resource* resource,
                              log_t log,
                              type join_type,
                              size_t left_col,
-                             size_t right_col);
+                             size_t right_col,
+                             bool swapped = false);
 
         // The join is a SINK on its build side (it must fully retain the right
         // input before any match can be decided) and STREAMING on its probe side
@@ -86,6 +94,10 @@ namespace components::operators {
 
     private:
         type join_type_;
+        // Plan-time orientation: true iff the physical build (right_) side is the
+        // LOGICAL-left table. Fixed at construction — NOT cleared in
+        // reset_pipeline_state() (a re-driven recursive-CTE term keeps the same plan).
+        bool swapped_;
         // Equi-key column indices into the left (probe) / right (build) input
         // chunks. Stored as one-element lists so the build/probe machinery iterates
         // a key column list uniformly for single- and (future) multi-column keys.

--- a/components/physical_plan/operators/operator_hash_join.hpp
+++ b/components/physical_plan/operators/operator_hash_join.hpp
@@ -56,8 +56,8 @@ namespace components::operators {
         // right_col are the probe/build key columns after that swap). It is passed
         // through to compute_join_layout so the output is re-assembled in logical
         // [left, right] order. Defaulted so the (still unswapped) call sites and the
-        // nested-loop lowering compile unchanged; the build-side heuristic (Stage 2b)
-        // sets it. INNER-only — an outer join is never swapped.
+        // nested-loop lowering compile unchanged; the build-side heuristic sets it.
+        // INNER-only — an outer join is never swapped.
         operator_hash_join_t(std::pmr::memory_resource* resource,
                              log_t log,
                              type join_type,

--- a/components/physical_plan/operators/operator_join.cpp
+++ b/components/physical_plan/operators/operator_join.cpp
@@ -25,7 +25,14 @@ namespace components::operators {
         assert(!build_chunks.empty());
 
         res_types_ = std::pmr::vector<types::complex_logical_type>{resource_};
-        join_detail::compute_join_layout(probe_front, build_chunks.front(), res_types_, indices_left_, indices_right_);
+        // Nested-loop is never swapped: it evaluates its ON via key.side(), so the
+        // probe is always logical-left and the build always logical-right.
+        join_detail::compute_join_layout(probe_front,
+                                         build_chunks.front(),
+                                         /*swapped=*/false,
+                                         res_types_,
+                                         indices_left_,
+                                         indices_right_);
 
         predicate_ = expression_ ? predicates::create_predicate(resource_,
                                                                 context->function_registry,

--- a/components/physical_plan/operators/operator_lateral_join.cpp
+++ b/components/physical_plan/operators/operator_lateral_join.cpp
@@ -12,7 +12,7 @@
 
 namespace components::operators {
 
-    using join_detail::join_builder;
+    using join_detail::eager_join_builder;
     using join_type = components::logical_plan::join_type;
 
     operator_lateral_join_t::operator_lateral_join_t(std::pmr::memory_resource* resource,
@@ -147,7 +147,7 @@ namespace components::operators {
         }
 
         chunks_vector_t result(res);
-        join_builder builder(res, out_types, indices_left, indices_right, result);
+        eager_join_builder builder(res, out_types, indices_left, indices_right, result);
         // The ON predicate spans (outer columns | inner columns); build it over the
         // outer (left/probe) and inner (right/build) schemas. all_true for the comma /
         // ON true forms passes every inner row. Correlation parameters are read live

--- a/components/physical_plan_generator/impl/create_plan_join.cpp
+++ b/components/physical_plan_generator/impl/create_plan_join.cpp
@@ -83,7 +83,7 @@ namespace services::planner::impl {
         // equi-key column indices. Lower straight to operator_hash_join_t (O(L+R)). No
         // detection here — the annotation is the single source of truth.
         if (join_node->algo() == join_algo::hash) {
-            // Build-side selection (Stage 2b): operator_hash_join_t materializes its
+            // Build-side selection: operator_hash_join_t materializes its
             // physical RIGHT child as the hash build side, so the default build is the
             // LOGICAL-right table. Move the SMALLER table onto the build side IFF this
             // is an INNER join, both children are distinct base tables whose live row

--- a/components/physical_plan_generator/impl/create_plan_join.cpp
+++ b/components/physical_plan_generator/impl/create_plan_join.cpp
@@ -83,12 +83,43 @@ namespace services::planner::impl {
         // equi-key column indices. Lower straight to operator_hash_join_t (O(L+R)). No
         // detection here — the annotation is the single source of truth.
         if (join_node->algo() == join_algo::hash) {
+            // Build-side selection (Stage 2b): operator_hash_join_t materializes its
+            // physical RIGHT child as the hash build side, so the default build is the
+            // LOGICAL-right table. Move the SMALLER table onto the build side IFF this
+            // is an INNER join, both children are distinct base tables whose live row
+            // counts are known (fetched into context.row_counts by execute_plan_full),
+            // and the current build (right) is the LARGER side. When swapping, the
+            // smaller logical-left child moves into the physical build slot and
+            // swapped_=true tells compute_join_layout to re-assemble the output in
+            // logical [left, right] order, so results are byte-for-byte identical.
+            // Outer joins are never swapped (their NULL-pad side is orientation-fixed);
+            // a self-join (same oid), a missing/equal count, or an INVALID_OID side
+            // keeps the default child order. A wrong estimate only picks a
+            // slower-but-correct plan.
+            bool swap_build_side = false;
+            if (join_node->type() == join_type::inner && left_oid != components::catalog::INVALID_OID &&
+                right_oid != components::catalog::INVALID_OID && left_oid != right_oid) {
+                const auto left_it = context.row_counts.find(left_oid);
+                const auto right_it = context.row_counts.find(right_oid);
+                if (left_it != context.row_counts.end() && right_it != context.row_counts.end() &&
+                    left_it->second < right_it->second) {
+                    swap_build_side = true;
+                }
+            }
+
+            // After a swap the probe (physical left_) is the logical-right table and
+            // the build (physical right_) is the logical-left table, so the ctor key
+            // columns are swapped too (left_col == probe key col, right_col == build
+            // key col — see operator_hash_join_t's ctor contract).
+            const std::size_t probe_key_col = swap_build_side ? join_node->right_col() : join_node->left_col();
+            const std::size_t build_key_col = swap_build_side ? join_node->left_col() : join_node->right_col();
             components::operators::operator_ptr hash_join =
                 boost::intrusive_ptr(new components::operators::operator_hash_join_t(resource,
                                                                                      log.clone(),
                                                                                      join_node->type(),
-                                                                                     join_node->left_col(),
-                                                                                     join_node->right_col()));
+                                                                                     probe_key_col,
+                                                                                     build_key_col,
+                                                                                     swap_build_side));
             // Push the LIMIT down to whichever side an outer join preserves. The hash
             // path covers inner/left/right/full only (cross never carries an equi-key).
             auto hash_limit_left = components::logical_plan::limit_t::unlimit();
@@ -109,13 +140,21 @@ namespace services::planner::impl {
                     // nullptr -> executor surfaces the error (rule 9: no throw here).
                     return nullptr;
             }
+            // Physical roles: probe = left_, build = right_. When swapped the
+            // logical-right child becomes the probe and the logical-left child the
+            // build; the per-side LIMIT follows the LOGICAL side (only outer joins ever
+            // set a limit, and those never swap, so this is a no-op under a swap).
+            const auto& probe_child = swap_build_side ? node->children().back() : node->children().front();
+            const auto& build_child = swap_build_side ? node->children().front() : node->children().back();
+            const auto probe_limit = swap_build_side ? hash_limit_right : hash_limit_left;
+            const auto build_limit = swap_build_side ? hash_limit_left : hash_limit_right;
             components::operators::operator_ptr hash_left;
             components::operators::operator_ptr hash_right;
-            if (node->children().front()) {
-                hash_left = create_plan(context, function_registry, node->children().front(), hash_limit_left, params);
+            if (probe_child) {
+                hash_left = create_plan(context, function_registry, probe_child, probe_limit, params);
             }
-            if (node->children().back()) {
-                hash_right = create_plan(context, function_registry, node->children().back(), hash_limit_right, params);
+            if (build_child) {
+                hash_right = create_plan(context, function_registry, build_child, build_limit, params);
             }
             hash_join->set_children(std::move(hash_left), std::move(hash_right));
             return hash_join;

--- a/components/planner/CMakeLists.txt
+++ b/components/planner/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCE_${PROJECT_NAME}
         optimizer.cpp
         optimizer/rules/constant_folding.cpp
         optimizer/rules/column_pruning.cpp
+        optimizer/rules/promote_cross_join.cpp
         optimizer/rules/pushdown_filter.cpp
         optimizer/rules/hash_join.cpp
         optimizer/rules/pushdown_aggregate.cpp

--- a/components/planner/optimizer.cpp
+++ b/components/planner/optimizer.cpp
@@ -2,6 +2,7 @@
 
 #include "optimizer/rules/constant_folding.hpp"
 #include "optimizer/rules/hash_join.hpp"
+#include "optimizer/rules/promote_cross_join.hpp"
 #include "optimizer/rules/pushdown_aggregate.hpp"
 #include "optimizer/rules/pushdown_filter.hpp"
 
@@ -24,7 +25,13 @@ namespace components::planner {
         if (parameters) {
             optimizer::fold_constants(resource, node, parameters);
         }
-        node = optimizer::pushdown_filter(resource, node);
+        // Promote comma-join CROSS joins to INNER before pushdown_filter: its join
+        // branch wraps the join's children in fresh, unstamped aggregates whose
+        // output_types() is empty (validation already ran), which would collapse the
+        // promote rule's left_width to 0. fold_constants (above) never restructures
+        // joins, so the children stay stamped for the range classification.
+        node = optimizer::promote_cross_joins(resource, std::move(node));
+        node = optimizer::pushdown_filter(resource, std::move(node));
         node = optimizer::rewrite_hash_joins(resource, std::move(node));
 
         // Annotate pushable single-owned-table aggregates. Runs LAST — it only

--- a/components/planner/optimizer/rules/conjunct_utils.hpp
+++ b/components/planner/optimizer/rules/conjunct_utils.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <memory_resource>
+#include <vector>
+
+#include <components/expressions/compare_expression.hpp>
+#include <components/expressions/expression.hpp>
+
+namespace components::planner::optimizer {
+
+    // Split a predicate tree into its top-level AND-conjuncts. A `union_and` node
+    // flattens (recursively) into its children; any other expression is a single
+    // conjunct. The result vector is built on `resource` (rule 8). Shared by
+    // pushdown_filter and promote_cross_join.
+    inline std::pmr::vector<components::expressions::expression_ptr>
+    split_conjuncts(std::pmr::memory_resource* resource, const components::expressions::expression_ptr& expr) {
+        using namespace components::expressions;
+        std::pmr::vector<expression_ptr> result{resource};
+        if (!expr) {
+            return result;
+        }
+        if (expr->group() == expression_group::compare) {
+            auto* cmp = static_cast<compare_expression_t*>(expr.get());
+            if (cmp->type() == compare_type::union_and) {
+                for (const auto& child : cmp->children()) {
+                    auto sub = split_conjuncts(resource, child);
+                    result.insert(result.end(), sub.begin(), sub.end());
+                }
+                return result;
+            }
+        }
+        result.push_back(expr);
+        return result;
+    }
+
+    // Recombine conjuncts into one predicate: nullptr when empty, the single element
+    // when size 1, otherwise a `union_and` over all of them. Built on `resource`
+    // (rule 8).
+    inline components::expressions::expression_ptr
+    rebuild_conjunction(std::pmr::memory_resource* resource,
+                        const std::pmr::vector<components::expressions::expression_ptr>& conjuncts) {
+        using namespace components::expressions;
+        if (conjuncts.empty()) {
+            return nullptr;
+        }
+        if (conjuncts.size() == 1) {
+            return conjuncts.front();
+        }
+        auto conj = make_compare_union_expression(resource, compare_type::union_and);
+        for (const auto& c : conjuncts) {
+            conj->append_child(c);
+        }
+        return conj;
+    }
+
+} // namespace components::planner::optimizer

--- a/components/planner/optimizer/rules/hash_join.cpp
+++ b/components/planner/optimizer/rules/hash_join.cpp
@@ -2,7 +2,6 @@
 
 #include <optional>
 #include <utility>
-#include <variant>
 
 #include <components/expressions/compare_expression.hpp>
 #include <components/logical_plan/node_join.hpp>
@@ -27,11 +26,11 @@ namespace components::planner::optimizer {
             if (cmp->type() != ce::compare_type::eq) {
                 return std::nullopt;
             }
-            if (!std::holds_alternative<ce::key_t>(cmp->left()) || !std::holds_alternative<ce::key_t>(cmp->right())) {
+            if (!ce::is_key(cmp->left()) || !ce::is_key(cmp->right())) {
                 return std::nullopt;
             }
-            const auto& lk = std::get<ce::key_t>(cmp->left());
-            const auto& rk = std::get<ce::key_t>(cmp->right());
+            const auto& lk = ce::as_key(cmp->left());
+            const auto& rk = ce::as_key(cmp->right());
             // Only a single top-level column maps to a hash-table probe. A multi-element
             // path is a nested-struct/UDT field access (e.g. `(custom_type).f1`); path()[0]
             // would address the whole struct column, not the scalar being compared, so we

--- a/components/planner/optimizer/rules/promote_cross_join.cpp
+++ b/components/planner/optimizer/rules/promote_cross_join.cpp
@@ -4,10 +4,16 @@
 
 #include <memory_resource>
 
+#include <components/expressions/aggregate_expression.hpp>
 #include <components/expressions/compare_expression.hpp>
+#include <components/expressions/scalar_expression.hpp>
+#include <components/expressions/sort_expression.hpp>
 #include <components/logical_plan/node_aggregate.hpp>
+#include <components/logical_plan/node_group.hpp>
 #include <components/logical_plan/node_join.hpp>
 #include <components/logical_plan/node_match.hpp>
+#include <components/logical_plan/node_select.hpp>
+#include <components/logical_plan/node_sort.hpp>
 
 namespace components::planner::optimizer {
 
@@ -169,6 +175,528 @@ namespace components::planner::optimizer {
             return inner;
         }
 
+        // === Star-schema pre-normalizer (rules 6/17) ===============================
+        //
+        // A fact-LAST comma-join star (`FROM dim0, dim1, .., fact`) lowers to a
+        // left-deep CROSS chain whose inner joins hold only DIMENSIONS -> no straddling
+        // equi -> the canonical promotion leaves them CROSS -> a dimension cartesian.
+        // normalize_star_shape is a pure PRE-NORMALIZER over the ONE canonical path: it
+        // can only reshape the CROSS tree (fact-FIRST) and re-coordinate frozen consumers
+        // by a block permutation P; it NEVER promotes anything. So a fact-FIRST chain has
+        // a straddling equi at every boundary that the UNCHANGED promote_join_subtree then
+        // claims. A non-star / already-claimable input flows through as a no-op.
+        //
+        // All read-only work (detect, verify) precedes ALL mutation, so any bail leaves
+        // the tree pristine and the canonical path runs exactly as today.
+
+        // Read-only mirror of promote_join_subtree's claiming, on a scratch `claimed`
+        // array: returns true iff EVERY cross-join boundary in the subtree claims a
+        // straddling equi. That is a chain / fact-threaded shape the canonical path
+        // already promotes fully; reordering it would MIS-select the fact (rule 17
+        // short-circuit -> caller returns the tree unchanged).
+        bool simulate_all_boundaries_claim(const node_ptr& node,
+                                           const std::pmr::vector<expression_ptr>& conjuncts,
+                                           std::pmr::vector<char>& claimed) {
+            if (!node || node->type() != node_type::join_t) {
+                return true; // leaf: no boundary here
+            }
+            auto* join = static_cast<node_join_t*>(node.get());
+            if (join->children().size() < 2) {
+                return true;
+            }
+            const bool classifiable = join->type() == join_type::cross &&
+                                      join->children()[0]->has_output_types() &&
+                                      join->children()[1]->has_output_types();
+            const size_t left_width = classifiable ? join->children()[0]->output_types().size() : 0;
+            const size_t right_width = classifiable ? join->children()[1]->output_types().size() : 0;
+
+            const bool left_all = simulate_all_boundaries_claim(join->children()[0], conjuncts, claimed);
+            const bool right_all = simulate_all_boundaries_claim(join->children()[1], conjuncts, claimed);
+
+            if (!classifiable || left_width == 0 || right_width == 0) {
+                // Not a promotable cross boundary (already inner / unstamped): pass the
+                // children's verdict through unchanged.
+                return left_all && right_all;
+            }
+
+            for (size_t i = 0; i < conjuncts.size(); ++i) {
+                if (!claimed[i] && is_boundary_equi(conjuncts[i], left_width, right_width)) {
+                    claimed[i] = 1;
+                    return left_all && right_all; // this boundary claims
+                }
+            }
+            return false; // this cross boundary does NOT claim
+        }
+
+        // Collect the left-deep spine leaves in FROM (merged) order. A leaf must be a base
+        // table-scan: a childless node carrying output_types (a childless aggregate_t for
+        // SSB, or a node_data raw scan in tests). An aggregate_t WITH a child (sub-select /
+        // CTE) is NOT a base scan -> bail. Deliberately NOT gated on node_type == data_t:
+        // SSB's leaves are aggregate_t, so that gate would reject the very case this fixes.
+        bool collect_spine_leaves(const node_ptr& node, std::pmr::vector<node_ptr>& leaves) {
+            if (!node) {
+                return false;
+            }
+            if (node->type() == node_type::join_t) {
+                auto* join = static_cast<node_join_t*>(node.get());
+                if (join->children().size() != 2) {
+                    return false;
+                }
+                if (!collect_spine_leaves(join->children()[0], leaves)) {
+                    return false;
+                }
+                return collect_spine_leaves(join->children()[1], leaves);
+            }
+            if (!node->children().empty()) {
+                return false; // sub-select / CTE / non-scan in a leaf position
+            }
+            if (!node->has_output_types()) {
+                return false;
+            }
+            leaves.push_back(node);
+            return true;
+        }
+
+        // The walker (rule-14-compliant; per-form OWN-key dispatch). One pass over the
+        // aggregate's non-source children, either VERIFY (apply=false: only classify every
+        // merged locus, flag `ok=false` on any that is out of range / unresolvable) or
+        // APPLY (apply=true: remap each merged locus IN PLACE via P). Every param_storage
+        // is read through is_key/as_key/is_expr/as_expr (never raw std::get); every key is
+        // remapped in place `k.path()[0] = perm[old]` (never set_path).
+        struct key_remapper {
+            const std::pmr::vector<size_t>* perm; // size n; perm[old] = new
+            size_t n;
+            bool has_group;
+            bool apply;
+            bool ok;
+
+            // Remap the merged column index held in the ROOT of a key path (path()[0]);
+            // a nested struct/subfield suffix rides along unchanged.
+            void remap_key(key_t& k) {
+                if (k.path().empty()) {
+                    return; // no merged locus
+                }
+                const size_t idx = k.path()[0];
+                if (idx == SIZE_MAX) {
+                    return; // post-aggregate sentinel: not a merged locus
+                }
+                if (idx >= n) {
+                    ok = false; // not classifiable against the merged schema -> verify fails
+                    return;
+                }
+                if (apply) {
+                    k.path()[0] = (*perm)[idx];
+                }
+            }
+
+            // A single operand: a key is remapped; a nested compare / scalar operand is
+            // recursed (own key of a nested scalar is an alias/sentinel -> not touched).
+            void walk_operand(param_storage& p) {
+                if (is_key(p)) {
+                    remap_key(as_key(p));
+                    return;
+                }
+                if (is_expr(p)) {
+                    auto& sub = as_expr(p);
+                    if (!sub) {
+                        return;
+                    }
+                    if (sub->group() == expression_group::compare) {
+                        walk_compare(sub);
+                    } else if (sub->group() == expression_group::scalar) {
+                        auto* s = static_cast<scalar_expression_t*>(sub.get());
+                        walk_params(s->params());
+                    }
+                }
+                // parameter_id_t: no locus
+            }
+
+            void walk_params(std::pmr::vector<param_storage>& params) {
+                for (auto& p : params) {
+                    walk_operand(p);
+                }
+            }
+
+            // A compare node: union_and / union_or / union_not carry their operands in
+            // children(); a binary compare carries them in left()/right() (either of which
+            // may itself be a nested expression, e.g. arithmetic or a CASE condition).
+            void walk_compare(const expression_ptr& expr) {
+                if (!expr || expr->group() != expression_group::compare) {
+                    return;
+                }
+                auto* cmp = static_cast<compare_expression_t*>(expr.get());
+                const compare_type t = cmp->type();
+                if (t == compare_type::union_and || t == compare_type::union_or ||
+                    t == compare_type::union_not) {
+                    for (auto& child : cmp->children()) {
+                        walk_compare(child);
+                    }
+                    return;
+                }
+                walk_operand(cmp->left());
+                walk_operand(cmp->right());
+            }
+
+            void walk_match(const node_ptr& match) {
+                if (!match || match->expressions().empty()) {
+                    return;
+                }
+                walk_compare(match->expressions()[0]);
+            }
+
+            // A group node's merged loci: group_field OWN key; get_field params().front()
+            // (else OWN key); every aggregate's params() (the merged agg-argument keys,
+            // incl. nested arithmetic like SUM(a - b)); pre-group computed operands. A
+            // post-aggregate arithmetic (path()[0] == SIZE_MAX) is group-output -> skipped
+            // whole. A group coalesce key is unresolved by group Pass 1 -> bail.
+            void walk_group_scalar(scalar_expression_t* s) {
+                switch (s->type()) {
+                    case scalar_type::group_field:
+                        remap_key(s->key());
+                        break;
+                    case scalar_type::get_field:
+                        if (!s->params().empty() && is_key(s->params().front())) {
+                            remap_key(as_key(s->params().front()));
+                        } else {
+                            remap_key(s->key());
+                        }
+                        break;
+                    case scalar_type::coalesce:
+                        ok = false; // group Pass 1 has no coalesce handler -> unresolved -> bail
+                        break;
+                    case scalar_type::constant:
+                        break;
+                    case scalar_type::star_expand:
+                        ok = false; // must not leak merged order upward
+                        break;
+                    default:
+                        // arithmetic (add/subtract/multiply/divide/mod/case_expr/unary_minus)
+                        if (!s->key().path().empty() && s->key().path()[0] == SIZE_MAX) {
+                            break; // post-aggregate: group-output operands -> do not touch
+                        }
+                        walk_params(s->params()); // pre-group computed column operands (merged)
+                        break;
+                }
+            }
+
+            void walk_group(const node_ptr& group) {
+                for (auto& expr : group->expressions()) {
+                    if (!expr) {
+                        continue;
+                    }
+                    if (expr->group() == expression_group::scalar) {
+                        walk_group_scalar(static_cast<scalar_expression_t*>(expr.get()));
+                    } else if (expr->group() == expression_group::aggregate) {
+                        auto* a = static_cast<aggregate_expression_t*>(expr.get());
+                        walk_params(a->params()); // OWN key is the output alias -> not touched
+                    }
+                }
+            }
+
+            // WITHOUT a group, sort keys index the merged join schema. A plain sort key
+            // remaps its OWN key; a computed ORDER BY scalar keeps its OWN key (which
+            // encodes ASC/DESC) and remaps only its merged operands.
+            void walk_sort_nogroup(const node_ptr& sort) {
+                for (auto& expr : sort->expressions()) {
+                    if (!expr) {
+                        continue;
+                    }
+                    if (expr->group() == expression_group::sort) {
+                        remap_key(static_cast<sort_expression_t*>(expr.get())->key());
+                    } else if (expr->group() == expression_group::scalar) {
+                        walk_params(static_cast<scalar_expression_t*>(expr.get())->params());
+                    }
+                }
+            }
+
+            // WITHOUT a group, projection columns index the merged join schema.
+            void walk_select_nogroup(const node_ptr& select) {
+                for (auto& expr : select->expressions()) {
+                    if (!expr || expr->group() != expression_group::scalar) {
+                        continue;
+                    }
+                    auto* s = static_cast<scalar_expression_t*>(expr.get());
+                    switch (s->type()) {
+                        case scalar_type::group_field:
+                            remap_key(s->key());
+                            break;
+                        case scalar_type::get_field:
+                            if (!s->params().empty() && is_key(s->params().front())) {
+                                remap_key(as_key(s->params().front()));
+                            } else {
+                                remap_key(s->key());
+                            }
+                            break;
+                        case scalar_type::constant:
+                        case scalar_type::star_expand:
+                            break;
+                        default:
+                            // arithmetic / coalesce / case_expr operands (merged)
+                            walk_params(s->params());
+                            break;
+                    }
+                }
+            }
+
+            // Dispatch one aggregate child. match_t is walked in both group modes; group_t
+            // only with a group; sort_t / select_t only without a group; limit_t and any
+            // other sibling carry no merged loci.
+            void walk_sibling(const node_ptr& sib) {
+                if (!sib) {
+                    return;
+                }
+                switch (sib->type()) {
+                    case node_type::match_t:
+                        walk_match(sib);
+                        break;
+                    case node_type::group_t:
+                        if (has_group) {
+                            walk_group(sib);
+                        }
+                        break;
+                    case node_type::sort_t:
+                        if (!has_group) {
+                            walk_sort_nogroup(sib);
+                        }
+                        break;
+                    case node_type::select_t:
+                        if (!has_group) {
+                            walk_select_nogroup(sib);
+                        }
+                        break;
+                    default:
+                        break;
+                }
+            }
+        };
+
+        // Reshape a fact-LAST star `source` into a fact-FIRST cross chain and P-remap
+        // every frozen consumer (the match, plus the aggregate's other children in
+        // `siblings`). Returns the reshaped source, or `source` unchanged on any bail
+        // (short-circuit, non-star, leaking projection, or a Phase-A verify failure) so
+        // the caller's canonical promotion path runs on a pristine tree.
+        node_ptr normalize_star_shape(std::pmr::memory_resource* resource,
+                                      node_ptr source,
+                                      const node_ptr& match_child,
+                                      std::pmr::vector<node_ptr>& siblings) {
+            using components::types::complex_logical_type;
+
+            if (!source || source->type() != node_type::join_t) {
+                return source;
+            }
+            if (!match_child || match_child->expressions().empty()) {
+                return source;
+            }
+            auto conjuncts = split_conjuncts(resource, match_child->expressions()[0]);
+            if (conjuncts.empty()) {
+                return source;
+            }
+
+            // (1a) Rule-17 short-circuit: if the canonical path already claims every cross
+            // boundary, this is a chain / fact-threaded shape -> leave it untouched.
+            {
+                std::pmr::vector<char> scratch{resource};
+                scratch.resize(conjuncts.size(), 0);
+                if (simulate_all_boundaries_claim(source, conjuncts, scratch)) {
+                    return source;
+                }
+            }
+
+            // (1b) Spine leaves + widths/offsets from output_types() (FROM/merged order).
+            std::pmr::vector<node_ptr> leaves{resource};
+            if (!collect_spine_leaves(source, leaves)) {
+                return source; // non-scan leaf / sub-select
+            }
+            if (leaves.size() < 3) {
+                return source; // fewer than fact + 2 dims is not a star
+            }
+            std::pmr::vector<size_t> width{resource};
+            std::pmr::vector<size_t> offset_old{resource};
+            width.reserve(leaves.size());
+            offset_old.reserve(leaves.size());
+            size_t n = 0;
+            for (const auto& lf : leaves) {
+                offset_old.push_back(n);
+                const size_t w = lf->output_types().size();
+                if (w == 0) {
+                    return source; // unstamped leaf
+                }
+                width.push_back(w);
+                n += w;
+            }
+
+            // An explicit, non-star projection is required: a SELECT * / absent node_select
+            // leaks the merged order upward (validate_logical_plan star_expand path).
+            {
+                node_ptr select_node = nullptr;
+                for (size_t i = 1; i < siblings.size(); ++i) {
+                    if (siblings[i] && siblings[i]->type() == node_type::select_t) {
+                        select_node = siblings[i];
+                        break;
+                    }
+                }
+                if (!select_node) {
+                    return source; // SELECT * (no projection node) -> leaks merged order
+                }
+                for (const auto& expr : select_node->expressions()) {
+                    if (expr && expr->group() == expression_group::scalar &&
+                        static_cast<scalar_expression_t*>(expr.get())->type() == scalar_type::star_expand) {
+                        return source;
+                    }
+                }
+            }
+
+            // leaf_of(merged_idx) -> owning leaf, or leaves.size() if out of range.
+            auto leaf_of = [&](size_t idx) -> size_t {
+                for (size_t l = 0; l < leaves.size(); ++l) {
+                    if (idx >= offset_old[l] && idx < offset_old[l] + width[l]) {
+                        return l;
+                    }
+                }
+                return leaves.size();
+            };
+
+            // Classify each eq(key,key) with single-element paths into a leaf edge; drop
+            // same-leaf pairs and non-classifiable / non-key comparisons (filters).
+            std::pmr::vector<size_t> edge_a{resource};
+            std::pmr::vector<size_t> edge_b{resource};
+            for (const auto& c : conjuncts) {
+                if (!c || c->group() != expression_group::compare) {
+                    continue;
+                }
+                auto* cmp = static_cast<compare_expression_t*>(c.get());
+                if (cmp->type() != compare_type::eq || !is_key(cmp->left()) || !is_key(cmp->right())) {
+                    continue;
+                }
+                const auto& kl = as_key(cmp->left());
+                const auto& kr = as_key(cmp->right());
+                if (kl.path().size() != 1 || kr.path().size() != 1) {
+                    continue;
+                }
+                const size_t li = leaf_of(kl.path()[0]);
+                const size_t lj = leaf_of(kr.path()[0]);
+                if (li == leaves.size() || lj == leaves.size() || li == lj) {
+                    continue;
+                }
+                edge_a.push_back(li < lj ? li : lj);
+                edge_b.push_back(li < lj ? lj : li);
+            }
+            if (edge_a.empty()) {
+                return source; // no join edge
+            }
+
+            // Star = exactly one fact leaf incident to EVERY edge.
+            size_t fact = leaves.size();
+            for (size_t f = 0; f < leaves.size(); ++f) {
+                bool in_all = true;
+                for (size_t e = 0; e < edge_a.size(); ++e) {
+                    if (edge_a[e] != f && edge_b[e] != f) {
+                        in_all = false;
+                        break;
+                    }
+                }
+                if (in_all) {
+                    fact = f;
+                    break;
+                }
+            }
+            if (fact == leaves.size()) {
+                return source; // snowflake dim-dim edge / multi-fact
+            }
+            // Every non-fact leaf must have EXACTLY one edge to the fact: 0 = a dim with no
+            // fact-equi; >1 = a composite fact key (track multiplicity) -> bail.
+            std::pmr::vector<size_t> deg{resource};
+            deg.resize(leaves.size(), 0);
+            for (size_t e = 0; e < edge_a.size(); ++e) {
+                const size_t dim = (edge_a[e] == fact) ? edge_b[e] : edge_a[e];
+                deg[dim] += 1;
+            }
+            for (size_t l = 0; l < leaves.size(); ++l) {
+                if (l != fact && deg[l] != 1) {
+                    return source;
+                }
+            }
+
+            // (2) choose_dim_order (v1 = FROM order, fact first) + offset_new + P.
+            std::pmr::vector<size_t> new_order{resource};
+            new_order.reserve(leaves.size());
+            new_order.push_back(fact);
+            for (size_t l = 0; l < leaves.size(); ++l) {
+                if (l != fact) {
+                    new_order.push_back(l);
+                }
+            }
+            std::pmr::vector<size_t> offset_new{resource};
+            offset_new.resize(leaves.size(), 0);
+            {
+                size_t acc = 0;
+                for (size_t pos = 0; pos < new_order.size(); ++pos) {
+                    const size_t l = new_order[pos];
+                    offset_new[l] = acc;
+                    acc += width[l];
+                }
+            }
+            std::pmr::vector<size_t> perm{resource}; // perm[old_merged] = new_merged
+            perm.resize(n, 0);
+            for (size_t l = 0; l < leaves.size(); ++l) {
+                for (size_t local = 0; local < width[l]; ++local) {
+                    perm[offset_old[l] + local] = offset_new[l] + local;
+                }
+            }
+
+            bool has_group = false;
+            for (size_t i = 1; i < siblings.size(); ++i) {
+                if (siblings[i] && siblings[i]->type() == node_type::group_t) {
+                    has_group = true;
+                    break;
+                }
+            }
+
+            // (3) Phase-A verify (READ-ONLY): every merged locus classifiable (< n) and no
+            // unsupported form. On any failure the tree stays pristine for the canonical path.
+            {
+                key_remapper verify{&perm, n, has_group, /*apply=*/false, /*ok=*/true};
+                for (size_t i = 1; i < siblings.size(); ++i) {
+                    verify.walk_sibling(siblings[i]);
+                }
+                if (!verify.ok) {
+                    return source;
+                }
+            }
+
+            // (4) Commit. Rebuild the CROSS chain fact-first over the ORIGINAL leaf scans
+            // (oids flow, rule 16); stamp each new cross join's output_types = left ++ right
+            // BOTTOM-UP so a parent reads its freshly-stamped child's width.
+            node_ptr new_source = leaves[new_order[0]];
+            for (size_t pos = 1; pos < new_order.size(); ++pos) {
+                const node_ptr& dim = leaves[new_order[pos]];
+                auto cross = make_node_join(resource, core::dbname_t{}, core::relname_t{}, join_type::cross);
+                cross->append_child(new_source);
+                cross->append_child(dim);
+                cross->append_expression(make_compare_expression(resource, compare_type::all_true));
+                std::pmr::vector<complex_logical_type> merged{resource};
+                merged.reserve(new_source->output_types().size() + dim->output_types().size());
+                for (const auto& t : new_source->output_types()) {
+                    merged.push_back(t);
+                }
+                for (const auto& t : dim->output_types()) {
+                    merged.push_back(t);
+                }
+                cross->set_output_types(std::move(merged));
+                new_source = cross;
+            }
+
+            // Phase-B apply: remap every merged locus in the match + siblings via P. The
+            // match keys move merged->new; the canonical promote_join_subtree then re-stamps
+            // each claimed equi new->child-local (two in-place mutations of a single-owned key).
+            key_remapper commit{&perm, n, has_group, /*apply=*/true, /*ok=*/true};
+            for (size_t i = 1; i < siblings.size(); ++i) {
+                commit.walk_sibling(siblings[i]);
+            }
+
+            return new_source;
+        }
+
         node_ptr promote_impl(std::pmr::memory_resource* resource, node_ptr node) {
             if (!node) {
                 return node;
@@ -214,6 +742,15 @@ namespace components::planner::optimizer {
             if (conjuncts.empty()) {
                 return node;
             }
+
+            // Star pre-normalizer (rules 6/17): reshape a fact-LAST star into a fact-FIRST
+            // cross chain and P-remap frozen consumers so the ONE canonical promotion path
+            // below claims every boundary. This mutates `match_child`'s keys (and the other
+            // siblings') in place merged->new; since `conjuncts` holds those same shared
+            // expressions they are now in NEW coordinates for promote_join_subtree. A
+            // non-star / already-claimable shape returns `source` unchanged (no-op).
+            source = normalize_star_shape(resource, source, match_child, agg->children());
+
             std::pmr::vector<char> claimed{resource};
             claimed.resize(conjuncts.size(), 0);
             bool any_claimed = false;

--- a/components/planner/optimizer/rules/promote_cross_join.cpp
+++ b/components/planner/optimizer/rules/promote_cross_join.cpp
@@ -73,8 +73,8 @@ namespace components::planner::optimizer {
         //
         // Returns the (possibly new) subtree root. A leaf / non-join subtree, an
         // unstamped or non-cross join, or a join with no straddling equi is returned
-        // unchanged (kept as-is), never throwing — optimizer rules have no error channel
-        // (rules 2, 9). Each claimed conjunct is flagged so a later join cannot re-claim
+        // unchanged (kept as-is), never throwing — optimizer rules have no error channel.
+        // Each claimed conjunct is flagged so a later join cannot re-claim
         // it and so the caller can keep the unclaimed ones as the residual match.
         node_ptr promote_join_subtree(std::pmr::memory_resource* resource,
                                       node_ptr node,
@@ -133,8 +133,8 @@ namespace components::planner::optimizer {
             auto* eq = static_cast<compare_expression_t*>(picked.get());
             // Re-stamp both keys against THIS join's boundary. The right-range key
             // becomes side=right with a right-local path (mergedIdx - left_width) built on
-            // the rule's resource (NOT set_path({...}), which pulls the default resource —
-            // rule 14). The left-range key's merged path is already left-child-local, so
+            // the rule's resource (NOT set_path({...}), which pulls the default resource).
+            // The left-range key's merged path is already left-child-local, so
             // only its side is (re)affirmed left.
             key_t& kl = as_key(eq->left());
             key_t& kr = as_key(eq->right());
@@ -149,7 +149,7 @@ namespace components::planner::optimizer {
             left_key.set_side(side_t::left);
 
             // Immutable join_type -> a fresh inner join. oid flows from the moved scan
-            // children (rule 16 OK). Hash selection stays in rewrite_hash_joins (runs
+            // children. Hash selection stays in rewrite_hash_joins (runs
             // after); the re-stamp makes detect_equi_columns accept it. Use the PROMOTED
             // children so a nested inner join is carried up.
             auto inner = make_node_join(resource, core::dbname_t{}, core::relname_t{}, join_type::inner);
@@ -162,7 +162,7 @@ namespace components::planner::optimizer {
             // from children()[i]->output_types() — a PARENT promoted join (nested left-deep)
             // and pushdown_filter, which re-localizes a pushed right-side conjunct by that
             // left_width. The promoted children preserve their pre-promotion widths, so this
-            // equals the width of the cross join it replaces. Built on `resource` (rule 8).
+            // equals the width of the cross join it replaces. Built on `resource`.
             std::pmr::vector<components::types::complex_logical_type> merged{resource};
             merged.reserve(new_left->output_types().size() + new_right->output_types().size());
             for (const auto& t : new_left->output_types()) {
@@ -175,7 +175,7 @@ namespace components::planner::optimizer {
             return inner;
         }
 
-        // === Star-schema pre-normalizer (rules 6/17) ===============================
+        // === Star-schema pre-normalizer ===========================================
         //
         // A fact-LAST comma-join star (`FROM dim0, dim1, .., fact`) lowers to a
         // left-deep CROSS chain whose inner joins hold only DIMENSIONS -> no straddling
@@ -192,8 +192,8 @@ namespace components::planner::optimizer {
         // Read-only mirror of promote_join_subtree's claiming, on a scratch `claimed`
         // array: returns true iff EVERY cross-join boundary in the subtree claims a
         // straddling equi. That is a chain / fact-threaded shape the canonical path
-        // already promotes fully; reordering it would MIS-select the fact (rule 17
-        // short-circuit -> caller returns the tree unchanged).
+        // already promotes fully; reordering it would MIS-select the fact
+        // (short-circuit -> caller returns the tree unchanged).
         bool simulate_all_boundaries_claim(const node_ptr& node,
                                            const std::pmr::vector<expression_ptr>& conjuncts,
                                            std::pmr::vector<char>& claimed) {
@@ -257,7 +257,7 @@ namespace components::planner::optimizer {
             return true;
         }
 
-        // The walker (rule-14-compliant; per-form OWN-key dispatch). One pass over the
+        // The walker (per-form OWN-key dispatch). One pass over the
         // aggregate's non-source children, either VERIFY (apply=false: only classify every
         // merged locus, flag `ok=false` on any that is out of range / unresolvable) or
         // APPLY (apply=true: remap each merged locus IN PLACE via P). Every param_storage
@@ -492,7 +492,7 @@ namespace components::planner::optimizer {
                 return source;
             }
 
-            // (1a) Rule-17 short-circuit: if the canonical path already claims every cross
+            // (1a) short-circuit: if the canonical path already claims every cross
             // boundary, this is a chain / fact-threaded shape -> leave it untouched.
             {
                 std::pmr::vector<char> scratch{resource};
@@ -665,7 +665,7 @@ namespace components::planner::optimizer {
             }
 
             // (4) Commit. Rebuild the CROSS chain fact-first over the ORIGINAL leaf scans
-            // (oids flow, rule 16); stamp each new cross join's output_types = left ++ right
+            // (oids flow); stamp each new cross join's output_types = left ++ right
             // BOTTOM-UP so a parent reads its freshly-stamped child's width.
             node_ptr new_source = leaves[new_order[0]];
             for (size_t pos = 1; pos < new_order.size(); ++pos) {
@@ -743,7 +743,7 @@ namespace components::planner::optimizer {
                 return node;
             }
 
-            // Star pre-normalizer (rules 6/17): reshape a fact-LAST star into a fact-FIRST
+            // Star pre-normalizer: reshape a fact-LAST star into a fact-FIRST
             // cross chain and P-remap frozen consumers so the ONE canonical promotion path
             // below claims every boundary. This mutates `match_child`'s keys (and the other
             // siblings') in place merged->new; since `conjuncts` holds those same shared

--- a/components/planner/optimizer/rules/promote_cross_join.cpp
+++ b/components/planner/optimizer/rules/promote_cross_join.cpp
@@ -1,0 +1,258 @@
+#include "promote_cross_join.hpp"
+
+#include "conjunct_utils.hpp"
+
+#include <memory_resource>
+
+#include <components/expressions/compare_expression.hpp>
+#include <components/logical_plan/node_aggregate.hpp>
+#include <components/logical_plan/node_join.hpp>
+#include <components/logical_plan/node_match.hpp>
+
+namespace components::planner::optimizer {
+
+    namespace {
+
+        using namespace components::expressions;
+        using namespace components::logical_plan;
+
+        // A conjunct qualifies as a promotable join key iff it is an eq(key, key)
+        // whose two single-element paths straddle the join boundary: one path in the
+        // left range [0, left_width), the other in the right range
+        // [left_width, left_width + right_width). Both keys are stamped side=left by
+        // the validator (unqualified names over the merged schema), so we cannot use
+        // side_t here — we classify by the merged-relative path index. Correctness of
+        // the range test rests on the validator rejecting ambiguous duplicate names
+        // (validate_logical_plan.cpp), so a name resolves to exactly one merged column.
+        bool is_boundary_equi(const expression_ptr& expr, size_t left_width, size_t right_width) {
+            if (!expr || expr->group() != expression_group::compare) {
+                return false;
+            }
+            auto* cmp = static_cast<compare_expression_t*>(expr.get());
+            if (cmp->type() != compare_type::eq) {
+                return false;
+            }
+            if (!is_key(cmp->left()) || !is_key(cmp->right())) {
+                return false;
+            }
+            const auto& kl = as_key(cmp->left());
+            const auto& kr = as_key(cmp->right());
+            if (kl.path().size() != 1 || kr.path().size() != 1) {
+                return false;
+            }
+            const size_t pl = kl.path()[0];
+            const size_t pr = kr.path()[0];
+            const size_t total = left_width + right_width;
+            const bool l_left = pl < left_width;
+            const bool l_right = pl >= left_width && pl < total;
+            const bool r_left = pr < left_width;
+            const bool r_right = pr >= left_width && pr < total;
+            return (l_left && r_right) || (l_right && r_left);
+        }
+
+        // Promote every CROSS join in a (left-deep / bushy) join subtree to an INNER
+        // join, claiming one straddling equi conjunct per join. `conjuncts` are in the
+        // OUTER-merged coordinate space (paths stamped by the validator against the
+        // whole join's merged schema). For any single join, the left child spans the
+        // merged prefix [0, left_width), so a key's merged path equals its column index
+        // within the left child; the right child spans [left_width, left_width+right_width)
+        // contiguously, so a right-range key re-localizes to mergedIdx - left_width. That
+        // holds recursively (a nested join's own merged schema is exactly this join's
+        // left-child prefix), so each nested join classifies its two keys against ITS OWN
+        // children widths — not the outer schema.
+        //
+        // Widths are read from the ORIGINAL stamped children BEFORE promoting them: a
+        // promoted inner join is a fresh node with no output_types(), but it shares the
+        // cross join's schema, so the captured widths stay valid.
+        //
+        // Returns the (possibly new) subtree root. A leaf / non-join subtree, an
+        // unstamped or non-cross join, or a join with no straddling equi is returned
+        // unchanged (kept as-is), never throwing — optimizer rules have no error channel
+        // (rules 2, 9). Each claimed conjunct is flagged so a later join cannot re-claim
+        // it and so the caller can keep the unclaimed ones as the residual match.
+        node_ptr promote_join_subtree(std::pmr::memory_resource* resource,
+                                      node_ptr node,
+                                      const std::pmr::vector<expression_ptr>& conjuncts,
+                                      std::pmr::vector<char>& claimed,
+                                      bool& any_claimed) {
+            if (!node || node->type() != node_type::join_t) {
+                return node; // leaf scan / non-join subtree
+            }
+            auto* join = static_cast<node_join_t*>(node.get());
+            if (join->children().size() < 2) {
+                return node;
+            }
+
+            // Capture this join's boundary from the intact stamped children first.
+            const bool classifiable = join->type() == join_type::cross &&
+                                      join->children()[0]->has_output_types() &&
+                                      join->children()[1]->has_output_types();
+            const size_t left_width = classifiable ? join->children()[0]->output_types().size() : 0;
+            const size_t right_width = classifiable ? join->children()[1]->output_types().size() : 0;
+
+            // Recurse into children first — nested cross joins live in child[0] (left-deep).
+            auto new_left = promote_join_subtree(resource, join->children()[0], conjuncts, claimed, any_claimed);
+            auto new_right = promote_join_subtree(resource, join->children()[1], conjuncts, claimed, any_claimed);
+
+            auto splice_children = [&]() {
+                if (new_left != join->children()[0]) {
+                    join->children()[0] = new_left;
+                }
+                if (new_right != join->children()[1]) {
+                    join->children()[1] = new_right;
+                }
+            };
+
+            if (!classifiable || left_width == 0 || right_width == 0) {
+                splice_children(); // carry promoted children, but leave THIS join as-is
+                return node;
+            }
+
+            size_t picked_index = conjuncts.size();
+            for (size_t i = 0; i < conjuncts.size(); ++i) {
+                if (!claimed[i] && is_boundary_equi(conjuncts[i], left_width, right_width)) {
+                    picked_index = i;
+                    break;
+                }
+            }
+            if (picked_index == conjuncts.size()) {
+                splice_children(); // no key for this join -> keep it cross
+                return node;
+            }
+
+            claimed[picked_index] = 1;
+            any_claimed = true;
+
+            auto picked = conjuncts[picked_index];
+            auto* eq = static_cast<compare_expression_t*>(picked.get());
+            // Re-stamp both keys against THIS join's boundary. The right-range key
+            // becomes side=right with a right-local path (mergedIdx - left_width) built on
+            // the rule's resource (NOT set_path({...}), which pulls the default resource —
+            // rule 14). The left-range key's merged path is already left-child-local, so
+            // only its side is (re)affirmed left.
+            key_t& kl = as_key(eq->left());
+            key_t& kr = as_key(eq->right());
+            const bool kl_is_right = kl.path()[0] >= left_width;
+            key_t& right_key = kl_is_right ? kl : kr;
+            key_t& left_key = kl_is_right ? kr : kl;
+            const size_t merged_idx = right_key.path()[0];
+            right_key.set_side(side_t::right);
+            std::pmr::vector<size_t> p{resource};
+            p.push_back(merged_idx - left_width);
+            right_key.set_path(std::move(p));
+            left_key.set_side(side_t::left);
+
+            // Immutable join_type -> a fresh inner join. oid flows from the moved scan
+            // children (rule 16 OK). Hash selection stays in rewrite_hash_joins (runs
+            // after); the re-stamp makes detect_equi_columns accept it. Use the PROMOTED
+            // children so a nested inner join is carried up.
+            auto inner = make_node_join(resource, core::dbname_t{}, core::relname_t{}, join_type::inner);
+            inner->append_child(new_left);
+            inner->append_child(new_right);
+            inner->append_expression(picked);
+            // Stamp the promoted join's own output schema = left ++ right output_types in
+            // logical [left, right] order. The validator stamps a cross join, but a fresh
+            // make_node_join is unstamped; every consumer then reads a reliable left_width
+            // from children()[i]->output_types() — a PARENT promoted join (nested left-deep)
+            // and pushdown_filter, which re-localizes a pushed right-side conjunct by that
+            // left_width. The promoted children preserve their pre-promotion widths, so this
+            // equals the width of the cross join it replaces. Built on `resource` (rule 8).
+            std::pmr::vector<components::types::complex_logical_type> merged{resource};
+            merged.reserve(new_left->output_types().size() + new_right->output_types().size());
+            for (const auto& t : new_left->output_types()) {
+                merged.push_back(t);
+            }
+            for (const auto& t : new_right->output_types()) {
+                merged.push_back(t);
+            }
+            inner->set_output_types(std::move(merged));
+            return inner;
+        }
+
+        node_ptr promote_impl(std::pmr::memory_resource* resource, node_ptr node) {
+            if (!node) {
+                return node;
+            }
+
+            for (size_t i = 0; i < node->children().size(); ++i) {
+                auto optimized = promote_impl(resource, node->children()[i]);
+                if (optimized != node->children()[i]) {
+                    node->children()[i] = optimized;
+                }
+            }
+
+            if (node->type() != node_type::aggregate_t) {
+                return node;
+            }
+            auto* agg = static_cast<node_aggregate_t*>(node.get());
+            // child[0] = data source, child[1..] = pipeline operations.
+            if (agg->children().size() < 2) {
+                return node;
+            }
+
+            node_ptr match_child = nullptr;
+            for (size_t i = 1; i < agg->children().size(); ++i) {
+                if (agg->children()[i]->type() == node_type::match_t) {
+                    match_child = agg->children()[i];
+                    break;
+                }
+            }
+            if (!match_child || match_child->expressions().empty()) {
+                return node;
+            }
+
+            auto source = agg->children()[0];
+            if (source->type() != node_type::join_t) {
+                return node;
+            }
+
+            // Split the WHERE into top-level conjuncts (OUTER-merged coordinates) and
+            // promote every cross join in the source subtree — each nested join claims
+            // the single conjunct that straddles ITS boundary. The current 2-table case
+            // is the depth-1 instance of this (one join, one claimed conjunct).
+            auto conjuncts = split_conjuncts(resource, match_child->expressions()[0]);
+            if (conjuncts.empty()) {
+                return node;
+            }
+            std::pmr::vector<char> claimed{resource};
+            claimed.resize(conjuncts.size(), 0);
+            bool any_claimed = false;
+            auto promoted = promote_join_subtree(resource, source, conjuncts, claimed, any_claimed);
+            if (!any_claimed) {
+                return node; // no qualifying equi anywhere -> leave the subtree untouched
+            }
+
+            // Residual = every unclaimed conjunct (incl. extra eqs of a composite key and
+            // non-join filters). Never bail — the residual match keeps applying them.
+            std::pmr::vector<expression_ptr> residual{resource};
+            for (size_t i = 0; i < conjuncts.size(); ++i) {
+                if (!claimed[i]) {
+                    residual.push_back(conjuncts[i]);
+                }
+            }
+            auto residual_expr = rebuild_conjunction(resource, residual);
+            if (residual_expr) {
+                match_child->expressions()[0] = residual_expr;
+            } else {
+                // Nothing left to filter -> drop the residual match. The join sits at
+                // index 0, the match at index >= 1, so erasing it does not shift index 0.
+                auto& children = agg->children();
+                for (size_t i = 0; i < children.size(); ++i) {
+                    if (children[i] == match_child) {
+                        children.erase(children.begin() + static_cast<std::ptrdiff_t>(i));
+                        break;
+                    }
+                }
+            }
+
+            agg->children()[0] = promoted;
+            return node;
+        }
+
+    } // namespace
+
+    logical_plan::node_ptr promote_cross_joins(std::pmr::memory_resource* resource, logical_plan::node_ptr node) {
+        return promote_impl(resource, std::move(node));
+    }
+
+} // namespace components::planner::optimizer

--- a/components/planner/optimizer/rules/promote_cross_join.hpp
+++ b/components/planner/optimizer/rules/promote_cross_join.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <components/logical_plan/node.hpp>
+
+namespace components::planner::optimizer {
+
+    // Promote a comma-join (SQL-89 `FROM a, b WHERE a.k = b.k`) from a nested-loop
+    // CROSS join into an INNER join carrying the equi-key on its ON condition, so
+    // rewrite_hash_joins (which runs after) can lower it to a hash join.
+    //
+    // Shape targeted: an aggregate_t whose children()[0] is a node_join_t{cross}
+    // with a sibling match_t. The comma-join transformer lowers the WHERE into that
+    // sibling match_t and stamps BOTH equi keys side=left (unqualified columns over
+    // the merged join schema, validate_logical_plan.cpp same_schema path), so
+    // detect_equi_columns can never accept the cross join as-is. This rule classifies
+    // the equi keys by PATH RANGE against the intact stamped scan children
+    // (left_width = children()[0]->output_types().size()), moves ONE qualifying
+    // eq(key,key) onto a fresh inner join, re-localizes + re-sides the right-range
+    // key, and keeps every other conjunct as a residual match.
+    //
+    // Multi-way: `FROM a, b, c` lowers to a left-deep chain
+    // join{cross}(join{cross}(a, b), c). This rule recurses into EVERY cross join in
+    // the source subtree — each nested join classifies its two keys against ITS OWN
+    // children's output_types() (not the outer merged schema) and claims the one WHERE
+    // conjunct that straddles ITS boundary. A key's outer-merged path equals its index
+    // within the left child (which spans the merged prefix), so classification and the
+    // right-range re-localization (path = mergedIdx - left_width) hold at every depth.
+    // If a nested join's children are unstamped, that join is left cross (safe no-op)
+    // while the others still promote — partial promotion is correct, never wrong.
+    //
+    // Must run BEFORE pushdown_filter (whose join branch wraps the join's children in
+    // fresh, unstamped aggregates that would collapse left_width to 0) and BEFORE
+    // rewrite_hash_joins (which then accepts the promoted inner join).
+    //
+    // Any malformed / unclassifiable shape is left unchanged (no-op skip) — optimizer
+    // rules have no error channel, so they never throw (rules 2, 9).
+    logical_plan::node_ptr promote_cross_joins(std::pmr::memory_resource* resource, logical_plan::node_ptr node);
+
+} // namespace components::planner::optimizer

--- a/components/planner/optimizer/rules/promote_cross_join.hpp
+++ b/components/planner/optimizer/rules/promote_cross_join.hpp
@@ -35,7 +35,7 @@ namespace components::planner::optimizer {
     // star, rebuilds the CROSS chain fact-FIRST over the ORIGINAL leaf scans, and
     // block-permutes every frozen column ref (the match, group keys, aggregate
     // arguments, and — without a GROUP BY — sort/select loci) so this same canonical
-    // path then claims every boundary. It NEVER promotes anything itself (rule 6, one
+    // path then claims every boundary. It NEVER promotes anything itself (one
     // promotion engine). All detection/verify is read-only and precedes any mutation, so
     // a non-star / already-claimable / unclassifiable shape leaves the tree pristine and
     // flows through unchanged.
@@ -45,7 +45,7 @@ namespace components::planner::optimizer {
     // rewrite_hash_joins (which then accepts the promoted inner join).
     //
     // Any malformed / unclassifiable shape is left unchanged (no-op skip) — optimizer
-    // rules have no error channel, so they never throw (rules 2, 9).
+    // rules have no error channel, so they never throw.
     logical_plan::node_ptr promote_cross_joins(std::pmr::memory_resource* resource, logical_plan::node_ptr node);
 
 } // namespace components::planner::optimizer

--- a/components/planner/optimizer/rules/promote_cross_join.hpp
+++ b/components/planner/optimizer/rules/promote_cross_join.hpp
@@ -28,6 +28,18 @@ namespace components::planner::optimizer {
     // If a nested join's children are unstamped, that join is left cross (safe no-op)
     // while the others still promote — partial promotion is correct, never wrong.
     //
+    // Star reordering (fact-LAST): `FROM dim0, .., fact WHERE fact=dim0 AND ..` lowers
+    // to a left-deep CROSS chain whose inner joins hold only DIMENSIONS, so no equi
+    // straddles them and the canonical promotion leaves them CROSS — a dimension
+    // cartesian. A pure pre-normalizer (normalize_star_shape) detects the single-fact
+    // star, rebuilds the CROSS chain fact-FIRST over the ORIGINAL leaf scans, and
+    // block-permutes every frozen column ref (the match, group keys, aggregate
+    // arguments, and — without a GROUP BY — sort/select loci) so this same canonical
+    // path then claims every boundary. It NEVER promotes anything itself (rule 6, one
+    // promotion engine). All detection/verify is read-only and precedes any mutation, so
+    // a non-star / already-claimable / unclassifiable shape leaves the tree pristine and
+    // flows through unchanged.
+    //
     // Must run BEFORE pushdown_filter (whose join branch wraps the join's children in
     // fresh, unstamped aggregates that would collapse left_width to 0) and BEFORE
     // rewrite_hash_joins (which then accepts the promoted inner join).

--- a/components/planner/optimizer/rules/pushdown_filter.cpp
+++ b/components/planner/optimizer/rules/pushdown_filter.cpp
@@ -1,5 +1,7 @@
 #include "pushdown_filter.hpp"
 
+#include "conjunct_utils.hpp"
+
 #include <optional>
 #include <set>
 #include <string>
@@ -110,6 +112,90 @@ namespace components::planner::optimizer {
             return result;
         }
 
+        // Re-localize a conjunct's column keys from the join's MERGED coordinate space
+        // to the right child's LOCAL space when a right-side single-table filter is
+        // pushed below the join. A key's merged path()[0] equals its local index only
+        // for the left prefix ([0, left_width)); a right-side column sits at
+        // left_width + local, so pushing it into the right child unchanged leaves an
+        // out-of-range column index. Subtract left_width from the leading path element
+        // (deeper elements index nested struct fields and stay put). The new path is
+        // built on `resource` — never set_path({...}), which pulls the default resource
+        // (rule 14). The left bucket needs no rewrite (merged == local there) and the
+        // residual keeps its merged paths (it evaluates over the join's merged output).
+        void relocalize_key_path(key_t& k, size_t left_width, std::pmr::memory_resource* resource) {
+            const auto& old_path = k.path();
+            if (old_path.empty()) {
+                return;
+            }
+            std::pmr::vector<size_t> p{resource};
+            p.reserve(old_path.size());
+            p.push_back(old_path[0] - left_width);
+            for (size_t i = 1; i < old_path.size(); ++i) {
+                p.push_back(old_path[i]);
+            }
+            k.set_path(std::move(p));
+        }
+
+        void relocalize_keys(const expression_ptr& expr, size_t left_width, std::pmr::memory_resource* resource);
+
+        void relocalize_param(param_storage& param, size_t left_width, std::pmr::memory_resource* resource) {
+            if (is_key(param)) {
+                relocalize_key_path(as_key(param), left_width, resource);
+            } else if (is_expr(param)) {
+                relocalize_keys(as_expr(param), left_width, resource);
+            }
+        }
+
+        // Mirrors collect_referenced_columns exactly: it visits precisely the keys that
+        // classify a conjunct as right-side, so every such key is re-localized here.
+        void relocalize_keys(const expression_ptr& expr, size_t left_width, std::pmr::memory_resource* resource) {
+            if (!expr) {
+                return;
+            }
+            switch (expr->group()) {
+                case expression_group::compare: {
+                    auto* cmp = static_cast<compare_expression_t*>(expr.get());
+                    if (is_union_compare_condition(cmp->type())) {
+                        for (auto& child : cmp->children()) {
+                            relocalize_keys(child, left_width, resource);
+                        }
+                    } else {
+                        relocalize_param(cmp->left(), left_width, resource);
+                        relocalize_param(cmp->right(), left_width, resource);
+                    }
+                    break;
+                }
+                case expression_group::scalar: {
+                    auto* sc = static_cast<scalar_expression_t*>(expr.get());
+                    for (auto& param : sc->params()) {
+                        relocalize_param(param, left_width, resource);
+                    }
+                    break;
+                }
+                case expression_group::aggregate: {
+                    auto* agg = static_cast<aggregate_expression_t*>(expr.get());
+                    for (auto& param : agg->params()) {
+                        relocalize_param(param, left_width, resource);
+                    }
+                    break;
+                }
+                case expression_group::sort: {
+                    auto* srt = static_cast<sort_expression_t*>(expr.get());
+                    relocalize_key_path(srt->key(), left_width, resource);
+                    break;
+                }
+                case expression_group::function: {
+                    auto* fn = static_cast<function_expression_t*>(expr.get());
+                    for (auto& arg : fn->args()) {
+                        relocalize_param(arg, left_width, resource);
+                    }
+                    break;
+                }
+                default:
+                    break;
+            }
+        }
+
         bool filter_supported_through_identity_select(const node_select_t& sel,
                                                       const std::set<std::string>& filter_cols,
                                                       const std::set<std::string>& input_cols) {
@@ -161,12 +247,19 @@ namespace components::planner::optimizer {
             if (!node) {
                 return;
             }
-            if (node->type() == node_type::data_t) {
-                auto* data = static_cast<node_data_t*>(node.get());
-                auto types = data->data_chunk().types();
-                for (size_t i = 0; i < types.size(); ++i) {
-                    if (!types[i].alias().empty()) {
-                        cols.insert(types[i].alias());
+            // Single canonical source (rule 6): a node's own validate_schema-stamped
+            // output_types() carries its VISIBLE column names (aliases) — this is the
+            // set a predicate above the node references, and it is stamped for disk
+            // scans (aggregate_t{db,rel}), in-memory data_t, subquery and join nodes
+            // alike. Read it directly. Only when a node is UNstamped (an
+            // optimizer-synthesized wrapper — e.g. the aggregate this rule's own join
+            // branch appends) do we recurse into its children to the first stamped
+            // node. Never recurse straight to a leaf: a renamed side (`… AS x`) carries
+            // the pre-rename name at the leaf, which would mis-bucket a predicate on `x`.
+            if (node->has_output_types()) {
+                for (const auto& t : node->output_types()) {
+                    if (!t.alias().empty()) {
+                        cols.insert(t.alias());
                     }
                 }
                 return;
@@ -174,40 +267,6 @@ namespace components::planner::optimizer {
             for (const auto& child : node->children()) {
                 collect_subtree_columns(child, cols);
             }
-        }
-
-        std::vector<expression_ptr> split_conjuncts(const expression_ptr& expr) {
-            std::vector<expression_ptr> result;
-            if (!expr) {
-                return result;
-            }
-            if (expr->group() == expression_group::compare) {
-                auto* cmp = static_cast<compare_expression_t*>(expr.get());
-                if (cmp->type() == compare_type::union_and) {
-                    for (const auto& child : cmp->children()) {
-                        auto sub = split_conjuncts(child);
-                        result.insert(result.end(), sub.begin(), sub.end());
-                    }
-                    return result;
-                }
-            }
-            result.push_back(expr);
-            return result;
-        }
-
-        expression_ptr rebuild_conjunction(std::pmr::memory_resource* resource,
-                                           const std::vector<expression_ptr>& conjuncts) {
-            if (conjuncts.empty()) {
-                return nullptr;
-            }
-            if (conjuncts.size() == 1) {
-                return conjuncts.front();
-            }
-            auto conj = make_compare_union_expression(resource, compare_type::union_and);
-            for (const auto& c : conjuncts) {
-                conj->append_child(c);
-            }
-            return conj;
         }
 
         size_t type_width(const components::types::complex_logical_type& t) { return t.size(); }
@@ -321,13 +380,29 @@ namespace components::planner::optimizer {
                 }
             }
 
-            if (!match_child || group_child || sort_child) {
+            // Only a match child is required to attempt a push. A group_t/sort_t above
+            // the join no longer bails: pushing a single-table filter below the join
+            // under GROUP BY/ORDER BY + a projection is now driven end-to-end. That
+            // shape wraps the join's probe child in a streaming filter over its scan
+            // source (a 2-operator sub-plan); the executor's streaming driver
+            // (executor.cpp execute_pipeline) was taught to treat the TOPMOST executed
+            // operator — not a contiguous bottom prefix — as the materialized sub-plan
+            // boundary, so the filtered probe rows now reach the group/sort instead of
+            // the drained scan source being re-driven to 0 rows (repro:
+            // test_batch_execution "join + WHERE with UDF batch predicate",
+            // test_column_projection "inner JOIN + GROUP BY with WHERE on non-select
+            // column").
+            //
+            // The aggregate-SOURCE branch below keeps its original !group_child &&
+            // !sort_child guard: only the join-source branch is validated under
+            // grouping/sort here.
+            if (!match_child) {
                 return node;
             }
 
             auto source = agg->children()[0];
 
-            if (source->type() == node_type::aggregate_t) {
+            if (source->type() == node_type::aggregate_t && !group_child && !sort_child) {
                 auto* source_agg = static_cast<node_aggregate_t*>(source.get());
                 bool source_has_sort = false;
                 bool source_has_group = false;
@@ -427,8 +502,8 @@ namespace components::planner::optimizer {
                         }
                     }
                     if (!group_keys.empty() && !match_child->expressions().empty()) {
-                        auto conjuncts = split_conjuncts(match_child->expressions()[0]);
-                        std::vector<expression_ptr> pushable, residual;
+                        auto conjuncts = split_conjuncts(resource, match_child->expressions()[0]);
+                        std::pmr::vector<expression_ptr> pushable{resource}, residual{resource};
                         for (const auto& conj : conjuncts) {
                             auto cols = collect_referenced_columns(conj);
                             if (!cols.empty() &&
@@ -462,16 +537,32 @@ namespace components::planner::optimizer {
                     collect_subtree_columns(join->children()[0], left_cols);
                     collect_subtree_columns(join->children()[1], right_cols);
 
+                    // Width of the left child's output = the merged prefix that the left
+                    // columns occupy. A right-side column's merged path()[0] is
+                    // left_width + its local index, so pushing a right-side filter into
+                    // the right child requires subtracting left_width (relocalize_keys).
+                    // Read it from the child's stamped output_types() — reliable for a
+                    // validator-stamped scan/cross join AND a promoted inner join (which
+                    // promote_cross_join now stamps). MUST be captured BEFORE the left
+                    // bucket wraps children()[0] in an unstamped aggregate below.
+                    const bool left_width_known = join->children()[0]->has_output_types();
+                    const size_t left_width =
+                        left_width_known ? join->children()[0]->output_types().size() : 0;
+
                     // Only push below a row-preserving side of an outer join
                     // Left preserves left, right preserves right, full preserves none, inner/cross preserve both.
                     const auto jt = join->type();
                     const bool can_push_left =
                         jt == join_type::inner || jt == join_type::cross || jt == join_type::left;
+                    // A right-side push also needs a known left_width to re-localize the
+                    // conjunct; without it, keep the conjunct in the residual (safe no-op,
+                    // rules 2/9) rather than push an out-of-range merged path.
                     const bool can_push_right =
-                        jt == join_type::inner || jt == join_type::cross || jt == join_type::right;
+                        (jt == join_type::inner || jt == join_type::cross || jt == join_type::right) &&
+                        left_width_known;
 
-                    auto conjuncts = split_conjuncts(match_child->expressions()[0]);
-                    std::vector<expression_ptr> left_bucket, right_bucket, residual;
+                    auto conjuncts = split_conjuncts(resource, match_child->expressions()[0]);
+                    std::pmr::vector<expression_ptr> left_bucket{resource}, right_bucket{resource}, residual{resource};
                     for (const auto& conj : conjuncts) {
                         auto cols = collect_referenced_columns(conj);
                         bool in_left = !cols.empty() &&
@@ -499,6 +590,17 @@ namespace components::planner::optimizer {
                         }
                         if (!right_bucket.empty()) {
                             auto [r_db, r_rel] = node_cfn(join->children()[1]);
+                            // Re-localize each pushed right-side conjunct from the join's
+                            // merged coordinates to the right child's local space (subtract
+                            // left_width). Each conjunct lands in exactly one bucket, so the
+                            // right-bucket entries are not shared with the residual or the
+                            // left bucket — mutating their keys in place is safe. The nested
+                            // recursion below re-applies this at each deeper level with that
+                            // level's own left_width, so a deep left-then-right push
+                            // localizes step by step.
+                            for (const auto& conj : right_bucket) {
+                                relocalize_keys(conj, left_width, resource);
+                            }
                             auto new_agg = make_node_aggregate(resource, r_db, r_rel);
                             new_agg->append_child(join->children()[1]);
                             new_agg->append_child(
@@ -507,7 +609,35 @@ namespace components::planner::optimizer {
                         }
                         auto residual_expr = rebuild_conjunction(resource, residual);
                         if (!residual_expr) {
-                            return pushdown_filter_impl(resource, source);
+                            // All conjuncts pushed below the join → the match is empty.
+                            // Drop ONLY the (now-empty) match child, NOT the enclosing
+                            // aggregate: returning `source` here would discard node's
+                            // group_t/sort_t — reachable now that Stage 3 lifted the
+                            // group/sort bail for this join branch (e.g. SSB
+                            // `SUM(...) ... GROUP BY ... ORDER BY` whose WHERE, after
+                            // promote moved the equi onto the join ON, is entirely
+                            // single-table filters). Preserve the aggregate; recurse
+                            // into the pushed join. The match sits at index >= 1, the
+                            // join at index 0, so erasing it does not shift index 0.
+                            auto& agg_children = node->children();
+                            for (size_t i = 0; i < agg_children.size(); ++i) {
+                                if (agg_children[i] == match_child) {
+                                    agg_children.erase(agg_children.begin() + static_cast<std::ptrdiff_t>(i));
+                                    break;
+                                }
+                            }
+                            auto pushed_source = pushdown_filter_impl(resource, source);
+                            // If the aggregate now wraps ONLY the join (its match was the
+                            // sole pipeline stage), it is a redundant pass-through — expose
+                            // the pushed join directly (the canonical minimal plan the
+                            // unit tests assert). Keep the aggregate only when a group_t/
+                            // sort_t (or other pipeline stage) still needs it (the SSB
+                            // SUM/GROUP BY/ORDER BY case, which then keeps its residual).
+                            if (node->children().size() == 1) {
+                                return pushed_source;
+                            }
+                            node->children()[0] = pushed_source;
+                            return node;
                         }
                         match_child->expressions()[0] = residual_expr;
                         node->children()[0] = pushdown_filter_impl(resource, source);

--- a/components/planner/optimizer/rules/pushdown_filter.cpp
+++ b/components/planner/optimizer/rules/pushdown_filter.cpp
@@ -119,8 +119,8 @@ namespace components::planner::optimizer {
         // left_width + local, so pushing it into the right child unchanged leaves an
         // out-of-range column index. Subtract left_width from the leading path element
         // (deeper elements index nested struct fields and stay put). The new path is
-        // built on `resource` — never set_path({...}), which pulls the default resource
-        // (rule 14). The left bucket needs no rewrite (merged == local there) and the
+        // built on `resource` — never set_path({...}), which pulls the default resource.
+        // The left bucket needs no rewrite (merged == local there) and the
         // residual keeps its merged paths (it evaluates over the join's merged output).
         void relocalize_key_path(key_t& k, size_t left_width, std::pmr::memory_resource* resource) {
             const auto& old_path = k.path();
@@ -247,7 +247,7 @@ namespace components::planner::optimizer {
             if (!node) {
                 return;
             }
-            // Single canonical source (rule 6): a node's own validate_schema-stamped
+            // Single canonical source: a node's own validate_schema-stamped
             // output_types() carries its VISIBLE column names (aliases) — this is the
             // set a predicate above the node references, and it is stamped for disk
             // scans (aggregate_t{db,rel}), in-memory data_t, subquery and join nodes
@@ -555,8 +555,8 @@ namespace components::planner::optimizer {
                     const bool can_push_left =
                         jt == join_type::inner || jt == join_type::cross || jt == join_type::left;
                     // A right-side push also needs a known left_width to re-localize the
-                    // conjunct; without it, keep the conjunct in the residual (safe no-op,
-                    // rules 2/9) rather than push an out-of-range merged path.
+                    // conjunct; without it, keep the conjunct in the residual (safe
+                    // no-op) rather than push an out-of-range merged path.
                     const bool can_push_right =
                         (jt == join_type::inner || jt == join_type::cross || jt == join_type::right) &&
                         left_width_known;
@@ -612,8 +612,8 @@ namespace components::planner::optimizer {
                             // All conjuncts pushed below the join → the match is empty.
                             // Drop ONLY the (now-empty) match child, NOT the enclosing
                             // aggregate: returning `source` here would discard node's
-                            // group_t/sort_t — reachable now that Stage 3 lifted the
-                            // group/sort bail for this join branch (e.g. SSB
+                            // group_t/sort_t — reachable now that the group/sort bail
+                            // was lifted for this join branch (e.g. SSB
                             // `SUM(...) ... GROUP BY ... ORDER BY` whose WHERE, after
                             // promote moved the equi onto the join ON, is entirely
                             // single-table filters). Preserve the aggregate; recurse

--- a/components/planner/test/CMakeLists.txt
+++ b/components/planner/test/CMakeLists.txt
@@ -4,6 +4,7 @@ set(${PROJECT_NAME}_SOURCES
         test_logical_plan.cpp
         test_optimizer.cpp
         test_promote_multiway.cpp
+        test_promote_star.cpp
         test_pushed_spec_build.cpp
         test_create_plan_pushdown.cpp
 )

--- a/components/planner/test/CMakeLists.txt
+++ b/components/planner/test/CMakeLists.txt
@@ -3,6 +3,7 @@ project(test_translator)
 set(${PROJECT_NAME}_SOURCES
         test_logical_plan.cpp
         test_optimizer.cpp
+        test_promote_multiway.cpp
         test_pushed_spec_build.cpp
         test_create_plan_pushdown.cpp
 )

--- a/components/planner/test/test_optimizer.cpp
+++ b/components/planner/test/test_optimizer.cpp
@@ -1217,7 +1217,7 @@ TEST_CASE("optimizer::pushdown_aggregate::udf_reference_is_skipped") {
 }
 
 // ================================================================
-// Stage 1. Cross->inner promotion (promote_cross_join.cpp)
+// Cross->inner promotion (promote_cross_join.cpp)
 //
 // SELECT SUM(ap) FROM a, b WHERE ak = bk AND ap < ?
 // lowers to:
@@ -1240,7 +1240,7 @@ TEST_CASE("optimizer::pushdown_aggregate::udf_reference_is_skipped") {
 //
 // The scans are driven through the REAL validate_schema (never hand-stamped) so
 // key.side()/key.path()/output_types() are exactly what the SQL pipeline produces
-// (Stage 1 note: make_agg 5-arg would stamp the wrapper, not the scans).
+// (make_agg 5-arg would stamp the wrapper, not the scans).
 // ================================================================
 namespace {
     // A raw BIGINT scan, left UNstamped on purpose: validate_schema derives and

--- a/components/planner/test/test_optimizer.cpp
+++ b/components/planner/test/test_optimizer.cpp
@@ -1060,21 +1060,21 @@ namespace {
 } // namespace
 
 TEST_CASE("optimizer::pushdown_aggregate::scalar_mergeable_is_stamped") {
-    auto resource = std::pmr::synchronized_pool_resource();
+    auto resource = core::pmr::otterbrix_resource();
     auto group = make_agg_group(&resource, /*with_group_key=*/false, /*distinct=*/false);
     auto agg = make_agg(&resource, group);
     REQUIRE(run_and_get_pushdown(&resource, agg, /*enable=*/true) == true);
 }
 
 TEST_CASE("optimizer::pushdown_aggregate::grouped_mergeable_is_stamped") {
-    auto resource = std::pmr::synchronized_pool_resource();
+    auto resource = core::pmr::otterbrix_resource();
     auto group = make_agg_group(&resource, /*with_group_key=*/true, /*distinct=*/false);
     auto agg = make_agg(&resource, group);
     REQUIRE(run_and_get_pushdown(&resource, agg, /*enable=*/true) == true);
 }
 
 TEST_CASE("optimizer::pushdown_aggregate::no_agent_capability_does_not_stamp") {
-    auto resource = std::pmr::synchronized_pool_resource();
+    auto resource = core::pmr::otterbrix_resource();
     auto group = make_agg_group(&resource, /*with_group_key=*/false, /*distinct=*/false);
     auto agg = make_agg(&resource, group);
     // Capability precondition (NOT a rollout flag): can_push_to_agent==false means
@@ -1084,14 +1084,14 @@ TEST_CASE("optimizer::pushdown_aggregate::no_agent_capability_does_not_stamp") {
 }
 
 TEST_CASE("optimizer::pushdown_aggregate::count_distinct_is_skipped") {
-    auto resource = std::pmr::synchronized_pool_resource();
+    auto resource = core::pmr::otterbrix_resource();
     auto group = make_agg_group(&resource, /*with_group_key=*/false, /*distinct=*/true);
     auto agg = make_agg(&resource, group);
     REQUIRE(run_and_get_pushdown(&resource, agg, /*enable=*/true) == false);
 }
 
 TEST_CASE("optimizer::pushdown_aggregate::having_is_skipped") {
-    auto resource = std::pmr::synchronized_pool_resource();
+    auto resource = core::pmr::otterbrix_resource();
     auto having = make_scalar_expression(&resource, scalar_type::get_field, key(&resource, "h"));
     auto group = make_agg_group(&resource, /*with_group_key=*/false, /*distinct=*/false, expression_ptr(having));
     auto agg = make_agg(&resource, group);
@@ -1099,7 +1099,7 @@ TEST_CASE("optimizer::pushdown_aggregate::having_is_skipped") {
 }
 
 TEST_CASE("optimizer::pushdown_aggregate::join_child_is_skipped") {
-    auto resource = std::pmr::synchronized_pool_resource();
+    auto resource = core::pmr::otterbrix_resource();
     auto group = make_agg_group(&resource, /*with_group_key=*/false, /*distinct=*/false);
     auto agg = make_agg(&resource, group);
     // A join sibling means this is not one owned base table => skip (a).
@@ -1111,7 +1111,7 @@ TEST_CASE("optimizer::pushdown_aggregate::join_child_is_skipped") {
 }
 
 TEST_CASE("optimizer::pushdown_aggregate::nested_aggregate_child_is_skipped") {
-    auto resource = std::pmr::synchronized_pool_resource();
+    auto resource = core::pmr::otterbrix_resource();
     auto group = make_agg_group(&resource, /*with_group_key=*/false, /*distinct=*/false);
     auto agg = make_agg(&resource, group);
     // A nested aggregate child => not a single owned base table => skip (a).
@@ -1123,7 +1123,7 @@ TEST_CASE("optimizer::pushdown_aggregate::nested_aggregate_child_is_skipped") {
 }
 
 TEST_CASE("optimizer::pushdown_aggregate::union_child_is_skipped") {
-    auto resource = std::pmr::synchronized_pool_resource();
+    auto resource = core::pmr::otterbrix_resource();
     auto group = make_agg_group(&resource, /*with_group_key=*/false, /*distinct=*/false);
     auto agg = make_agg(&resource, group);
     // A union sibling => multi-source, not one owned base table => skip (a).
@@ -1135,7 +1135,7 @@ TEST_CASE("optimizer::pushdown_aggregate::union_child_is_skipped") {
 }
 
 TEST_CASE("optimizer::pushdown_aggregate::cte_scan_child_is_skipped") {
-    auto resource = std::pmr::synchronized_pool_resource();
+    auto resource = core::pmr::otterbrix_resource();
     auto group = make_agg_group(&resource, /*with_group_key=*/false, /*distinct=*/false);
     auto agg = make_agg(&resource, group);
     // A cte_scan sibling => multi-source, not one owned base table => skip (a).
@@ -1144,7 +1144,7 @@ TEST_CASE("optimizer::pushdown_aggregate::cte_scan_child_is_skipped") {
 }
 
 TEST_CASE("optimizer::pushdown_aggregate::non_mergeable_kind_is_skipped") {
-    auto resource = std::pmr::synchronized_pool_resource();
+    auto resource = core::pmr::otterbrix_resource();
     // A non-whitelisted aggregate kind (no fragment-merge kernel) must stay
     // coordinator-side => skip (b), has_unmergeable_aggregate.
     std::vector<expression_ptr> exprs;
@@ -1163,7 +1163,7 @@ TEST_CASE("optimizer::pushdown_aggregate::mergeable_capability_gates_stamp") {
     // function::is_mergeable()) instead of a hardcoded name list.
     // A mergeable builtin SUM over one owned table IS stamped; the SAME SUM made
     // DISTINCT must stay coordinator-side.
-    auto resource = std::pmr::synchronized_pool_resource();
+    auto resource = core::pmr::otterbrix_resource();
     {
         std::vector<expression_ptr> exprs;
         auto sum = make_aggregate_expression(&resource, "sum", key(&resource, "s"));
@@ -1196,7 +1196,7 @@ TEST_CASE("optimizer::pushdown_aggregate::mergeable_capability_gates_stamp") {
 }
 
 TEST_CASE("optimizer::pushdown_aggregate::udf_reference_is_skipped") {
-    auto resource = std::pmr::synchronized_pool_resource();
+    auto resource = core::pmr::otterbrix_resource();
     // A shape-/kind-pushable fragment, but an aggregate arg references a UDF
     // (function_uid >= DEFAULT_FUNCTIONS.size()). The owning agent rebuilds its
     // registry with builtins only, so the pushed fragment could not resolve it
@@ -1256,7 +1256,7 @@ namespace {
 } // namespace
 
 TEST_CASE("optimizer::promote_cross_join::comma_join_becomes_inner_hash") {
-    auto resource = std::pmr::synchronized_pool_resource();
+    auto resource = core::pmr::otterbrix_resource();
     auto params = make_parameter_node(&resource);
     auto lt_param = params->add_parameter(int64_t(5));
 

--- a/components/planner/test/test_optimizer.cpp
+++ b/components/planner/test/test_optimizer.cpp
@@ -7,6 +7,7 @@
 #include <components/expressions/scalar_expression.hpp>
 #include <components/logical_plan/node_aggregate.hpp>
 #include <components/logical_plan/node_cte_scan.hpp>
+#include <components/logical_plan/node_data.hpp>
 #include <components/logical_plan/node_group.hpp>
 #include <components/logical_plan/node_join.hpp>
 #include <components/logical_plan/node_match.hpp>
@@ -17,7 +18,12 @@
 #include <components/physical_plan_generator/impl/create_plan_match.hpp>
 #include <components/physical_plan_generator/impl/index_selection_helpers.hpp>
 #include <components/planner/optimizer.hpp>
+#include <components/planner/optimizer/rules/hash_join.hpp>
+#include <components/planner/optimizer/rules/promote_cross_join.hpp>
+#include <components/tests/generaty.hpp>
+#include <components/types/types.hpp>
 #include <services/collection/context_storage.hpp>
+#include <services/dispatcher/validate_logical_plan.hpp>
 
 #include "pushdown_plan_builders.hpp"
 
@@ -1208,4 +1214,132 @@ TEST_CASE("optimizer::pushdown_aggregate::udf_reference_is_skipped") {
         make_node_group(&resource, core::dbname_t{database_name}, core::relname_t{collection_name}, exprs, nullptr);
     auto agg = make_agg(&resource, group);
     REQUIRE(run_and_get_pushdown(&resource, agg, /*enable=*/true) == false);
+}
+
+// ================================================================
+// Stage 1. Cross->inner promotion (promote_cross_join.cpp)
+//
+// SELECT SUM(ap) FROM a, b WHERE ak = bk AND ap < ?
+// lowers to:
+//   aggregate_t[ join{cross}(scan_a{ak,ap}, scan_b{bk}) + all_true,
+//                match{ union_and[ eq(ak, bk), lt(ap, ?) ] },
+//                group{ SUM(ap) } ].
+//
+// The comma-join uses UNQUALIFIED column names, so validate_schema stamps BOTH
+// equi keys side=left over the merged [ak, ap, bk] schema (the same_schema path)
+// and stamps output_types() on the scan children. Because both keys are side=left,
+// detect_equi_columns cannot accept the cross join as-is.
+//
+// promote_cross_joins classifies the equi keys by PATH RANGE against the intact
+// stamped scans (left_width = scan_a.output_types().size() == 2): ak -> merged
+// idx 0 (left range), bk -> merged idx 2 (right range). It moves the eq onto a
+// fresh INNER join, re-localizes + re-sides the right-range key (merged 2 ->
+// right-local 0, side=right), and keeps the non-join lt filter as the residual
+// match. rewrite_hash_joins (run AFTER, as optimize() orders it) then lowers the
+// promoted inner join to algo()==hash.
+//
+// The scans are driven through the REAL validate_schema (never hand-stamped) so
+// key.side()/key.path()/output_types() are exactly what the SQL pipeline produces
+// (Stage 1 note: make_agg 5-arg would stamp the wrapper, not the scans).
+// ================================================================
+namespace {
+    // A raw BIGINT scan, left UNstamped on purpose: validate_schema derives and
+    // stamps its output_types() from the data chunk (the test must not hand-stamp).
+    static node_ptr make_promote_scan(std::pmr::memory_resource* r, std::initializer_list<const char*> cols) {
+        std::pmr::vector<components::types::complex_logical_type> types(r);
+        for (const char* name : cols) {
+            types.emplace_back(components::types::logical_type::BIGINT, name);
+        }
+        auto chunk = gen_data_chunk(/*size=*/1, /*start=*/0, types, r);
+        return make_node_raw_data(r, std::move(chunk));
+    }
+} // namespace
+
+TEST_CASE("optimizer::promote_cross_join::comma_join_becomes_inner_hash") {
+    auto resource = std::pmr::synchronized_pool_resource();
+    auto params = make_parameter_node(&resource);
+    auto lt_param = params->add_parameter(int64_t(5));
+
+    // Distinct column names => each unqualified reference resolves to exactly one
+    // merged column (the validator rejects ambiguous duplicates), which is what
+    // makes the promote rule's path-range classification well-defined.
+    auto scan_a = make_promote_scan(&resource, {"ak", "ap"});
+    auto scan_b = make_promote_scan(&resource, {"bk"});
+
+    auto join =
+        make_node_join(&resource, core::dbname_t{database_name}, core::relname_t{collection_name}, join_type::cross);
+    join->append_child(scan_a);
+    join->append_child(scan_b);
+    // FROM a, b lowers the join with an all_true ON placeholder.
+    join->append_expression(make_compare_expression(&resource, compare_type::all_true));
+
+    // WHERE ak = bk AND ap < ?  (unqualified keys => both stamped side=left)
+    auto eq = make_compare_expression(&resource, compare_type::eq, key(&resource, "ak"), key(&resource, "bk"));
+    auto lt = make_compare_expression(&resource, compare_type::lt, key(&resource, "ap"), lt_param);
+    auto where = make_compare_union_expression(&resource, compare_type::union_and);
+    where->append_child(eq);
+    where->append_child(lt);
+
+    auto outer = make_node_aggregate(&resource, core::dbname_t{database_name}, core::relname_t{collection_name});
+    outer->append_child(join);
+    outer->append_child(
+        make_node_match(&resource, core::dbname_t{database_name}, core::relname_t{collection_name}, where));
+
+    // group { SUM(ap) }
+    auto sum_expr = make_aggregate_expression(&resource, "sum", key(&resource, "sum_ap"));
+    sum_expr->append_param(key(&resource, "ap"));
+    std::vector<expression_ptr> group_exprs;
+    group_exprs.emplace_back(expression_ptr(sum_expr));
+    outer->append_child(
+        make_node_group(&resource, core::dbname_t{database_name}, core::relname_t{collection_name}, group_exprs));
+
+    // Drive the REAL validator: stamps key.side()/key.path() and output_types().
+    auto validated = services::dispatcher::validate_schema(&resource, nullptr, outer.get(), params->parameters());
+    REQUIRE_FALSE(validated.has_error());
+    // Precondition the promote rule relies on: the scans carry their columns in
+    // output_types() (left_width == 2, right_width == 1).
+    REQUIRE(scan_a->output_types().size() == 2);
+    REQUIRE(scan_b->output_types().size() == 1);
+
+    // Rule under test, then the hash-selection that runs after it in optimize().
+    node_ptr out = components::planner::optimizer::promote_cross_joins(&resource, outer);
+    out = components::planner::optimizer::rewrite_hash_joins(&resource, out);
+
+    REQUIRE(out == outer);
+    auto* agg = static_cast<node_aggregate_t*>(out.get());
+    REQUIRE(agg->children().size() == 3);
+
+    // child[0] is now an INNER hash join with the detected equi columns.
+    REQUIRE(agg->children()[0]->type() == node_type::join_t);
+    auto* jn = static_cast<node_join_t*>(agg->children()[0].get());
+    REQUIRE(jn->type() == join_type::inner);
+    REQUIRE(jn->algo() == node_join_t::join_algo::hash);
+    REQUIRE(jn->left_col() == 0);  // ak, left input col 0
+    REQUIRE(jn->right_col() == 0); // bk, right input col 0
+
+    // The equi moved onto the join's ON; the right-range key is re-localized
+    // (merged idx 2 -> right-local 0) and re-sided (side=right).
+    REQUIRE(jn->expressions().size() == 1);
+    auto* on = static_cast<compare_expression_t*>(jn->expressions()[0].get());
+    REQUIRE(on->type() == compare_type::eq);
+    REQUIRE(is_key(on->left()));
+    REQUIRE(is_key(on->right()));
+    const auto& lk = as_key(on->left());
+    const auto& rk = as_key(on->right());
+    REQUIRE(lk.side() == side_t::left);
+    REQUIRE(lk.path().size() == 1);
+    REQUIRE(lk.path()[0] == 0);
+    REQUIRE(rk.side() == side_t::right);
+    REQUIRE(rk.path().size() == 1);
+    REQUIRE(rk.path()[0] == 0);
+
+    // The residual match holds ONLY the non-join lt filter.
+    REQUIRE(agg->children()[1]->type() == node_type::match_t);
+    auto residual_match = agg->children()[1];
+    REQUIRE(residual_match->expressions().size() == 1);
+    auto* residual = static_cast<compare_expression_t*>(residual_match->expressions()[0].get());
+    REQUIRE(residual->type() == compare_type::lt);
+
+    // The group{SUM} pipeline stage is left untouched by the promotion.
+    REQUIRE(agg->children()[2]->type() == node_type::group_t);
 }

--- a/components/planner/test/test_promote_multiway.cpp
+++ b/components/planner/test/test_promote_multiway.cpp
@@ -1,0 +1,158 @@
+#include <catch2/catch.hpp>
+
+#include <components/expressions/compare_expression.hpp>
+#include <components/expressions/key.hpp>
+#include <components/logical_plan/node_aggregate.hpp>
+#include <components/logical_plan/node_data.hpp>
+#include <components/logical_plan/node_join.hpp>
+#include <components/logical_plan/node_match.hpp>
+#include <components/logical_plan/param_storage.hpp>
+#include <components/planner/optimizer/rules/hash_join.hpp>
+#include <components/planner/optimizer/rules/promote_cross_join.hpp>
+#include <components/types/types.hpp>
+#include <components/vector/data_chunk.hpp>
+#include <services/dispatcher/validate_logical_plan.hpp>
+
+#include <memory_resource>
+#include <utility>
+
+using namespace components;
+using namespace components::logical_plan;
+using expressions::compare_type;
+using expressions::side_t;
+
+// ----------------------------------------------------------------------------
+// Stage 4 — multi-way (nested) cross-join promotion.
+//
+// `FROM a, b, c WHERE a.k = b.k AND b.v = c.k` lowers to a left-deep chain
+//   aggregate_t
+//     child0: join{cross}( join{cross}(a, b), c )   <- source
+//     child1: match_t( a_k=b_k AND b_v=c_k AND a_id!=b_v )
+// with the WHERE keys stamped side=left over the merged [a|b|c] schema by the
+// validator. promote_cross_joins must promote BOTH nested cross joins: the inner
+// join claims a_k=b_k (its boundary), the outer join claims b_v=c_k (its
+// boundary), each re-localizing its right-range key. The non-join residual
+// (a_id != b_v) stays in the match. rewrite_hash_joins then lowers both to hash.
+//
+// This drives the real services::dispatcher::validate_schema so the keys carry
+// the true both-sides-left, merged-relative paths and every scan/join node gets
+// output_types() stamped (the promote rule reads those widths).
+//
+// Against the depth-1-only rule this is RED: only the outer join would promote,
+// leaving the inner join a nested-loop cross join.
+// ----------------------------------------------------------------------------
+namespace {
+
+    // A raw-data scan with two BIGINT columns named `c0`/`c1`. The column type
+    // alias is the bare column name the WHERE keys resolve against.
+    node_data_ptr make_scan(std::pmr::memory_resource* res, const char* c0, const char* c1) {
+        std::pmr::vector<types::complex_logical_type> types(res);
+        types.emplace_back(types::logical_type::BIGINT, c0);
+        types.emplace_back(types::logical_type::BIGINT, c1);
+        vector::data_chunk_t chunk(res, types, 1);
+        chunk.set_cardinality(1);
+        chunk.set_value(0, 0, int64_t{1});
+        chunk.set_value(1, 0, int64_t{2});
+        return make_node_raw_data(res, std::move(chunk));
+    }
+
+    components::expressions::key_t bare_key(std::pmr::memory_resource* res, const char* name) {
+        return components::expressions::key_t{res, name};
+    }
+
+    expressions::expression_ptr
+    make_cmp(std::pmr::memory_resource* res, compare_type type, const char* l, const char* r) {
+        return expressions::make_compare_expression(res,
+                                                    type,
+                                                    expressions::param_storage{bare_key(res, l)},
+                                                    expressions::param_storage{bare_key(res, r)});
+    }
+
+} // namespace
+
+TEST_CASE("optimizer::promote_cross_join::multiway_three_table") {
+    std::pmr::monotonic_buffer_resource arena;
+    auto* res = &arena;
+
+    // Tables: a(a_id, a_k) | b(b_k, b_v) | c(c_k, c_v)
+    // merged schema indices: a_id=0 a_k=1 | b_k=2 b_v=3 | c_k=4 c_v=5
+    auto a = make_scan(res, "a_id", "a_k");
+    auto b = make_scan(res, "b_k", "b_v");
+    auto c = make_scan(res, "c_k", "c_v");
+
+    auto inner_cross = make_node_join(res, core::dbname_t{}, core::relname_t{}, join_type::cross);
+    inner_cross->append_child(a);
+    inner_cross->append_child(b);
+    inner_cross->append_expression(expressions::make_compare_expression(res, compare_type::all_true));
+
+    auto outer_cross = make_node_join(res, core::dbname_t{}, core::relname_t{}, join_type::cross);
+    outer_cross->append_child(inner_cross);
+    outer_cross->append_child(c);
+    outer_cross->append_expression(expressions::make_compare_expression(res, compare_type::all_true));
+
+    // WHERE a_k = b_k AND b_v = c_k AND a_id != b_v
+    auto where = expressions::make_compare_union_expression(res, compare_type::union_and);
+    where->append_child(make_cmp(res, compare_type::eq, "a_k", "b_k"));  // straddles the inner join
+    where->append_child(make_cmp(res, compare_type::eq, "b_v", "c_k"));  // straddles the outer join
+    where->append_child(make_cmp(res, compare_type::ne, "a_id", "b_v")); // residual (non-join filter)
+    auto match = make_node_match(res, core::dbname_t{}, core::relname_t{}, where);
+
+    auto agg = make_node_aggregate(res, core::dbname_t{}, core::relname_t{});
+    agg->append_child(outer_cross);
+    agg->append_child(match);
+
+    // Real validation: stamps side()/path() on the keys and output_types() on the
+    // scans + both joins (left_width/right_width the promote rule classifies against).
+    logical_plan::storage_parameters params{res};
+    auto validated = services::dispatcher::validate_schema(res, nullptr, agg.get(), params);
+    REQUIRE_FALSE(validated.has_error());
+    REQUIRE(inner_cross->has_output_types());
+    REQUIRE(inner_cross->output_types().size() == 4); // [a|b]
+    REQUIRE(outer_cross->has_output_types());
+    REQUIRE(outer_cross->output_types().size() == 6); // [a|b|c]
+
+    node_ptr root = agg;
+    root = planner::optimizer::promote_cross_joins(res, root);
+    root = planner::optimizer::rewrite_hash_joins(res, root);
+
+    auto* agg_after = static_cast<node_aggregate_t*>(root.get());
+    REQUIRE(agg_after->children().size() >= 2);
+
+    // Outer join: promoted to INNER + hash on b_v (left, merged idx 3) = c_k (right,
+    // re-localized to 0 within c).
+    auto outer_after = agg_after->children()[0];
+    REQUIRE(outer_after->type() == node_type::join_t);
+    auto* oj = static_cast<node_join_t*>(outer_after.get());
+    CHECK(oj->type() == join_type::inner);
+    CHECK(oj->algo() == node_join_t::join_algo::hash);
+    CHECK(oj->left_col() == 3);
+    CHECK(oj->right_col() == 0);
+    REQUIRE(oj->children().size() == 2);
+    CHECK(oj->children()[1].get() == c.get()); // right child is still table c
+
+    // Inner join (child0 of the outer): promoted to INNER + hash on a_k (left idx 1)
+    // = b_k (right, re-localized to 0 within b).
+    auto inner_after = oj->children()[0];
+    REQUIRE(inner_after->type() == node_type::join_t);
+    auto* ij = static_cast<node_join_t*>(inner_after.get());
+    CHECK(ij->type() == join_type::inner);
+    CHECK(ij->algo() == node_join_t::join_algo::hash);
+    CHECK(ij->left_col() == 1);
+    CHECK(ij->right_col() == 0);
+    REQUIRE(ij->children().size() == 2);
+    CHECK(ij->children()[0].get() == a.get());
+    CHECK(ij->children()[1].get() == b.get());
+
+    // Residual match keeps only the non-join filter (a_id != b_v).
+    node_ptr match_after = nullptr;
+    for (size_t i = 1; i < agg_after->children().size(); ++i) {
+        if (agg_after->children()[i]->type() == node_type::match_t) {
+            match_after = agg_after->children()[i];
+            break;
+        }
+    }
+    REQUIRE(match_after);
+    REQUIRE(match_after->expressions().size() == 1);
+    auto* residual = static_cast<expressions::compare_expression_t*>(match_after->expressions()[0].get());
+    CHECK(residual->type() == compare_type::ne);
+}

--- a/components/planner/test/test_promote_multiway.cpp
+++ b/components/planner/test/test_promote_multiway.cpp
@@ -22,7 +22,7 @@ using expressions::compare_type;
 using expressions::side_t;
 
 // ----------------------------------------------------------------------------
-// Stage 4 — multi-way (nested) cross-join promotion.
+// Multi-way (nested) cross-join promotion.
 //
 // `FROM a, b, c WHERE a.k = b.k AND b.v = c.k` lowers to a left-deep chain
 //   aggregate_t
@@ -38,8 +38,8 @@ using expressions::side_t;
 // the true both-sides-left, merged-relative paths and every scan/join node gets
 // output_types() stamped (the promote rule reads those widths).
 //
-// Against the depth-1-only rule this is RED: only the outer join would promote,
-// leaving the inner join a nested-loop cross join.
+// A depth-1-only rule would promote only the outer join, leaving the inner join
+// a nested-loop cross join.
 // ----------------------------------------------------------------------------
 namespace {
 

--- a/components/planner/test/test_promote_star.cpp
+++ b/components/planner/test/test_promote_star.cpp
@@ -1,0 +1,734 @@
+#include <catch2/catch.hpp>
+
+#include <components/expressions/aggregate_expression.hpp>
+#include <components/expressions/compare_expression.hpp>
+#include <components/expressions/forward.hpp>
+#include <components/expressions/key.hpp>
+#include <components/expressions/scalar_expression.hpp>
+#include <components/expressions/sort_expression.hpp>
+#include <components/logical_plan/node_aggregate.hpp>
+#include <components/logical_plan/node_data.hpp>
+#include <components/logical_plan/node_group.hpp>
+#include <components/logical_plan/node_join.hpp>
+#include <components/logical_plan/node_match.hpp>
+#include <components/logical_plan/node_select.hpp>
+#include <components/logical_plan/node_sort.hpp>
+#include <components/logical_plan/param_storage.hpp>
+#include <components/planner/optimizer/rules/hash_join.hpp>
+#include <components/planner/optimizer/rules/promote_cross_join.hpp>
+#include <components/types/types.hpp>
+#include <components/vector/data_chunk.hpp>
+#include <services/dispatcher/validate_logical_plan.hpp>
+
+#include <initializer_list>
+#include <memory_resource>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace components;
+using namespace components::logical_plan;
+using namespace components::expressions;
+using expressions::compare_type;
+using expressions::scalar_type;
+using expressions::side_t;
+using expressions::sort_order;
+
+// ============================================================================
+// Star-schema join reordering (SSB q4 fix) — planner unit tests.
+//
+// Model: test_promote_multiway.cpp / test_optimizer.cpp's
+// `comma_join_becomes_inner_hash`. These drive the REAL
+// services::dispatcher::validate_schema on synthetic node_data scans (so the
+// keys carry the true both-sides-left, merged-relative paths and every scan/join
+// node gets output_types() stamped), then run promote_cross_joins +
+// rewrite_hash_joins and assert on node structure + resolved column indices.
+//
+// The scenario is SSB q4-1: a fact-LAST 5-table star
+//   FROM dim_date, customer, supplier, part, lineorder
+// which lowers to a left-deep CROSS chain
+//   ((((dim_date x customer) x supplier) x part) x lineorder)
+// Fact-last => the inner cross joins hold only dimension tables => no straddling
+// equi => they stay CROSS (dimension cartesian). The star pre-normalizer must
+// detect the star and reorder the fact to the FRONT so every boundary becomes a
+// claimable fact<->dim equi:
+//   ((((lineorder x dim_date) x customer) x supplier) x part)
+// then the canonical promote_join_subtree lowers each level to an inner hash join
+// with each dim on the (small) build side.
+//
+// SSB column layout (benchmark/ssb/_setup.sql) and merged FROM-order offsets:
+//   dim_date  (17 cols) @ 0    d_datekey=0  ... d_year=4  ...
+//   customer  ( 8 cols) @ 17   c_custkey=17 ... c_nation=21 c_region=22 ...
+//   supplier  ( 7 cols) @ 25   s_suppkey=25 ... s_region=30 ...
+//   part      ( 9 cols) @ 32   p_partkey=32 p_name=33 p_mfgr=34 ...
+//   lineorder (17 cols) @ 41   lo_orderkey=41 lo_custkey=43 lo_partkey=44
+//                              lo_suppkey=45 lo_orderdate=46 ...
+//                              lo_revenue=53 lo_supplycost=54 ...
+// Total width = 58.
+//
+// The chosen fact-first order (v1 = FROM order, fact pinned to position 0) is
+//   lineorder(17) @ 0, dim_date(17) @ 17, customer(8) @ 34, supplier(7) @ 42,
+//   part(9) @ 49.
+// Block permutation P(old) = offset_new[T] + (old - offset_old[T]):
+//   d_year       4  -> 17 + (4-0)   = 21     (dim_date)
+//   c_nation     21 -> 34 + (21-17) = 38     (customer)
+//   c_region     22 -> 34 + (22-17) = 39     (customer)
+//   s_region     30 -> 42 + (30-25) = 47     (supplier)
+//   p_mfgr       34 -> 49 + (34-32) = 51     (part)
+//   lo_revenue   53 ->  0 + (53-41) = 12     (lineorder)
+//   lo_supplycost54 ->  0 + (54-41) = 13     (lineorder)
+// ============================================================================
+namespace {
+
+    // An all-BIGINT scan whose column type aliases are the SSB column names the
+    // unqualified WHERE/GROUP/SORT keys resolve against. Widths (not types) are
+    // what the star reorder + P remap depend on, so BIGINT throughout is fine for
+    // a planner-only test.
+    node_data_ptr make_scan(std::pmr::memory_resource* res, std::initializer_list<const char*> cols) {
+        std::pmr::vector<types::complex_logical_type> types(res);
+        for (const char* name : cols) {
+            types.emplace_back(types::logical_type::BIGINT, name);
+        }
+        vector::data_chunk_t chunk(res, types, 1);
+        chunk.set_cardinality(1);
+        for (size_t i = 0; i < types.size(); ++i) {
+            chunk.set_value(i, 0, static_cast<int64_t>(i + 1));
+        }
+        return make_node_raw_data(res, std::move(chunk));
+    }
+
+    // `key_t` (unqualified) is ambiguous — POSIX also declares a `key_t` (aka int).
+    // Always name the expressions one fully-qualified and never rely on a `using`.
+    components::expressions::key_t bare_key(std::pmr::memory_resource* res, const char* name) {
+        return components::expressions::key_t{res, name};
+    }
+
+    // Operands must be wrapped in param_storage{...} (mirrors test_promote_multiway.cpp).
+    expressions::expression_ptr
+    cmp_keys(std::pmr::memory_resource* res, compare_type type, const char* l, const char* r) {
+        return make_compare_expression(res,
+                                       type,
+                                       expressions::param_storage{bare_key(res, l)},
+                                       expressions::param_storage{bare_key(res, r)});
+    }
+
+    expressions::expression_ptr eq_keys(std::pmr::memory_resource* res, const char* l, const char* r) {
+        return cmp_keys(res, compare_type::eq, l, r);
+    }
+
+    expressions::expression_ptr
+    cmp_key_param(std::pmr::memory_resource* res, compare_type type, const char* l, core::parameter_id_t p) {
+        return make_compare_expression(res,
+                                       type,
+                                       expressions::param_storage{bare_key(res, l)},
+                                       expressions::param_storage{p});
+    }
+
+    expressions::expression_ptr
+    eq_key_param(std::pmr::memory_resource* res, const char* l, core::parameter_id_t p) {
+        return cmp_key_param(res, compare_type::eq, l, p);
+    }
+
+    // Left-deep CROSS chain over `leaves` in FROM order, each boundary carrying an
+    // all_true ON placeholder (the comma-join lowering).
+    node_ptr cross_chain(std::pmr::memory_resource* res, const std::vector<node_ptr>& leaves) {
+        node_ptr acc = leaves.front();
+        for (size_t i = 1; i < leaves.size(); ++i) {
+            auto j = make_node_join(res, core::dbname_t{}, core::relname_t{}, join_type::cross);
+            j->append_child(acc);
+            j->append_child(leaves[i]);
+            j->append_expression(make_compare_expression(res, compare_type::all_true));
+            acc = j;
+        }
+        return acc;
+    }
+
+    // The 5 SSB spine leaves in FROM order (fact LAST).
+    struct star_leaves {
+        node_data_ptr dim_date;
+        node_data_ptr customer;
+        node_data_ptr supplier;
+        node_data_ptr part;
+        node_data_ptr lineorder;
+
+        std::vector<node_ptr> from_order() const { return {dim_date, customer, supplier, part, lineorder}; }
+    };
+
+    star_leaves make_ssb_leaves(std::pmr::memory_resource* res) {
+        star_leaves s;
+        s.dim_date = make_scan(res,
+                               {"d_datekey", "d_date", "d_dayofweek", "d_month", "d_year", "d_yearmonthnum",
+                                "d_yearmonth", "d_daynuminweek", "d_daynuminmonth", "d_daynuminyear",
+                                "d_monthnuminyear", "d_weeknuminyear", "d_sellingseason", "d_lastdayinweekfl",
+                                "d_lastdayinmonthfl", "d_holidayfl", "d_weekdayfl"});
+        s.customer = make_scan(
+            res, {"c_custkey", "c_name", "c_address", "c_city", "c_nation", "c_region", "c_phone", "c_mktsegment"});
+        s.supplier = make_scan(res, {"s_suppkey", "s_name", "s_address", "s_city", "s_nation", "s_region", "s_phone"});
+        s.part = make_scan(res,
+                           {"p_partkey", "p_name", "p_mfgr", "p_category", "p_brand1", "p_color", "p_type", "p_size",
+                            "p_container"});
+        s.lineorder = make_scan(res,
+                                {"lo_orderkey", "lo_linenumber", "lo_custkey", "lo_partkey", "lo_suppkey",
+                                 "lo_orderdate", "lo_orderpriority", "lo_shippriority", "lo_quantity",
+                                 "lo_extendedprice", "lo_ordtotalprice", "lo_discount", "lo_revenue", "lo_supplycost",
+                                 "lo_tax", "lo_commitdate", "lo_shipmode"});
+        return s;
+    }
+
+    // The four fact<->dim equis, in FROM (WHERE) order.
+    void append_star_equis(std::pmr::memory_resource* res, const expressions::compare_expression_ptr& where) {
+        where->append_child(eq_keys(res, "lo_orderdate", "d_datekey")); // lineorder <-> dim_date
+        where->append_child(eq_keys(res, "lo_custkey", "c_custkey"));   // lineorder <-> customer
+        where->append_child(eq_keys(res, "lo_suppkey", "s_suppkey"));   // lineorder <-> supplier
+        where->append_child(eq_keys(res, "lo_partkey", "p_partkey"));   // lineorder <-> part
+    }
+
+    bool is_join_equi(const expressions::expression_ptr& e) {
+        if (!e || e->group() != expression_group::compare) {
+            return false;
+        }
+        auto* c = static_cast<compare_expression_t*>(e.get());
+        if (c->type() != compare_type::eq) {
+            return false;
+        }
+        return is_key(c->left()) && is_key(c->right());
+    }
+
+    size_t count_cross(const node_ptr& node) {
+        if (!node) {
+            return 0;
+        }
+        size_t n = 0;
+        if (node->type() == node_type::join_t &&
+            static_cast<node_join_t*>(node.get())->type() == join_type::cross) {
+            ++n;
+        }
+        for (const auto& c : node->children()) {
+            n += count_cross(c);
+        }
+        return n;
+    }
+
+    node_ptr find_child_by_type(const node_aggregate_t* agg, node_type type) {
+        for (size_t i = 1; i < agg->children().size(); ++i) {
+            if (agg->children()[i]->type() == type) {
+                return agg->children()[i];
+            }
+        }
+        return nullptr;
+    }
+
+    // Merged column index of the left operand of a single conjunct (assumes it is a
+    // key). Used to inspect residual single-table filters.
+    size_t left_key_path0(const expressions::expression_ptr& e) {
+        auto* c = static_cast<compare_expression_t*>(e.get());
+        return as_key(c->left()).path()[0];
+    }
+
+} // namespace
+
+// ----------------------------------------------------------------------------
+// Primary case — SSB q4-1: fact-LAST 5-table star with GROUP BY + ORDER BY.
+//
+// Expected AFTER the star reorder + canonical promotion + hash lowering:
+//  * a fact-first left-deep tree, `lineorder` at the bottom-left leaf;
+//  * all four joins inner + hash with (left_col/right_col), bottom-up:
+//        lineorder x dim_date : 5/0   (lo_orderdate=5, d_datekey local 0)
+//        ... x customer       : 2/0   (lo_custkey=2,  c_custkey  local 0)
+//        ... x supplier       : 4/0   (lo_suppkey=4,  s_suppkey  local 0)
+//        ... x part           : 3/0   (lo_partkey=3,  p_partkey  local 0)
+//  * NO residual join-equi (all four claimed onto the joins);
+//  * MERGED loci remapped by P: group keys d_year 4->21, c_nation 21->38;
+//    aggregate args lo_revenue 53->12, lo_supplycost 54->13; residual filters
+//    c_region 22->39, s_region 30->47, p_mfgr 34->51;
+//  * GROUP-OUTPUT loci (sort/select keys) UNCHANGED (they index the small group
+//    output schema 0,1,2 — never the merged join schema).
+//
+// RED until the star pre-normalizer lands: today's rule promotes only the top
+// (fact-bearing) boundary, leaving three CROSS joins and the three fact-dim equis
+// unclaimed in the residual match.
+// ----------------------------------------------------------------------------
+TEST_CASE("optimizer::promote_star::fact_last_star_reordered_fact_first") {
+    std::pmr::monotonic_buffer_resource arena;
+    auto* res = &arena;
+    auto params = make_parameter_node(res);
+    auto p_creg = params->add_parameter(int64_t(1));
+    auto p_sreg = params->add_parameter(int64_t(1));
+    auto p_mfgr1 = params->add_parameter(int64_t(1));
+    auto p_mfgr2 = params->add_parameter(int64_t(2));
+
+    auto s = make_ssb_leaves(res);
+    auto source = cross_chain(res, s.from_order());
+
+    // WHERE: 4 fact-dim equis + c_region=? + s_region=? + (p_mfgr=? OR p_mfgr=?)
+    auto where = make_compare_union_expression(res, compare_type::union_and);
+    append_star_equis(res, where);
+    where->append_child(eq_key_param(res, "c_region", p_creg));
+    where->append_child(eq_key_param(res, "s_region", p_sreg));
+    auto p_or = make_compare_union_expression(res, compare_type::union_or);
+    p_or->append_child(eq_key_param(res, "p_mfgr", p_mfgr1));
+    p_or->append_child(eq_key_param(res, "p_mfgr", p_mfgr2));
+    where->append_child(p_or);
+    auto match = make_node_match(res, core::dbname_t{}, core::relname_t{}, where);
+
+    // GROUP BY d_year, c_nation ; SUM(lo_revenue - lo_supplycost) AS profit
+    std::vector<expression_ptr> group_exprs;
+    group_exprs.emplace_back(make_scalar_expression(res, scalar_type::group_field, bare_key(res, "d_year")));
+    group_exprs.emplace_back(make_scalar_expression(res, scalar_type::group_field, bare_key(res, "c_nation")));
+    auto sum_profit = make_aggregate_expression(res, "sum", bare_key(res, "profit"));
+    auto profit_arith = make_scalar_expression(res, scalar_type::subtract);
+    profit_arith->append_param(bare_key(res, "lo_revenue"));
+    profit_arith->append_param(bare_key(res, "lo_supplycost"));
+    sum_profit->append_param(std::move(profit_arith));
+    group_exprs.emplace_back(expression_ptr(sum_profit));
+    auto group = make_node_group(res, core::dbname_t{}, core::relname_t{}, group_exprs);
+
+    // ORDER BY d_year, c_nation  (resolved against the GROUP OUTPUT schema)
+    std::vector<expression_ptr> sort_exprs;
+    sort_exprs.emplace_back(make_sort_expression(bare_key(res, "d_year"), sort_order::asc));
+    sort_exprs.emplace_back(make_sort_expression(bare_key(res, "c_nation"), sort_order::asc));
+    auto sort = make_node_sort(res, core::dbname_t{}, core::relname_t{}, sort_exprs);
+
+    // SELECT d_year, c_nation, profit  (resolved against the GROUP OUTPUT schema)
+    auto select = make_node_select(res, core::dbname_t{}, core::relname_t{});
+    select->append_expression(make_scalar_expression(res, scalar_type::get_field, bare_key(res, "d_year")));
+    select->append_expression(make_scalar_expression(res, scalar_type::get_field, bare_key(res, "c_nation")));
+    select->append_expression(make_scalar_expression(res, scalar_type::get_field, bare_key(res, "profit")));
+
+    auto agg = make_node_aggregate(res, core::dbname_t{}, core::relname_t{});
+    agg->append_child(source);
+    agg->append_child(match);
+    agg->append_child(group);
+    agg->append_child(sort);
+    agg->append_child(select);
+
+    auto validated = services::dispatcher::validate_schema(res, nullptr, agg.get(), params->parameters());
+    REQUIRE_FALSE(validated.has_error());
+
+    // --- Sanity: the validator resolved every locus against the MERGED FROM-order
+    // schema exactly as the offsets above predict (this pins the layout the P remap
+    // is derived from). ---
+    auto* g_dyear = static_cast<scalar_expression_t*>(group->expressions()[0].get());
+    auto* g_cnat = static_cast<scalar_expression_t*>(group->expressions()[1].get());
+    auto* g_sum = static_cast<aggregate_expression_t*>(group->expressions()[2].get());
+    REQUIRE(g_dyear->key().path()[0] == 4);  // d_year   (dim_date @0 + 4)
+    REQUIRE(g_cnat->key().path()[0] == 21);  // c_nation (customer @17 + 4)
+    REQUIRE(g_sum->params().size() == 1);
+    REQUIRE(is_expr(g_sum->params()[0]));
+    auto* g_sub = static_cast<scalar_expression_t*>(as_expr(g_sum->params()[0]).get());
+    REQUIRE(g_sub->params().size() == 2);
+    REQUIRE(as_key(g_sub->params()[0]).path()[0] == 53); // lo_revenue
+    REQUIRE(as_key(g_sub->params()[1]).path()[0] == 54); // lo_supplycost
+
+    // GROUP-OUTPUT loci: sort + select carry small group-output indices (0,1,2),
+    // NOT merged indices. Capture them to prove the reorder leaves them untouched.
+    auto* srt_dyear = static_cast<sort_expression_t*>(sort->expressions()[0].get());
+    auto* srt_cnat = static_cast<sort_expression_t*>(sort->expressions()[1].get());
+    const size_t sort_dyear_before = srt_dyear->key().path()[0];
+    const size_t sort_cnat_before = srt_cnat->key().path()[0];
+    std::vector<size_t> select_before;
+    for (auto& e : select->expressions()) {
+        select_before.push_back(static_cast<scalar_expression_t*>(e.get())->key().path()[0]);
+    }
+    // Group output schema is [d_year(0), c_nation(1), profit(2)]; the sort keys
+    // index THAT, not the merged join schema (merged d_year/c_nation would be 4/21).
+    REQUIRE(sort_dyear_before == 0);
+    REQUIRE(sort_cnat_before == 1);
+
+    // The rule under test, then the hash selection that runs after it.
+    node_ptr out = planner::optimizer::promote_cross_joins(res, agg);
+    out = planner::optimizer::rewrite_hash_joins(res, out);
+    REQUIRE(out.get() == agg.get());
+    auto* agg_after = static_cast<node_aggregate_t*>(out.get());
+
+    // --- Fact-first left-deep tree ---------------------------------------------
+    // agg child0 = outermost join (x part), descend to the bottom-left lineorder leaf.
+    REQUIRE(agg_after->children()[0]->type() == node_type::join_t);
+    auto* j_part = static_cast<node_join_t*>(agg_after->children()[0].get());
+    CHECK(j_part->type() == join_type::inner);
+    CHECK(j_part->algo() == node_join_t::join_algo::hash);
+    CHECK(j_part->left_col() == 3);
+    CHECK(j_part->right_col() == 0);
+    REQUIRE(j_part->children().size() == 2);
+    CHECK(j_part->children()[1].get() == s.part.get());
+
+    auto* j_supp = static_cast<node_join_t*>(j_part->children()[0].get());
+    REQUIRE(j_supp->type() == join_type::inner);
+    CHECK(j_supp->algo() == node_join_t::join_algo::hash);
+    CHECK(j_supp->left_col() == 4);
+    CHECK(j_supp->right_col() == 0);
+    CHECK(j_supp->children()[1].get() == s.supplier.get());
+
+    auto* j_cust = static_cast<node_join_t*>(j_supp->children()[0].get());
+    REQUIRE(j_cust->type() == join_type::inner);
+    CHECK(j_cust->algo() == node_join_t::join_algo::hash);
+    CHECK(j_cust->left_col() == 2);
+    CHECK(j_cust->right_col() == 0);
+    CHECK(j_cust->children()[1].get() == s.customer.get());
+
+    auto* j_date = static_cast<node_join_t*>(j_cust->children()[0].get());
+    REQUIRE(j_date->type() == join_type::inner);
+    CHECK(j_date->algo() == node_join_t::join_algo::hash);
+    CHECK(j_date->left_col() == 5);
+    CHECK(j_date->right_col() == 0);
+    CHECK(j_date->children()[0].get() == s.lineorder.get()); // fact bottom-left
+    CHECK(j_date->children()[1].get() == s.dim_date.get());
+
+    // --- Residual match: no join-equi left; single-table filters P-remapped ------
+    auto match_after = find_child_by_type(agg_after, node_type::match_t);
+    REQUIRE(match_after);
+    REQUIRE(match_after->expressions().size() == 1);
+    auto* residual = static_cast<compare_expression_t*>(match_after->expressions()[0].get());
+    REQUIRE(residual->type() == compare_type::union_and);
+    REQUIRE(residual->children().size() == 3); // c_region, s_region, (p_mfgr OR)
+    for (const auto& conj : residual->children()) {
+        CHECK_FALSE(is_join_equi(conj)); // every fact-dim equi was claimed onto a join
+    }
+    CHECK(left_key_path0(residual->children()[0]) == 39); // c_region 22 -> 39
+    CHECK(left_key_path0(residual->children()[1]) == 47); // s_region 30 -> 47
+    auto* or_after = static_cast<compare_expression_t*>(residual->children()[2].get());
+    REQUIRE(or_after->type() == compare_type::union_or);
+    CHECK(left_key_path0(or_after->children()[0]) == 51); // p_mfgr 34 -> 51
+    CHECK(left_key_path0(or_after->children()[1]) == 51);
+
+    // --- MERGED group/aggregate loci remapped by P ------------------------------
+    // Re-fetch from the optimized tree (robust to whether Phase-B mutates in place
+    // or rebuilds the sibling nodes).
+    auto group_after = find_child_by_type(agg_after, node_type::group_t);
+    REQUIRE(group_after);
+    auto* g_dyear_a = static_cast<scalar_expression_t*>(group_after->expressions()[0].get());
+    auto* g_cnat_a = static_cast<scalar_expression_t*>(group_after->expressions()[1].get());
+    auto* g_sum_a = static_cast<aggregate_expression_t*>(group_after->expressions()[2].get());
+    auto* g_sub_a = static_cast<scalar_expression_t*>(as_expr(g_sum_a->params()[0]).get());
+    CHECK(g_dyear_a->key().path()[0] == 21);            // d_year        4  -> 21
+    CHECK(g_cnat_a->key().path()[0] == 38);             // c_nation      21 -> 38
+    CHECK(as_key(g_sub_a->params()[0]).path()[0] == 12); // lo_revenue    53 -> 12
+    CHECK(as_key(g_sub_a->params()[1]).path()[0] == 13); // lo_supplycost 54 -> 13
+
+    // --- GROUP-OUTPUT loci UNCHANGED --------------------------------------------
+    auto sort_after = find_child_by_type(agg_after, node_type::sort_t);
+    auto select_after = find_child_by_type(agg_after, node_type::select_t);
+    REQUIRE(sort_after);
+    REQUIRE(select_after);
+    CHECK(static_cast<sort_expression_t*>(sort_after->expressions()[0].get())->key().path()[0] == sort_dyear_before);
+    CHECK(static_cast<sort_expression_t*>(sort_after->expressions()[1].get())->key().path()[0] == sort_cnat_before);
+    for (size_t i = 0; i < select_after->expressions().size(); ++i) {
+        CHECK(static_cast<scalar_expression_t*>(select_after->expressions()[i].get())->key().path()[0] ==
+              select_before[i]);
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Chain-negative — the 3-table chain from test_promote_multiway must be left
+// exactly as the canonical path handles it. The star pre-normalizer's load-bearing
+// short-circuit (rule 17): when EVERY boundary already claims an equi, the input is
+// a chain / fact-threaded shape (here the middle `b` is incident to both edges and
+// would be MIS-SELECTED as the "fact" and reordered), so it returns source
+// unchanged and the canonical path promotes it exactly as today.
+//
+// Observable proof of "not reordered": leaves stay in FROM order (a,b,c) and the
+// two joins claim their ORIGINAL boundaries (a_k=b_k -> 1/0, b_v=c_k -> 3/0). A
+// mistaken star reorder would permute the leaves and change these columns.
+// Green before AND after the fix.
+// ----------------------------------------------------------------------------
+TEST_CASE("optimizer::promote_star::three_table_chain_not_reordered") {
+    std::pmr::monotonic_buffer_resource arena;
+    auto* res = &arena;
+
+    // a(a_id, a_k) | b(b_k, b_v) | c(c_k, c_v)  => merged a_id=0 a_k=1 b_k=2 b_v=3 c_k=4 c_v=5
+    auto a = make_scan(res, {"a_id", "a_k"});
+    auto b = make_scan(res, {"b_k", "b_v"});
+    auto c = make_scan(res, {"c_k", "c_v"});
+    auto source = cross_chain(res, {a, b, c});
+
+    auto where = make_compare_union_expression(res, compare_type::union_and);
+    where->append_child(eq_keys(res, "a_k", "b_k"));  // straddles the inner join
+    where->append_child(eq_keys(res, "b_v", "c_k"));  // straddles the outer join
+    where->append_child(cmp_keys(res, compare_type::ne, "a_id", "b_v"));
+    auto match = make_node_match(res, core::dbname_t{}, core::relname_t{}, where);
+
+    auto agg = make_node_aggregate(res, core::dbname_t{}, core::relname_t{});
+    agg->append_child(source);
+    agg->append_child(match);
+
+    logical_plan::storage_parameters sp{res};
+    auto validated = services::dispatcher::validate_schema(res, nullptr, agg.get(), sp);
+    REQUIRE_FALSE(validated.has_error());
+
+    node_ptr out = planner::optimizer::promote_cross_joins(res, agg);
+    out = planner::optimizer::rewrite_hash_joins(res, out);
+    auto* agg_after = static_cast<node_aggregate_t*>(out.get());
+
+    // Outer join claims b_v=c_k, keeps `c` on the right (NOT reordered).
+    auto* oj = static_cast<node_join_t*>(agg_after->children()[0].get());
+    CHECK(oj->type() == join_type::inner);
+    CHECK(oj->algo() == node_join_t::join_algo::hash);
+    CHECK(oj->left_col() == 3);
+    CHECK(oj->right_col() == 0);
+    CHECK(oj->children()[1].get() == c.get());
+
+    // Inner join claims a_k=b_k, leaves a,b in FROM order.
+    auto* ij = static_cast<node_join_t*>(oj->children()[0].get());
+    CHECK(ij->type() == join_type::inner);
+    CHECK(ij->algo() == node_join_t::join_algo::hash);
+    CHECK(ij->left_col() == 1);
+    CHECK(ij->right_col() == 0);
+    CHECK(ij->children()[0].get() == a.get());
+    CHECK(ij->children()[1].get() == b.get());
+
+    CHECK(count_cross(agg_after->children()[0]) == 0);
+}
+
+// ----------------------------------------------------------------------------
+// No-group computed ORDER BY — a fact-LAST star WITHOUT a group. Its sort/select
+// index the MERGED join schema, so the reorder must P-remap them. The computed
+// ORDER BY is a scalar_expression whose OWN key carries the sort direction in
+// path()[0] (0=asc, 1=desc) and whose operands are the merged column keys.
+//
+// Expect after reorder: the sort operands are remapped (lo_revenue 53->12,
+// lo_supplycost 54->13), the direction (desc) is preserved on the OWN key, and the
+// no-group SELECT get_field is remapped too (lo_orderkey 41->0).
+// RED until the star reorder lands (today the fact-last star is not reordered, so
+// the operands stay at 53/54).
+// ----------------------------------------------------------------------------
+TEST_CASE("optimizer::promote_star::no_group_computed_order_by_remapped") {
+    std::pmr::monotonic_buffer_resource arena;
+    auto* res = &arena;
+    logical_plan::storage_parameters sp{res};
+
+    auto s = make_ssb_leaves(res);
+    auto source = cross_chain(res, s.from_order());
+
+    auto where = make_compare_union_expression(res, compare_type::union_and);
+    append_star_equis(res, where);
+    auto match = make_node_match(res, core::dbname_t{}, core::relname_t{}, where);
+
+    // ORDER BY (lo_revenue - lo_supplycost) DESC — encoded exactly as the SQL
+    // transformer does: a subtract scalar, direction in the OWN key's path()[0].
+    components::expressions::key_t order_key(res);
+    order_key.set_path({size_t(1)}); // 1 == descending
+    auto computed_sort = make_scalar_expression(res, scalar_type::subtract, order_key);
+    computed_sort->append_param(bare_key(res, "lo_revenue"));
+    computed_sort->append_param(bare_key(res, "lo_supplycost"));
+    std::vector<expression_ptr> sort_exprs;
+    sort_exprs.emplace_back(expression_ptr(computed_sort));
+    auto sort = make_node_sort(res, core::dbname_t{}, core::relname_t{}, sort_exprs);
+
+    // A minimal projection so the (no-group) aggregate has a SELECT list.
+    auto select = make_node_select(res, core::dbname_t{}, core::relname_t{});
+    select->append_expression(make_scalar_expression(res, scalar_type::get_field, bare_key(res, "lo_orderkey")));
+
+    auto agg = make_node_aggregate(res, core::dbname_t{}, core::relname_t{});
+    agg->append_child(source);
+    agg->append_child(match);
+    agg->append_child(sort);
+    agg->append_child(select);
+
+    auto validated = services::dispatcher::validate_schema(res, nullptr, agg.get(), sp);
+    REQUIRE_FALSE(validated.has_error());
+    // Pre-reorder merged coordinates.
+    REQUIRE(as_key(computed_sort->params()[0]).path()[0] == 53);
+    REQUIRE(as_key(computed_sort->params()[1]).path()[0] == 54);
+    REQUIRE(computed_sort->key().path()[0] == 1);
+    auto* sel0 = static_cast<scalar_expression_t*>(select->expressions()[0].get());
+    REQUIRE(sel0->key().path()[0] == 41); // lo_orderkey merged
+
+    node_ptr out = planner::optimizer::promote_cross_joins(res, agg);
+    out = planner::optimizer::rewrite_hash_joins(res, out);
+
+    // Sort operands P-remapped; ASC/DESC preserved on the own key.
+    CHECK(as_key(computed_sort->params()[0]).path()[0] == 12); // lo_revenue    53 -> 12
+    CHECK(as_key(computed_sort->params()[1]).path()[0] == 13); // lo_supplycost 54 -> 13
+    CHECK(computed_sort->key().path()[0] == 1);                // DESC preserved
+    CHECK(sel0->key().path()[0] == 0);                         // lo_orderkey   41 -> 0
+    CHECK(count_cross(out->children()[0]) == 0);               // fully promoted fact-first
+}
+
+// ----------------------------------------------------------------------------
+// No-group SELECT CASE — a fact-LAST star WITHOUT a group, projecting a real SQL
+// CASE. The CASE lowers to a case_expr scalar whose params are [condition, result,
+// ..., default]; the condition is a compare_expression whose column keys index the
+// MERGED schema. The walker must recurse INTO the case_expr and its nested compare
+// and P-remap the condition key (the OWN case key is an alias/sentinel — untouched).
+//
+// Expect after reorder: the CASE condition key lo_revenue is remapped 53->12.
+// RED until the star reorder lands.
+// ----------------------------------------------------------------------------
+TEST_CASE("optimizer::promote_star::no_group_select_case_condition_remapped") {
+    std::pmr::monotonic_buffer_resource arena;
+    auto* res = &arena;
+    auto params = make_parameter_node(res);
+    auto p_hi = params->add_parameter(int64_t(1000));
+    auto p_then = params->add_parameter(int64_t(1));
+    auto p_else = params->add_parameter(int64_t(0));
+
+    auto s = make_ssb_leaves(res);
+    auto source = cross_chain(res, s.from_order());
+
+    auto where = make_compare_union_expression(res, compare_type::union_and);
+    append_star_equis(res, where);
+    auto match = make_node_match(res, core::dbname_t{}, core::relname_t{}, where);
+
+    // SELECT CASE WHEN lo_revenue > ? THEN ? ELSE ? END AS flag
+    auto cond = cmp_key_param(res, compare_type::gt, "lo_revenue", p_hi);
+    auto case_expr = make_scalar_expression(res, scalar_type::case_expr, bare_key(res, "flag"));
+    case_expr->append_param(expression_ptr(cond)); // condition
+    case_expr->append_param(p_then);               // result
+    case_expr->append_param(p_else);               // default (ELSE)
+    auto select = make_node_select(res, core::dbname_t{}, core::relname_t{});
+    select->append_expression(expression_ptr(case_expr));
+
+    auto agg = make_node_aggregate(res, core::dbname_t{}, core::relname_t{});
+    agg->append_child(source);
+    agg->append_child(match);
+    agg->append_child(select);
+
+    auto validated = services::dispatcher::validate_schema(res, nullptr, agg.get(), params->parameters());
+    REQUIRE_FALSE(validated.has_error());
+    // The condition key resolved against the merged schema.
+    auto* cond_after_validate = static_cast<compare_expression_t*>(as_expr(case_expr->params()[0]).get());
+    REQUIRE(as_key(cond_after_validate->left()).path()[0] == 53); // lo_revenue merged
+
+    node_ptr out = planner::optimizer::promote_cross_joins(res, agg);
+    out = planner::optimizer::rewrite_hash_joins(res, out);
+
+    auto* cond_after = static_cast<compare_expression_t*>(as_expr(case_expr->params()[0]).get());
+    CHECK(as_key(cond_after->left()).path()[0] == 12); // lo_revenue 53 -> 12 (condition remapped)
+    CHECK(count_cross(out->children()[0]) == 0);
+}
+
+// ----------------------------------------------------------------------------
+// SELECT * bail — a fact-LAST star with NO explicit projection (SELECT *) leaks the
+// merged column order upward, which the reorder would silently permute. The star
+// pre-normalizer must bail (leave the tree pristine) so the canonical path runs its
+// per-boundary promotion: fact-last => only the top (fact-bearing) boundary claims,
+// three CROSS joins remain. Assert the canonical PARTIAL promotion (CROSS joins
+// survive) — i.e. the star full-reorder did NOT run.
+//
+// A green guard (bail behavior is unchanged by the fix).
+// ----------------------------------------------------------------------------
+TEST_CASE("optimizer::promote_star::select_star_bails_to_canonical") {
+    std::pmr::monotonic_buffer_resource arena;
+    auto* res = &arena;
+    logical_plan::storage_parameters sp{res};
+
+    auto s = make_ssb_leaves(res);
+    auto source = cross_chain(res, s.from_order());
+
+    auto where = make_compare_union_expression(res, compare_type::union_and);
+    append_star_equis(res, where);
+    auto match = make_node_match(res, core::dbname_t{}, core::relname_t{}, where);
+
+    // No node_select / no node_group at all => pure SELECT * (merged order leaks).
+    auto agg = make_node_aggregate(res, core::dbname_t{}, core::relname_t{});
+    agg->append_child(source);
+    agg->append_child(match);
+
+    auto validated = services::dispatcher::validate_schema(res, nullptr, agg.get(), sp);
+    REQUIRE_FALSE(validated.has_error());
+
+    node_ptr out = planner::optimizer::promote_cross_joins(res, agg);
+    out = planner::optimizer::rewrite_hash_joins(res, out);
+
+    // Canonical partial promotion: at least one CROSS join survives (the dimension
+    // boundaries the fact-last shape cannot claim). A full star reorder would leave
+    // zero CROSS joins, so this pins "bailed, did not reorder".
+    CHECK(count_cross(out->children()[0]) >= 1);
+    // The fact stays where the FROM order put it (bottom-left is dim_date, not
+    // lineorder) — the tree was not fact-fronted.
+    auto* top = static_cast<node_join_t*>(out->children()[0].get());
+    CHECK(top->children()[1].get() == s.lineorder.get()); // lineorder still the last (right) leaf
+}
+
+// ----------------------------------------------------------------------------
+// Fact-last snowflake — a dim-dim edge makes this NOT a clean single-fact star, so
+// the pre-normalizer bails and the canonical per-boundary promotion runs (a partial
+// promotion, not a full reorder).
+//
+// FROM d1, d2, d3, fact with edges fact<->d1, fact<->d3, and a snowflake d2<->d3
+// (d2 has NO fact edge). Fact LAST lowers to (((d1 x d2) x d3) x fact):
+//   (d1 x d2)          : no straddling equi          -> stays CROSS
+//   (.. x d3)          : d2<->d3 straddles           -> inner
+//   (.. x fact)        : fact<->d1 (or fact<->d3)    -> inner
+// => exactly one surviving CROSS. Green guard.
+// ----------------------------------------------------------------------------
+TEST_CASE("optimizer::promote_star::snowflake_bails_to_partial_promotion") {
+    std::pmr::monotonic_buffer_resource arena;
+    auto* res = &arena;
+    logical_plan::storage_parameters sp{res};
+
+    // d1(d1_k, d1_v) | d2(d2_k, d2_r) | d3(d3_k, d3_r) | fact(f_d1, f_d3, f_v)
+    // merged: d1_k=0 d1_v=1 | d2_k=2 d2_r=3 | d3_k=4 d3_r=5 | f_d1=6 f_d3=7 f_v=8
+    auto d1 = make_scan(res, {"d1_k", "d1_v"});
+    auto d2 = make_scan(res, {"d2_k", "d2_r"});
+    auto d3 = make_scan(res, {"d3_k", "d3_r"});
+    auto fact = make_scan(res, {"f_d1", "f_d3", "f_v"});
+    auto source = cross_chain(res, {d1, d2, d3, fact});
+
+    auto where = make_compare_union_expression(res, compare_type::union_and);
+    where->append_child(eq_keys(res, "f_d1", "d1_k")); // fact <-> d1
+    where->append_child(eq_keys(res, "f_d3", "d3_k")); // fact <-> d3
+    where->append_child(eq_keys(res, "d2_r", "d3_r")); // d2 <-> d3 (snowflake edge)
+    auto match = make_node_match(res, core::dbname_t{}, core::relname_t{}, where);
+
+    auto agg = make_node_aggregate(res, core::dbname_t{}, core::relname_t{});
+    agg->append_child(source);
+    agg->append_child(match);
+
+    auto validated = services::dispatcher::validate_schema(res, nullptr, agg.get(), sp);
+    REQUIRE_FALSE(validated.has_error());
+
+    node_ptr out = planner::optimizer::promote_cross_joins(res, agg);
+    out = planner::optimizer::rewrite_hash_joins(res, out);
+
+    // Partial promotion: at least one CROSS remains, and the leaves were NOT
+    // fact-fronted (fact stays the outermost right leaf).
+    CHECK(count_cross(out->children()[0]) >= 1);
+    auto* top = static_cast<node_join_t*>(out->children()[0].get());
+    CHECK(top->children()[1].get() == fact.get());
+}
+
+// ----------------------------------------------------------------------------
+// Bail-then-pristine — a star with a composite fact<->dim key (two equis for the
+// SAME (fact,dim) pair) is not a clean single-key star; the detector must track
+// multiplicity and bail, leaving the tree pristine for the canonical partial
+// promotion. Whatever the precise bail trigger (detection multiplicity here, or a
+// Phase-A verify failure on some other shape), the OBSERVABLE contract is identical:
+// the star full-reorder does NOT run, and the canonical path promotes what it can.
+//
+// FROM d1, d2, fact ; fact<->d1 via TWO equis (f_a=d1_a AND f_b=d1_b), fact<->d2 via
+// one. Fact LAST ((d1 x d2) x fact): (d1 x d2) stays CROSS (no straddle); the top
+// boundary claims one equi -> partial. Green guard.
+// ----------------------------------------------------------------------------
+TEST_CASE("optimizer::promote_star::composite_key_bails_to_partial_promotion") {
+    std::pmr::monotonic_buffer_resource arena;
+    auto* res = &arena;
+    logical_plan::storage_parameters sp{res};
+
+    // d1(d1_a, d1_b) | d2(d2_k, d2_v) | fact(f_a, f_b, f_d2)
+    auto d1 = make_scan(res, {"d1_a", "d1_b"});
+    auto d2 = make_scan(res, {"d2_k", "d2_v"});
+    auto fact = make_scan(res, {"f_a", "f_b", "f_d2"});
+    auto source = cross_chain(res, {d1, d2, fact});
+
+    auto where = make_compare_union_expression(res, compare_type::union_and);
+    where->append_child(eq_keys(res, "f_a", "d1_a"));  // fact <-> d1  (composite, key 1)
+    where->append_child(eq_keys(res, "f_b", "d1_b"));  // fact <-> d1  (composite, key 2)
+    where->append_child(eq_keys(res, "f_d2", "d2_k")); // fact <-> d2
+    auto match = make_node_match(res, core::dbname_t{}, core::relname_t{}, where);
+
+    auto agg = make_node_aggregate(res, core::dbname_t{}, core::relname_t{});
+    agg->append_child(source);
+    agg->append_child(match);
+
+    auto validated = services::dispatcher::validate_schema(res, nullptr, agg.get(), sp);
+    REQUIRE_FALSE(validated.has_error());
+
+    node_ptr out = planner::optimizer::promote_cross_joins(res, agg);
+    out = planner::optimizer::rewrite_hash_joins(res, out);
+
+    // Not fact-fronted; a CROSS survives (canonical partial promotion).
+    CHECK(count_cross(out->children()[0]) >= 1);
+    auto* top = static_cast<node_join_t*>(out->children()[0].get());
+    CHECK(top->children()[1].get() == fact.get());
+}

--- a/components/planner/test/test_promote_star.cpp
+++ b/components/planner/test/test_promote_star.cpp
@@ -56,7 +56,7 @@ using expressions::sort_order;
 // then the canonical promote_join_subtree lowers each level to an inner hash join
 // with each dim on the (small) build side.
 //
-// SSB column layout (benchmark/ssb/_setup.sql) and merged FROM-order offsets:
+// SSB column layout and merged FROM-order offsets:
 //   dim_date  (17 cols) @ 0    d_datekey=0  ... d_year=4  ...
 //   customer  ( 8 cols) @ 17   c_custkey=17 ... c_nation=21 c_region=22 ...
 //   supplier  ( 7 cols) @ 25   s_suppkey=25 ... s_region=30 ...
@@ -244,9 +244,9 @@ namespace {
 //  * GROUP-OUTPUT loci (sort/select keys) UNCHANGED (they index the small group
 //    output schema 0,1,2 — never the merged join schema).
 //
-// RED until the star pre-normalizer lands: today's rule promotes only the top
-// (fact-bearing) boundary, leaving three CROSS joins and the three fact-dim equis
-// unclaimed in the residual match.
+// Without the star pre-normalizer, the rule promotes only the top (fact-bearing)
+// boundary, leaving three CROSS joins and the three fact-dim equis unclaimed in
+// the residual match.
 // ----------------------------------------------------------------------------
 TEST_CASE("optimizer::promote_star::fact_last_star_reordered_fact_first") {
     std::pmr::monotonic_buffer_resource arena;
@@ -421,7 +421,7 @@ TEST_CASE("optimizer::promote_star::fact_last_star_reordered_fact_first") {
 // ----------------------------------------------------------------------------
 // Chain-negative — the 3-table chain from test_promote_multiway must be left
 // exactly as the canonical path handles it. The star pre-normalizer's load-bearing
-// short-circuit (rule 17): when EVERY boundary already claims an equi, the input is
+// short-circuit: when EVERY boundary already claims an equi, the input is
 // a chain / fact-threaded shape (here the middle `b` is incident to both edges and
 // would be MIS-SELECTED as the "fact" and reordered), so it returns source
 // unchanged and the canonical path promotes it exactly as today.
@@ -429,7 +429,6 @@ TEST_CASE("optimizer::promote_star::fact_last_star_reordered_fact_first") {
 // Observable proof of "not reordered": leaves stay in FROM order (a,b,c) and the
 // two joins claim their ORIGINAL boundaries (a_k=b_k -> 1/0, b_v=c_k -> 3/0). A
 // mistaken star reorder would permute the leaves and change these columns.
-// Green before AND after the fix.
 // ----------------------------------------------------------------------------
 TEST_CASE("optimizer::promote_star::three_table_chain_not_reordered") {
     std::pmr::monotonic_buffer_resource arena;
@@ -488,8 +487,6 @@ TEST_CASE("optimizer::promote_star::three_table_chain_not_reordered") {
 // Expect after reorder: the sort operands are remapped (lo_revenue 53->12,
 // lo_supplycost 54->13), the direction (desc) is preserved on the OWN key, and the
 // no-group SELECT get_field is remapped too (lo_orderkey 41->0).
-// RED until the star reorder lands (today the fact-last star is not reordered, so
-// the operands stay at 53/54).
 // ----------------------------------------------------------------------------
 TEST_CASE("optimizer::promote_star::no_group_computed_order_by_remapped") {
     std::pmr::monotonic_buffer_resource arena;
@@ -552,7 +549,6 @@ TEST_CASE("optimizer::promote_star::no_group_computed_order_by_remapped") {
 // and P-remap the condition key (the OWN case key is an alias/sentinel — untouched).
 //
 // Expect after reorder: the CASE condition key lo_revenue is remapped 53->12.
-// RED until the star reorder lands.
 // ----------------------------------------------------------------------------
 TEST_CASE("optimizer::promote_star::no_group_select_case_condition_remapped") {
     std::pmr::monotonic_buffer_resource arena;
@@ -604,8 +600,6 @@ TEST_CASE("optimizer::promote_star::no_group_select_case_condition_remapped") {
 // per-boundary promotion: fact-last => only the top (fact-bearing) boundary claims,
 // three CROSS joins remain. Assert the canonical PARTIAL promotion (CROSS joins
 // survive) — i.e. the star full-reorder did NOT run.
-//
-// A green guard (bail behavior is unchanged by the fix).
 // ----------------------------------------------------------------------------
 TEST_CASE("optimizer::promote_star::select_star_bails_to_canonical") {
     std::pmr::monotonic_buffer_resource arena;
@@ -650,7 +644,7 @@ TEST_CASE("optimizer::promote_star::select_star_bails_to_canonical") {
 //   (d1 x d2)          : no straddling equi          -> stays CROSS
 //   (.. x d3)          : d2<->d3 straddles           -> inner
 //   (.. x fact)        : fact<->d1 (or fact<->d3)    -> inner
-// => exactly one surviving CROSS. Green guard.
+// => exactly one surviving CROSS.
 // ----------------------------------------------------------------------------
 TEST_CASE("optimizer::promote_star::snowflake_bails_to_partial_promotion") {
     std::pmr::monotonic_buffer_resource arena;
@@ -698,7 +692,7 @@ TEST_CASE("optimizer::promote_star::snowflake_bails_to_partial_promotion") {
 //
 // FROM d1, d2, fact ; fact<->d1 via TWO equis (f_a=d1_a AND f_b=d1_b), fact<->d2 via
 // one. Fact LAST ((d1 x d2) x fact): (d1 x d2) stays CROSS (no straddle); the top
-// boundary claims one equi -> partial. Green guard.
+// boundary claims one equi -> partial.
 // ----------------------------------------------------------------------------
 TEST_CASE("optimizer::promote_star::composite_key_bails_to_partial_promotion") {
     std::pmr::monotonic_buffer_resource arena;

--- a/integration/cpp/test/CMakeLists.txt
+++ b/integration/cpp/test/CMakeLists.txt
@@ -32,6 +32,7 @@ set( ${PROJECT_NAME}_SOURCES
         test_pushdown_filter.cpp
         test_subqueries.cpp
         test_hash_join.cpp
+        test_star_join_e2e.cpp
         test_returning.cpp
         test_parser_extension.cpp
         test_engine_lifecycle.cpp

--- a/integration/cpp/test/test_hash_join.cpp
+++ b/integration/cpp/test/test_hash_join.cpp
@@ -58,6 +58,25 @@ namespace {
         return k;
     }
 
+    // Two-column (key,val) chunk with caller-chosen column names + row count. The
+    // distinct column names let a create_plan-level test identify which source
+    // table backs each physical join child (build vs probe) after a build-side swap.
+    vector::data_chunk_t build_named_chunk(std::pmr::memory_resource* res,
+                                           const char* key_name,
+                                           const char* val_name,
+                                           uint64_t rows) {
+        std::pmr::vector<types::complex_logical_type> types(res);
+        types.emplace_back(types::logical_type::BIGINT, key_name);
+        types.emplace_back(types::logical_type::BIGINT, val_name);
+        vector::data_chunk_t chunk(res, types, rows == 0 ? 1 : rows);
+        chunk.set_cardinality(rows);
+        for (uint64_t i = 0; i < rows; ++i) {
+            chunk.set_value(0, i, static_cast<int64_t>(i + 1));
+            chunk.set_value(1, i, static_cast<int64_t>((i + 1) * 10));
+        }
+        return chunk;
+    }
+
 } // namespace
 
 TEST_CASE("integration::cpp::hash_join::substitution") {
@@ -222,5 +241,334 @@ TEST_CASE("integration::cpp::hash_join::correctness") {
         REQUIRE(run("INSERT INTO " + db + ".sr (s, rv) VALUES ('a', 10), ('c', 30);")->is_success());
         // 'a' → 2 left × 1 right = 2 matched rows; 'b','c' unmatched.
         CHECK(run("SELECT * FROM " + db + ".sl INNER JOIN " + db + ".sr ON sl.s = sr.s;")->size() == 2);
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Stage 2 guard — the batched join_builder gathers matched rows one output chunk
+// at a time with ONE indexed copy per (build-chunk, column), REORDERING rows so
+// that each such copy targets a contiguous range from a single build chunk. That
+// reorder makes output row order unspecified, so every value assert here is under
+// ORDER BY. A build side wider than DEFAULT_VECTOR_CAPACITY (2500 rows → 3 build
+// chunks) forces one output flush to span several build chunks, and > 1024 matches
+// force several output chunks — the exact paths a mis-built gather index would
+// scramble. The LEFT join additionally mixes > 1024 left-only NULL-pad rows with
+// matched rows inside a single builder.
+// ----------------------------------------------------------------------------
+TEST_CASE("integration::cpp::hash_join::multi_build_chunk_values") {
+    auto config = test_create_config("/tmp/test_hash_join/mbchunk");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto dispatcher = space.dispatcher();
+    auto session = otterbrix::session_id_t();
+
+    const std::string mdb = "mbchunkdb";
+    dispatcher->execute_sql(session, "CREATE DATABASE " + mdb + ";");
+    REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE " + mdb + ".mbl();")->is_success());
+    REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE " + mdb + ".mbr();")->is_success());
+
+    const int n = 2500;   // > 2 * DEFAULT_VECTOR_CAPACITY → 3 chunks per side
+    const int shift = 1250; // build keys start here → half the probe keys are left-only
+    {
+        std::stringstream l, r;
+        l << "INSERT INTO " << mdb << ".mbl (k, lv) VALUES ";
+        r << "INSERT INTO " << mdb << ".mbr (k, rv) VALUES ";
+        for (int i = 0; i < n; ++i) {
+            l << "(" << i << ", " << static_cast<int64_t>(i) * 100 << ")" << (i == n - 1 ? ";" : ", ");
+            r << "(" << (i + shift) << ", " << static_cast<int64_t>(i + shift) * 7 << ")" << (i == n - 1 ? ";" : ", ");
+        }
+        REQUIRE(dispatcher->execute_sql(session, l.str())->is_success());
+        REQUIRE(dispatcher->execute_sql(session, r.str())->is_success());
+    }
+    // Left keys [0, n); right keys [shift, n + shift). Overlap = [shift, n) = n-shift
+    // unique keys → n-shift matched rows (> 1024). SELECT * column order is logical
+    // [left, right] = [mbl.k, mbl.lv, mbr.k, mbr.rv].
+    const int matched = n - shift; // 1250
+
+    INFO("inner: every matched row gathered correctly across build chunks") {
+        auto cur = dispatcher->execute_sql(session,
+                                           "SELECT * FROM " + mdb + ".mbl INNER JOIN " + mdb +
+                                               ".mbr ON mbl.k = mbr.k ORDER BY mbl.k ASC;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == static_cast<size_t>(matched));
+        for (size_t row = 0; row < static_cast<size_t>(matched); ++row) {
+            const int64_t k = static_cast<int64_t>(row) + shift; // 1250, 1251, ...
+            REQUIRE(cur->value(0, row).value<int64_t>() == k);       // mbl.k
+            REQUIRE(cur->value(1, row).value<int64_t>() == k * 100); // mbl.lv
+            REQUIRE(cur->value(2, row).value<int64_t>() == k);       // mbr.k
+            REQUIRE(cur->value(3, row).value<int64_t>() == k * 7);   // mbr.rv
+        }
+    }
+
+    INFO("left: > 1024 left-only NULL-pad rows mixed with matched, all correct") {
+        auto cur = dispatcher->execute_sql(session,
+                                           "SELECT * FROM " + mdb + ".mbl LEFT JOIN " + mdb +
+                                               ".mbr ON mbl.k = mbr.k ORDER BY mbl.k ASC;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == static_cast<size_t>(n)); // every left row once
+        for (size_t row = 0; row < static_cast<size_t>(n); ++row) {
+            const int64_t k = static_cast<int64_t>(row); // 0, 1, ... (sorted probe key)
+            REQUIRE(cur->value(0, row).value<int64_t>() == k);       // mbl.k
+            REQUIRE(cur->value(1, row).value<int64_t>() == k * 100); // mbl.lv
+            if (k < shift) {
+                // left-only: no build match → NULL right columns.
+                REQUIRE(cur->value(2, row).is_null());
+                REQUIRE(cur->value(3, row).is_null());
+            } else {
+                REQUIRE(cur->value(2, row).value<int64_t>() == k);     // mbr.k
+                REQUIRE(cur->value(3, row).value<int64_t>() == k * 7); // mbr.rv
+            }
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Stage 2b — build-side selection ("smaller side → hash build"), plan-time.
+//
+// operator_hash_join_t materializes its physical RIGHT child as the hash build.
+// create_plan_join moves the SMALLER table onto that build slot IFF the join is
+// INNER, both children are distinct base tables whose live row counts are known
+// (fetched into context.row_counts by execute_plan_full), and the current build
+// (logical-right) is the LARGER side. The swap re-orders the physical children,
+// so the ORIGIN table of the build (right_) child flips — observable here via the
+// build child's distinct key-column name. Outer joins, equal/missing/self-join
+// counts keep the default order. swapped_=true (part 1, Stage 2) restores the
+// logical [left,right] output order so results stay identical (checked E2E below).
+// ----------------------------------------------------------------------------
+TEST_CASE("integration::cpp::hash_join::build_side_selection") {
+    std::pmr::monotonic_buffer_resource arena;
+    auto* res = &arena;
+    compute::function_registry_t registry(res);
+
+    using components::catalog::oid_t;
+    constexpr oid_t left_table_oid = 42;
+    constexpr oid_t right_table_oid = 43;
+
+    // Build an INNER-shaped hash join over two base tables (logical-left key col
+    // "lk", logical-right key col "rk"), stamp per-child table oids + the given row
+    // counts, lower via create_plan, and return the key-column NAME of whichever
+    // physical child became the hash build (right_). "lk" ⇒ the logical-left table
+    // moved into the build slot (swapped); "rk" ⇒ default order (not swapped).
+    auto build_side_key_name = [&](join_type jt,
+                                   uint64_t left_rows,
+                                   uint64_t right_rows,
+                                   bool populate_counts,
+                                   bool same_oid) -> std::string {
+        services::context_storage_t context(res, log_t{}, core::date::timezone_offset_t{});
+        const oid_t l = left_table_oid;
+        const oid_t r = same_oid ? left_table_oid : right_table_oid;
+        context.known_oids.insert(l);
+        context.known_oids.insert(r);
+        if (populate_counts) {
+            context.row_counts[l] = left_rows;
+            context.row_counts[r] = right_rows;
+        }
+
+        auto cond = expressions::make_compare_expression(res,
+                                                         compare_type::eq,
+                                                         expressions::param_storage{make_key(res, "lk", side_t::left, 0)},
+                                                         expressions::param_storage{make_key(res, "rk", side_t::right, 0)});
+        auto join = logical_plan::make_node_join(res, core::dbname_t{}, core::relname_t{}, jt);
+        auto left_child = logical_plan::make_node_raw_data(res, build_named_chunk(res, "lk", "lv", left_rows));
+        auto right_child = logical_plan::make_node_raw_data(res, build_named_chunk(res, "rk", "rv", right_rows));
+        left_child->set_table_oid(l);
+        right_child->set_table_oid(r);
+        join->append_child(left_child);
+        join->append_child(right_child);
+        join->append_expression(cond);
+
+        auto optimized = planner::optimizer::rewrite_hash_joins(res, join);
+        auto plan =
+            services::planner::create_plan(context, registry, optimized, logical_plan::limit_t::unlimit(), nullptr);
+        REQUIRE(plan);
+        REQUIRE(plan->type() == operator_type::hash_join);
+        REQUIRE(plan->right()); // physical build side
+        REQUIRE(plan->right()->output());
+        REQUIRE(!plan->right()->output()->chunks().empty());
+        return plan->right()->output()->chunks().front().types()[0].alias();
+    };
+
+    INFO("INNER, larger table on the RIGHT → smaller (logical-left) side becomes build") {
+        CHECK(build_side_key_name(join_type::inner, 2, 5, true, false) == "lk");
+    }
+    INFO("INNER, larger table on the LEFT → no swap (right is already the smaller build)") {
+        CHECK(build_side_key_name(join_type::inner, 5, 2, true, false) == "rk");
+    }
+    INFO("INNER, equal row counts → no swap") {
+        CHECK(build_side_key_name(join_type::inner, 4, 4, true, false) == "rk");
+    }
+    INFO("INNER, counts missing (in-memory / no disk agent) → no swap") {
+        CHECK(build_side_key_name(join_type::inner, 2, 5, false, false) == "rk");
+    }
+    INFO("INNER self-join (same table oid) → no swap even though counts would favor it") {
+        CHECK(build_side_key_name(join_type::inner, 2, 5, true, true) == "rk");
+    }
+    INFO("OUTER (left) join is never swapped, even with a larger right table") {
+        CHECK(build_side_key_name(join_type::left, 2, 5, true, false) == "rk");
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Stage 2b — build-side selection end-to-end (disk ON). execute_plan_full fetches
+// live row counts for the INNER hash join's child tables, and create_plan_join
+// moves the SMALLER table onto the hash build. This query puts the SMALL table on
+// the LEFT and the LARGE table on the RIGHT, so the default build (right) is the
+// larger side → a correct impl swaps. The swap is correctness-neutral, so a
+// SELECT * per-cell check and a two-sided SUM over the join catch any column-order
+// inversion the swap could introduce.
+// ----------------------------------------------------------------------------
+TEST_CASE("integration::cpp::hash_join::build_side_swap_values") {
+    auto config = test_create_config("/tmp/test_hash_join/buildside");
+    test_clear_directory(config);
+    config.disk.on = true; // row-count fetch is gated on an owning disk agent
+    config.wal.on = false;
+    test_spaces space(config);
+    auto dispatcher = space.dispatcher();
+    auto session = otterbrix::session_id_t();
+
+    const std::string sdb = "buildsidedb";
+    dispatcher->execute_sql(session, "CREATE DATABASE " + sdb + ";");
+    REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE " + sdb + ".small();")->is_success());
+    REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE " + sdb + ".large();")->is_success());
+
+    // small: keys 1..3 (sv = k*100). large: keys 1..30 (lv = k). Overlap = {1,2,3}.
+    REQUIRE(dispatcher
+                ->execute_sql(session,
+                              "INSERT INTO " + sdb + ".small (k, sv) VALUES (1, 100), (2, 200), (3, 300);")
+                ->is_success());
+    {
+        std::stringstream l;
+        l << "INSERT INTO " << sdb << ".large (k, lv) VALUES ";
+        for (int i = 1; i <= 30; ++i) {
+            l << "(" << i << ", " << i << ")" << (i == 30 ? ";" : ", ");
+        }
+        REQUIRE(dispatcher->execute_sql(session, l.str())->is_success());
+    }
+
+    INFO("small on LEFT, large on RIGHT → swap fires; SELECT * columns/values stay correct") {
+        // logical output columns are [small.k, small.sv, large.k, large.lv].
+        auto cur = dispatcher->execute_sql(session,
+                                           "SELECT * FROM " + sdb + ".small INNER JOIN " + sdb +
+                                               ".large ON small.k = large.k ORDER BY small.k ASC;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 3);
+        for (size_t row = 0; row < 3; ++row) {
+            const int64_t k = static_cast<int64_t>(row) + 1; // 1, 2, 3
+            REQUIRE(cur->value(0, row).value<int64_t>() == k);       // small.k
+            REQUIRE(cur->value(1, row).value<int64_t>() == k * 100); // small.sv
+            REQUIRE(cur->value(2, row).value<int64_t>() == k);       // large.k
+            REQUIRE(cur->value(3, row).value<int64_t>() == k);       // large.lv
+        }
+    }
+
+    INFO("SUM over each side after the swap is correct (catches a column inversion)") {
+        auto cur = dispatcher->execute_sql(session,
+                                           "SELECT SUM(s.sv) AS ssv, SUM(l.lv) AS slv FROM " + sdb + ".small s "
+                                           "INNER JOIN " + sdb + ".large l ON s.k = l.k;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        // matched keys {1,2,3}: SUM(small.sv) = 100+200+300 = 600; SUM(large.lv) = 1+2+3 = 6.
+        REQUIRE(cur->value(0, 0).value<int64_t>() == 600);
+        REQUIRE(cur->value(1, 0).value<int64_t>() == 6);
+    }
+
+    // A single-table filter that matches NOTHING on the build (right) side. Stage 3
+    // pushes it below the join, so the build scan yields ZERO chunks (not one empty
+    // chunk). operator_hash_join_t::push must treat an empty build the same as an
+    // absent one — emit nothing — instead of dereferencing build_chunks.front() on
+    // an empty vector. RED before the fix: null data_chunk_t → EXC_BAD_ACCESS in
+    // compute_join_layout under -O2 (Debug fires assert(!build_chunks.empty())).
+    // `small` (3 rows) stays the build side: it is smaller than `large` (30), so
+    // build-side selection does not swap it out. This is the SSB-load crash shrunk
+    // to a deterministic 2-table case.
+    INFO("empty build side (filter matches nothing) → 0 rows, no crash") {
+        auto cur = dispatcher->execute_sql(session,
+                                           "SELECT * FROM " + sdb + ".large INNER JOIN " + sdb +
+                                               ".small ON large.k = small.k WHERE small.sv = 99999;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 0);
+    }
+
+    INFO("empty build side under GROUP BY + ORDER BY (SSB shape) → 0 groups, no crash") {
+        auto cur = dispatcher->execute_sql(session,
+                                           "SELECT small.k, SUM(large.lv) AS s FROM " + sdb + ".large INNER JOIN " +
+                                               sdb + ".small ON large.k = small.k WHERE small.sv = 99999 "
+                                               "GROUP BY small.k ORDER BY small.k;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 0);
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Stage 4 — multi-way (nested) cross-join promotion. An SSB-q2-shaped 3-table
+// comma join `FROM lo, p, s` lowers to a left-deep chain of CROSS joins with the
+// two equi predicates in a sibling match_t (WHERE), both keys stamped side=left.
+// promote_cross_joins must promote BOTH nested cross joins to INNER (each claiming
+// the conjunct that straddles its boundary) so rewrite_hash_joins can lower them to
+// hash joins; the single-table residual filter must keep applying. Column names are
+// distinct so the unqualified WHERE columns resolve unambiguously (the SSB shape).
+//
+// Hash lowering of the promoted joins is asserted at the plan level by
+// components/planner/test/test_promote_multiway.cpp; here we assert end-to-end row
+// correctness of the 3-table comma join (which without promotion runs as a slow
+// cross-product + residual filter — same rows, so this pins the join semantics).
+// ----------------------------------------------------------------------------
+TEST_CASE("integration::cpp::hash_join::multiway_comma_join") {
+    auto config = test_create_config("/tmp/test_hash_join/multiway");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto dispatcher = space.dispatcher();
+    auto session = otterbrix::session_id_t();
+
+    const std::string wdb = "multiwaydb";
+    dispatcher->execute_sql(session, "CREATE DATABASE " + wdb + ";");
+    auto run = [&](const std::string& sql) { return dispatcher->execute_sql(session, sql); };
+
+    REQUIRE(run("CREATE TABLE " + wdb + ".lo();")->is_success()); // lineorder-shaped fact
+    REQUIRE(run("CREATE TABLE " + wdb + ".p();")->is_success());  // part-shaped dim
+    REQUIRE(run("CREATE TABLE " + wdb + ".s();")->is_success());  // supplier-shaped dim
+
+    // lo(l_pk, l_sk, l_rev): part key, supplier key, revenue.
+    REQUIRE(run("INSERT INTO " + wdb +
+                ".lo (l_pk, l_sk, l_rev) VALUES (1, 10, 100), (1, 20, 200), (2, 10, 300), (2, 20, 400), (3, 30, 500);")
+                ->is_success());
+    // p(p_pk, p_cat): every part key present; the l_sk=30 row has NO supplier.
+    REQUIRE(run("INSERT INTO " + wdb + ".p (p_pk, p_cat) VALUES (1, 'A'), (2, 'B'), (3, 'A');")->is_success());
+    // s(s_sk, s_reg): only suppliers 10 and 20 (so l_sk=30 drops in the join).
+    REQUIRE(run("INSERT INTO " + wdb + ".s (s_sk, s_reg) VALUES (10, 'X'), (20, 'Y');")->is_success());
+
+    // SELECT * column order = [lo | p | s] = [l_pk, l_sk, l_rev, p_pk, p_cat, s_sk, s_reg].
+    // Matches: l_pk=p_pk (all lo rows) then l_sk=s_sk drops the l_sk=30 row -> 4 rows.
+    INFO("3-table comma join returns the correctly joined rows") {
+        auto cur =
+            run("SELECT * FROM " + wdb + ".lo, " + wdb + ".p, " + wdb + ".s WHERE l_pk = p_pk AND l_sk = s_sk;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 4);
+        int64_t rev_sum = 0;
+        for (size_t row = 0; row < cur->size(); ++row) {
+            // Both equi predicates must actually hold on every emitted row.
+            REQUIRE(cur->value(0, row).value<int64_t>() == cur->value(3, row).value<int64_t>()); // l_pk == p_pk
+            REQUIRE(cur->value(1, row).value<int64_t>() == cur->value(5, row).value<int64_t>()); // l_sk == s_sk
+            rev_sum += cur->value(2, row).value<int64_t>();                                      // l_rev
+        }
+        CHECK(rev_sum == 1000); // 100 + 200 + 300 + 400 (the l_sk=30 / rev=500 row is unmatched)
+    }
+
+    // A single-table residual filter (p_cat = 'A') must still apply after promotion:
+    // it keeps only the two rev-100/rev-200 rows (both p_pk=1, cat 'A').
+    INFO("residual single-table filter still applies through multi-way promotion") {
+        auto cur = run("SELECT * FROM " + wdb + ".lo, " + wdb + ".p, " + wdb +
+                       ".s WHERE l_pk = p_pk AND l_sk = s_sk AND p_cat = 'A';");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 2);
+        int64_t rev_sum = 0;
+        for (size_t row = 0; row < cur->size(); ++row) {
+            rev_sum += cur->value(2, row).value<int64_t>();
+        }
+        CHECK(rev_sum == 300); // 100 + 200
     }
 }

--- a/integration/cpp/test/test_hash_join.cpp
+++ b/integration/cpp/test/test_hash_join.cpp
@@ -245,7 +245,7 @@ TEST_CASE("integration::cpp::hash_join::correctness") {
 }
 
 // ----------------------------------------------------------------------------
-// Stage 2 guard — the batched join_builder gathers matched rows one output chunk
+// The batched join_builder gathers matched rows one output chunk
 // at a time with ONE indexed copy per (build-chunk, column), REORDERING rows so
 // that each such copy targets a contiguous range from a single build chunk. That
 // reorder makes output row order unspecified, so every value assert here is under
@@ -325,7 +325,7 @@ TEST_CASE("integration::cpp::hash_join::multi_build_chunk_values") {
 }
 
 // ----------------------------------------------------------------------------
-// Stage 2b — build-side selection ("smaller side → hash build"), plan-time.
+// Build-side selection ("smaller side → hash build"), plan-time.
 //
 // operator_hash_join_t materializes its physical RIGHT child as the hash build.
 // create_plan_join moves the SMALLER table onto that build slot IFF the join is
@@ -334,7 +334,7 @@ TEST_CASE("integration::cpp::hash_join::multi_build_chunk_values") {
 // (logical-right) is the LARGER side. The swap re-orders the physical children,
 // so the ORIGIN table of the build (right_) child flips — observable here via the
 // build child's distinct key-column name. Outer joins, equal/missing/self-join
-// counts keep the default order. swapped_=true (part 1, Stage 2) restores the
+// counts keep the default order. swapped_=true restores the
 // logical [left,right] output order so results stay identical (checked E2E below).
 // ----------------------------------------------------------------------------
 TEST_CASE("integration::cpp::hash_join::build_side_selection") {
@@ -411,7 +411,7 @@ TEST_CASE("integration::cpp::hash_join::build_side_selection") {
 }
 
 // ----------------------------------------------------------------------------
-// Stage 2b — build-side selection end-to-end (disk ON). execute_plan_full fetches
+// Build-side selection end-to-end (disk ON). execute_plan_full fetches
 // live row counts for the INNER hash join's child tables, and create_plan_join
 // moves the SMALLER table onto the hash build. This query puts the SMALL table on
 // the LEFT and the LARGE table on the RIGHT, so the default build (right) is the
@@ -474,11 +474,11 @@ TEST_CASE("integration::cpp::hash_join::build_side_swap_values") {
         REQUIRE(cur->value(1, 0).value<int64_t>() == 6);
     }
 
-    // A single-table filter that matches NOTHING on the build (right) side. Stage 3
+    // A single-table filter that matches NOTHING on the build (right) side. Pushdown
     // pushes it below the join, so the build scan yields ZERO chunks (not one empty
     // chunk). operator_hash_join_t::push must treat an empty build the same as an
     // absent one — emit nothing — instead of dereferencing build_chunks.front() on
-    // an empty vector. RED before the fix: null data_chunk_t → EXC_BAD_ACCESS in
+    // an empty vector. Before the fix: null data_chunk_t → EXC_BAD_ACCESS in
     // compute_join_layout under -O2 (Debug fires assert(!build_chunks.empty())).
     // `small` (3 rows) stays the build side: it is smaller than `large` (30), so
     // build-side selection does not swap it out. This is the SSB-load crash shrunk
@@ -502,7 +502,7 @@ TEST_CASE("integration::cpp::hash_join::build_side_swap_values") {
 }
 
 // ----------------------------------------------------------------------------
-// Stage 4 — multi-way (nested) cross-join promotion. An SSB-q2-shaped 3-table
+// Multi-way (nested) cross-join promotion. An SSB-q2-shaped 3-table
 // comma join `FROM lo, p, s` lowers to a left-deep chain of CROSS joins with the
 // two equi predicates in a sibling match_t (WHERE), both keys stamped side=left.
 // promote_cross_joins must promote BOTH nested cross joins to INNER (each claiming

--- a/integration/cpp/test/test_lateral_subquery.cpp
+++ b/integration/cpp/test/test_lateral_subquery.cpp
@@ -78,6 +78,77 @@ TEST_CASE("integration::cpp::lateral_subquery::correlated_where") {
     REQUIRE(collect(*cur, id_i, n_i, v_i) == expected);
 }
 
+// Regression (red-first) for the batched-join_builder use-after-free / row-mixup under
+// LATERAL. The lazy builder buffered a raw pointer to each outer row's per-iteration
+// inner result (destroyed each iteration) and a SINGLE left_chunk_ pointer overwritten
+// across outer chunks; with > DEFAULT_VECTOR_CAPACITY (1024) outer rows the correlated
+// inner is re-run per row, so the post-loop flush() gathered from freed inner chunks
+// (heap-use-after-free under ASan) and, when a flush window spanned two outer chunks,
+// paired left rows with the wrong outer chunk. The eager LATERAL builder copies each row
+// at emit time, fixing both. This asserts the full, correct 1:1 output at scale.
+TEST_CASE("integration::cpp::lateral_subquery::correlated_where_multichunk") {
+    constexpr int64_t N = 1100; // > 1024 so the outer input spans >= 2 chunks
+    auto config = test_create_config("/tmp/test_lateral_subquery_multichunk");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    auto session = otterbrix::session_id_t();
+    dispatcher->execute_sql(session, "CREATE DATABASE s;");
+    dispatcher->execute_sql(session, "CREATE TABLE s.outer_big (id BIGINT);");
+    dispatcher->execute_sql(session, "CREATE TABLE s.inr (k BIGINT, v BIGINT);");
+    // Each outer id 0..N-1 matches exactly one inner row (v = id + 100000). Insert in
+    // batches to keep individual INSERT statements small.
+    auto insert_batched = [&](const std::string& head, auto tuple_for) {
+        std::string sql;
+        int in_batch = 0;
+        for (int64_t i = 0; i < N; ++i) {
+            if (in_batch == 0) {
+                sql = head;
+            }
+            sql += tuple_for(i);
+            if (++in_batch == 200 || i == N - 1) {
+                sql += ";";
+                dispatcher->execute_sql(session, sql);
+                in_batch = 0;
+            } else {
+                sql += ",";
+            }
+        }
+    };
+    insert_batched("INSERT INTO s.outer_big (id) VALUES ",
+                   [](int64_t i) { return "(" + std::to_string(i) + ")"; });
+    insert_batched("INSERT INTO s.inr (k, v) VALUES ",
+                   [](int64_t i) { return "(" + std::to_string(i) + "," + std::to_string(i + 100000) + ")"; });
+
+    auto cur = dispatcher->execute_sql(
+        session,
+        "SELECT * FROM s.outer_big, LATERAL (SELECT inr.v FROM s.inr WHERE inr.k = outer_big.id) sub;");
+    INFO("error: " << (cur->is_error() ? cur->get_error().what.c_str() : "none"));
+    REQUIRE(cur->is_success());
+    REQUIRE(cur->size() == static_cast<uint64_t>(N));
+    int id_i = find_column(*cur, "id");
+    int v_i = find_column(*cur, "v");
+    REQUIRE(id_i >= 0);
+    REQUIRE(v_i >= 0);
+    // Every outer id must appear exactly once, paired with its own inner v (id + 100000).
+    // A left/right chunk mixup would break the pairing; a UAF would abort under ASan.
+    std::set<int64_t> seen_ids;
+    for (uint64_t r = 0; r < cur->size(); ++r) {
+        auto id_cell = cur->value(static_cast<uint64_t>(id_i), r);
+        auto v_cell = cur->value(static_cast<uint64_t>(v_i), r);
+        REQUIRE_FALSE(id_cell.is_null());
+        REQUIRE_FALSE(v_cell.is_null());
+        const int64_t id = id_cell.value<int64_t>();
+        const int64_t v = v_cell.value<int64_t>();
+        REQUIRE(v == id + 100000);
+        seen_ids.insert(id);
+    }
+    REQUIRE(seen_ids.size() == static_cast<size_t>(N));
+}
+
 TEST_CASE("integration::cpp::lateral_subquery::left_join_empty") {
     auto config = test_create_config("/tmp/test_lateral_subquery_left");
     test_clear_directory(config);

--- a/integration/cpp/test/test_lateral_subquery.cpp
+++ b/integration/cpp/test/test_lateral_subquery.cpp
@@ -78,7 +78,7 @@ TEST_CASE("integration::cpp::lateral_subquery::correlated_where") {
     REQUIRE(collect(*cur, id_i, n_i, v_i) == expected);
 }
 
-// Regression (red-first) for the batched-join_builder use-after-free / row-mixup under
+// Regression for the batched-join_builder use-after-free / row-mixup under
 // LATERAL. The lazy builder buffered a raw pointer to each outer row's per-iteration
 // inner result (destroyed each iteration) and a SINGLE left_chunk_ pointer overwritten
 // across outer chunks; with > DEFAULT_VECTOR_CAPACITY (1024) outer rows the correlated

--- a/integration/cpp/test/test_pushdown_filter.cpp
+++ b/integration/cpp/test/test_pushdown_filter.cpp
@@ -35,7 +35,32 @@ static node_data_ptr make_data(std::pmr::memory_resource* r, std::initializer_li
     }
     // optimizer only looks at the schema, so one row is enough
     auto chunk = gen_data_chunk(/*size=*/1, /*start=*/0, types, r);
-    return make_node_raw_data(r, std::move(chunk));
+    auto node = make_node_raw_data(r, std::move(chunk));
+    // Stage 3: collect_subtree_columns() now reads a node's output_types() (the
+    // node_data_t column-name branch was removed). Stamp them here so a scan used
+    // under a join exposes its columns to pushdown exactly as validate_schema would
+    // — otherwise the columns come back empty and nothing is pushed. Build the list
+    // on `r` (rule 8) and move it in.
+    std::pmr::vector<components::types::complex_logical_type> out_types(r);
+    for (const char* name : col_names) {
+        out_types.emplace_back(components::types::logical_type::BIGINT, name);
+    }
+    node->set_output_types(std::move(out_types));
+    return node;
+}
+
+// disk-shaped scan: an aggregate_t{db,rel} that carries its columns ONLY in
+// output_types() (a real disk scan has no in-memory node_data_t child). Used to
+// prove collect_subtree_columns() reads output_types() rather than a data node.
+static node_aggregate_ptr
+make_disk_scan(std::pmr::memory_resource* r, std::initializer_list<const char*> col_names) {
+    auto agg = make_node_aggregate(r, db, rel);
+    std::pmr::vector<components::types::complex_logical_type> out_types(r);
+    for (const char* name : col_names) {
+        out_types.emplace_back(components::types::logical_type::BIGINT, name);
+    }
+    agg->set_output_types(std::move(out_types));
+    return agg;
 }
 
 // --- Filter through projection ----------------------------------------------
@@ -584,3 +609,121 @@ TEST_CASE("kernel_bug_proof::projection_reports_selected_columns") {
     // BUGGY kernel returns incoming [a, b, c] = 3
     REQUIRE(schema.size() == 2);
 }
+
+// --- Stage 3: pushdown reads output_types(), not a node_data_t --------------
+
+// A disk scan is an aggregate_t{db,rel} whose columns live ONLY in output_types()
+// (no in-memory node_data_t). Stage 3 made collect_subtree_columns() read
+// output_types(), so single-table filters still bucket to the correct join side.
+// RED before Stage 3: the old code looked for a node_data_t under each side, found
+// none, produced empty column sets, and pushed nothing (out == outer).
+TEST_CASE("logical_plan::pushdown_filter_into_join_branch_disk_shaped_scans") {
+    auto resource = std::pmr::synchronized_pool_resource();
+    auto left_scan = make_disk_scan(&resource, {"a", "b"});
+    auto right_scan = make_disk_scan(&resource, {"c", "d"});
+
+    auto join = make_node_join(&resource, db, rel, join_type::inner);
+    join->append_child(left_scan);
+    join->append_child(right_scan);
+
+    auto cmp_a = make_compare_expression(&resource, compare_type::gt, key(&resource, "a", side_t::left), id_par{1});
+    auto cmp_c = make_compare_expression(&resource, compare_type::gt, key(&resource, "c", side_t::left), id_par{2});
+    auto conj = make_compare_union_expression(&resource, compare_type::union_and);
+    conj->append_child(cmp_a);
+    conj->append_child(cmp_c);
+
+    node_aggregate_ptr outer = make_node_aggregate(&resource, db, rel);
+    outer->append_child(join);
+    outer->append_child(make_node_match(&resource, db, rel, conj));
+
+    node_ptr out = components::planner::optimize(&resource, outer, nullptr);
+
+    REQUIRE(out == join);
+    REQUIRE(join->children().size() == 2);
+    REQUIRE(join->children()[0]->type() == node_type::aggregate_t);
+    REQUIRE(join->children()[1]->type() == node_type::aggregate_t);
+
+    // Each single-table filter was pushed below its side, wrapping the disk-shaped
+    // scan (still present, unchanged) in aggregate{scan, match}.
+    auto left_pushed = join->children()[0];
+    REQUIRE(left_pushed->children().size() == 2);
+    REQUIRE(left_pushed->children()[0] == left_scan);
+    REQUIRE(left_pushed->children()[1]->type() == node_type::match_t);
+
+    auto right_pushed = join->children()[1];
+    REQUIRE(right_pushed->children().size() == 2);
+    REQUIRE(right_pushed->children()[0] == right_scan);
+    REQUIRE(right_pushed->children()[1]->type() == node_type::match_t);
+}
+
+// --- Stage 3 part 2: pushdown below a join UNDER GROUP BY + ORDER BY ---------
+
+// The bail-lift: a group_t AND a sort_t above an inner join no longer stop
+// single-table filters from being pushed below the join. group/sort commute with
+// pushing a per-side filter down (they only reorder/aggregate the join's output).
+// Both filters land on their respective join side; the match above the join is
+// fully consumed and dropped; group_t + sort_t stay above the join. This is the
+// structural counterpart of the end-to-end repro (test_batch_execution
+// "join + WHERE ... GROUP BY", test_column_projection "inner JOIN + GROUP BY with
+// WHERE on non-select column") that returned 0 rows before the executor fix.
+// RED before the bail-lift: the old group/sort guard returned the node unchanged,
+// leaving both filters in the match above the join.
+TEST_CASE("logical_plan::pushdown_filter_into_join_branch_under_group_and_sort") {
+    auto resource = std::pmr::synchronized_pool_resource();
+    auto left_scan = make_disk_scan(&resource, {"a", "b"});
+    auto right_scan = make_disk_scan(&resource, {"c", "d"});
+
+    auto join = make_node_join(&resource, db, rel, join_type::inner);
+    join->append_child(left_scan);
+    join->append_child(right_scan);
+
+    auto cmp_a = make_compare_expression(&resource, compare_type::gt, key(&resource, "a", side_t::left), id_par{1});
+    auto cmp_c = make_compare_expression(&resource, compare_type::gt, key(&resource, "c", side_t::left), id_par{2});
+    auto conj = make_compare_union_expression(&resource, compare_type::union_and);
+    conj->append_child(cmp_a);
+    conj->append_child(cmp_c);
+
+    auto group = make_node_group(&resource, db, rel);
+    group->append_expression(make_scalar_expression(&resource, scalar_type::group_field, key(&resource, "a")));
+    auto sum_expr = make_aggregate_expression(&resource, "sum", key(&resource, "sum_b"));
+    sum_expr->append_param(key(&resource, "b"));
+    group->append_expression(std::move(sum_expr));
+
+    std::vector<components::expressions::expression_ptr> sort_exprs;
+    sort_exprs.emplace_back(make_sort_expression(key(&resource, "a"), sort_order::asc));
+    auto sort = make_node_sort(&resource, db, rel, sort_exprs);
+
+    node_aggregate_ptr outer = make_node_aggregate(&resource, db, rel);
+    outer->append_child(join);
+    outer->append_child(make_node_match(&resource, db, rel, conj));
+    outer->append_child(group);
+    outer->append_child(sort);
+
+    node_ptr out = components::planner::optimize(&resource, outer, nullptr);
+
+    // outer keeps group + sort, so it is not elided; the join stays its source.
+    REQUIRE(out == outer);
+    REQUIRE(outer->children()[0] == join);
+    bool has_group = false, has_sort = false, has_match = false;
+    for (size_t i = 1; i < outer->children().size(); ++i) {
+        auto t = outer->children()[i]->type();
+        if (t == node_type::group_t)
+            has_group = true;
+        if (t == node_type::sort_t)
+            has_sort = true;
+        if (t == node_type::match_t)
+            has_match = true;
+    }
+    REQUIRE(has_group);
+    REQUIRE(has_sort);
+    REQUIRE_FALSE(has_match); // both filters consumed -> no residual above the join
+
+    // Each single-table filter was pushed below its side despite group + sort.
+    REQUIRE(join->children()[0]->children().size() == 2);
+    REQUIRE(join->children()[0]->children()[0] == left_scan);
+    REQUIRE(join->children()[0]->children()[1]->type() == node_type::match_t);
+    REQUIRE(join->children()[1]->children().size() == 2);
+    REQUIRE(join->children()[1]->children()[0] == right_scan);
+    REQUIRE(join->children()[1]->children()[1]->type() == node_type::match_t);
+}
+

--- a/integration/cpp/test/test_pushdown_filter.cpp
+++ b/integration/cpp/test/test_pushdown_filter.cpp
@@ -36,11 +36,11 @@ static node_data_ptr make_data(std::pmr::memory_resource* r, std::initializer_li
     // optimizer only looks at the schema, so one row is enough
     auto chunk = gen_data_chunk(/*size=*/1, /*start=*/0, types, r);
     auto node = make_node_raw_data(r, std::move(chunk));
-    // Stage 3: collect_subtree_columns() now reads a node's output_types() (the
+    // collect_subtree_columns() now reads a node's output_types() (the
     // node_data_t column-name branch was removed). Stamp them here so a scan used
     // under a join exposes its columns to pushdown exactly as validate_schema would
     // — otherwise the columns come back empty and nothing is pushed. Build the list
-    // on `r` (rule 8) and move it in.
+    // on `r` and move it in.
     std::pmr::vector<components::types::complex_logical_type> out_types(r);
     for (const char* name : col_names) {
         out_types.emplace_back(components::types::logical_type::BIGINT, name);
@@ -610,12 +610,12 @@ TEST_CASE("kernel_bug_proof::projection_reports_selected_columns") {
     REQUIRE(schema.size() == 2);
 }
 
-// --- Stage 3: pushdown reads output_types(), not a node_data_t --------------
+// --- pushdown reads output_types(), not a node_data_t --------------
 
 // A disk scan is an aggregate_t{db,rel} whose columns live ONLY in output_types()
-// (no in-memory node_data_t). Stage 3 made collect_subtree_columns() read
+// (no in-memory node_data_t). collect_subtree_columns() reads
 // output_types(), so single-table filters still bucket to the correct join side.
-// RED before Stage 3: the old code looked for a node_data_t under each side, found
+// Before the fix: the old code looked for a node_data_t under each side, found
 // none, produced empty column sets, and pushed nothing (out == outer).
 TEST_CASE("logical_plan::pushdown_filter_into_join_branch_disk_shaped_scans") {
     auto resource = core::pmr::otterbrix_resource();
@@ -656,7 +656,7 @@ TEST_CASE("logical_plan::pushdown_filter_into_join_branch_disk_shaped_scans") {
     REQUIRE(right_pushed->children()[1]->type() == node_type::match_t);
 }
 
-// --- Stage 3 part 2: pushdown below a join UNDER GROUP BY + ORDER BY ---------
+// --- pushdown below a join UNDER GROUP BY + ORDER BY ---------
 
 // The bail-lift: a group_t AND a sort_t above an inner join no longer stop
 // single-table filters from being pushed below the join. group/sort commute with
@@ -666,7 +666,7 @@ TEST_CASE("logical_plan::pushdown_filter_into_join_branch_disk_shaped_scans") {
 // structural counterpart of the end-to-end repro (test_batch_execution
 // "join + WHERE ... GROUP BY", test_column_projection "inner JOIN + GROUP BY with
 // WHERE on non-select column") that returned 0 rows before the executor fix.
-// RED before the bail-lift: the old group/sort guard returned the node unchanged,
+// Before the bail-lift: the old group/sort guard returned the node unchanged,
 // leaving both filters in the match above the join.
 TEST_CASE("logical_plan::pushdown_filter_into_join_branch_under_group_and_sort") {
     auto resource = core::pmr::otterbrix_resource();

--- a/integration/cpp/test/test_pushdown_filter.cpp
+++ b/integration/cpp/test/test_pushdown_filter.cpp
@@ -618,7 +618,7 @@ TEST_CASE("kernel_bug_proof::projection_reports_selected_columns") {
 // RED before Stage 3: the old code looked for a node_data_t under each side, found
 // none, produced empty column sets, and pushed nothing (out == outer).
 TEST_CASE("logical_plan::pushdown_filter_into_join_branch_disk_shaped_scans") {
-    auto resource = std::pmr::synchronized_pool_resource();
+    auto resource = core::pmr::otterbrix_resource();
     auto left_scan = make_disk_scan(&resource, {"a", "b"});
     auto right_scan = make_disk_scan(&resource, {"c", "d"});
 
@@ -669,7 +669,7 @@ TEST_CASE("logical_plan::pushdown_filter_into_join_branch_disk_shaped_scans") {
 // RED before the bail-lift: the old group/sort guard returned the node unchanged,
 // leaving both filters in the match above the join.
 TEST_CASE("logical_plan::pushdown_filter_into_join_branch_under_group_and_sort") {
-    auto resource = std::pmr::synchronized_pool_resource();
+    auto resource = core::pmr::otterbrix_resource();
     auto left_scan = make_disk_scan(&resource, {"a", "b"});
     auto right_scan = make_disk_scan(&resource, {"c", "d"});
 

--- a/integration/cpp/test/test_star_join_e2e.cpp
+++ b/integration/cpp/test/test_star_join_e2e.cpp
@@ -139,7 +139,7 @@ TEST_CASE("integration::cpp::star_join_e2e::rows_correct") {
 // Fact-first target order fct(6) @0, dd(2) @6, cust(3) @8, supp(2) @11, prt(2) @13,
 // so the four joins come out (left_col/right_col) bottom-up 0/0, 1/0, 2/0, 3/0.
 //
-// RED until the star reorder lands: today the fact-last star promotes only the top
+// Without the star reorder, the fact-last star promotes only the top
 // boundary, leaving three CROSS joins and three unclaimed fact-dim equis in the
 // residual match.
 // ----------------------------------------------------------------------------

--- a/integration/cpp/test/test_star_join_e2e.cpp
+++ b/integration/cpp/test/test_star_join_e2e.cpp
@@ -1,0 +1,328 @@
+#include "test_config.hpp"
+#include <catch2/catch.hpp>
+
+#include <components/expressions/aggregate_expression.hpp>
+#include <components/expressions/compare_expression.hpp>
+#include <components/expressions/forward.hpp>
+#include <components/expressions/key.hpp>
+#include <components/expressions/scalar_expression.hpp>
+#include <components/expressions/sort_expression.hpp>
+#include <components/logical_plan/node_aggregate.hpp>
+#include <components/logical_plan/node_data.hpp>
+#include <components/logical_plan/node_group.hpp>
+#include <components/logical_plan/node_join.hpp>
+#include <components/logical_plan/node_match.hpp>
+#include <components/logical_plan/node_select.hpp>
+#include <components/logical_plan/node_sort.hpp>
+#include <components/logical_plan/param_storage.hpp>
+#include <components/planner/optimizer/rules/hash_join.hpp>
+#include <components/planner/optimizer/rules/promote_cross_join.hpp>
+#include <components/types/types.hpp>
+#include <components/vector/data_chunk.hpp>
+#include <services/dispatcher/validate_logical_plan.hpp>
+
+#include <initializer_list>
+#include <memory_resource>
+#include <string>
+#include <vector>
+
+using namespace components;
+using namespace components::logical_plan;
+using namespace components::expressions;
+using expressions::compare_type;
+using expressions::scalar_type;
+using expressions::sort_order;
+
+// ============================================================================
+// Star-schema join reordering (SSB q4 fix) — end-to-end.
+//
+// A SMALL SSB-q4-shaped 5-table star: one fact table + four dimensions, joined by
+// comma-join, with single-table filters (including an OR group like q4's p_mfgr),
+// a GROUP BY, a two-column SUM arithmetic (SUM(f_rev - f_cost), like q4's
+// SUM(lo_revenue - lo_supplycost)) and an ORDER BY. Fact is LAST in the FROM list
+// (the shape that pushes the star reorder).
+//
+// This is the ONLY test that runs the reorder + aggregate-arg remap under REAL
+// EXECUTION on `aggregate_t` table-scan leaves:
+//   Part A asserts the result rows are correct (a wrong aggregate-arg or a wrong
+//     column remap changes the SUM values or the group keys — caught here).
+//   Part B builds the identical star as a hand plan (node_data leaves), drives the
+//     real validator + promote_cross_joins + rewrite_hash_joins, and inspects the
+//     optimized plan: N inner hash joins, no `$type: cross`, no residual join-equi.
+// ============================================================================
+
+static const std::string db = "starjoindb";
+
+TEST_CASE("integration::cpp::star_join_e2e::rows_correct") {
+    auto config = test_create_config("/tmp/test_star_join_e2e/rows");
+    test_clear_directory(config);
+    config.disk.on = true;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto dispatcher = space.dispatcher();
+    auto session = otterbrix::session_id_t();
+
+    dispatcher->execute_sql(session, "CREATE DATABASE " + db + ";");
+    auto run = [&](const std::string& sql) { return dispatcher->execute_sql(session, sql); };
+    auto create = [&](const std::string& t) {
+        REQUIRE(run("CREATE TABLE " + db + "." + t + "();")->is_success());
+    };
+
+    // dim_date, customer, supplier, part, fact — fact LAST (the q4 FROM order).
+    create("dd");   // (d_key, d_year)
+    create("cust"); // (c_key, c_nation, c_region)
+    create("supp"); // (s_key, s_region)
+    create("prt");  // (p_key, p_mfgr)
+    create("fct");  // (f_dk, f_ck, f_sk, f_pk, f_rev, f_cost)
+
+    REQUIRE(run("INSERT INTO " + db + ".dd (d_key, d_year) VALUES (1, 1997), (2, 1998);")->is_success());
+    REQUIRE(run("INSERT INTO " + db +
+                ".cust (c_key, c_nation, c_region) VALUES "
+                "(10, 'BRAZIL', 'AMERICA'), (11, 'CANADA', 'AMERICA'), (12, 'FRANCE', 'EUROPE');")
+                ->is_success());
+    REQUIRE(run("INSERT INTO " + db + ".supp (s_key, s_region) VALUES (20, 'AMERICA'), (21, 'EUROPE');")
+                ->is_success());
+    REQUIRE(run("INSERT INTO " + db +
+                ".prt (p_key, p_mfgr) VALUES (30, 'MFGR#1'), (31, 'MFGR#2'), (32, 'MFGR#3');")
+                ->is_success());
+    // fact rows: (date, cust, supp, part, revenue, cost)
+    //   surviving all filters (c_region/s_region = AMERICA, p_mfgr in {1,2}):
+    //     (1,10,20,30,100,40)  -> profit 60,  (1997, BRAZIL)
+    //     (1,10,20,31,200,90)  -> profit 110, (1997, BRAZIL)   [same group]
+    //     (2,11,20,30,300,100) -> profit 200, (1998, CANADA)
+    //     (2,11,20,31,500,150) -> profit 350, (1998, CANADA)   [same group]
+    //   filtered/dropped:
+    //     (1,12,20,30,999,1)   -> c_region EUROPE  (filtered)
+    //     (1,10,21,30,999,1)   -> s_region EUROPE  (filtered)
+    //     (1,10,20,32,999,1)   -> p_mfgr MFGR#3    (filtered by the OR group)
+    //     (1,99,20,30,999,1)   -> no customer key  (dropped by the inner join)
+    REQUIRE(run("INSERT INTO " + db +
+                ".fct (f_dk, f_ck, f_sk, f_pk, f_rev, f_cost) VALUES "
+                "(1, 10, 20, 30, 100, 40), (1, 10, 20, 31, 200, 90), "
+                "(2, 11, 20, 30, 300, 100), (2, 11, 20, 31, 500, 150), "
+                "(1, 12, 20, 30, 999, 1), (1, 10, 21, 30, 999, 1), "
+                "(1, 10, 20, 32, 999, 1), (1, 99, 20, 30, 999, 1);")
+                ->is_success());
+
+    // SSB-q4-shaped star. Fact LAST; unqualified WHERE columns (distinct names).
+    const std::string sql = "SELECT d_year, c_nation, SUM(f_rev - f_cost) AS profit "
+                            "FROM " +
+                            db + ".dd, " + db + ".cust, " + db + ".supp, " + db + ".prt, " + db + ".fct "
+                            "WHERE f_dk = d_key AND f_ck = c_key AND f_sk = s_key AND f_pk = p_key "
+                            "AND c_region = 'AMERICA' AND s_region = 'AMERICA' "
+                            "AND (p_mfgr = 'MFGR#1' OR p_mfgr = 'MFGR#2') "
+                            "GROUP BY d_year, c_nation ORDER BY d_year, c_nation;";
+
+    auto cur = run(sql);
+    REQUIRE(cur->is_success());
+    // Two surviving groups, ORDER BY d_year, c_nation ASC:
+    //   (1997, BRAZIL): SUM(profit) = 60 + 110 = 170
+    //   (1998, CANADA): SUM(profit) = 200 + 350 = 550
+    REQUIRE(cur->size() == 2);
+
+    REQUIRE(cur->value(0, 0).value<int64_t>() == 1997);
+    REQUIRE(cur->value(1, 0).value<std::string_view>() == "BRAZIL");
+    REQUIRE(cur->value(2, 0).value<int64_t>() == 170);
+
+    REQUIRE(cur->value(0, 1).value<int64_t>() == 1998);
+    REQUIRE(cur->value(1, 1).value<std::string_view>() == "CANADA");
+    REQUIRE(cur->value(2, 1).value<int64_t>() == 550);
+}
+
+// ----------------------------------------------------------------------------
+// Part B — plan structure. Rebuild the identical star as a hand plan over
+// node_data leaves (mirroring the five tables), drive the real validator, then run
+// promote_cross_joins + rewrite_hash_joins and inspect the optimized plan.
+//
+// Small FROM-order layout (fact LAST):
+//   dd(2) @0  cust(3) @2  supp(2) @5  prt(2) @7  fct(6) @9   (total 15)
+// Fact-first target order fct(6) @0, dd(2) @6, cust(3) @8, supp(2) @11, prt(2) @13,
+// so the four joins come out (left_col/right_col) bottom-up 0/0, 1/0, 2/0, 3/0.
+//
+// RED until the star reorder lands: today the fact-last star promotes only the top
+// boundary, leaving three CROSS joins and three unclaimed fact-dim equis in the
+// residual match.
+// ----------------------------------------------------------------------------
+namespace {
+
+    node_data_ptr make_scan(std::pmr::memory_resource* res, std::initializer_list<const char*> cols) {
+        std::pmr::vector<types::complex_logical_type> types(res);
+        for (const char* name : cols) {
+            types.emplace_back(types::logical_type::BIGINT, name);
+        }
+        vector::data_chunk_t chunk(res, types, 1);
+        chunk.set_cardinality(1);
+        for (size_t i = 0; i < types.size(); ++i) {
+            chunk.set_value(i, 0, static_cast<int64_t>(i + 1));
+        }
+        return make_node_raw_data(res, std::move(chunk));
+    }
+
+    // `key_t` (unqualified) is ambiguous — POSIX also declares a `key_t` (aka int).
+    // Always name the expressions one fully-qualified and never rely on a `using`.
+    components::expressions::key_t bare_key(std::pmr::memory_resource* res, const char* name) {
+        return components::expressions::key_t{res, name};
+    }
+
+    // Operands must be wrapped in param_storage{...} (mirrors test_promote_multiway.cpp).
+    expression_ptr eq_keys(std::pmr::memory_resource* res, const char* l, const char* r) {
+        return make_compare_expression(res,
+                                       compare_type::eq,
+                                       expressions::param_storage{bare_key(res, l)},
+                                       expressions::param_storage{bare_key(res, r)});
+    }
+
+    expression_ptr
+    eq_key_param(std::pmr::memory_resource* res, const char* l, core::parameter_id_t p) {
+        return make_compare_expression(res,
+                                       compare_type::eq,
+                                       expressions::param_storage{bare_key(res, l)},
+                                       expressions::param_storage{p});
+    }
+
+    node_ptr cross_chain(std::pmr::memory_resource* res, const std::vector<node_ptr>& leaves) {
+        node_ptr acc = leaves.front();
+        for (size_t i = 1; i < leaves.size(); ++i) {
+            auto j = make_node_join(res, core::dbname_t{}, core::relname_t{}, join_type::cross);
+            j->append_child(acc);
+            j->append_child(leaves[i]);
+            j->append_expression(make_compare_expression(res, compare_type::all_true));
+            acc = j;
+        }
+        return acc;
+    }
+
+    size_t count_substr(const std::string& hay, const std::string& needle) {
+        size_t n = 0;
+        for (size_t pos = hay.find(needle); pos != std::string::npos; pos = hay.find(needle, pos + needle.size())) {
+            ++n;
+        }
+        return n;
+    }
+
+    // Any residual join-equi (eq(column_key, column_key)) surviving in a match node
+    // anywhere in the optimized tree — the fix must have claimed them all onto joins.
+    bool has_residual_join_equi(const node_ptr& node) {
+        if (!node) {
+            return false;
+        }
+        if (node->type() == node_type::match_t) {
+            std::pmr::vector<expression_ptr> stack{node->resource()};
+            for (const auto& e : node->expressions()) {
+                stack.push_back(e);
+            }
+            while (!stack.empty()) {
+                auto e = stack.back();
+                stack.pop_back();
+                if (!e || e->group() != expression_group::compare) {
+                    continue;
+                }
+                auto* c = static_cast<compare_expression_t*>(e.get());
+                if (c->type() == compare_type::eq && is_key(c->left()) && is_key(c->right())) {
+                    return true;
+                }
+                for (const auto& ch : c->children()) {
+                    stack.push_back(ch);
+                }
+            }
+        }
+        for (const auto& ch : node->children()) {
+            if (has_residual_join_equi(ch)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+} // namespace
+
+TEST_CASE("integration::cpp::star_join_e2e::optimized_plan_all_hash_no_cross") {
+    std::pmr::monotonic_buffer_resource arena;
+    auto* res = &arena;
+    auto params = make_parameter_node(res);
+    auto p_creg = params->add_parameter(int64_t(1));
+    auto p_sreg = params->add_parameter(int64_t(1));
+    auto p_m1 = params->add_parameter(int64_t(1));
+    auto p_m2 = params->add_parameter(int64_t(2));
+
+    auto dd = make_scan(res, {"d_key", "d_year"});
+    auto cust = make_scan(res, {"c_key", "c_nation", "c_region"});
+    auto supp = make_scan(res, {"s_key", "s_region"});
+    auto prt = make_scan(res, {"p_key", "p_mfgr"});
+    auto fct = make_scan(res, {"f_dk", "f_ck", "f_sk", "f_pk", "f_rev", "f_cost"});
+    auto source = cross_chain(res, {dd, cust, supp, prt, fct});
+
+    auto where = make_compare_union_expression(res, compare_type::union_and);
+    where->append_child(eq_keys(res, "f_dk", "d_key"));
+    where->append_child(eq_keys(res, "f_ck", "c_key"));
+    where->append_child(eq_keys(res, "f_sk", "s_key"));
+    where->append_child(eq_keys(res, "f_pk", "p_key"));
+    where->append_child(eq_key_param(res, "c_region", p_creg));
+    where->append_child(eq_key_param(res, "s_region", p_sreg));
+    auto p_or = make_compare_union_expression(res, compare_type::union_or);
+    p_or->append_child(eq_key_param(res, "p_mfgr", p_m1));
+    p_or->append_child(eq_key_param(res, "p_mfgr", p_m2));
+    where->append_child(p_or);
+    auto match = make_node_match(res, core::dbname_t{}, core::relname_t{}, where);
+
+    std::vector<expression_ptr> group_exprs;
+    group_exprs.emplace_back(make_scalar_expression(res, scalar_type::group_field, bare_key(res, "d_year")));
+    group_exprs.emplace_back(make_scalar_expression(res, scalar_type::group_field, bare_key(res, "c_nation")));
+    auto sum_profit = make_aggregate_expression(res, "sum", bare_key(res, "profit"));
+    auto profit_arith = make_scalar_expression(res, scalar_type::subtract);
+    profit_arith->append_param(bare_key(res, "f_rev"));
+    profit_arith->append_param(bare_key(res, "f_cost"));
+    sum_profit->append_param(std::move(profit_arith));
+    group_exprs.emplace_back(expression_ptr(sum_profit));
+    auto group = make_node_group(res, core::dbname_t{}, core::relname_t{}, group_exprs);
+
+    std::vector<expression_ptr> sort_exprs;
+    sort_exprs.emplace_back(make_sort_expression(bare_key(res, "d_year"), sort_order::asc));
+    sort_exprs.emplace_back(make_sort_expression(bare_key(res, "c_nation"), sort_order::asc));
+    auto sort = make_node_sort(res, core::dbname_t{}, core::relname_t{}, sort_exprs);
+
+    // An EXPLICIT projection (present, not SELECT *) so the reorder does not bail.
+    auto select = make_node_select(res, core::dbname_t{}, core::relname_t{});
+    select->append_expression(make_scalar_expression(res, scalar_type::get_field, bare_key(res, "d_year")));
+    select->append_expression(make_scalar_expression(res, scalar_type::get_field, bare_key(res, "c_nation")));
+    select->append_expression(make_scalar_expression(res, scalar_type::get_field, bare_key(res, "profit")));
+
+    auto agg = make_node_aggregate(res, core::dbname_t{}, core::relname_t{});
+    agg->append_child(source);
+    agg->append_child(match);
+    agg->append_child(group);
+    agg->append_child(sort);
+    agg->append_child(select);
+
+    auto validated = services::dispatcher::validate_schema(res, nullptr, agg.get(), params->parameters());
+    REQUIRE_FALSE(validated.has_error());
+
+    node_ptr out = planner::optimizer::promote_cross_joins(res, agg);
+    out = planner::optimizer::rewrite_hash_joins(res, out);
+
+    const std::string plan = out->to_string();
+    INFO(plan);
+    // Four inner hash joins, no cross join survives.
+    CHECK(count_substr(plan, "$algo: hash") == 4);
+    CHECK(plan.find("$type: cross") == std::string::npos);
+    // No fact-dim equi left behind in any residual match — all claimed onto joins.
+    CHECK_FALSE(has_residual_join_equi(out));
+
+    // Fact-first left-deep tree with the expected equi columns (bottom-up 0/0,1/0,2/0,3/0).
+    auto* j_prt = static_cast<node_join_t*>(out->children()[0].get());
+    REQUIRE(j_prt->type() == join_type::inner);
+    CHECK(j_prt->left_col() == 3);
+    CHECK(j_prt->right_col() == 0);
+    CHECK(j_prt->children()[1].get() == prt.get());
+    auto* j_supp = static_cast<node_join_t*>(j_prt->children()[0].get());
+    CHECK(j_supp->left_col() == 2);
+    CHECK(j_supp->right_col() == 0);
+    auto* j_cust = static_cast<node_join_t*>(j_supp->children()[0].get());
+    CHECK(j_cust->left_col() == 1);
+    CHECK(j_cust->right_col() == 0);
+    auto* j_dd = static_cast<node_join_t*>(j_cust->children()[0].get());
+    CHECK(j_dd->left_col() == 0);
+    CHECK(j_dd->right_col() == 0);
+    CHECK(j_dd->children()[0].get() == fct.get()); // fact at the bottom-left
+    CHECK(j_dd->children()[1].get() == dd.get());
+}

--- a/services/collection/context_storage.hpp
+++ b/services/collection/context_storage.hpp
@@ -33,6 +33,13 @@ namespace services {
         // Slot pointers for recursive CTE working sets. Keyed by CTE name.
         // Each entry points into the owning operator_recursive_cte_t's working_set_ field.
         std::pmr::unordered_map<std::pmr::string, components::operators::operator_data_ptr*> cte_working_sets;
+        // Live per-table row counts (physical appended count from
+        // manager_disk_t::storage_total_rows), keyed by resolved table_oid.
+        // execute_plan_full fetches these for the child tables of every INNER
+        // hash join BEFORE lowering; create_plan_join reads them to put the
+        // smaller side on the hash build (Stage 2b build-side selection). Empty
+        // in in-memory mode (no owning disk agent) -> the build-side swap no-ops.
+        std::pmr::unordered_map<components::catalog::oid_t, uint64_t> row_counts;
 
         context_storage_t(std::pmr::memory_resource* resource,
                           log_t log,
@@ -42,7 +49,8 @@ namespace services {
             , session_timezone(session_timezone)
             , indexed_keys(resource)
             , indexed_descriptions(resource)
-            , cte_working_sets(resource) {}
+            , cte_working_sets(resource)
+            , row_counts(resource) {}
 
         bool has_table_oid(components::catalog::oid_t oid) const noexcept {
             return oid != components::catalog::INVALID_OID && known_oids.count(oid) > 0;

--- a/services/collection/context_storage.hpp
+++ b/services/collection/context_storage.hpp
@@ -37,8 +37,8 @@ namespace services {
         // manager_disk_t::storage_total_rows), keyed by resolved table_oid.
         // execute_plan_full fetches these for the child tables of every INNER
         // hash join BEFORE lowering; create_plan_join reads them to put the
-        // smaller side on the hash build (Stage 2b build-side selection). Empty
-        // in in-memory mode (no owning disk agent) -> the build-side swap no-ops.
+        // smaller side on the hash build. Empty in in-memory mode (no owning
+        // disk agent) -> the build-side swap no-ops.
         std::pmr::unordered_map<components::catalog::oid_t, uint64_t> row_counts;
 
         context_storage_t(std::pmr::memory_resource* resource,

--- a/services/collection/executor.cpp
+++ b/services/collection/executor.cpp
@@ -113,7 +113,7 @@ namespace services::collection::executor {
     } // namespace
 
     namespace {
-        // Stage 2b build-side selection: collect the resolved child table oids of
+        // Build-side selection: collect the resolved child table oids of
         // every INNER hash join in the optimized plan tree. execute_plan_full
         // fetches each oid's live row count so create_plan_join can put the
         // smaller table on the hash build side. Recurses the whole tree because
@@ -1412,7 +1412,7 @@ namespace services::collection::executor {
                                                                plan.parameters.get(),
                                                                can_push_to_agent);
 
-        // (O2) Stage 2b build-side selection — fetch live row counts for the child
+        // Build-side selection: fetch live row counts for the child
         // tables of every INNER hash join so create_plan_join can put the smaller
         // side on the hash build. Gated on an owning agent existing (reuse
         // can_push_to_agent); in-memory mode leaves row_counts empty and the swap

--- a/services/collection/executor.cpp
+++ b/services/collection/executor.cpp
@@ -584,10 +584,9 @@ namespace services::collection::executor {
         // is not visible to promise_type::operator new). The throw-away
         // context_storage keeps the caller's own context_storage untouched.
         auto run_resolve_subplan = [this, session, resolve_txn, &session_ctx, &context_storage](
-                                       executor_t* self,
+                                       [[maybe_unused]] executor_t* self,
                                        std::pmr::vector<components::logical_plan::node_ptr> resolve_nodes)
             -> executor_t::unique_future<execute_result_t> {
-            (void) self;
             auto root = boost::intrusive_ptr<components::logical_plan::node_t>(
                 new components::logical_plan::node_sequence_t(resource()));
             for (auto& n : resolve_nodes) {
@@ -1177,9 +1176,8 @@ namespace services::collection::executor {
             // via self->resource() — the [this] capture is not visible to the
             // coroutine frame allocator, and without `self` extract_resource_or_abort
             // fires.
-            auto allocate_oids_inline = [this, session, &context_storage](executor_t* self, std::size_t count)
+            auto allocate_oids_inline = [this, session, &context_storage]([[maybe_unused]] executor_t* self, std::size_t count)
                 -> executor_t::unique_future<std::vector<components::catalog::oid_t>> {
-                (void) self;
                 auto node = components::logical_plan::make_node_allocate_oids(resource(), count);
                 components::compute::function_registry_t local_fn_registry{resource()};
                 services::context_storage_t cstor{resource(), log_.clone(), context_storage.session_timezone};
@@ -1450,9 +1448,8 @@ namespace services::collection::executor {
         // finds the PMR resource — the [this] capture is not visible to
         // promise_type::operator new (same pattern as allocate_oids_inline).
         auto revert_failed_txn = [this, session, resolve_txn, &session_ctx](
-                                     executor_t* self,
+                                     [[maybe_unused]] executor_t* self,
                                      execute_result_t& exec_result) -> executor_t::unique_future<void> {
-            (void) self;
             // Storage revert: fold DML append ranges + pg_catalog append ranges
             // into a single storage_revert_appends (each range carries its own
             // table_oid; the handler routes per-range).
@@ -1677,10 +1674,9 @@ namespace services::collection::executor {
             // longer reference a valid index once indisvalid stays false).
             auto undo_create_index =
                 [this, session, resolve_txn, &create_index_pg_index_range, &has_create_index_pg_index_range](
-                    executor_t* self,
+                    [[maybe_unused]] executor_t* self,
                     components::catalog::oid_t table_oid,
                     std::pmr::string index_name) -> executor_t::unique_future<void> {
-                (void) self;
                 if (has_create_index_pg_index_range && disk_address_ != actor_zeta::address_t::empty_address()) {
                     std::vector<components::pg_catalog_append_range_t> revert_ranges;
                     revert_ranges.push_back(create_index_pg_index_range);

--- a/services/collection/executor.cpp
+++ b/services/collection/executor.cpp
@@ -112,6 +112,40 @@ namespace services::collection::executor {
                       "add a case to behavior() AND an entry to kBehaviorHandledIds");
     } // namespace
 
+    namespace {
+        // Stage 2b build-side selection: collect the resolved child table oids of
+        // every INNER hash join in the optimized plan tree. execute_plan_full
+        // fetches each oid's live row count so create_plan_join can put the
+        // smaller table on the hash build side. Recurses the whole tree because
+        // q2-q4 lower to several stacked joins. A child that is not a single base
+        // table (nested join / subquery -> INVALID_OID) is dropped here, so it is
+        // never sent to disk. Duplicate oids collapse in the set.
+        void collect_inner_hash_join_oids(const components::logical_plan::node_ptr& node,
+                                          std::pmr::set<components::catalog::oid_t>& out) {
+            if (!node) {
+                return;
+            }
+            if (node->type() == components::logical_plan::node_type::join_t) {
+                const auto* join = static_cast<const components::logical_plan::node_join_t*>(node.get());
+                if (join->type() == components::logical_plan::join_type::inner &&
+                    join->algo() == components::logical_plan::node_join_t::join_algo::hash &&
+                    !node->children().empty()) {
+                    const auto left_oid = node->children().front()->table_oid();
+                    const auto right_oid = node->children().back()->table_oid();
+                    if (left_oid != components::catalog::INVALID_OID) {
+                        out.insert(left_oid);
+                    }
+                    if (right_oid != components::catalog::INVALID_OID) {
+                        out.insert(right_oid);
+                    }
+                }
+            }
+            for (const auto& child : node->children()) {
+                collect_inner_hash_join_oids(child, out);
+            }
+        }
+    } // namespace
+
     plan_t::plan_t(std::stack<components::operators::operator_ptr>&& sub_plans,
                    const components::logical_plan::storage_parameters* parameters,
                    services::context_storage_t&& context_storage,
@@ -1380,6 +1414,27 @@ namespace services::collection::executor {
                                                                plan.parameters.get(),
                                                                can_push_to_agent);
 
+        // (O2) Stage 2b build-side selection — fetch live row counts for the child
+        // tables of every INNER hash join so create_plan_join can put the smaller
+        // side on the hash build. Gated on an owning agent existing (reuse
+        // can_push_to_agent); in-memory mode leaves row_counts empty and the swap
+        // no-ops. The sequential co_await loop is safe (actor-zeta inter-await
+        // guard; operator_vacuum drains storage_total_rows the same way), and a
+        // wrong/absent count only picks a slower-but-correct plan (the join output
+        // is orientation-restored regardless). INVALID_OID children are dropped by
+        // the walk, so nothing invalid is ever sent.
+        if (can_push_to_agent) {
+            std::pmr::set<components::catalog::oid_t> inner_hash_join_oids{resource()};
+            collect_inner_hash_join_oids(plan.sub_queries.back(), inner_hash_join_oids);
+            for (auto oid : inner_hash_join_oids) {
+                auto [_tr, trf] = actor_zeta::send(disk_address_,
+                                                   &services::disk::manager_disk_t::storage_total_rows,
+                                                   session,
+                                                   oid);
+                context_storage.row_counts[oid] = co_await std::move(trf);
+            }
+        }
+
         trace(log_, "executor::execute_plan_full: delegating to execute_plan, session: {}", session.data());
         // Operator-pipeline run, forwarding resolve_txn so the operator path
         // sees the same MVCC snapshot the resolves did.
@@ -1818,9 +1873,23 @@ namespace services::collection::executor {
         // operator's source_next would read an already-drained cursor (0 rows). So drive
         // source_next only when this pipeline owns its scan source (chain bottom); when
         // the bottom is already executed, stream from that operator's materialized output_.
+        // A materialized sub-plan (a join build/probe side split off by
+        // traverse_plan_) marks only its ROOT operator executed and stashes the rows
+        // in that root's output_; the drained SOURCE beneath it stays un-executed. So
+        // when a side is more than one operator deep — e.g. a single-table filter
+        // pushed below a join lowers to a streaming match/full_scan over its scan
+        // source — the executed operators are NOT a contiguous bottom prefix:
+        // chain[k] (the sub-plan root) is executed while chain[k-1] (its drained
+        // source) is not. Take the materialized boundary as the operator just ABOVE
+        // the TOPMOST executed op: everything at or below it belongs to an already-run
+        // sub-plan (stream from that root's output_), and re-driving the drained
+        // source below it would read an empty cursor. A bottom-scan-owned pipeline
+        // (nothing pre-executed) leaves start == 0.
         std::size_t start = 0;
-        while (start < chain.size() && chain[start]->is_executed()) {
-            ++start;
+        for (std::size_t i = 0; i < chain.size(); ++i) {
+            if (chain[i]->is_executed()) {
+                start = i + 1;
+            }
         }
         // SOURCELESS SINK BOTTOM: a DDL/txn/catalog-read operator (create_collection,
         // set_timezone, begin_transaction, resolve_*, ...) OR a producing recursive_cte


### PR DESCRIPTION
## What

SSB comma-joins (`FROM a, b WHERE a.k = b.k`) ran as nested-loop CROSS products. This makes them hash joins and fixes the join execution path.

## Changes

- **Optimizer** — new `promote_cross_join` rule (CROSS→INNER via path-range key
  classification + re-stamp, registered before `pushdown_filter`); free
  `is_key`/`as_key` accessors on `compare_expression`; `split_conjuncts` /
  `rebuild_conjunction` extracted to `conjunct_utils.hpp`.
- **Join execution** — batched `join_builder` (one indexed `vector_ops::copy`
  per source-chunk/column) replacing per-cell `indexing_vector_t` churn;
  side-aware `swapped_` layout; empty-build-side guard.
- **Build-side selection** — smaller table → hash build via async
  `storage_total_rows` row-count fetch (INNER only).
- **Disk pushdown** — `collect_subtree_columns` reads `output_types` (single
  source); single-table filters pushed below inner joins under GROUP BY/ORDER BY;
  executor streaming pipeline takes the materialized boundary as the topmost
  executed op.
- **Benchmark** — reset `disk/`+`wal/` between SSB runs.

## Results

- Full suite green (1061/1061).

## Follow-up (same branch)

- q4 star-schema join reordering (fact-first pre-normalizer over the canonical
  promotion path) — in progress; q4 today runs 6+ min (dimension cartesian) →
  expected sub-second.
