### PR TITLE
Fix four crashes and a silent mis-execution in UPDATE SET and CREATE INDEX

### DIFF
--- a/components/expressions/update_expression.cpp
+++ b/components/expressions/update_expression.cpp
@@ -107,6 +107,18 @@ namespace components::expressions {
         auto* col_vec = to.at(key_.path());
         auto* new_vec = left_->output_vec();
 
+        // A bare NULL literal arrives as an NA-typed constant vector; there is
+        // no NA cast kernel, so write nulls into the target directly. Element
+        // paths (a[1] = NULL) are rejected at transform time, so path size 1
+        // covers every reachable case.
+        if (new_vec->type().type() == types::logical_type::NA) {
+            for (uint64_t row = 0; row < count; ++row) {
+                col_vec->set_null(row, true);
+            }
+            std::fill(modified.begin(), modified.end(), true);
+            return modified;
+        }
+
         // Full-column assignment into an array-like column (e.g. UPDATE v = ARRAY[...]
         // where v is a fixed ARRAY or a variadic LIST). The value is itself an
         // array-like vector whose flat support vector (entry()) holds the actual

--- a/components/sql/transformer/impl/transform_index.cpp
+++ b/components/sql/transformer/impl/transform_index.cpp
@@ -30,7 +30,17 @@ namespace components::sql::transform {
                                                                  core::indexname_t{std::string(node.idxname)},
                                                                  detect_index_type(node.accessMethod));
         for (auto key : node.indexParams->lst) {
-            create_index->keys().emplace_back(resource_, pg_ptr_cast<IndexElem>(key.data)->name);
+            auto* elem = pg_ptr_cast<IndexElem>(key.data);
+            // An expression element — CREATE INDEX ... ((expr)) — has no name
+            // (elem->expr instead); only plain column elements are supported.
+            if (elem->name == nullptr) {
+                error_ = core::error_t(core::error_code_t::sql_parse_error,
+                                       std::pmr::string{"expression indexes are not supported; "
+                                                        "CREATE INDEX accepts plain column names only",
+                                                        resource_});
+                return nullptr;
+            }
+            create_index->keys().emplace_back(resource_, elem->name);
         }
         // Wrap with catalog_resolve so Pass 1 stamps ns_oid + table_oid +
         // columns; enrich_logical_plan reads from the plan-tree idx.

--- a/components/sql/transformer/impl/transform_update.cpp
+++ b/components/sql/transformer/impl/transform_update.cpp
@@ -41,8 +41,17 @@ namespace components::sql::transform {
                         id = params->add_parameter(types::logical_value_t(resource_, float_value));
                         break;
                     }
-                    default:
-                        assert(false);
+                    default: {
+                        // NULL and any other literal kind (get_value maps T_Null to an
+                        // NA value; the old assert left `id` uninitialized in Release).
+                        auto res = get_value(resource_, node);
+                        if (res.has_error()) {
+                            error_ = res.error();
+                            return nullptr;
+                        }
+                        id = params->add_parameter(std::move(res.value()));
+                        break;
+                    }
                 }
                 return {new update_expr_get_const_value_t(id)};
             }
@@ -220,6 +229,15 @@ namespace components::sql::transform {
                     updates.emplace_back(new update_expr_set_t(expressions::key_t{resource_, res->name, side_t::left}));
                     updates.back()->left() = transform_update_expr(res->val, names, plan->parameters.get());
                 } else {
+                    // The set executor nulls whole columns for a NULL literal but has
+                    // no NA cast kernel for element writes — reject those here.
+                    if (nodeTag(res->val) == T_A_Const &&
+                        nodeTag(&pg_ptr_cast<A_Const>(res->val)->val) == T_Null) {
+                        error_ = core::error_t(
+                            core::error_code_t::sql_parse_error,
+                            std::pmr::string{"setting a nested element to NULL is not supported", resource_});
+                        return nullptr;
+                    }
                     std::pmr::vector<std::pmr::string> path{resource_};
                     path.emplace_back(std::pmr::string{res->name, resource_});
                     for (const auto& val : res->indirection->lst) {

--- a/components/sql/transformer/impl/transform_update.cpp
+++ b/components/sql/transformer/impl/transform_update.cpp
@@ -121,6 +121,36 @@ namespace components::sql::transform {
                                 return nullptr;
                             }
                         }
+                        // The calculate executor evaluates unary operators on its LEFT
+                        // operand, but a prefix operator parses with the operand on the
+                        // right; binary operators dereference both operands. Enforce
+                        // arity here — a missing operand used to reach the executor as
+                        // a null child and crash it.
+                        const bool is_unary = type == update_expr_type::sqr_root ||
+                                              type == update_expr_type::cube_root ||
+                                              type == update_expr_type::factorial ||
+                                              type == update_expr_type::abs || type == update_expr_type::NOT;
+                        if (is_unary) {
+                            if (!res->left() && res->right()) {
+                                res->left() = std::move(res->right());
+                                res->right() = nullptr;
+                            }
+                            if (!res->left() || res->right()) {
+                                error_ = core::error_t(
+                                    core::error_code_t::sql_parse_error,
+                                    std::pmr::string{"operator '" + op +
+                                                         "' takes exactly one operand in UPDATE SET expression",
+                                                     resource_});
+                                return nullptr;
+                            }
+                        } else if (!res->left() || !res->right()) {
+                            error_ = core::error_t(
+                                core::error_code_t::sql_parse_error,
+                                std::pmr::string{"operator '" + op +
+                                                     "' requires two operands in UPDATE SET expression",
+                                                 resource_});
+                            return nullptr;
+                        }
                         return res;
                     }
                     default:

--- a/components/sql/transformer/impl/transform_update.cpp
+++ b/components/sql/transformer/impl/transform_update.cpp
@@ -63,73 +63,71 @@ namespace components::sql::transform {
                 auto expr = pg_ptr_cast<A_Expr>(node);
                 switch (expr->kind) {
                     case AEXPR_OP: {
-                        update_expr_ptr res;
                         auto t = pg_ptr_cast<ResTarget>(expr->name->lst.front().data);
-                        //sqr_root,
-                        //cube_root,
-                        //// bitwise:
-                        //AND,
-                        //OR,
-                        //XOR,
-                        //NOT,
-                        switch (*t->name) {
-                            case '+':
-                                res = new update_expr_calculate_t(update_expr_type::add);
-                                break;
-                            case '-':
-                                res = new update_expr_calculate_t(update_expr_type::sub);
-                                break;
-                            case '*':
-                                res = new update_expr_calculate_t(update_expr_type::mult);
-                                break;
-                            case '/':
-                                res = new update_expr_calculate_t(update_expr_type::div);
-                                break;
-                            case '%':
-                                res = new update_expr_calculate_t(update_expr_type::mod);
-                                break;
-                            case '^':
-                                res = new update_expr_calculate_t(update_expr_type::exp);
-                                break;
-                            case '!':
-                                res = new update_expr_calculate_t(update_expr_type::factorial);
-                                break;
-                            case '@':
-                                res = new update_expr_calculate_t(update_expr_type::abs);
-                                break;
-                            case '<':
-                                res = new update_expr_calculate_t(update_expr_type::shift_left);
-                                break;
-                            case '>':
-                                res = new update_expr_calculate_t(update_expr_type::shift_right);
-                                break;
-                            case '~':
-                                res = new update_expr_calculate_t(update_expr_type::NOT);
-                                break;
-                            case '&':
-                                res = new update_expr_calculate_t(update_expr_type::AND);
-                                break;
-                            case '#':
-                                res = new update_expr_calculate_t(update_expr_type::XOR);
-                                break;
-                            case '|': {
-                                if (*std::next(t->name) == '/') {
-                                    res = new update_expr_calculate_t(update_expr_type::sqr_root);
-                                } else if (*std::next(t->name) == '|') {
-                                    res = new update_expr_calculate_t(update_expr_type::cube_root);
-                                } else {
-                                    res = new update_expr_calculate_t(update_expr_type::OR);
-                                }
-                                break;
+                        // Dispatch on the FULL operator name: a prefix match would
+                        // swallow multi-char operators that merely share a first
+                        // character with an arithmetic one (e.g. jsonb '->', '#>').
+                        const std::string op{t->name};
+                        update_expr_type type;
+                        if (op == "+") {
+                            type = update_expr_type::add;
+                        } else if (op == "-") {
+                            type = update_expr_type::sub;
+                        } else if (op == "*") {
+                            type = update_expr_type::mult;
+                        } else if (op == "/") {
+                            type = update_expr_type::div;
+                        } else if (op == "%") {
+                            type = update_expr_type::mod;
+                        } else if (op == "^") {
+                            type = update_expr_type::exp;
+                        } else if (op == "!") {
+                            type = update_expr_type::factorial;
+                        } else if (op == "@") {
+                            type = update_expr_type::abs;
+                        } else if (op == "<<") {
+                            type = update_expr_type::shift_left;
+                        } else if (op == ">>") {
+                            type = update_expr_type::shift_right;
+                        } else if (op == "~") {
+                            type = update_expr_type::NOT;
+                        } else if (op == "&") {
+                            type = update_expr_type::AND;
+                        } else if (op == "|") {
+                            type = update_expr_type::OR;
+                        } else if (op == "#") {
+                            type = update_expr_type::XOR;
+                        } else if (op == "|/") {
+                            type = update_expr_type::sqr_root;
+                        } else if (op == "||/") {
+                            type = update_expr_type::cube_root;
+                        } else {
+                            error_ = core::error_t(
+                                core::error_code_t::sql_parse_error,
+                                std::pmr::string{"unsupported operator '" + op + "' in UPDATE SET expression",
+                                                 resource_});
+                            return nullptr;
+                        }
+                        update_expr_ptr res{new update_expr_calculate_t(type)};
+                        if (expr->lexpr) {
+                            res->left() = transform_update_expr(expr->lexpr, names, params);
+                            if (has_error()) {
+                                return nullptr;
                             }
                         }
-                        assert(res);
-                        res->left() = transform_update_expr(expr->lexpr, names, params);
-                        res->right() = transform_update_expr(expr->rexpr, names, params);
+                        if (expr->rexpr) {
+                            res->right() = transform_update_expr(expr->rexpr, names, params);
+                            if (has_error()) {
+                                return nullptr;
+                            }
+                        }
                         return res;
                     }
                     default:
-                        assert(false);
+                        error_ = core::error_t(
+                            core::error_code_t::sql_parse_error,
+                            std::pmr::string{"unsupported expression kind in UPDATE SET expression", resource_});
+                        return nullptr;
                 }
             }
             case T_A_Indirection: {
@@ -196,6 +194,9 @@ namespace components::sql::transform {
                     }
                     updates.emplace_back(new update_expr_set_t(expressions::key_t{std::move(path), side_t::left}));
                     updates.back()->left() = transform_update_expr(res->val, names, plan->parameters.get());
+                }
+                if (has_error()) {
+                    return nullptr;
                 }
             }
         }

--- a/components/sql/transformer/impl/transform_update.cpp
+++ b/components/sql/transformer/impl/transform_update.cpp
@@ -176,7 +176,15 @@ namespace components::sql::transform {
                 key.deduce_side(names);
                 return {new update_expr_get_value_t(std::move(key.field))};
             }
+            default:
+                break;
         }
+        // Returning a bare nullptr here would ship a null child in the update
+        // expression tree and crash (or silently no-op) at execution.
+        error_ = core::error_t(core::error_code_t::sql_parse_error,
+                               std::pmr::string{"unsupported expression in UPDATE SET (function calls, "
+                                                "subqueries and CASE are not supported here)",
+                                                resource_});
         return nullptr;
     }
 

--- a/integration/cpp/test/CMakeLists.txt
+++ b/integration/cpp/test/CMakeLists.txt
@@ -9,6 +9,7 @@ set( ${PROJECT_NAME}_SOURCES
         test_collection_sql.cpp
         test_index.cpp
         test_insert.cpp
+        test_update.cpp
         test_wal_pool.cpp
         test_persistence.cpp
         test_sql_features.cpp

--- a/integration/cpp/test/test_index.cpp
+++ b/integration/cpp/test/test_index.cpp
@@ -918,3 +918,28 @@ TEST_CASE("integration::cpp::test_index::drop_index_folds_catalog_deletes") {
         CHECK(count_ops_of_type(plan, ops::operator_type::remove) == delete_specs.size());
     }
 }
+
+// Expression index elements — CREATE INDEX ... ((expr)) — parse with a null
+// IndexElem.name; the transformer read it unconditionally and threw an
+// uncaught std::logic_error out of execute_sql. They must be rejected with a
+// proper error cursor; plain column indexes keep working.
+TEST_CASE("integration::cpp::test_index::expression_elements_rejected") {
+    auto config = test_create_config("/tmp/otterbrix/integration/test_index/expression_elements_rejected");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+    auto exec = [&](const std::string& sql) {
+        auto session = otterbrix::session_id_t();
+        return dispatcher->execute_sql(session, sql);
+    };
+
+    REQUIRE(exec("CREATE DATABASE t;")->is_success());
+    REQUIRE(exec("CREATE TABLE t.ix (x BIGINT, y TEXT);")->is_success());
+    REQUIRE(exec("INSERT INTO t.ix (x, y) VALUES (1, 'a');")->is_success());
+
+    CHECK_FALSE(exec("CREATE INDEX arith_idx ON t.ix ((x + 1));")->is_success());
+    CHECK_FALSE(exec("CREATE INDEX func_idx ON t.ix ((lower(y)));")->is_success());
+    REQUIRE(exec("CREATE INDEX plain_idx ON t.ix (x);")->is_success());
+}

--- a/integration/cpp/test/test_update.cpp
+++ b/integration/cpp/test/test_update.cpp
@@ -1,0 +1,44 @@
+#include "test_config.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <components/types/logical_value.hpp>
+
+// UPDATE SET used to dispatch operators by their FIRST character: '?' matched
+// no case and left a null expression that the executor dereferenced (segfault
+// in Release), '->' silently lowered to numeric subtraction, '!=' to
+// factorial. Unknown operators must error; arithmetic keeps working, including
+// operators that merely share a first character with a rejected one.
+TEST_CASE("integration::cpp::test_update::set_unknown_operators") {
+    auto config = test_create_config("/tmp/otterbrix/integration/test_update/set_unknown_operators");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+    auto exec = [&](const std::string& sql) {
+        auto session = otterbrix::session_id_t();
+        return dispatcher->execute_sql(session, sql);
+    };
+
+    REQUIRE(exec("CREATE DATABASE t;")->is_success());
+    REQUIRE(exec("CREATE TABLE t.u (x BIGINT);")->is_success());
+    REQUIRE(exec("INSERT INTO t.u (x) VALUES (9);")->is_success());
+
+    CHECK_FALSE(exec("UPDATE t.u SET x = x ? 3;")->is_success());  // was a null-deref segfault
+    CHECK_FALSE(exec("UPDATE t.u SET x = x -> 3;")->is_success()); // was silent subtraction
+    CHECK_FALSE(exec("UPDATE t.u SET x = x != 3;")->is_success()); // was factorial
+    {
+        auto cur = exec("SELECT x FROM t.u;");
+        REQUIRE(cur->is_success());
+        CHECK(cur->value(0, 0).value<int64_t>() == 9); // untouched by the rejects
+    }
+
+    REQUIRE(exec("UPDATE t.u SET x = x + 1;")->is_success());  // 10
+    REQUIRE(exec("UPDATE t.u SET x = x # 3;")->is_success());  // 10 XOR 3 = 9
+    REQUIRE(exec("UPDATE t.u SET x = x << 1;")->is_success()); // 18
+    {
+        auto cur = exec("SELECT x FROM t.u;");
+        REQUIRE(cur->is_success());
+        CHECK(cur->value(0, 0).value<int64_t>() == 18);
+    }
+}

--- a/integration/cpp/test/test_update.cpp
+++ b/integration/cpp/test/test_update.cpp
@@ -75,3 +75,35 @@ TEST_CASE("integration::cpp::test_update::set_unary_operand_arity") {
         CHECK(cur->value(0, 0).value<int64_t>() == 9); // @9 = 9
     }
 }
+
+// transform_update_expr's switch fell off for node tags it does not handle
+// (function calls, CASE, subqueries) and returned nullptr WITHOUT setting the
+// transformer error, so a null child shipped in the plan: nested cases
+// segfaulted the executor, a top-level one was silently dropped (success
+// reported, nothing updated).
+TEST_CASE("integration::cpp::test_update::set_unsupported_expressions") {
+    auto config = test_create_config("/tmp/otterbrix/integration/test_update/set_unsupported_expressions");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+    auto exec = [&](const std::string& sql) {
+        auto session = otterbrix::session_id_t();
+        return dispatcher->execute_sql(session, sql);
+    };
+
+    REQUIRE(exec("CREATE DATABASE t;")->is_success());
+    REQUIRE(exec("CREATE TABLE t.uf (x BIGINT, s TEXT);")->is_success());
+    REQUIRE(exec("INSERT INTO t.uf (x, s) VALUES (9, 'ab');")->is_success());
+
+    CHECK_FALSE(exec("UPDATE t.uf SET s = upper(s);")->is_success());
+    CHECK_FALSE(exec("UPDATE t.uf SET x = x + abs(x);")->is_success());
+    CHECK_FALSE(exec("UPDATE t.uf SET x = CASE WHEN x > 0 THEN 1 ELSE 0 END;")->is_success());
+    {
+        auto cur = exec("SELECT x, s FROM t.uf;");
+        REQUIRE(cur->is_success());
+        CHECK(cur->value(0, 0).value<int64_t>() == 9); // data untouched
+        CHECK(cur->value(1, 0).value<std::string_view>() == "ab");
+    }
+}

--- a/integration/cpp/test/test_update.cpp
+++ b/integration/cpp/test/test_update.cpp
@@ -42,3 +42,36 @@ TEST_CASE("integration::cpp::test_update::set_unknown_operators") {
         CHECK(cur->value(0, 0).value<int64_t>() == 18);
     }
 }
+
+// A prefix unary operator (-x, @ x, ~x) parses with a null lexpr; the update
+// executor dereferences its LEFT operand unconditionally and evaluates unary
+// ops on it, so these used to segfault at execution (and even well-formed
+// prefix spellings had the operand in the wrong slot). Unary operators route
+// the operand to the left slot; binary ones require both operands.
+TEST_CASE("integration::cpp::test_update::set_unary_operand_arity") {
+    auto config = test_create_config("/tmp/otterbrix/integration/test_update/set_unary_operand_arity");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+    auto exec = [&](const std::string& sql) {
+        auto session = otterbrix::session_id_t();
+        return dispatcher->execute_sql(session, sql);
+    };
+
+    REQUIRE(exec("CREATE DATABASE t;")->is_success());
+    REQUIRE(exec("CREATE TABLE t.ua (x BIGINT);")->is_success());
+    REQUIRE(exec("INSERT INTO t.ua (x) VALUES (9);")->is_success());
+
+    // '-' has no unary form in update_expr_type: clean error, not a null-deref.
+    CHECK_FALSE(exec("UPDATE t.ua SET x = -x;")->is_success());
+    CHECK_FALSE(exec("UPDATE t.ua SET x = +x;")->is_success());
+    // Genuinely unary operators work in prefix form.
+    REQUIRE(exec("UPDATE t.ua SET x = @ x;")->is_success());
+    {
+        auto cur = exec("SELECT x FROM t.ua;");
+        REQUIRE(cur->is_success());
+        CHECK(cur->value(0, 0).value<int64_t>() == 9); // @9 = 9
+    }
+}

--- a/integration/cpp/test/test_update.cpp
+++ b/integration/cpp/test/test_update.cpp
@@ -107,3 +107,34 @@ TEST_CASE("integration::cpp::test_update::set_unsupported_expressions") {
         CHECK(cur->value(1, 0).value<std::string_view>() == "ab");
     }
 }
+
+// UPDATE SET column = NULL hit the T_A_Const default arm: assert(false) in
+// Debug, an UNINITIALIZED parameter id in Release (garbage lookup, segfault).
+// The executor also had no NA cast kernel, so an NA-typed constant vector
+// crashed cast_vector; nulls are now written directly.
+TEST_CASE("integration::cpp::test_update::set_null") {
+    auto config = test_create_config("/tmp/otterbrix/integration/test_update/set_null");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+    auto exec = [&](const std::string& sql) {
+        auto session = otterbrix::session_id_t();
+        return dispatcher->execute_sql(session, sql);
+    };
+
+    REQUIRE(exec("CREATE DATABASE t;")->is_success());
+    REQUIRE(exec("CREATE TABLE t.un (x BIGINT, y BIGINT);")->is_success());
+    REQUIRE(exec("INSERT INTO t.un (x, y) VALUES (9, 1), (10, 2);")->is_success());
+
+    REQUIRE(exec("UPDATE t.un SET x = NULL WHERE y = 1;")->is_success());
+    {
+        auto cur = exec("SELECT x FROM t.un ORDER BY y;");
+        REQUIRE(cur->is_success());
+        CHECK(cur->value(0, 0).is_null());
+        CHECK(cur->value(0, 1).value<int64_t>() == 10); // other row untouched
+    }
+    // Nested-element NULL writes have no NA cast kernel: clean transform error.
+    CHECK_FALSE(exec("UPDATE t.un SET x[1] = NULL;")->is_success());
+}


### PR DESCRIPTION
While systematically probing edge cases in the UPDATE and CREATE INDEX transformer paths I found five defects: three reproducible server segfaults (Release build), one uncaught exception escaping `execute_sql`, and one class of statements that silently mis-executed or reported success without doing anything. Each fix is a separate commit with an end-to-end regression test (driven through `dispatcher->execute_sql`).

All reproductions below were verified against current `main`.

## 1. UPDATE SET dispatched operators by their first character (segfault + silent mis-execution)

`transform_update_expr` classified `AEXPR_OP` by `switch (*t->name)` — the first character only. Consequences:

- `UPDATE t SET x = x ? 3;` — `?` matched no case, the expression stayed null, `assert(res)` compiled out under NDEBUG, and the null was dereferenced: **segfault**.
- `UPDATE t SET x = x -> 3;` — silently lowered to numeric **subtraction** (`-` prefix match).
- `UPDATE t SET x = x != 3;` — silently lowered to **factorial** (`!` prefix match); `<`/`<=` became shift-left, `#>` became XOR, etc.

Also, non-`AEXPR_OP` expression kinds hit `default: assert(false);` and, in Release, fell through into the `T_A_Indirection` case, reinterpreting an `A_Expr` as an `A_Indirection`.

Fixed by dispatching on the full operator name, returning a proper error for unsupported operators and expression kinds, guarding null unary operands, and propagating transformer errors out of the SET-target loop.

## 2. Prefix unary operators shipped a null operand to the executor (segfault)

`UPDATE t SET x = -x;` parses as `A_Expr{"-", lexpr=NULL, rexpr=x}`. With the null guards in place the null child survived transform, and `update_expr_calculate_t::execute_impl` dereferences `left_` unconditionally: **segfault at execution time**. The executor also evaluates every unary op on its *left* operand, so even the well-formed prefix spellings (`@ x`, `~x`, `|/ x`) had their operand in the wrong slot and could never have worked.

Fixed by routing a prefix operand into the left slot and enforcing arity: unary operators take exactly one operand; binary operators require both. `-x` is now a clean error (there is no negate op in `update_expr_type` — `0 - x` works), and `@ x` / `~x` actually execute correctly.

## 3. Unsupported SET expressions passed a null child without any error (segfault / silent no-op)

`transform_update_expr`'s switch fell off the end for node tags it does not handle (function calls, CASE, subqueries) and returned `nullptr` **without setting the transformer error**, so validation passed:

- `UPDATE t SET x = x + abs(x);` — null binary operand → **segfault** in the executor.
- `UPDATE t SET s = upper(s);` — top-level null hit `update_expr_set_t`'s null guard: the statement **reported success and updated nothing**.

Fixed by producing a transform error at the fall-off.

## 4. UPDATE SET column = NULL used an uninitialized parameter id (segfault)

A NULL literal reached the `T_A_Const` default arm: `assert(false)` in Debug; in Release the `core::parameter_id_t id` stayed **uninitialized** and was used to build the constant expression — a garbage parameter lookup that crashed the executor. Beneath that, the executor had no NA cast kernel: `cast_vector` segfaults on an NA-typed input, so even a correctly-built NA constant could not be applied.

Fixed by routing unrecognized constant kinds through `get_value` (which maps `T_Null` to an NA value) and teaching `update_expr_set_t` to write nulls into the target directly for an NA-typed source. Nested-element NULL writes (`SET x[1] = NULL`) are rejected at transform time for the same missing-kernel reason. `UPDATE t SET x = NULL;` now works end to end.

## 5. Expression elements in CREATE INDEX crashed on a null name (uncaught exception)

The grammar accepts expression index elements — `CREATE INDEX i ON t ((x + 1));` — which carry a null `IndexElem.name` (the expression lives in `elem->expr`). `transform_create_index` read the name unconditionally, constructing a `std::string` from `nullptr`; the resulting `std::logic_error` escaped `execute_sql` uncaught. Fixed by returning a proper error cursor for expression elements (only plain column elements are supported); plain column indexes are unaffected.

## Testing

- Each commit adds a regression test asserting the fixed behavior (clean error cursors for the rejects, correct values for `SET x = NULL`, `@ x`, and the arithmetic operators that share first characters with rejected ones).
- The UPDATE SET tests start a dedicated `integration/cpp/test/test_update.cpp` (UPDATE was the only DML verb without its own suite); the CREATE INDEX test joins the existing cases in `test_index.cpp`.
- Full integration suite (`ctest`) and `components/sql` unit tests pass.
