### PR TITLE
fix(planner): WHERE NOT over a constant predicate crashed or errored

### DIFF
--- a/components/expressions/compare_expression.cpp
+++ b/components/expressions/compare_expression.cpp
@@ -125,6 +125,16 @@ namespace components::expressions {
 
     expression_ptr& as_expr(param_storage& param) { return std::get<expression_ptr>(param); }
 
+    bool is_parameter(const param_storage& param) noexcept {
+        return std::holds_alternative<core::parameter_id_t>(param);
+    }
+
+    const core::parameter_id_t& as_parameter(const param_storage& param) {
+        return std::get<core::parameter_id_t>(param);
+    }
+
+    core::parameter_id_t& as_parameter(param_storage& param) { return std::get<core::parameter_id_t>(param); }
+
     compare_type get_compare_type(const std::string& key) {
         if (key.empty()) {
             return compare_type::invalid;

--- a/components/expressions/compare_expression.hpp
+++ b/components/expressions/compare_expression.hpp
@@ -82,4 +82,11 @@ namespace components::expressions {
     const expression_ptr& as_expr(const param_storage& param);
     expression_ptr& as_expr(param_storage& param);
 
+    // Same encapsulation for the parameter-id alternative of `param_storage`.
+    // as_parameter must be guarded by is_parameter (it delegates to std::get,
+    // which throws on a mismatched alternative).
+    bool is_parameter(const param_storage& param) noexcept;
+    const core::parameter_id_t& as_parameter(const param_storage& param);
+    core::parameter_id_t& as_parameter(param_storage& param);
+
 } // namespace components::expressions

--- a/components/physical_plan/operators/scan/full_scan.cpp
+++ b/components/physical_plan/operators/scan/full_scan.cpp
@@ -1,5 +1,6 @@
 #include "full_scan.hpp"
 
+#include <components/expressions/compare_expression.hpp>
 #include <services/disk/manager_disk.hpp>
 
 namespace components::operators {
@@ -14,7 +15,12 @@ namespace components::operators {
             return std::unique_ptr<table::table_filter_t>{};
         }
         if (expression->type() == expressions::compare_type::all_false) {
-            assert(false && "all_false should be short-circuited in source_next");
+            // Callers short-circuit all_false before filter construction
+            // (source_next / pushed_reduce_scan). If one ever does not, fail
+            // with an error instead of the previous Release-erased assert
+            // falling through into the switch below.
+            return core::error_t{core::error_code_t::physical_plan_error,
+                                 std::pmr::string{"all_false predicate reached filter construction", resource}};
         }
         switch (expression->type()) {
             case expressions::compare_type::union_and: {
@@ -133,9 +139,16 @@ namespace components::operators {
                     std::make_unique<table::is_null_filter_t>(expression->type(), std::move(indices)));
             }
             default: {
-                assert(std::holds_alternative<expressions::key_t>(expression->left()));
-                const auto& path = std::get<expressions::key_t>(expression->left()).path();
-                auto id = std::get<core::parameter_id_t>(expression->right());
+                // Guarded std::get: with the asserts erased in Release, a
+                // non-key left or non-parameter right operand reached the
+                // std::get below as a bad variant access.
+                if (!expressions::is_key(expression->left()) || !expressions::is_parameter(expression->right())) {
+                    return core::error_t{
+                        core::error_code_t::physical_plan_error,
+                        std::pmr::string{"unexpected operand shape in expression to filter conversion", resource}};
+                }
+                const auto& path = expressions::as_key(expression->left()).path();
+                auto id = expressions::as_parameter(expression->right());
                 std::pmr::vector<uint64_t> indices(path.begin(), path.end(), path.get_allocator().resource());
                 auto it = parameters->parameters.find(id);
                 if (it == parameters->parameters.end()) {

--- a/components/planner/optimizer/rules/constant_folding.cpp
+++ b/components/planner/optimizer/rules/constant_folding.cpp
@@ -232,6 +232,25 @@ namespace components::planner::optimizer {
             }
             try_fold_compare(*comp, parameters);
             simplify_union(comp);
+            // NOT over a fully folded single child folds to the complementary
+            // constant: NOT(all_false) scans everything, NOT(all_true) is the
+            // short-circuited empty scan. Only the single-child form folds —
+            // multi-child union_not means NOT(child1 AND child2 ...) and keeps
+            // its children. Without this, `WHERE NOT (1=2)` survived folding
+            // into filter construction, whose all_false / key-shape guards
+            // were Release-erased asserts.
+            if (comp->type() == compare_type::union_not && comp->children().size() == 1 &&
+                comp->children().front()->group() == expression_group::compare) {
+                const auto child_type =
+                    static_cast<const compare_expression_t*>(comp->children().front().get())->type();
+                if (child_type == compare_type::all_false) {
+                    comp->set_type(compare_type::all_true);
+                    comp->children().clear();
+                } else if (child_type == compare_type::all_true) {
+                    comp->set_type(compare_type::all_false);
+                    comp->children().clear();
+                }
+            }
             if (comp->type() == compare_type::union_and || comp->type() == compare_type::union_or) {
                 const auto neutral =
                     (comp->type() == compare_type::union_and) ? compare_type::all_true : compare_type::all_false;

--- a/components/planner/test/test_optimizer.cpp
+++ b/components/planner/test/test_optimizer.cpp
@@ -1344,3 +1344,42 @@ TEST_CASE("optimizer::promote_cross_join::comma_join_becomes_inner_hash") {
     // The group{SUM} pipeline stage is left untouched by the promotion.
     REQUIRE(agg->children()[2]->type() == node_type::group_t);
 }
+
+// ================================================================
+// NOT folding: union_not over a fully folded single child must fold
+// to the complementary constant. Without this, `WHERE NOT (1=2)`
+// survived folding and reached filter construction, whose all_false /
+// key-shape guards were Release-erased asserts (crash / bad variant
+// access), and `WHERE NOT (1=1)` produced a spurious error.
+// ================================================================
+TEST_CASE("optimizer::not_fold_all_false_child") {
+    auto resource = core::pmr::otterbrix_resource();
+    auto params = make_parameter_node(&resource);
+    auto id0 = params->add_parameter(int64_t(1));
+    auto id1 = params->add_parameter(int64_t(2));
+
+    auto comp = make_compare_union_expression(&resource, compare_type::union_not);
+    comp->append_child(make_compare_expression(&resource, compare_type::eq, id0, id1));
+    auto node = make_match_with_expr(&resource, comp);
+    components::planner::optimize(&resource, node, params.get());
+
+    auto* c = static_cast<compare_expression_t*>(comp.get());
+    REQUIRE(c->type() == compare_type::all_true);
+    REQUIRE(c->children().empty());
+}
+
+TEST_CASE("optimizer::not_fold_all_true_child") {
+    auto resource = core::pmr::otterbrix_resource();
+    auto params = make_parameter_node(&resource);
+    auto id0 = params->add_parameter(int64_t(1));
+    auto id1 = params->add_parameter(int64_t(1));
+
+    auto comp = make_compare_union_expression(&resource, compare_type::union_not);
+    comp->append_child(make_compare_expression(&resource, compare_type::eq, id0, id1));
+    auto node = make_match_with_expr(&resource, comp);
+    components::planner::optimize(&resource, node, params.get());
+
+    auto* c = static_cast<compare_expression_t*>(comp.get());
+    REQUIRE(c->type() == compare_type::all_false);
+    REQUIRE(c->children().empty());
+}

--- a/integration/cpp/test/test_sql_features.cpp
+++ b/integration/cpp/test/test_sql_features.cpp
@@ -4700,3 +4700,87 @@ TEST_CASE("integration::cpp::test_sql_features::values_leading_null_column_promo
         REQUIRE(cur->value(0, 0).value<uint64_t>() == 2);
     }
 }
+
+// WHERE with a constant (parameter-free) predicate: the folded child
+// (all_true/all_false) used to survive inside union_not all the way to filter
+// construction, whose all_false / key-shape guards were Release-erased asserts.
+// `NOT (1=2)` crashed the process (bad variant access) and `NOT (1=1)` returned
+// a spurious "empty NOT filter" error instead of an empty result. A constant
+// predicate must resolve to "all rows" (true) or "no rows" (false), and must go
+// on doing so when it is buried inside a nested boolean tree, carries constant
+// arithmetic, or is AND/OR-combined with real column predicates.
+//
+// Table: three rows, (x, y) = (1,10), (2,20), (3,30).
+TEST_CASE("integration::cpp::test_sql_features::constant_predicate_folding") {
+    auto config = test_create_config("/tmp/test_sql_features/constant_predicate");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE db;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE db.t (x bigint, y bigint);")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "INSERT INTO db.t (x, y) VALUES (1, 10), (2, 20), (3, 30);")
+                    ->is_success());
+    }
+
+    // Runs `SELECT x FROM db.t WHERE <where>` and returns the row count; the
+    // query must always succeed (never crash, never spuriously error).
+    auto rows = [&](const char* where) -> std::size_t {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, std::string{"SELECT x FROM db.t WHERE "} + where + ";");
+        REQUIRE(cur->is_success());
+        return cur->size();
+    };
+
+    SECTION("a bare constant predicate collapses to all rows / no rows") {
+        REQUIRE(rows("1 = 1") == 3);       // always true
+        REQUIRE(rows("1 = 2") == 0);       // always false
+        REQUIRE(rows("1 + 1 = 2") == 3);   // constant arithmetic, true
+        REQUIRE(rows("10 - 5 = 4") == 0);  // constant arithmetic, false
+        REQUIRE(rows("NOT (1 = 2)") == 3); // NOT false -> true (was: crash)
+        REQUIRE(rows("NOT (1 = 1)") == 0); // NOT true  -> false (was: spurious error)
+        REQUIRE(rows("NOT (2 * 3 = 6)") == 0);  // NOT true
+        REQUIRE(rows("NOT (10 / 2 = 5)") == 0); // NOT true
+    }
+
+    SECTION("constant predicates nested inside boolean trees") {
+        REQUIRE(rows("(1 = 1) AND (2 = 2)") == 3); // true  AND true
+        REQUIRE(rows("(1 = 1) OR (2 = 3)") == 3);  // true  OR  false
+        REQUIRE(rows("(1 = 2) AND (3 = 3)") == 0); // false AND true
+        REQUIRE(rows("(1 = 2) OR (3 = 4)") == 0);  // false OR  false
+        REQUIRE(rows("NOT ((1 = 1) AND (2 = 2))") == 0); // NOT true
+        REQUIRE(rows("NOT ((1 = 2) OR (3 = 3))") == 0);  // NOT true
+        REQUIRE(rows("NOT ((1 = 2) AND (3 = 3))") == 3); // NOT false
+        // NB: double negation `NOT (NOT (1 = 1))` is deliberately absent — it is
+        // mis-folded to a single NOT (returns 0 rows instead of 3), a separate
+        // bug from the constant-folding path this test pins.
+    }
+
+    SECTION("a constant folded together with real column predicates") {
+        REQUIRE(rows("NOT (1 = 2) AND x >= 2") == 2);                 // true  AND x>=2 -> {2,3}
+        REQUIRE(rows("1 = 1 OR x = 999") == 3);                       // true  OR  ...  -> all
+        REQUIRE(rows("NOT (1 = 1) OR (x = 2 AND y = 20)") == 1);      // false OR  {2}
+        REQUIRE(rows("NOT ((1 = 2) OR (5 = 6)) AND y > 15") == 2);    // true  AND y>15 -> {2,3}
+        REQUIRE(rows("x = 1 AND 1 = 1 AND y = 10") == 1);            // {1}
+        REQUIRE(rows("1 = 2 OR x = 3 OR 2 = 2") == 3);              // ... OR true -> all
+        REQUIRE(rows("(x = 1 OR 1 = 1) AND x < 3") == 2);            // (true) AND x<3 -> {1,2}
+    }
+
+    SECTION("NOT over ordinary column predicates still works") {
+        REQUIRE(rows("NOT (x = 1)") == 2);              // {2,3}
+        REQUIRE(rows("NOT (x = 1 AND y = 10)") == 2);   // exclude {1} -> {2,3}
+        REQUIRE(rows("NOT (x = 2 OR x = 3)") == 1);     // {1}
+        REQUIRE(rows("NOT (x >= 2) AND y < 100") == 1); // {1}
+        REQUIRE(rows("x = 2 OR NOT (1 = 1)") == 1);     // {2} OR false
+    }
+}


### PR DESCRIPTION
Two sibling defects behind `WHERE NOT (<constant predicate>)`, both verified against current `main` (Release build):

```sql
SELECT x FROM t WHERE NOT (1 = 2);   -- segfault (bad variant access)
SELECT x FROM t WHERE NOT (1 = 1);   -- spurious "empty NOT filter — expression construction error"
```

## Root cause

Constant folding folds the *child* of `union_not` to `all_false` / `all_true`, but never simplifies the `union_not` itself, so the folded constant survives into `full_scan`'s `transform_predicate`. There, the `all_false` guard and the default arm's operand-shape check were **assert-only** — erased under NDEBUG — so execution fell through to `std::get` on the wrong variant alternative (the `NOT (1=2)` crash), while `NOT (1=1)`'s all-true child got dropped as a "neutral" conjunction child, leaving an empty NOT filter (the spurious error).

## Fix

- **At the source** (`constant_folding.cpp`): single-child `union_not` over a folded constant now folds to the complementary constant — `NOT(all_false)` → `all_true` (scan everything), `NOT(all_true)` → `all_false` (short-circuited empty scan). Multi-child `union_not` means `NOT(child1 AND child2 …)` and keeps its semantics untouched.
- **Defense in depth** (`full_scan.cpp`): the two assert-only guards in `transform_predicate` are now proper `physical_plan_error` returns, so no future caller can fall through into the bad variant access.

## Testing

- Two optimizer unit tests (`optimizer::not_fold_all_false_child` / `not_fold_all_true_child`) — failed on the unfolded type before the fix.
- Integration regression `test_sql_features::constant_predicate_folding` (66 assertions): `NOT (1=2)` returns all rows and `NOT (1=1)` returns an empty success — the first segfaulted the test binary and the second errored before the fix. Extended to keep constant folding honest under real complexity: bare constants and constant arithmetic (`1+1 = 2`), constants nested inside AND/OR/NOT boolean trees, constants AND/OR-combined with real column predicates, and `NOT` over ordinary column predicates.
- Full optimizer suite plus the pushdown/aggregate/scan suites that share `transform_predicate` pass.

