### PR TITLE
Fix gcc 14 compilation errors in test_table target

### DIFF
--- a/components/session/session.cpp
+++ b/components/session/session.cpp
@@ -13,10 +13,6 @@ namespace components::session {
         return data_ == other.data_ && counter_ == other.counter_;
     }
 
-    bool session_id_t::operator==(const session_id_t& other) {
-        return data_ == other.data_ && counter_ == other.counter_;
-    }
-
     bool session_id_t::operator<(const session_id_t& other) const {
         return data_ < other.data_ || (data_ == other.data_ && counter_ < other.counter_);
     }

--- a/components/session/session.hpp
+++ b/components/session/session.hpp
@@ -11,7 +11,6 @@ namespace components::session {
         session_id_t();
         std::size_t hash() const;
         bool operator==(const session_id_t& other) const;
-        bool operator==(const session_id_t& other);
         bool operator<(const session_id_t& other) const;
         auto data() const -> std::uint64_t;
 

--- a/components/table/test/test_table.cpp
+++ b/components/table/test/test_table.cpp
@@ -387,11 +387,13 @@ TEST_CASE("components::table::data_table") {
         conj_and->child_filters.emplace_back(
             std::make_unique<constant_filter_t>(components::expressions::compare_type::gte,
                                                 logical_value_t{&resource, row_range.first},
-                                                std::pmr::vector<uint64_t>{{uint64_t{0}}, &resource}));
+                                                std::pmr::vector<uint64_t>{{uint64_t{0}},
+                                                                           std::pmr::polymorphic_allocator<uint64_t>{&resource}}));
         conj_and->child_filters.emplace_back(
             std::make_unique<constant_filter_t>(components::expressions::compare_type::lt,
                                                 logical_value_t{&resource, generate_string(row_range.second)},
-                                                std::pmr::vector<uint64_t>{{uint64_t{1}}, &resource}));
+                                                std::pmr::vector<uint64_t>{{uint64_t{1}},
+                                                                           std::pmr::polymorphic_allocator<uint64_t>{&resource}}));
         data_table->initialize_scan(state, column_indices, conj_and.get());
         scan_and_check(*data_table, state, base_layout, row_range.second - row_range.first, [&](size_t produced) {
             return row_range.first + produced;


### PR DESCRIPTION
Two issues broke the build on gcc 14 (CI's gcc 11 accepts both):

- session_id_t declared both const and non-const operator== with identical bodies. Under C++20 reversed-candidate rules the non-const overload makes every session comparison formally ambiguous, which gcc 14 diagnoses (fatal with -Werror). Drop the redundant non-const overload.

- test_table.cpp constructed std::pmr::vector<uint64_t> from a braced list plus a raw memory_resource*, which gcc 14 considers ambiguous against the (InputIterator, InputIterator, alloc) constructor since a raw pointer satisfies the iterator constraint. Pass an explicit polymorphic_allocator instead.