### PR TITLE
fix(disk): apply column DEFAULTs to inserts after restart

### DIFF
--- a/components/logical_plan/node_check_constraint.hpp
+++ b/components/logical_plan/node_check_constraint.hpp
@@ -5,7 +5,9 @@
 
 #include <components/catalog/catalog_oids.hpp>
 #include <components/types/logical_value.hpp>
+#include <components/vector/data_chunk.hpp>
 
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -34,16 +36,13 @@ namespace components::logical_plan {
         const std::vector<std::vector<std::string>>& unique_groups() const { return unique_groups_; }
         void set_unique_groups(std::vector<std::vector<std::string>> v) { unique_groups_ = std::move(v); }
 
-        // Decoded column DEFAULT values (name -> value), copied from the DML node by
-        // the planner. An INSERT omitting a defaulted column stores the default
-        // (filled agent-side at storage_append), so the check/unique operators must
-        // evaluate an ABSENT column AS its default.
-        const std::vector<std::pair<std::string, types::logical_value_t>>& column_defaults() const {
-            return column_defaults_;
-        }
-        void set_column_defaults(std::vector<std::pair<std::string, types::logical_value_t>> v) {
-            column_defaults_ = std::move(v);
-        }
+        // Decoded column DEFAULTs as a one-row data_chunk_t (column name in the type
+        // alias, row 0 the value; nullptr = the table has none), deep-copied from the
+        // DML node by the planner. An INSERT omitting a defaulted column stores the
+        // default (filled agent-side at storage_append), so the check/unique operators
+        // must evaluate an ABSENT column AS its default.
+        const vector::data_chunk_t* column_defaults() const noexcept { return column_defaults_.get(); }
+        void set_column_defaults(std::unique_ptr<vector::data_chunk_t> v) { column_defaults_ = std::move(v); }
 
         // TRUE when the DML write-set is NAME-ADDRESSED: its column aliases are the
         // statement's explicit column names (SQL INSERT with a column list; every
@@ -69,7 +68,7 @@ namespace components::logical_plan {
         std::vector<std::pair<std::string, std::string>> check_exprs_;  // (name, expr)
         std::vector<std::pair<std::string, uint64_t>> array_size_reqs_; // (name, declared array size)
         std::vector<std::vector<std::string>> unique_groups_;           // UNIQUE / PK column groups
-        std::vector<std::pair<std::string, types::logical_value_t>> column_defaults_; // decoded DEFAULTs
+        std::unique_ptr<vector::data_chunk_t> column_defaults_;         // one-row chunk; nullptr = none
         bool write_set_named_{false}; // write-set aliases are statement column names
         components::catalog::oid_t table_oid_{components::catalog::INVALID_OID};
     };

--- a/components/logical_plan/node_insert.hpp
+++ b/components/logical_plan/node_insert.hpp
@@ -6,6 +6,7 @@
 #include <components/types/logical_value.hpp>
 #include <components/vector/data_chunk.hpp>
 
+#include <memory>
 #include <utility>
 
 namespace components::logical_plan {
@@ -45,17 +46,19 @@ namespace components::logical_plan {
         void set_unique_groups(std::vector<std::vector<std::string>> v) { unique_groups_ = std::move(v); }
         const std::vector<std::vector<std::string>>& unique_groups() const { return unique_groups_; }
 
-        // Decoded column DEFAULT values (name -> value), stamped by the enrich pass
-        // from pg_attribute.attdefspec. A column omitted from the INSERT column list
-        // stores its DEFAULT (filled agent-side at storage_append), so the constraint
-        // operators must evaluate an ABSENT column AS its default — the planner
-        // forwards these onto the node_check_constraint_t wrapper.
-        void set_column_defaults(std::vector<std::pair<std::string, types::logical_value_t>> v) {
-            column_defaults_ = std::move(v);
-        }
-        const std::vector<std::pair<std::string, types::logical_value_t>>& column_defaults() const {
-            return column_defaults_;
-        }
+        // Decoded column DEFAULTs as a ONE-ROW data_chunk_t: one column per default,
+        // the column name in the column's type alias, row 0 the decoded value; nullptr
+        // when the table has no usable DEFAULT. Stamped by the enrich pass from
+        // pg_attribute.attdefspec, and the shape the disk contract speaks — the chunk
+        // travels unchanged into operator_insert and on to storage_append, where the
+        // agent fills omitted columns from it. The values stay UN-cast: only the agent
+        // knows the live physical column types.
+        // A column omitted from the INSERT column list stores its DEFAULT, so the
+        // constraint operators must evaluate an ABSENT column AS its default — the
+        // planner deep-copies the chunk onto the node_check_constraint_t wrapper.
+        // MOVE-ONLY: consumers take their own copy via components::vector::deep_copy.
+        void set_column_defaults(std::unique_ptr<vector::data_chunk_t> v) { column_defaults_ = std::move(v); }
+        const vector::data_chunk_t* column_defaults() const noexcept { return column_defaults_.get(); }
 
     private:
         hash_t hash_impl() const override;
@@ -68,8 +71,8 @@ namespace components::logical_plan {
         std::vector<catalog::fk_info_t> outgoing_fks_;
         std::vector<std::pair<std::string, std::string>> check_exprs_;  // (name, expr)
         std::vector<std::pair<std::string, uint64_t>> array_size_reqs_; // (name, declared array size)
-        std::vector<std::vector<std::string>> unique_groups_;           // UNIQUE / PK column groups
-        std::vector<std::pair<std::string, types::logical_value_t>> column_defaults_; // decoded DEFAULTs
+        std::vector<std::vector<std::string>> unique_groups_;    // UNIQUE / PK column groups
+        std::unique_ptr<vector::data_chunk_t> column_defaults_;  // one-row chunk; nullptr = no defaults
     };
 
     using node_insert_ptr = boost::intrusive_ptr<node_insert_t>;

--- a/components/logical_plan/node_update.hpp
+++ b/components/logical_plan/node_update.hpp
@@ -7,7 +7,9 @@
 #include <components/catalog/fk_info.hpp>
 #include <components/expressions/update_expression.hpp>
 #include <components/types/logical_value.hpp>
+#include <components/vector/data_chunk.hpp>
 
+#include <memory>
 #include <utility>
 
 namespace components::logical_plan {
@@ -40,15 +42,11 @@ namespace components::logical_plan {
         void set_unique_groups(std::vector<std::vector<std::string>> v) { unique_groups_ = std::move(v); }
         const std::vector<std::vector<std::string>>& unique_groups() const { return unique_groups_; }
 
-        // Decoded column DEFAULT values (name -> value) for the constraint operators
-        // (see node_insert_t::column_defaults). Stamped by enrich; forwarded onto the
-        // node_check_constraint_t wrapper by the planner.
-        void set_column_defaults(std::vector<std::pair<std::string, types::logical_value_t>> v) {
-            column_defaults_ = std::move(v);
-        }
-        const std::vector<std::pair<std::string, types::logical_value_t>>& column_defaults() const {
-            return column_defaults_;
-        }
+        // Decoded column DEFAULTs as a one-row data_chunk_t for the constraint operators
+        // (see node_insert_t::column_defaults for the shape). Stamped by enrich; the
+        // planner deep-copies it onto the node_check_constraint_t wrapper.
+        void set_column_defaults(std::unique_ptr<vector::data_chunk_t> v) { column_defaults_ = std::move(v); }
+        const vector::data_chunk_t* column_defaults() const noexcept { return column_defaults_.get(); }
 
     private:
         std::pmr::vector<expressions::update_expr_ptr> update_expressions_;
@@ -60,8 +58,8 @@ namespace components::logical_plan {
 
         std::vector<std::string> not_null_cols_;
         std::vector<catalog::fk_info_t> outgoing_fks_;
-        std::vector<std::vector<std::string>> unique_groups_; // UNIQUE / PK column groups
-        std::vector<std::pair<std::string, types::logical_value_t>> column_defaults_; // decoded DEFAULTs
+        std::vector<std::vector<std::string>> unique_groups_;   // UNIQUE / PK column groups
+        std::unique_ptr<vector::data_chunk_t> column_defaults_; // one-row chunk; nullptr = no defaults
     };
 
     using node_update_ptr = boost::intrusive_ptr<node_update_t>;

--- a/components/physical_plan/operators/operator_check_constraint.cpp
+++ b/components/physical_plan/operators/operator_check_constraint.cpp
@@ -18,25 +18,25 @@ namespace components::operators {
 
         const vector::vector_t* find_col(const vector::data_chunk_t& chunk, std::string_view name) {
             for (uint64_t c = 0; c < chunk.column_count(); ++c) {
-                if (chunk.data[c].type().alias() == name)
+                // complex_logical_type::alias() asserts on (and dereferences) a missing
+                // extension, so an alias-less column must not reach it.
+                const auto& type = chunk.data[c].type();
+                if (type.has_alias() && type.alias() == name)
                     return &chunk.data[c];
             }
             return nullptr;
         }
 
-        // The decoded DEFAULT value for `col`, or nullptr when the column has none.
-        const types::logical_value_t*
-        find_default(const std::vector<std::pair<std::string, types::logical_value_t>>* defaults,
-                     std::string_view col) {
-            if (defaults == nullptr) {
+        // The DEFAULT column of `col` in the one-row defaults chunk (column name in the
+        // type alias, row 0 the value), or nullptr when the table has no default for it.
+        // Callers test NULL-ness with def->is_null(0) and read the value with
+        // def->value(0) — data_chunk_t::column_index() is unusable here: it asserts on a
+        // miss, and a miss is the normal case.
+        const vector::vector_t* find_default(const vector::data_chunk_t* defaults, std::string_view col) {
+            if (defaults == nullptr || defaults->size() == 0) {
                 return nullptr;
             }
-            for (const auto& [name, value] : *defaults) {
-                if (name == col) {
-                    return &value;
-                }
-            }
-            return nullptr;
+            return find_col(*defaults, col);
         }
 
         // Parse a literal constant string into a logical_value_t without a type hint.
@@ -92,17 +92,15 @@ namespace components::operators {
         // strict_absent: TRUE when the write-set is name-addressed (absence by alias
         // means the statement omitted the column, so it stores DEFAULT-or-NULL);
         // FALSE keeps the legacy absent-column pass-through.
-        predicates::predicate_ptr
-        build_check_predicate(std::pmr::memory_resource* r,
-                              std::string_view expr,
-                              const std::vector<std::pair<std::string, types::logical_value_t>>* defaults,
-                              bool strict_absent);
+        predicates::predicate_ptr build_check_predicate(std::pmr::memory_resource* r,
+                                                        std::string_view expr,
+                                                        const vector::data_chunk_t* defaults,
+                                                        bool strict_absent);
 
-        predicates::predicate_ptr
-        build_check_predicate(std::pmr::memory_resource* r,
-                              std::string_view expr,
-                              const std::vector<std::pair<std::string, types::logical_value_t>>* defaults,
-                              bool strict_absent) {
+        predicates::predicate_ptr build_check_predicate(std::pmr::memory_resource* r,
+                                                        std::string_view expr,
+                                                        const vector::data_chunk_t* defaults,
+                                                        bool strict_absent) {
             using CT = expressions::compare_type;
             expr = trim(expr);
 
@@ -164,7 +162,7 @@ namespace components::operators {
                 // `INSERT (a) VALUES (..)` would silently bypass `CHECK (b IS NOT
                 // NULL)` for the omitted column b. Resolved once at compile time.
                 const auto* def = find_default(defaults, col);
-                const bool absent_is_valid = !strict_absent || (def != nullptr && !def->is_null());
+                const bool absent_is_valid = !strict_absent || (def != nullptr && !def->is_null(0));
                 return {new predicates::simple_predicate(
                     r,
                     [col, absent_is_valid](const vector::data_chunk_t& chunk,
@@ -181,7 +179,7 @@ namespace components::operators {
                 // DEFAULT when one exists, so IS NULL fails; with no default the
                 // stored value IS NULL.
                 const auto* def = find_default(defaults, col);
-                const bool absent_is_null = !strict_absent || def == nullptr || def->is_null();
+                const bool absent_is_null = !strict_absent || def == nullptr || def->is_null(0);
                 return {new predicates::simple_predicate(
                     r,
                     [col, absent_is_null](const vector::data_chunk_t& chunk,
@@ -221,8 +219,11 @@ namespace components::operators {
                 // DEFAULT the stored row carries that value — evaluate the comparison
                 // against it; without one, keep the legacy pass (untyped/unknown shape).
                 const auto* def = find_default(defaults, col_name);
-                const bool has_def = strict_absent && def != nullptr && !def->is_null();
-                auto def_val = has_def ? *def : const_val;
+                const bool has_def = strict_absent && def != nullptr && !def->is_null(0);
+                // vector_t::value() materializes a logical_value_t BY VALUE (a chunk hands
+                // out no stable pointer); the predicate below captures it by value, so it
+                // owns its copy and the defaults chunk may die afterwards.
+                auto def_val = has_def ? def->value(0) : const_val;
 
                 return {new predicates::simple_predicate(
                     r,
@@ -273,7 +274,7 @@ namespace components::operators {
         std::vector<std::string> not_null_columns,
         std::vector<std::pair<std::string, std::string>> check_exprs,
         std::vector<std::pair<std::string, uint64_t>> array_size_reqs,
-        std::vector<std::pair<std::string, types::logical_value_t>> column_defaults,
+        std::unique_ptr<vector::data_chunk_t> column_defaults,
         bool write_set_named)
         : read_write_operator_t(resource, log, operator_type::check_constraint)
         , not_null_columns_(std::move(not_null_columns))
@@ -284,7 +285,7 @@ namespace components::operators {
         for (auto& [name, expr_str] : check_exprs) {
             check_predicates_.emplace_back(
                 std::move(name),
-                build_check_predicate(resource, expr_str, &column_defaults_, write_set_named_));
+                build_check_predicate(resource, expr_str, column_defaults_.get(), write_set_named_));
         }
     }
 
@@ -345,8 +346,8 @@ namespace components::operators {
                     break;
                 }
                 if (!found && write_set_named_) {
-                    const auto* def = find_default(&column_defaults_, col_name);
-                    if (def == nullptr || def->is_null()) {
+                    const auto* def = find_default(column_defaults_.get(), col_name);
+                    if (def == nullptr || def->is_null(0)) {
                         set_error(core::error_t{
                             core::error_code_t::other_error,
                             std::pmr::string{"NOT NULL constraint violated for column: " + col_name, resource_}});

--- a/components/physical_plan/operators/operator_check_constraint.hpp
+++ b/components/physical_plan/operators/operator_check_constraint.hpp
@@ -3,7 +3,9 @@
 #include <components/physical_plan/operators/operator.hpp>
 #include <components/physical_plan/operators/predicates/predicate.hpp>
 #include <components/types/logical_value.hpp>
+#include <components/vector/data_chunk.hpp>
 
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -15,10 +17,12 @@ namespace components::operators {
     // evaluated per-row without re-parsing.
     class operator_check_constraint_t final : public read_write_operator_t {
     public:
-        // column_defaults: decoded DEFAULT values (name -> value) of the target
-        // table. A column ABSENT from the write-set stores its DEFAULT (filled
-        // agent-side at storage_append), so the compiled predicates evaluate an
-        // absent column AS its default; absent with NO default means stored NULL.
+        // column_defaults: the target table's decoded DEFAULTs as a ONE-ROW chunk —
+        // one column per default, the column name in the column's type alias, row 0
+        // the value; nullptr when the table has none. A column ABSENT from the
+        // write-set stores its DEFAULT (filled agent-side at storage_append), so the
+        // compiled predicates evaluate an absent column AS its default; absent with
+        // NO (or NULL) default means stored NULL.
         // write_set_named: absent-by-name is only meaningful when the write-set's
         // aliases are the statement's column names (SQL INSERT with a column list;
         // every UPDATE). Positional / hand-built inserts alias arbitrarily, so
@@ -28,7 +32,7 @@ namespace components::operators {
                                     std::vector<std::string> not_null_columns,
                                     std::vector<std::pair<std::string, std::string>> check_exprs = {},
                                     std::vector<std::pair<std::string, uint64_t>> array_size_reqs = {},
-                                    std::vector<std::pair<std::string, types::logical_value_t>> column_defaults = {},
+                                    std::unique_ptr<vector::data_chunk_t> column_defaults = nullptr,
                                     bool write_set_named = false);
 
         // STREAMING CONSTRAINT SINK. check_constraint is the PARENT of a DML sink in
@@ -61,9 +65,10 @@ namespace components::operators {
         void validate_();
 
         std::vector<std::string> not_null_columns_;
-        // Decoded DEFAULTs (name -> value); consulted for columns absent from the
-        // write-set by the NOT NULL loop and the compiled CHECK predicates.
-        std::vector<std::pair<std::string, types::logical_value_t>> column_defaults_;
+        // Decoded DEFAULTs as a one-row chunk (column name in the type alias, row 0 the
+        // value; nullptr = none); consulted for columns absent from the write-set by the
+        // NOT NULL loop and — at compile time — by the CHECK predicates.
+        std::unique_ptr<vector::data_chunk_t> column_defaults_;
         bool write_set_named_{false}; // see ctor note
         std::vector<std::pair<std::string, predicates::predicate_ptr>> check_predicates_; // (name, compiled)
         // Fixed-ARRAY columns (NOT NULL, no DEFAULT) and their declared sizes: a value

--- a/components/physical_plan/operators/operator_insert.cpp
+++ b/components/physical_plan/operators/operator_insert.cpp
@@ -131,12 +131,10 @@ namespace components::operators {
                 // storage_append — WAL-FIRST canonical append (batched, handles
                 // schema adoption + _id dedup). The reply carries any
                 // write_conflict / out_of_memory as a value.
-                // The flush lambda can run multiple times (mid-pump flushes), so
-                // send a copy of the defaults each round — never move the member
-                // out, or later rounds would append with no defaults at all.
-                auto defaults_copy = column_defaults_
-                                         ? std::make_unique<data_chunk_t>(copy_of(*column_defaults_))
-                                         : nullptr;
+                // The flush lambda can run multiple times (mid-pump flushes), so send a
+                // copy of the defaults each round — never move the member out, or later
+                // rounds would append with no defaults at all.
+                auto defaults_copy = vector::deep_copy(resource_, column_defaults_.get());
                 auto [_a, af] = actor_zeta::send(ctx->disk_address,
                                                  &services::disk::manager_disk_t::storage_append,
                                                  exec_ctx,

--- a/components/physical_plan/operators/operator_insert.cpp
+++ b/components/physical_plan/operators/operator_insert.cpp
@@ -14,10 +14,12 @@ namespace components::operators {
     operator_insert::operator_insert(std::pmr::memory_resource* resource,
                                      log_t log,
                                      catalog::oid_t table_oid,
-                                     std::pmr::vector<select_column_t> returning)
+                                     std::pmr::vector<select_column_t> returning,
+                                     std::unique_ptr<vector::data_chunk_t> column_defaults)
         : read_write_operator_t(resource, log, operator_type::insert)
         , table_oid_(table_oid)
-        , returning_(std::move(returning)) {}
+        , returning_(std::move(returning))
+        , column_defaults_(std::move(column_defaults)) {}
 
     core::error_t
     operator_insert::push(pipeline::context_t* /*ctx*/, vector::data_chunk_t&& input, chunks_vector_t& /*out*/) {
@@ -129,11 +131,18 @@ namespace components::operators {
                 // storage_append — WAL-FIRST canonical append (batched, handles
                 // schema adoption + _id dedup). The reply carries any
                 // write_conflict / out_of_memory as a value.
+                // The flush lambda can run multiple times (mid-pump flushes), so
+                // send a copy of the defaults each round — never move the member
+                // out, or later rounds would append with no defaults at all.
+                auto defaults_copy = column_defaults_
+                                         ? std::make_unique<data_chunk_t>(copy_of(*column_defaults_))
+                                         : nullptr;
                 auto [_a, af] = actor_zeta::send(ctx->disk_address,
                                                  &services::disk::manager_disk_t::storage_append,
                                                  exec_ctx,
                                                  table_oid_,
-                                                 std::move(append_data));
+                                                 std::move(append_data),
+                                                 std::move(defaults_copy));
                 auto append_result = co_await std::move(af);
                 if (append_result.has_error()) {
                     co_return dml_detail::flush_outcome_t{append_result.error()};

--- a/components/physical_plan/operators/operator_insert.hpp
+++ b/components/physical_plan/operators/operator_insert.hpp
@@ -4,6 +4,8 @@
 #include <components/physical_plan/operators/operator.hpp>
 #include <components/physical_plan/operators/operator_select.hpp>
 
+#include <memory>
+
 namespace components::operators {
 
     class operator_insert final : public read_write_operator_t {
@@ -13,10 +15,18 @@ namespace components::operators {
         // the appended segment back from storage (so DB-applied DEFAULTs and
         // generated columns are present) and projects these columns into its
         // output instead of an empty result chunk.
+        // `column_defaults` carries the catalog-decoded DEFAULT values of the
+        // target table as a one-row chunk: one column per default, the column
+        // name in the type alias, row 0 the decoded value (nullptr when the
+        // table has none). Built by create_plan_insert from
+        // node_insert_t::column_defaults() and forwarded to storage_append so
+        // the agent-side fill of omitted columns works even when the
+        // storage-level column defs lost their defaults (restart).
         operator_insert(std::pmr::memory_resource* resource,
                         log_t log,
                         catalog::oid_t table_oid,
-                        std::pmr::vector<select_column_t> returning);
+                        std::pmr::vector<select_column_t> returning,
+                        std::unique_ptr<vector::data_chunk_t> column_defaults = nullptr);
 
         catalog::oid_t table_oid() const noexcept { return table_oid_; }
 
@@ -47,6 +57,7 @@ namespace components::operators {
     private:
         catalog::oid_t table_oid_;
         std::pmr::vector<select_column_t> returning_;
+        std::unique_ptr<vector::data_chunk_t> column_defaults_;
         // Cross-flush accumulators for the incremental drive. RETURNING rows are
         // projected into returning_accum_ as each slice is read back; when the
         // statement has no RETURNING, affected_rows_ tallies the appended count.

--- a/components/physical_plan/operators/operator_unique_constraint.cpp
+++ b/components/physical_plan/operators/operator_unique_constraint.cpp
@@ -29,7 +29,10 @@ namespace components::operators {
         constexpr uint64_t kAbsentCol = std::numeric_limits<uint64_t>::max();
         uint64_t find_col_index(const vector::data_chunk_t& chunk, const std::string& name) {
             for (uint64_t c = 0; c < chunk.column_count(); ++c) {
-                if (chunk.data[c].type().alias() == name)
+                // complex_logical_type::alias() asserts on (and dereferences) a missing
+                // extension, so an alias-less column must not reach it.
+                const auto& type = chunk.data[c].type();
+                if (type.has_alias() && type.alias() == name)
                     return c;
             }
             return kAbsentCol;
@@ -42,7 +45,7 @@ namespace components::operators {
         log_t log,
         catalog::oid_t table_oid,
         std::vector<std::vector<std::string>> unique_groups,
-        std::vector<std::pair<std::string, types::logical_value_t>> column_defaults,
+        std::unique_ptr<vector::data_chunk_t> column_defaults,
         bool write_set_named)
         : read_write_operator_t(resource, std::move(log), operator_type::unique_constraint)
         , table_oid_(table_oid)
@@ -82,8 +85,8 @@ namespace components::operators {
             // NULL => NULLS DISTINCT voids the group (nothing to compare), matching
             // operator_fk_check_t's has_absent skip.
             struct key_source_t {
-                uint64_t col{kAbsentCol};                   // present: column index in the chunk
-                const types::logical_value_t* def{nullptr}; // absent: the non-NULL default
+                uint64_t col{kAbsentCol};     // present: column index in the write-set chunk
+                uint64_t def_col{kAbsentCol}; // absent: column index in the DEFAULTS chunk
             };
             std::vector<key_source_t> sources;
             sources.reserve(group.size());
@@ -94,15 +97,15 @@ namespace components::operators {
                 if (src.col == kAbsentCol) {
                     // Only a NAMED write-set proves the statement omitted the column
                     // (a positional insert aliases arbitrarily — legacy skip).
-                    if (write_set_named_) {
-                        for (const auto& [name, value] : column_defaults_) {
-                            if (name == col_name && !value.is_null()) {
-                                src.def = &value;
-                                break;
-                            }
+                    if (write_set_named_ && column_defaults_ && column_defaults_->size() > 0) {
+                        const uint64_t dc = find_col_index(*column_defaults_, col_name);
+                        // A NULL default is not a usable key value: the stored value is
+                        // NULL, and NULLS DISTINCT voids the group.
+                        if (dc != kAbsentCol && !column_defaults_->is_null(dc, 0)) {
+                            src.def_col = dc;
                         }
                     }
-                    if (src.def == nullptr) {
+                    if (src.def_col == kAbsentCol) {
                         group_void = true;
                         break;
                     }
@@ -121,7 +124,7 @@ namespace components::operators {
             key_types.reserve(sources.size());
             for (const auto& src : sources) {
                 key_types.push_back(src.col != kAbsentCol ? in_chunks.front().data[src.col].type()
-                                                          : src.def->type());
+                                                          : column_defaults_->data[src.def_col].type());
             }
             std::pmr::vector<components::vector::data_chunk_t> key_chunks(resource_);
             key_chunks.reserve(in_chunks.size());
@@ -133,11 +136,14 @@ namespace components::operators {
                         keys_chunk.data[j].reference(chunk.data[sources[j].col]);
                     } else {
                         // Absent-with-default: reference the default as ONE CONSTANT
-                        // vector rather than n per-row logical_value_t writes (LAYER-0
-                        // minimize, rule 1). A CONSTANT column with cardinality n is
-                        // valid — downstream hash / vector_ops::copy / cells_equal all
-                        // read CONSTANT via get_value / zero-indexing.
-                        keys_chunk.data[j].reference(*sources[j].def);
+                        // vector rather than n per-row writes (LAYER-0 minimize, rule 1).
+                        // A CONSTANT column with cardinality n is valid — downstream hash /
+                        // vector_ops::copy / cells_equal all read CONSTANT via get_value /
+                        // zero-indexing. reference(const logical_value_t&) deep-copies into
+                        // a fresh 1-element buffer, so the materialized temporary is safe.
+                        // Referencing the defaults chunk's VECTOR instead would be wrong:
+                        // it is FLAT with a single row and would read OOB for rows > 0.
+                        keys_chunk.data[j].reference(column_defaults_->value(sources[j].def_col, 0));
                     }
                 }
                 keys_chunk.set_cardinality(n);

--- a/components/physical_plan/operators/operator_unique_constraint.hpp
+++ b/components/physical_plan/operators/operator_unique_constraint.hpp
@@ -3,7 +3,9 @@
 #include <components/catalog/catalog_oids.hpp>
 #include <components/physical_plan/operators/operator.hpp>
 #include <components/types/logical_value.hpp>
+#include <components/vector/data_chunk.hpp>
 
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -38,11 +40,12 @@ namespace components::operators {
     // sets a core::error_t — no silent dedup, no throw across the mailbox (R2/R9).
     class operator_unique_constraint_t final : public read_write_operator_t {
     public:
-        // column_defaults: decoded DEFAULT values (name -> value) of the target
-        // table. A key column ABSENT from the write-set stores its DEFAULT (filled
-        // agent-side at storage_append), so it is materialized as a constant key
-        // column; absent with NO (or NULL) default stores NULL => NULLS DISTINCT
-        // voids the group.
+        // column_defaults: the target table's decoded DEFAULTs as a ONE-ROW chunk —
+        // one column per default, the column name in the column's type alias, row 0
+        // the value; nullptr when the table has none. A key column ABSENT from the
+        // write-set stores its DEFAULT (filled agent-side at storage_append), so it is
+        // materialized as a constant key column; absent with NO (or NULL) default
+        // stores NULL => NULLS DISTINCT voids the group.
         // write_set_named: absent-by-name is only meaningful when the write-set's
         // aliases are the statement's column names (SQL INSERT with a column list;
         // every UPDATE). A positional / hand-built insert aliases arbitrarily, so
@@ -52,7 +55,7 @@ namespace components::operators {
                                      log_t log,
                                      catalog::oid_t table_oid,
                                      std::vector<std::vector<std::string>> unique_groups,
-                                     std::vector<std::pair<std::string, types::logical_value_t>> column_defaults = {},
+                                     std::unique_ptr<vector::data_chunk_t> column_defaults = nullptr,
                                      bool write_set_named = false);
 
         [[nodiscard]] bool needs_async_finalize() const noexcept override { return true; }
@@ -73,9 +76,10 @@ namespace components::operators {
 
         catalog::oid_t table_oid_;
         std::vector<std::vector<std::string>> unique_groups_;
-        // Decoded DEFAULTs (name -> value); consulted for key columns absent from
-        // the write-set (see ctor note).
-        std::vector<std::pair<std::string, types::logical_value_t>> column_defaults_;
+        // Decoded DEFAULTs as a one-row chunk (column name in the type alias, row 0 the
+        // value; nullptr = none); consulted for key columns absent from the write-set
+        // (see ctor note).
+        std::unique_ptr<vector::data_chunk_t> column_defaults_;
         bool write_set_named_{false}; // see ctor note
     };
 

--- a/components/physical_plan_generator/impl/create_plan_check_constraint.cpp
+++ b/components/physical_plan_generator/impl/create_plan_check_constraint.cpp
@@ -4,6 +4,7 @@
 #include <components/physical_plan/operators/operator_check_constraint.hpp>
 #include <components/physical_plan/operators/operator_unique_constraint.hpp>
 #include <components/physical_plan_generator/create_plan.hpp>
+#include <components/vector/data_chunk.hpp>
 
 namespace services::planner::impl {
 
@@ -13,13 +14,16 @@ namespace services::planner::impl {
                                  const components::logical_plan::node_ptr& node,
                                  const components::logical_plan::storage_parameters* params) {
         auto* n = static_cast<components::logical_plan::node_check_constraint_t*>(node.get());
-        auto plan = boost::intrusive_ptr(new components::operators::operator_check_constraint_t(context.resource,
-                                                                                                context.log.clone(),
-                                                                                                n->not_null_columns(),
-                                                                                                n->check_exprs(),
-                                                                                                n->array_size_reqs(),
-                                                                                                n->column_defaults(),
-                                                                                                n->write_set_named()));
+        // The node owns ONE defaults chunk but both constraint operators consume it and
+        // the chunk is move-only — each operator gets its own deep copy.
+        auto plan = boost::intrusive_ptr(new components::operators::operator_check_constraint_t(
+            context.resource,
+            context.log.clone(),
+            n->not_null_columns(),
+            n->check_exprs(),
+            n->array_size_reqs(),
+            components::vector::deep_copy(context.resource, n->column_defaults()),
+            n->write_set_named()));
         // Child sub-plan (the DML sink, possibly under an fk_check chain).
         components::operators::operator_ptr child;
         if (!node->children().empty()) {
@@ -32,13 +36,13 @@ namespace services::planner::impl {
         // reads its child DML's constraint_input(), exactly like an fk_check chain).
         // With no unique groups the check sink adopts the child directly.
         if (!n->unique_groups().empty()) {
-            auto unique = boost::intrusive_ptr(
-                new components::operators::operator_unique_constraint_t(context.resource,
-                                                                        context.log.clone(),
-                                                                        n->table_oid(),
-                                                                        n->unique_groups(),
-                                                                        n->column_defaults(),
-                                                                        n->write_set_named()));
+            auto unique = boost::intrusive_ptr(new components::operators::operator_unique_constraint_t(
+                context.resource,
+                context.log.clone(),
+                n->table_oid(),
+                n->unique_groups(),
+                components::vector::deep_copy(context.resource, n->column_defaults()),
+                n->write_set_named()));
             if (child) {
                 unique->set_children(child);
             }

--- a/components/physical_plan_generator/impl/create_plan_insert.cpp
+++ b/components/physical_plan_generator/impl/create_plan_insert.cpp
@@ -5,7 +5,49 @@
 #include <components/physical_plan/operators/operator_insert.hpp>
 #include <components/physical_plan_generator/create_plan.hpp>
 
+#include <memory>
+
 namespace services::planner::impl {
+
+    namespace {
+
+        // Pack the catalog-decoded (name, value) DEFAULTs of the target table into
+        // the shape the disk contract already speaks: a one-row data_chunk_t whose
+        // column aliases carry the column names and whose row 0 holds the decoded
+        // values. The values stay UN-cast — the disk agent casts them to the live
+        // storage type (with the session timezone), which is the only place the
+        // physical column types are known. Null/undecodable defaults are dropped
+        // here; a table with no usable default yields nullptr.
+        std::unique_ptr<components::vector::data_chunk_t> build_column_defaults_chunk(
+            std::pmr::memory_resource* resource,
+            const std::vector<std::pair<std::string, components::types::logical_value_t>>& defaults) {
+            std::pmr::vector<components::types::complex_logical_type> types{resource};
+            std::pmr::vector<const components::types::logical_value_t*> values{resource};
+            types.reserve(defaults.size());
+            values.reserve(defaults.size());
+            for (const auto& [name, value] : defaults) {
+                if (value.is_null()) {
+                    continue;
+                }
+                // The column type is the value's own type: vector_t::set_value gates
+                // on type equality (and ignores the alias), so this always passes.
+                auto type = value.type();
+                type.set_alias(name);
+                types.emplace_back(std::move(type));
+                values.emplace_back(&value);
+            }
+            if (types.empty()) {
+                return nullptr;
+            }
+            auto chunk = std::make_unique<components::vector::data_chunk_t>(resource, types, /*capacity=*/1);
+            chunk->set_cardinality(1);
+            for (size_t i = 0; i < values.size(); ++i) {
+                chunk->set_value(i, 0, *values[i]);
+            }
+            return chunk;
+        }
+
+    } // namespace
 
     components::operators::operator_ptr
     create_plan_insert(const context_storage_t& context,
@@ -31,7 +73,10 @@ namespace services::planner::impl {
         auto plan = boost::intrusive_ptr(new components::operators::operator_insert(context.resource,
                                                                                     context.log.clone(),
                                                                                     node->table_oid(),
-                                                                                    std::move(returning)));
+                                                                                    std::move(returning),
+                                                                                    build_column_defaults_chunk(
+                                                                                        context.resource,
+                                                                                        node_insert->column_defaults())));
         plan->set_children(create_plan(context, function_registry, node->children().front(), std::move(limit), params));
 
         return plan;

--- a/components/physical_plan_generator/impl/create_plan_insert.cpp
+++ b/components/physical_plan_generator/impl/create_plan_insert.cpp
@@ -5,49 +5,9 @@
 #include <components/physical_plan/operators/operator_insert.hpp>
 #include <components/physical_plan_generator/create_plan.hpp>
 
-#include <memory>
+#include <components/vector/data_chunk.hpp>
 
 namespace services::planner::impl {
-
-    namespace {
-
-        // Pack the catalog-decoded (name, value) DEFAULTs of the target table into
-        // the shape the disk contract already speaks: a one-row data_chunk_t whose
-        // column aliases carry the column names and whose row 0 holds the decoded
-        // values. The values stay UN-cast — the disk agent casts them to the live
-        // storage type (with the session timezone), which is the only place the
-        // physical column types are known. Null/undecodable defaults are dropped
-        // here; a table with no usable default yields nullptr.
-        std::unique_ptr<components::vector::data_chunk_t> build_column_defaults_chunk(
-            std::pmr::memory_resource* resource,
-            const std::vector<std::pair<std::string, components::types::logical_value_t>>& defaults) {
-            std::pmr::vector<components::types::complex_logical_type> types{resource};
-            std::pmr::vector<const components::types::logical_value_t*> values{resource};
-            types.reserve(defaults.size());
-            values.reserve(defaults.size());
-            for (const auto& [name, value] : defaults) {
-                if (value.is_null()) {
-                    continue;
-                }
-                // The column type is the value's own type: vector_t::set_value gates
-                // on type equality (and ignores the alias), so this always passes.
-                auto type = value.type();
-                type.set_alias(name);
-                types.emplace_back(std::move(type));
-                values.emplace_back(&value);
-            }
-            if (types.empty()) {
-                return nullptr;
-            }
-            auto chunk = std::make_unique<components::vector::data_chunk_t>(resource, types, /*capacity=*/1);
-            chunk->set_cardinality(1);
-            for (size_t i = 0; i < values.size(); ++i) {
-                chunk->set_value(i, 0, *values[i]);
-            }
-            return chunk;
-        }
-
-    } // namespace
 
     components::operators::operator_ptr
     create_plan_insert(const context_storage_t& context,
@@ -74,7 +34,7 @@ namespace services::planner::impl {
                                                                                     context.log.clone(),
                                                                                     node->table_oid(),
                                                                                     std::move(returning),
-                                                                                    build_column_defaults_chunk(
+                                                                                    components::vector::deep_copy(
                                                                                         context.resource,
                                                                                         node_insert->column_defaults())));
         plan->set_children(create_plan(context, function_registry, node->children().front(), std::move(limit), params));

--- a/components/planner/planner.cpp
+++ b/components/planner/planner.cpp
@@ -22,6 +22,7 @@
 #include <logical_plan/node_dynamic_cascade_delete.hpp>
 #include <logical_plan/node_fk_cascade.hpp>
 #include <logical_plan/node_fk_check.hpp>
+#include <components/vector/data_chunk.hpp>
 #include <logical_plan/node_insert.hpp>
 #include <logical_plan/node_refresh_matview.hpp>
 #include <logical_plan/node_sequence.hpp>
@@ -75,7 +76,9 @@ namespace components::planner {
                 // the write-set as its default (the stored row carries it). Absent-by-
                 // name is only meaningful when the INSERT carried an explicit column
                 // list (key_translation) — positional inserts may alias arbitrarily.
-                cc->set_column_defaults(ins->column_defaults());
+                // The chunk is move-only and the insert node keeps its own (create_plan_insert
+                // forwards it to storage_append), so the wrapper takes a deep copy.
+                cc->set_column_defaults(vector::deep_copy(r, ins->column_defaults()));
                 cc->set_write_set_named(!ins->key_translation().empty());
                 cc->append_child(cur);
                 cur = cc;
@@ -104,7 +107,7 @@ namespace components::planner {
                 // UNIQUE / PK enforcement on the UPDATE write-set (see rewrite_insert).
                 cc->set_unique_groups(upd->unique_groups());
                 cc->set_table_oid(upd->table_oid());
-                cc->set_column_defaults(upd->column_defaults());
+                cc->set_column_defaults(vector::deep_copy(r, upd->column_defaults()));
                 // An UPDATE write-set is the gathered storage row — always named.
                 cc->set_write_set_named(true);
                 cc->append_child(cur);

--- a/components/vector/data_chunk.cpp
+++ b/components/vector/data_chunk.cpp
@@ -230,6 +230,18 @@ namespace components::vector {
         other.set_cardinality(size() - offset);
     }
 
+    std::unique_ptr<data_chunk_t> deep_copy(std::pmr::memory_resource* resource, const data_chunk_t* src) {
+        if (src == nullptr || src->column_count() == 0) {
+            return nullptr;
+        }
+        // copy() asserts the destination is empty with FLAT columns and sets its
+        // cardinality itself — a freshly constructed chunk of the same types satisfies
+        // that. Capacity must be >= src->size().
+        auto dst = std::make_unique<data_chunk_t>(resource, src->types(), src->size() == 0 ? 1 : src->size());
+        src->copy(*dst, 0);
+        return dst;
+    }
+
     void data_chunk_t::copy(data_chunk_t& other,
                             const indexing_vector_t& indexing,
                             uint64_t source_count,

--- a/components/vector/data_chunk.hpp
+++ b/components/vector/data_chunk.hpp
@@ -4,6 +4,8 @@
 #include <components/types/logical_value.hpp>
 #include <core/result_wrapper.hpp>
 
+#include <memory>
+
 namespace components::vector {
 
     class data_chunk_t {
@@ -117,6 +119,14 @@ namespace components::vector {
     };
 
     void validate_chunk_capacity(vector::data_chunk_t& chunk, size_t filled_size);
+
+    // DEEP copy of `src` onto `resource`: fresh buffers, the same column types (aliases
+    // included) and the same rows. nullptr in => nullptr out, which is the "no data"
+    // sentinel for an owning unique_ptr member (data_chunk_t is move-only and has no
+    // default ctor). Not partial_copy(): that builds SLICE vectors referencing the
+    // source's buffers, which dangle once the source dies.
+    [[nodiscard]] std::unique_ptr<data_chunk_t> deep_copy(std::pmr::memory_resource* resource,
+                                                          const data_chunk_t* src);
 
     core::result_wrapper_t<types::logical_value_t> compact_to_bool_value(const data_chunk_t& data);
     core::result_wrapper_t<types::logical_value_t> compact_to_single_value(const data_chunk_t& data);

--- a/integration/cpp/test/test_persistence.cpp
+++ b/integration/cpp/test/test_persistence.cpp
@@ -359,6 +359,62 @@ TEST_CASE("integration::cpp::test_persistence::default_application_in_session") 
     }
 }
 
+TEST_CASE("integration::cpp::test_persistence::default_application_survives_restart") {
+    auto config = test_create_config("/tmp/otterbrix/integration/test_persistence/default_after_restart");
+    test_clear_directory(config);
+
+    INFO("phase 1: create a table with DEFAULTs, insert one defaulted row");
+    {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+
+        {
+            auto session = otterbrix::session_id_t();
+            dispatcher->execute_sql(session, "CREATE DATABASE " + database_name + ";");
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur =
+                dispatcher->execute_sql(session,
+                                        "CREATE TABLE TestDatabase.TestCollection "
+                                        "(name string, status string DEFAULT 'active', count bigint DEFAULT 0);");
+            REQUIRE(cur->is_success());
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(
+                session,
+                "INSERT INTO TestDatabase.TestCollection (name) VALUES ('alice');");
+            REQUIRE(cur->is_success());
+        }
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE status = 'active';", 1);
+    }
+
+    INFO("phase 2: after restart, replayed rows keep defaults AND new inserts still apply them");
+    {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+
+        // The replayed row kept its default (WAL records post-expansion chunks).
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE status = 'active';", 1);
+
+        // A fresh INSERT after restart must apply defaults too. This used to
+        // silently store NULL: the storage-level column defs rebuilt on restart
+        // (WAL-replay synthesis / adopt_schema / .otbx load) carried no
+        // default_value_, and the agent-side fill consulted only those.
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = dispatcher->execute_sql(
+                session,
+                "INSERT INTO TestDatabase.TestCollection (name) VALUES ('bob');");
+            REQUIRE(cur->is_success());
+        }
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection;", 2);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE status = 'active';", 2);
+        CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE count = 0;", 2);
+    }
+}
+
 TEST_CASE("integration::cpp::test_persistence::partial_insert_consistent_wal_recovery") {
     auto config = test_create_config("/tmp/otterbrix/integration/test_persistence/partial_insert_wal");
     test_clear_directory(config);

--- a/services/disk/agent_disk.cpp
+++ b/services/disk/agent_disk.cpp
@@ -483,7 +483,8 @@ namespace services::disk {
     agent_disk_t::unique_future<core::result_wrapper_t<std::pair<uint64_t, uint64_t>>>
     agent_disk_t::storage_append_inner(execution_context_t ctx,
                                        components::catalog::oid_t table_oid,
-                                       std::unique_ptr<components::vector::data_chunk_t> data) {
+                                       std::unique_ptr<components::vector::data_chunk_t> data,
+                                       std::unique_ptr<components::vector::data_chunk_t> column_defaults) {
         const auto txn = ctx.txn;
         const auto session_tz = ctx.session_tz;
         auto it = storages_.find(table_oid);
@@ -601,10 +602,41 @@ namespace services::disk {
                     found = true;
                 }
                 if (!found) {
+                    // Fallback source: the catalog-decoded (pg_attribute.attdefspec)
+                    // defaults stamped on the INSERT node — a one-row chunk whose
+                    // column aliases carry the column names. Storage-level defaults do
+                    // not survive a restart (WAL-replay schema synthesis, adopt_schema
+                    // and .otbx load all drop default_value_), so without this the
+                    // first INSERT after a restart silently stored NULL into defaulted
+                    // columns. Computing tables are excluded: their per-type variant
+                    // columns must stay NULL for absent variants.
+                    const uint64_t defaults_count = column_defaults ? column_defaults->column_count() : 0;
+                    uint64_t default_col = defaults_count;
+                    if (defaults_count > 0 && !is_computed_table && !table_columns[t].has_default_value()) {
+                        // Guarded alias scan, like the input-column match above:
+                        // column_index() asserts on a miss, and a miss is the common case.
+                        for (uint64_t col = 0; col < defaults_count; col++) {
+                            if (column_defaults->data[col].type().has_alias() &&
+                                column_defaults->data[col].type().alias() == table_columns[t].name() &&
+                                !column_defaults->is_null(col, 0)) {
+                                default_col = col;
+                                break;
+                            }
+                        }
+                    }
                     if (table_columns[t].has_default_value()) {
                         expanded_data.emplace_back(resource(), full_types[t], data->size());
                         for (uint64_t row = 0; row < data->size(); row++) {
                             expanded_data.back().set_value(row, table_columns[t].default_value());
+                        }
+                    } else if (default_col < defaults_count) {
+                        expanded_data.emplace_back(resource(), full_types[t], data->size());
+                        auto catalog_default = column_defaults->value(default_col, 0);
+                        auto filled = catalog_default.type() != full_types[t]
+                                          ? catalog_default.cast_as(full_types[t], session_tz)
+                                          : std::move(catalog_default);
+                        for (uint64_t row = 0; row < data->size(); row++) {
+                            expanded_data.back().set_value(row, filled);
                         }
                     } else {
                         expanded_data.emplace_back(resource(), full_types[t], data->size());

--- a/services/disk/agent_disk.hpp
+++ b/services/disk/agent_disk.hpp
@@ -216,7 +216,8 @@ namespace services::disk {
         unique_future<core::result_wrapper_t<std::pair<uint64_t, uint64_t>>>
         storage_append_inner(execution_context_t ctx,
                              components::catalog::oid_t table_oid,
-                             std::unique_ptr<components::vector::data_chunk_t> data);
+                             std::unique_ptr<components::vector::data_chunk_t> data,
+                             std::unique_ptr<components::vector::data_chunk_t> column_defaults);
 
         // storage_publish_commits_inner — MVCC visibility flip. Iterates
         //   `ranges` and calls commit_append per range against owned twins;

--- a/services/disk/disk_contract.hpp
+++ b/services/disk/disk_contract.hpp
@@ -233,10 +233,16 @@ namespace services::disk {
 
         // Reply wraps (start_row, count) so a write_conflict / out_of_memory from the
         // table-layer append chain reaches operator_insert as a value.
+        // column_defaults: catalog-sourced (pg_attribute.attdefspec) DEFAULTs of the
+        // target table as a one-row chunk — column aliases carry the column names,
+        // row 0 the decoded (un-cast) values; nullptr when the table has none. Used
+        // as the fill fallback for omitted columns when the storage-level column defs
+        // carry no default (they never do after a restart).
         actor_zeta::unique_future<core::result_wrapper_t<std::pair<uint64_t, uint64_t>>>
         storage_append(execution_context_t ctx,
                        components::catalog::oid_t table_oid,
-                       std::pmr::vector<components::vector::data_chunk_t> data);
+                       std::pmr::vector<components::vector::data_chunk_t> data,
+                       std::unique_ptr<components::vector::data_chunk_t> column_defaults);
 
         // Reply wraps (updated, appended) so a write_conflict / out_of_memory from the
         // table-layer MVCC update reaches operator_update / fk_cascade as a value.

--- a/services/disk/manager_disk.hpp
+++ b/services/disk/manager_disk.hpp
@@ -678,7 +678,8 @@ namespace services::disk {
         unique_future<core::result_wrapper_t<std::pair<uint64_t, uint64_t>>>
         storage_append(execution_context_t ctx,
                        components::catalog::oid_t table_oid,
-                       std::pmr::vector<components::vector::data_chunk_t> data);
+                       std::pmr::vector<components::vector::data_chunk_t> data,
+                       std::unique_ptr<components::vector::data_chunk_t> column_defaults);
 
         // Updates every chunk in order; row_ids[i] are the storage row-ids for data[i]
         // (the two vectors are positionally aligned and must have equal length). Returns

--- a/services/disk/manager_disk_storage.cpp
+++ b/services/disk/manager_disk_storage.cpp
@@ -455,7 +455,8 @@ namespace services::disk {
     manager_disk_t::unique_future<core::result_wrapper_t<std::pair<uint64_t, uint64_t>>>
     manager_disk_t::storage_append(execution_context_t ctx,
                                    catalog::oid_t table_oid,
-                                   std::pmr::vector<components::vector::data_chunk_t> data) {
+                                   std::pmr::vector<components::vector::data_chunk_t> data,
+                                   std::unique_ptr<components::vector::data_chunk_t> column_defaults) {
         // The full preprocessing pipeline (schema adoption/growth, column
         // expansion, NOT NULL, dedup, type promotion) and the canonical write live
         // in the agent twin, so every same-oid access is serialized by the agent's
@@ -480,11 +481,21 @@ namespace services::disk {
                 continue;
             }
             auto one = std::make_unique<components::vector::data_chunk_t>(std::move(chunk));
+            // One inner send per chunk, so each carries its own copy of the
+            // (one-row) defaults; the member must survive for the next chunk.
+            std::unique_ptr<components::vector::data_chunk_t> defaults_copy;
+            if (column_defaults) {
+                defaults_copy = std::make_unique<components::vector::data_chunk_t>(resource(),
+                                                                                   column_defaults->types(),
+                                                                                   column_defaults->size());
+                column_defaults->copy(*defaults_copy, 0);
+            }
             auto [needs_sched, fut] = actor_zeta::otterbrix::send(agent->address(),
                                                                   &agent_disk_t::storage_append_inner,
                                                                   ctx,
                                                                   table_oid,
-                                                                  std::move(one));
+                                                                  std::move(one),
+                                                                  std::move(defaults_copy));
             if (needs_sched) {
                 scheduler_disk_->enqueue(agent.get());
             }

--- a/services/disk/manager_disk_storage.cpp
+++ b/services/disk/manager_disk_storage.cpp
@@ -481,15 +481,9 @@ namespace services::disk {
                 continue;
             }
             auto one = std::make_unique<components::vector::data_chunk_t>(std::move(chunk));
-            // One inner send per chunk, so each carries its own copy of the
-            // (one-row) defaults; the member must survive for the next chunk.
-            std::unique_ptr<components::vector::data_chunk_t> defaults_copy;
-            if (column_defaults) {
-                defaults_copy = std::make_unique<components::vector::data_chunk_t>(resource(),
-                                                                                   column_defaults->types(),
-                                                                                   column_defaults->size());
-                column_defaults->copy(*defaults_copy, 0);
-            }
+            // One inner send per chunk, so each carries its own copy of the (one-row)
+            // defaults; the parameter must survive for the next chunk.
+            auto defaults_copy = components::vector::deep_copy(resource(), column_defaults.get());
             auto [needs_sched, fut] = actor_zeta::otterbrix::send(agent->address(),
                                                                   &agent_disk_t::storage_append_inner,
                                                                   ctx,

--- a/services/disk/tests/test_ddl_methods.cpp
+++ b/services/disk/tests/test_ddl_methods.cpp
@@ -24,6 +24,12 @@
 #include <thread>
 #include <unistd.h>
 
+// storage_append gained a catalog-defaults parameter (a one-row chunk whose
+// column aliases carry the column names); these fixture tests exercise raw
+// appends with no INSERT node, so they pass no defaults.
+static std::unique_ptr<components::vector::data_chunk_t> no_defaults() { return nullptr; }
+
+
 // DDL roundtrip tests. Each test creates catalog objects via the build_create_*_writes
 // helpers and verifies that resolve_* methods see the written rows correctly.
 
@@ -613,7 +619,7 @@ TEST_CASE("services::disk::ddl::vacuum_physical_compaction_removes_dropped_colum
                                                    components::table::transaction_data{0, 0},
                                                    {},
                                                    table_oid};
-        fx.invoke(&manager_disk_t::storage_append, append_ctx, table_oid, to_batch(&fx.resource, std::move(chunk)));
+        fx.invoke(&manager_disk_t::storage_append, append_ctx, table_oid, to_batch(&fx.resource, std::move(chunk)), no_defaults());
     }
 
     // Verify storage now has 3 columns (post-#96).
@@ -766,7 +772,7 @@ TEST_CASE("services::disk::ddl::storage_expand_on_write_for_dynamic_schema") {
         auto append_r = fx.invoke(&manager_disk_t::storage_append,
                                   append_ctx(table_oid),
                                   table_oid,
-                                  to_batch(&fx.resource, std::move(chunk)));
+                                  to_batch(&fx.resource, std::move(chunk)), no_defaults());
         REQUIRE_FALSE(append_r.has_error());
         auto [start, count] = append_r.value();
         REQUIRE(count == 1);
@@ -790,7 +796,7 @@ TEST_CASE("services::disk::ddl::storage_expand_on_write_for_dynamic_schema") {
         fx.invoke(&manager_disk_t::storage_append,
                   append_ctx(table_oid),
                   table_oid,
-                  to_batch(&fx.resource, std::move(chunk)));
+                  to_batch(&fx.resource, std::move(chunk)), no_defaults());
     }
 
     {
@@ -832,7 +838,7 @@ TEST_CASE("services::disk::ddl::storage_expand_on_write_for_dynamic_schema") {
         fx.invoke(&manager_disk_t::storage_append,
                   append_ctx(table_oid),
                   table_oid,
-                  to_batch(&fx.resource, std::move(chunk)));
+                  to_batch(&fx.resource, std::move(chunk)), no_defaults());
     }
 
     {
@@ -897,7 +903,7 @@ TEST_CASE("services::disk::ddl::drop_storage_many_erases_n") {
         chunk->set_value(0, 0, kval);
         chunk->set_value(1, 0, std::int64_t{kval * 10});
         components::execution_context_t append_ctx{session_id_t{}, components::table::transaction_data{0, 0}, {}, oid};
-        fx.invoke(&manager_disk_t::storage_append, append_ctx, oid, to_batch(&fx.resource, std::move(chunk)));
+        fx.invoke(&manager_disk_t::storage_append, append_ctx, oid, to_batch(&fx.resource, std::move(chunk)), no_defaults());
     };
 
     // Create + populate the N targets and the survivor.

--- a/services/disk/tests/test_pushdown_reduce.cpp
+++ b/services/disk/tests/test_pushdown_reduce.cpp
@@ -35,6 +35,12 @@
 #include <map>
 #include <vector>
 
+// storage_append gained a catalog-defaults parameter (a one-row chunk whose
+// column aliases carry the column names); these fixture tests exercise raw
+// appends with no INSERT node, so they pass no defaults.
+static std::unique_ptr<components::vector::data_chunk_t> no_defaults() { return nullptr; }
+
+
 using namespace services::disk;
 using namespace pushdown_reduce_test;
 using pushdown_test::sum_uid;
@@ -113,7 +119,7 @@ TEST_CASE("pushdown_reduce: read-your-own-writes SUM over an uncommitted txn (D4
     components::execution_context_t append_ctx{session_id_t{}, txn, {}};
     append_ctx.table_oid = table_oid;
     auto appended =
-        fx.invoke(&manager_disk_t::storage_append, append_ctx, table_oid, batch_rows(&fx.resource, 1, {{10}, {20}, {30}}));
+        fx.invoke(&manager_disk_t::storage_append, append_ctx, table_oid, batch_rows(&fx.resource, 1, {{10}, {20}, {30}}), no_defaults());
     REQUIRE_FALSE(appended.has_error());
 
     auto partials = fx.drive_reduce(table_oid, build_sum_spec(&fx.resource, /*group_col=*/-1, /*val_col=*/0), txn);
@@ -178,7 +184,7 @@ TEST_CASE("pushdown_reduce: GROUP BY key + SUM returns the full grouped result")
     auto appended = fx.invoke(&manager_disk_t::storage_append,
                               append_ctx,
                               table_oid,
-                              batch_rows(&fx.resource, 2, {{1, 10}, {1, 20}, {2, 30}, {2, 5}}));
+                              batch_rows(&fx.resource, 2, {{1, 10}, {1, 20}, {2, 30}, {2, 5}}), no_defaults());
     REQUIRE_FALSE(appended.has_error());
 
     auto partials = fx.drive_reduce(table_oid, build_sum_spec(&fx.resource, /*group_col=*/0, /*val_col=*/1), txn);

--- a/services/disk/tests/test_resolve.cpp
+++ b/services/disk/tests/test_resolve.cpp
@@ -24,6 +24,12 @@
 #include <utility>
 #include <vector>
 
+// storage_append gained a catalog-defaults parameter (a one-row chunk whose
+// column aliases carry the column names); these fixture tests exercise raw
+// appends with no INSERT node, so they pass no defaults.
+static std::unique_ptr<components::vector::data_chunk_t> no_defaults() { return nullptr; }
+
+
 using namespace services::disk;
 namespace catalog = components::catalog;
 using namespace components::catalog;
@@ -225,7 +231,7 @@ TEST_CASE("services::disk::resolve::read_chunks_by_keys_multi_key_parity") {
                                                    {},
                                                    table_oid};
         auto append_r =
-            fx.invoke(&manager_disk_t::storage_append, append_ctx, table_oid, to_batch(&fx.resource, std::move(chunk)));
+            fx.invoke(&manager_disk_t::storage_append, append_ctx, table_oid, to_batch(&fx.resource, std::move(chunk)), no_defaults());
         REQUIRE_FALSE(append_r.has_error());
         auto [start, count] = append_r.value();
         REQUIRE(count == nrows);

--- a/services/dispatcher/enrich_logical_plan.cpp
+++ b/services/dispatcher/enrich_logical_plan.cpp
@@ -48,8 +48,12 @@
 #include <components/sql/transformer/utils.hpp>
 #include <services/index/manager_index.hpp>
 
+#include <components/vector/data_chunk.hpp>
+
 #include <algorithm>
 #include <limits>
+#include <memory>
+#include <optional>
 #include <queue>
 #include <string>
 #include <unordered_map>
@@ -100,22 +104,53 @@ namespace services::dispatcher { namespace {
         }
     }
 
-    // Decoded column DEFAULT values for the constraint operators: an INSERT omitting
-    // a defaulted column stores the default (filled agent-side at storage_append), so
-    // CHECK / UNIQUE must evaluate the ABSENT column AS its default.
-    std::vector<std::pair<std::string, components::types::logical_value_t>>
+    // Decoded column DEFAULTs of the target table as a ONE-ROW data_chunk_t: one column
+    // per default, the column name in the column's type alias, row 0 the decoded value;
+    // nullptr when the table has no usable default. This is the shape the disk contract
+    // speaks — the chunk rides the INSERT node into operator_insert and on to
+    // storage_append, where the agent fills omitted columns from it. Its values stay
+    // UN-cast: only the agent knows the live physical column types.
+    // An INSERT omitting a defaulted column stores the default, so CHECK / UNIQUE must
+    // evaluate the ABSENT column AS its default (the planner deep-copies the chunk onto
+    // the constraint node).
+    std::unique_ptr<components::vector::data_chunk_t>
     decode_column_defaults(std::pmr::memory_resource* resource,
                            const components::logical_plan::resolved_table_metadata_t& md) {
-        std::vector<std::pair<std::string, components::types::logical_value_t>> defaults;
+        // A default is usable when it decodes to a non-NULL value: a NULL default is
+        // indistinguishable from "no default" at every consumer, and an NA-typed value
+        // has no vector representation.
+        auto usable_default = [resource](const auto& col) {
+            auto v = col.atthasdefault && !col.attdefspec.empty()
+                         ? components::catalog::decode_default_spec(resource, col.attdefspec)
+                         : std::nullopt;
+            return v && !v->is_null() ? std::move(v) : std::nullopt;
+        };
+
+        // The chunk needs its full column list up front, so walk the columns once for
+        // the types and once for the values. decode_default_spec is a pure flat-text
+        // parse of a short spec, run once per plan — cheaper than staging the values.
+        std::pmr::vector<components::types::complex_logical_type> types{resource};
         for (const auto& col : md.columns) {
-            if (!col.atthasdefault || col.attdefspec.empty()) {
-                continue;
-            }
-            if (auto v = components::catalog::decode_default_spec(resource, col.attdefspec)) {
-                defaults.emplace_back(col.attname, std::move(*v));
+            if (auto v = usable_default(col)) {
+                // The column type is the value's own type: vector_t::set_value gates on
+                // type equality and ignores the alias, so this always passes.
+                auto type = v->type();
+                type.set_alias(col.attname);
+                types.emplace_back(std::move(type));
             }
         }
-        return defaults;
+        if (types.empty()) {
+            return nullptr; // nullptr is the only "no defaults" sentinel
+        }
+        auto chunk = std::make_unique<components::vector::data_chunk_t>(resource, types, /*capacity=*/1);
+        chunk->set_cardinality(1);
+        uint64_t col_idx = 0;
+        for (const auto& col : md.columns) {
+            if (auto v = usable_default(col)) {
+                chunk->set_value(col_idx++, 0, *v);
+            }
+        }
+        return chunk;
     }
 
     void enrich_insert_sync(components::logical_plan::node_insert_t* node,


### PR DESCRIPTION
After **any** engine restart — clean shutdown or crash, in-memory and disk-backed tables alike — an INSERT that omits a column with a declared DEFAULT silently stores **NULL** instead of the default. With `v BIGINT NOT NULL DEFAULT 42` the INSERT still reports success and materializes a NULL into a NOT NULL column: durable, constraint-violating corruption from an ordinary statement.

```sql
CREATE TABLE db.t (id BIGINT, v BIGINT DEFAULT 42);
INSERT INTO db.t (id) VALUES (1);   -- v = 42, correct
-- restart (clean or crash)
INSERT INTO db.t (id) VALUES (2);   -- v = NULL  ← the bug
```

All of the above was verified empirically against current `main` through the C API, in both storage modes.

## Root cause

The agent-side fill of omitted columns consults only the **storage-level** `column_definition_t` defaults (`agent_disk.cpp`, column-expansion stage), and no restore path preserves those:

- WAL-replay schema synthesis rebuilds columns from chunk types only;
- `data_table_t::adopt_schema` builds `(alias, type)` pairs only;
- the `.otbx` checkpoint format serializes name/type/not_null and loads without defaults.

So the first post-restart INSERT sees a schema with no defaults and NULL-fills. Replayed *rows* were never affected — the `PHYSICAL_INSERT` WAL record is written after the expansion, so recorded chunks carry default values baked in (also verified: crash-restart keeps `v = 42` for pre-restart rows).

Meanwhile the durable source of truth already exists end to end: `pg_attribute.attdefspec` persists the defaults, and the dispatcher decodes them onto every enriched INSERT node (`node_insert_t::column_defaults`) — but they were only used by the CHECK/UNIQUE constraint operators, never by the physical fill.

## Fix

Forward the node's catalog-sourced defaults through `operator_insert` → `storage_append` → the agent's existing fill, as a **fallback** when the storage-level column def carries no default:

- the live single-session path is unchanged (storage-level defaults still win when present);
- the fill still runs before the WAL chunk copy, so recorded and materialized rows stay identical — no replay-path change needed;
- computing tables (`relkind='g'`) are excluded: their per-type variant columns must stay NULL for absent variants;
- the decoded value is cast to the physical column type (session timezone honored) when they differ.

`storage_append` / `storage_append_inner` gain a `column_defaults` parameter (compile-checked across the actor contract; the disk-service fixture tests pass `nullptr`).

The fix is the first commit; the second commit reworks how the defaults are represented (below).

### Representation: a one-row `data_chunk_t` (second commit)

Column DEFAULTs used to travel as an ad-hoc `std::vector<std::pair<std::string, logical_value_t>>` — from the enrich pass, through the logical nodes and the planner, into the constraint operators. The second commit replaces that representation end to end with the shape the executor and the disk contract already speak: a **one-row `data_chunk_t`** — one column per default, the column name in the column's type alias, row 0 the decoded value, `nullptr` when the table has none.

- `services/dispatcher/enrich_logical_plan.cpp` — `decode_column_defaults` now **builds** the chunk from `pg_attribute.attdefspec`.
- `node_insert_t` / `node_update_t` / `node_check_constraint_t` — own the chunk; getters hand out a `const data_chunk_t*`.
- `planner` / `create_plan_insert` / `create_plan_check_constraint` — deep-copy it into each consumer (it is move-only, and the check and unique operators each need their own).
- `operator_check_constraint` / `operator_unique_constraint` — read defaults out of the chunk.
- `components/vector` — one shared `deep_copy(resource, chunk)` replaces five hand-rolled copies. (`partial_copy` is *not* a deep copy: it builds slice vectors aliasing the source's buffers.)

Why this shape: `storage_append_inner` already ships its main payload as a `unique_ptr<data_chunk_t>`, so the defaults parameter matches its sibling and `nullptr` is a natural "none"; `agent_disk` already builds exactly this one-row aliased chunk elsewhere; and alias-based column matching is already load-bearing in the agent's fill.

Two things worth a reviewer's eye. The unique operator's `key_source_t` used to hold a `const logical_value_t*` into the pair-vector's storage — `data_chunk_t::value()` **materializes** a value, so it now holds the defaults-chunk *column index* instead (a literal port would have dangled). And every defaults lookup is a guarded `has_alias()` scan rather than `data_chunk_t::column_index()`, which `assert(false)`s on a miss — a miss being the normal case here; the same guard fixes two pre-existing unguarded `alias()` calls in the constraint operators.

Semantics are unchanged: same exact case-sensitive name matching, same first-match-wins, NULL defaults still collapse to "no default", and the values stay un-cast because only the disk agent knows the live physical column types — which is exactly what drifts on restart.

## Testing

- New `integration::cpp::test_persistence::default_application_survives_restart`: two-scope restart; asserts the replayed row keeps its default (passes before and after — pins the verified-good WAL behavior) and that a **post-restart** INSERT omitting defaulted columns applies them. The second half stored NULLs before this fix.
- Existing `default_application_in_session` still passes (the live single-session path is unchanged).
- Full disk-service suite (130 cases), full persistence suite (31 cases), the 22 CHECK/UNIQUE constraint tests (the other consumers of the defaults), the component unit suites, and the rest of the integration suite in slices — all green.

## Known adjacent gaps, intentionally out of scope

- Persisting defaults into the `.otbx` column metadata (needs a format version bump) and restoring `not_null` on the WAL-replay synthesis path — this fix makes both unnecessary for correctness of the fill, but they'd be nice-to-have defense in depth.
- `encode_default_spec` returns an empty spec for ARRAY/STRUCT/LIST defaults, so complex-typed defaults still NULL-fill after restart (pre-existing limitation, unchanged).
- Verified separately and not fixed here: `SELECT` on a column added via `ALTER TABLE ADD COLUMN ... DEFAULT` crashes (SIGBUS) even in a fresh session — pre-existing on `main`, will file separately.

