### PR TITLE
fix(sql): bare subquery in predicate position crashed the server

### DIFF
--- a/components/sql/test/test_errors.cpp
+++ b/components/sql/test/test_errors.cpp
@@ -159,4 +159,12 @@ TEST_CASE("components::sql::errors") {
     TEST_PARSER_ERROR("CREATE INDEX base ON TEST_DATABASE.TEST_COLLECTION;", R"_(syntax error at or near ";")_");
 
     TEST_TRANSFORMER_ERROR("DROP INDEX TEST_DATABASE.TEST_COLLECTION;", R"_(incorrect drop: arguments size)_");
+
+    // A bare subquery in predicate position (EXPR_SUBLINK) — and the other
+    // SubLink kinds without transform support — used to fall off the end of
+    // transform_sublink_expr through a Release-erased assert(false): undefined
+    // behavior (observed as a segfault). They must be clean transformer errors.
+    TEST_TRANSFORMER_ERROR("SELECT * FROM TEST_DATABASE.TEST_COLLECTION WHERE (SELECT count FROM "
+                           "TEST_DATABASE.TEST_COLLECTION);",
+                           R"_(unsupported subquery expression in this context)_");
 }

--- a/components/sql/transformer/impl/transfrom_common.cpp
+++ b/components/sql/transformer/impl/transfrom_common.cpp
@@ -752,7 +752,13 @@ namespace components::sql::transform {
             case INITPLAN_FUNC_SUBLINK:
                 break;
         }
-        assert(false);
+        // Every unhandled SubLink kind lands here. This used to be a bare
+        // assert(false): erased under NDEBUG, execution fell off the end of a
+        // non-void function — undefined behavior, observed as a segfault for
+        // e.g. `WHERE (SELECT x FROM t)`.
+        error_ = core::error_t(core::error_code_t::sql_parse_error,
+                               std::pmr::string{"unsupported subquery expression in this context", resource_});
+        return nullptr;
     }
 
     expression_ptr transformer::transform_a_expr_func(FuncCall* node,


### PR DESCRIPTION
A bare subquery in predicate position segfaults the server (Release build), verified against current `main`:

```sql
SELECT * FROM t WHERE (SELECT x FROM t);   -- segfault
```

## Root cause

`transform_sublink_expr` implements only `EXISTS_SUBLINK`, `ANY_SUBLINK` and `ALL_SUBLINK`. The six other `SubLink` kinds (`NOT_EXISTS`, `ROWCOMPARE`, `EXPR`, `ARRAY`, `CTE`, `INITPLAN_FUNC`) all `break` out of the switch into a terminal `assert(false)` — which NDEBUG erases, so execution **falls off the end of a non-void function**: undefined behavior, observed as a crash on the `EXPR_SUBLINK` reproduction above.

## Fix

The fall-through now sets a clean transformer error ("unsupported subquery expression in this context") and returns null, matching the error convention used elsewhere in the same function. The handled EXISTS / ANY / ALL / `IN (SELECT …)` paths are untouched.

## Testing

- New case in `components::sql::errors` asserting the clean error message — it crashed the test binary before the fix (the transform executed UB).
- The full `components::sql` suite (44 tests) passes.
