### PR TITLE
fix(types): logical_value_t::children() dereferenced null for NULL values

### DIFF
--- a/components/types/logical_value.cpp
+++ b/components/types/logical_value.cpp
@@ -742,7 +742,17 @@ namespace components::types {
         }
     }
 
-    const std::vector<logical_value_t>& logical_value_t::children() const { return *vec_ptr(); }
+    const std::vector<logical_value_t>& logical_value_t::children() const {
+        // A NULL value carries no payload: data_ is zero, so dereferencing
+        // vec_ptr() is UB. NULL rows are ordinary result data — reading a
+        // nullable nested column via children() must be safe and yield "no
+        // elements", with is_null() staying the semantic null check.
+        static const std::vector<logical_value_t> empty;
+        if (is_null()) {
+            return empty;
+        }
+        return *vec_ptr();
+    }
 
     logical_value_t logical_value_t::create_struct(std::pmr::memory_resource* r,
                                                    const complex_logical_type& type,

--- a/components/types/tests/test_types.cpp
+++ b/components/types/tests/test_types.cpp
@@ -1,7 +1,9 @@
 #include "operations_helper.hpp"
 #include <catch2/catch_test_macros.hpp>
+#include <components/types/logical_value.hpp>
 #include <components/types/physical_value.hpp>
 #include <core/operations_helper.hpp>
+#include <memory_resource>
 #include <random>
 
 using namespace components::types;
@@ -241,4 +243,20 @@ TEST_CASE("components::types::decimal") {
             check_arithmetics.operator()<int128_t, int64_t>(-502, width, scale, "-50.2000");
         }
     }
+}
+TEST_CASE("components::types::logical_value::null_children_safe") {
+    // Regression: children() on a NULL (NA-typed) value dereferenced the null
+    // payload pointer. NULL nested values are ordinary result-set data, so
+    // reading them through the children() idiom must be safe.
+    auto* resource = std::pmr::get_default_resource();
+    logical_value_t null_value(resource, complex_logical_type{logical_type::NA});
+    REQUIRE(null_value.is_null());
+    CHECK(null_value.children().empty());
+    // A non-null nested value keeps returning its real elements.
+    auto list = logical_value_t::create_list(
+        resource,
+        complex_logical_type{logical_type::BIGINT},
+        {logical_value_t(resource, int64_t{1}), logical_value_t(resource, int64_t{2})});
+    REQUIRE_FALSE(list.is_null());
+    CHECK(list.children().size() == 2);
 }

--- a/integration/cpp/test/test_list_array.cpp
+++ b/integration/cpp/test/test_list_array.cpp
@@ -569,3 +569,94 @@ TEST_CASE("integration::list_array::full_list_update") {
         REQUIRE(v.children()[2].value<int32_t>() == 300);
     }
 }
+TEST_CASE("integration::list_array::null_array_value_reads_safely") {
+    auto config = test_create_config("/tmp/test_list_array/null_array_value");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    REQUIRE(exec(dispatcher, "CREATE DATABASE TestDatabase;")->is_success());
+    REQUIRE(exec(dispatcher, "CREATE TABLE TestDatabase.arr (id bigint, v int[3]);")->is_success());
+    REQUIRE(exec(dispatcher, "INSERT INTO TestDatabase.arr (id, v) VALUES (1, ARRAY[7,8,9]);")->is_success());
+    REQUIRE(exec(dispatcher, "INSERT INTO TestDatabase.arr (id, v) VALUES (2, NULL);")->is_success());
+
+    INFO("a NULL array row is readable through the children() idiom");
+    {
+        auto cur = exec(dispatcher, "SELECT id, v FROM TestDatabase.arr ORDER BY id;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 2);
+        auto full = cur->value(1, 0);
+        REQUIRE_FALSE(full.is_null());
+        REQUIRE(full.children().size() == 3);
+        REQUIRE(full.children()[0].value<int32_t>() == 7);
+        // Regression: children() on the NULL value dereferenced the null
+        // payload pointer and crashed the process.
+        auto null_value = cur->value(1, 1);
+        REQUIRE(null_value.is_null());
+        CHECK(null_value.children().empty());
+    }
+}
+
+// Automates the SQL battery from the logical_value_t::children() fix: with a
+// NULL array row present, every one of these read/scan/aggregate/DML statements
+// must complete cleanly (the engine's own call sites already guard is_null()),
+// and a NULL row's value read through the children() idiom must be empty rather
+// than crashing the process.
+TEST_CASE("integration::list_array::null_array_sql_operations_clean") {
+    auto config = test_create_config("/tmp/test_list_array/null_array_sql_ops");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    REQUIRE(exec(dispatcher, "CREATE DATABASE db;")->is_success());
+    REQUIRE(exec(dispatcher, "CREATE TABLE db.a (id bigint, v int[3]);")->is_success());
+    REQUIRE(exec(dispatcher, "INSERT INTO db.a (id, v) VALUES (1, ARRAY[7,8,9]);")->is_success());
+    REQUIRE(exec(dispatcher, "INSERT INTO db.a (id, v) VALUES (2, NULL);")->is_success());
+
+    auto ok = [&](const std::string& sql) {
+        INFO(sql);
+        return exec(dispatcher, sql);
+    };
+
+    SECTION("reads and scans over the NULL array row") {
+        {
+            auto cur = ok("SELECT v FROM db.a;");
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 2); // both rows returned, incl. the NULL one
+        }
+        {
+            auto cur = ok("SELECT v[1] FROM db.a;");
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 2);
+        }
+        {
+            auto cur = ok("SELECT id FROM db.a WHERE v = ARRAY[7,8,9];");
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 1); // only the non-NULL row matches
+        }
+        // NB: `WHERE v = v` (whole-array self-comparison) is intentionally not
+        // covered here — array = array is not a supported filter shape and is a
+        // separate concern from the children() NULL fix.
+        REQUIRE(ok("SELECT id FROM db.a ORDER BY v;")->is_success());
+        REQUIRE(ok("SELECT v, COUNT(*) FROM db.a GROUP BY v;")->is_success());
+        REQUIRE(ok("SELECT DISTINCT v FROM db.a;")->is_success());
+    }
+
+    SECTION("DML touching the NULL array row") {
+        REQUIRE(ok("UPDATE db.a SET v[1] = 5 WHERE id = 1;")->is_success());
+        REQUIRE(ok("UPDATE db.a SET v = ARRAY[1,2,3] WHERE id = 2;")->is_success());
+        {
+            auto cur = ok("INSERT INTO db.a (id, v) VALUES (3, NULL) RETURNING v;");
+            REQUIRE(cur->is_success());
+            // RETURNING a NULL array must read back safely through children().
+            REQUIRE(cur->size() == 1);
+            auto returned = cur->value(0, 0);
+            REQUIRE(returned.is_null());
+            CHECK(returned.children().empty());
+        }
+    }
+}


### PR DESCRIPTION
`logical_value_t::children()` was an unguarded `return *vec_ptr();`. A NULL (NA-typed) value carries no payload — `data_` is zero — so calling `children()` on it dereferenced a null pointer and crashed the process.

## Not reproducible through SQL — but dangerous

I could not find any way to trigger this with SQL alone, and not for lack of trying. With a NULL array row present in the table, all of the following execute cleanly, because every engine-internal call site checks `is_null()` before touching children:

```sql
SELECT v FROM t;                            SELECT v[1] FROM t;          -- incl. the NULL row
SELECT id FROM t WHERE v = ARRAY[7,8,9];    SELECT id FROM t ORDER BY v;
SELECT v, COUNT(*) FROM t GROUP BY v;       SELECT DISTINCT v FROM t;
UPDATE t SET v[1] = 5 WHERE ...;            UPDATE t SET v = ARRAY[1,2,3] WHERE ...;
INSERT INTO t (id, v) VALUES (3, NULL) RETURNING v;
```

(Whole-array self-comparison `WHERE v = v` is *not* in this list — `array = array` is not a supported filter shape and fails independently of this fix; it is out of scope here.)

The danger sits one layer up, in the C++ result API — where `children()` is the natural (and within this repo, the standard) idiom for reading nested values out of a cursor:

```cpp
auto v = cursor->value(col, row);
for (const auto& elem : v.children()) { ... }   // SIGSEGV if row's value is NULL
```

Nothing documents `is_null()` as a precondition, `value<T>()`-style reads don't need one, and the existing array test helpers use exactly this pattern. So the first time a nullable array/struct/list column actually contains a NULL — ordinary, valid data that `INSERT ... VALUES (2, NULL)` happily produces — any embedder or test binary reading the result dies. Minimal reproduction:

```sql
CREATE TABLE db.a (id BIGINT, v INT[3]);
INSERT INTO db.a (id, v) VALUES (1, ARRAY[7,8,9]);
INSERT INTO db.a (id, v) VALUES (2, NULL);
SELECT id, v FROM db.a ORDER BY id;
```

```text
row0: is_null=0 children=3      <- fine
row1: is_null=1
row1: calling children() ...    Segmentation fault (exit 139)
```

## Fix

`children()` returns a static empty vector for NULL values; `is_null()` remains the semantic null check, and non-null values are unaffected. This mirrors how the engine's own call sites already treat NULL ("no elements to visit").

## Testing

- `components::types::logical_value::null_children_safe` — unit pin: NULL value reports empty children, a real list still returns its elements.
- `integration::list_array::null_array_value_reads_safely` — end-to-end: a NULL `int[3]` row read through a cursor via the `children()` idiom, next to a non-null row that keeps returning its 3 elements. This test segfaults the suite without the fix.
- `integration::list_array::null_array_sql_operations_clean` — automates the SQL battery above over a table containing a NULL array row: every read / scan / aggregate / DML statement must complete cleanly, and a NULL-array value returned by `INSERT ... RETURNING` is read back through `children()` as empty.
- The out-of-tree reproduction above exits 0 after the fix (`children=0`), and the full `test_list_array` + `components::types` suites pass.
