### PR TITLE
fix(update): UPDATE with bitshift on non-integer columns silently zeroed data

### DIFF
--- a/components/expressions/update_expression.cpp
+++ b/components/expressions/update_expression.cpp
@@ -11,17 +11,24 @@ namespace components::expressions {
     update_expr_t::update_expr_t(update_expr_type type)
         : type_(type) {}
 
-    std::pmr::vector<bool> update_expr_t::execute(std::pmr::memory_resource* resource,
-                                                  vector::data_chunk_t& to,
-                                                  const vector::data_chunk_t& from,
-                                                  uint64_t count,
-                                                  const logical_plan::storage_parameters* parameters,
-                                                  core::date::timezone_offset_t session_tz) {
+    core::result_wrapper_t<std::pmr::vector<bool>>
+    update_expr_t::execute(std::pmr::memory_resource* resource,
+                           vector::data_chunk_t& to,
+                           const vector::data_chunk_t& from,
+                           uint64_t count,
+                           const logical_plan::storage_parameters* parameters,
+                           core::date::timezone_offset_t session_tz) {
         if (left_) {
-            left_->execute(resource, to, from, count, parameters, session_tz);
+            auto left_res = left_->execute(resource, to, from, count, parameters, session_tz);
+            if (left_res.has_error()) {
+                return left_res;
+            }
         }
         if (right_) {
-            right_->execute(resource, to, from, count, parameters, session_tz);
+            auto right_res = right_->execute(resource, to, from, count, parameters, session_tz);
+            if (right_res.has_error()) {
+                return right_res;
+            }
         }
         return execute_impl(resource, to, from, count, parameters, session_tz);
     }
@@ -92,12 +99,13 @@ namespace components::expressions {
         return left_ == rhs.left_ && key_ == rhs.key_;
     }
 
-    std::pmr::vector<bool> update_expr_set_t::execute_impl(std::pmr::memory_resource* resource,
-                                                           vector::data_chunk_t& to,
-                                                           const vector::data_chunk_t&,
-                                                           uint64_t count,
-                                                           const logical_plan::storage_parameters*,
-                                                           core::date::timezone_offset_t) {
+    core::result_wrapper_t<std::pmr::vector<bool>>
+    update_expr_set_t::execute_impl(std::pmr::memory_resource* resource,
+                                    vector::data_chunk_t& to,
+                                    const vector::data_chunk_t&,
+                                    uint64_t count,
+                                    const logical_plan::storage_parameters*,
+                                    core::date::timezone_offset_t) {
         std::pmr::vector<bool> modified(count, false, resource);
         if (!left_ || count == 0) {
             return modified;
@@ -255,12 +263,13 @@ namespace components::expressions {
         return left_ == rhs.left_ && key_ == rhs.key_ && key_.side() == rhs.key_.side();
     }
 
-    std::pmr::vector<bool> update_expr_get_value_t::execute_impl(std::pmr::memory_resource* resource,
-                                                                 vector::data_chunk_t& to,
-                                                                 const vector::data_chunk_t& from,
-                                                                 uint64_t,
-                                                                 const logical_plan::storage_parameters*,
-                                                                 core::date::timezone_offset_t) {
+    core::result_wrapper_t<std::pmr::vector<bool>>
+    update_expr_get_value_t::execute_impl(std::pmr::memory_resource* resource,
+                                          vector::data_chunk_t& to,
+                                          const vector::data_chunk_t& from,
+                                          uint64_t,
+                                          const logical_plan::storage_parameters*,
+                                          core::date::timezone_offset_t) {
         auto side = key_.side();
         assert(side != side_t::undefined && "validation must resolve side before execution");
         if (side == side_t::right) {
@@ -283,7 +292,7 @@ namespace components::expressions {
         return id_ == rhs.id_;
     }
 
-    std::pmr::vector<bool>
+    core::result_wrapper_t<std::pmr::vector<bool>>
     update_expr_get_const_value_t::execute_impl(std::pmr::memory_resource* resource,
                                                 vector::data_chunk_t&,
                                                 const vector::data_chunk_t&,
@@ -360,26 +369,45 @@ namespace components::expressions {
         }
     } // anonymous namespace
 
-    std::pmr::vector<bool> update_expr_calculate_t::execute_impl(std::pmr::memory_resource* resource,
-                                                                 vector::data_chunk_t&,
-                                                                 const vector::data_chunk_t&,
-                                                                 uint64_t count,
-                                                                 const logical_plan::storage_parameters*,
-                                                                 core::date::timezone_offset_t) {
+    core::result_wrapper_t<std::pmr::vector<bool>>
+    update_expr_calculate_t::execute_impl(std::pmr::memory_resource* resource,
+                                          vector::data_chunk_t&,
+                                          const vector::data_chunk_t&,
+                                          uint64_t count,
+                                          const logical_plan::storage_parameters*,
+                                          core::date::timezone_offset_t) {
         uint64_t vec_count = count > 0 ? count : 1;
         auto* left_vec = left_->output_vec();
 
+        // A non-integer physical type: strings and floating-point. Bitwise/shift
+        // kernels only support integers, and unary arithmetic kernels do not
+        // support strings. Reject these here (was: a Release-erased assert that
+        // let the kernel leave the destination unwritten, silently zeroing data).
+        auto is_non_integer = [](types::physical_type pt) {
+            return pt == types::physical_type::STRING || pt == types::physical_type::FLOAT ||
+                   pt == types::physical_type::DOUBLE;
+        };
+
         if (auto unary_op = to_unary_vec_op(type_)) {
+            if (types::is_string(left_vec->type().type())) {
+                return core::error_t{
+                    core::error_code_t::physical_plan_error,
+                    std::pmr::string{"unary arithmetic is not supported for string columns", resource}};
+            }
             owned_output_.emplace(vector_ops::apply_unary_vector_op(resource, *unary_op, *left_vec, vec_count));
         } else if (auto arith_op = to_arith_op(type_)) {
             owned_output_.emplace(
                 compute_binary_arithmetic(resource, *arith_op, *left_vec, *right_->output_vec(), vec_count));
         } else {
-            owned_output_.emplace(vector_ops::apply_binary_vector_op(resource,
-                                                                     to_binary_vec_op(type_),
-                                                                     *left_vec,
-                                                                     *right_->output_vec(),
-                                                                     vec_count));
+            auto* right_vec = right_->output_vec();
+            if (is_non_integer(left_vec->type().to_physical_type()) ||
+                is_non_integer(right_vec->type().to_physical_type())) {
+                return core::error_t{
+                    core::error_code_t::physical_plan_error,
+                    std::pmr::string{"bitwise/shift operations are unsupported for non-integer types", resource}};
+            }
+            owned_output_.emplace(
+                vector_ops::apply_binary_vector_op(resource, to_binary_vec_op(type_), *left_vec, *right_vec, vec_count));
         }
 
         output_vec_ = &owned_output_.value();

--- a/components/expressions/update_expression.hpp
+++ b/components/expressions/update_expression.hpp
@@ -4,6 +4,7 @@
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ref_counter.hpp>
 #include <components/vector/data_chunk.hpp>
+#include <core/result_wrapper.hpp>
 #include <optional>
 
 #include "key.hpp"
@@ -50,12 +51,15 @@ namespace components::expressions {
         // Non-set nodes: populate output_vec_; return empty vector.
         // Set nodes: write computed values into `to`; return per-row modification flags
         //            (true = value actually changed for that row).
-        std::pmr::vector<bool> execute(std::pmr::memory_resource* resource,
-                                       vector::data_chunk_t& to,
-                                       const vector::data_chunk_t& from,
-                                       uint64_t count,
-                                       const logical_plan::storage_parameters* parameters,
-                                       core::date::timezone_offset_t session_tz);
+        // On failure (e.g. a bitwise/shift on a non-integer column) returns the
+        // error via result_wrapper_t (never throws).
+        [[nodiscard]] core::result_wrapper_t<std::pmr::vector<bool>>
+        execute(std::pmr::memory_resource* resource,
+                vector::data_chunk_t& to,
+                const vector::data_chunk_t& from,
+                uint64_t count,
+                const logical_plan::storage_parameters* parameters,
+                core::date::timezone_offset_t session_tz);
 
         update_expr_type type() const noexcept;
         update_expr_ptr& left();
@@ -67,12 +71,13 @@ namespace components::expressions {
         const vector::vector_t* output_vec() const noexcept;
 
     protected:
-        virtual std::pmr::vector<bool> execute_impl(std::pmr::memory_resource* resource,
-                                                    vector::data_chunk_t& to,
-                                                    const vector::data_chunk_t& from,
-                                                    uint64_t count,
-                                                    const logical_plan::storage_parameters* parameters,
-                                                    core::date::timezone_offset_t session_tz) = 0;
+        virtual core::result_wrapper_t<std::pmr::vector<bool>>
+        execute_impl(std::pmr::memory_resource* resource,
+                     vector::data_chunk_t& to,
+                     const vector::data_chunk_t& from,
+                     uint64_t count,
+                     const logical_plan::storage_parameters* parameters,
+                     core::date::timezone_offset_t session_tz) = 0;
 
         update_expr_type type_;
         update_expr_ptr left_;
@@ -93,12 +98,13 @@ namespace components::expressions {
         bool operator==(const update_expr_set_t& rhs) const;
 
     protected:
-        std::pmr::vector<bool> execute_impl(std::pmr::memory_resource* resource,
-                                            vector::data_chunk_t& to,
-                                            const vector::data_chunk_t& from,
-                                            uint64_t count,
-                                            const logical_plan::storage_parameters* parameters,
-                                            core::date::timezone_offset_t session_tz) override;
+        core::result_wrapper_t<std::pmr::vector<bool>>
+        execute_impl(std::pmr::memory_resource* resource,
+                     vector::data_chunk_t& to,
+                     const vector::data_chunk_t& from,
+                     uint64_t count,
+                     const logical_plan::storage_parameters* parameters,
+                     core::date::timezone_offset_t session_tz) override;
 
     private:
         key_t key_;
@@ -116,12 +122,13 @@ namespace components::expressions {
         bool operator==(const update_expr_get_value_t& rhs) const;
 
     protected:
-        std::pmr::vector<bool> execute_impl(std::pmr::memory_resource* resource,
-                                            vector::data_chunk_t& to,
-                                            const vector::data_chunk_t& from,
-                                            uint64_t count,
-                                            const logical_plan::storage_parameters* parameters,
-                                            core::date::timezone_offset_t session_tz) override;
+        core::result_wrapper_t<std::pmr::vector<bool>>
+        execute_impl(std::pmr::memory_resource* resource,
+                     vector::data_chunk_t& to,
+                     const vector::data_chunk_t& from,
+                     uint64_t count,
+                     const logical_plan::storage_parameters* parameters,
+                     core::date::timezone_offset_t session_tz) override;
 
     private:
         key_t key_;
@@ -138,12 +145,13 @@ namespace components::expressions {
         bool operator==(const update_expr_get_const_value_t& rhs) const;
 
     protected:
-        std::pmr::vector<bool> execute_impl(std::pmr::memory_resource* resource,
-                                            vector::data_chunk_t& to,
-                                            const vector::data_chunk_t& from,
-                                            uint64_t count,
-                                            const logical_plan::storage_parameters* parameters,
-                                            core::date::timezone_offset_t session_tz) override;
+        core::result_wrapper_t<std::pmr::vector<bool>>
+        execute_impl(std::pmr::memory_resource* resource,
+                     vector::data_chunk_t& to,
+                     const vector::data_chunk_t& from,
+                     uint64_t count,
+                     const logical_plan::storage_parameters* parameters,
+                     core::date::timezone_offset_t session_tz) override;
 
     private:
         core::parameter_id_t id_;
@@ -158,12 +166,13 @@ namespace components::expressions {
         bool operator==(const update_expr_calculate_t& rhs) const;
 
     protected:
-        std::pmr::vector<bool> execute_impl(std::pmr::memory_resource* resource,
-                                            vector::data_chunk_t& to,
-                                            const vector::data_chunk_t& from,
-                                            uint64_t count,
-                                            const logical_plan::storage_parameters* parameters,
-                                            core::date::timezone_offset_t session_tz) override;
+        core::result_wrapper_t<std::pmr::vector<bool>>
+        execute_impl(std::pmr::memory_resource* resource,
+                     vector::data_chunk_t& to,
+                     const vector::data_chunk_t& from,
+                     uint64_t count,
+                     const logical_plan::storage_parameters* parameters,
+                     core::date::timezone_offset_t session_tz) override;
     };
 
     using update_expr_calculate_ptr = boost::intrusive_ptr<update_expr_calculate_t>;

--- a/components/physical_plan/operators/operator_update.cpp
+++ b/components/physical_plan/operators/operator_update.cpp
@@ -39,20 +39,26 @@ namespace components::operators {
 
     namespace {
         // Applies all update expressions to out_chunk[0..match_count) and
-        // records the modified rows in the modified_ list.
-        void apply_updates(std::pmr::memory_resource* resource,
-                           const std::pmr::vector<expressions::update_expr_ptr>& updates,
-                           vector::data_chunk_t& out_chunk,
-                           const vector::data_chunk_t& from_chunk,
-                           uint64_t match_count,
-                           const logical_plan::storage_parameters& parameters,
-                           core::date::timezone_offset_t session_tz,
-                           operators::operator_write_data_ptr& modified) {
+        // records the modified rows in the modified_ list. Returns an error (and
+        // leaves the row data untouched) if an update expression cannot be
+        // evaluated — e.g. a bitwise/shift on a non-integer column.
+        [[nodiscard]] core::error_t apply_updates(std::pmr::memory_resource* resource,
+                                                  const std::pmr::vector<expressions::update_expr_ptr>& updates,
+                                                  vector::data_chunk_t& out_chunk,
+                                                  const vector::data_chunk_t& from_chunk,
+                                                  uint64_t match_count,
+                                                  const logical_plan::storage_parameters& parameters,
+                                                  core::date::timezone_offset_t session_tz,
+                                                  operators::operator_write_data_ptr& modified) {
             std::pmr::vector<bool> any_modified(match_count, false, resource);
             for (const auto& expr : updates) {
                 auto row_flags = expr->execute(resource, out_chunk, from_chunk, match_count, &parameters, session_tz);
+                if (row_flags.has_error()) {
+                    return row_flags.error();
+                }
+                const auto& flags = row_flags.value();
                 for (uint64_t i = 0; i < match_count; i++) {
-                    if (i < row_flags.size() && row_flags[i]) {
+                    if (i < flags.size() && flags[i]) {
                         any_modified[i] = true;
                     }
                 }
@@ -62,6 +68,7 @@ namespace components::operators {
                     modified->append(i);
                 }
             }
+            return core::error_t::no_error();
         }
     } // anonymous namespace
 
@@ -133,14 +140,20 @@ namespace components::operators {
         out_chunk.copy(old_chunk, 0);
         index_old_chunks_.emplace_back(std::move(old_chunk));
 
-        apply_updates(resource,
-                      updates_,
-                      out_chunk,
-                      out_chunk,
-                      index,
-                      pipeline_context->parameters,
-                      pipeline_context->session_tz,
-                      modified_);
+        // apply_updates reports unsupported operations (e.g. bitwise/shift on a
+        // non-integer column) through the pipeline error channel so the statement
+        // fails cleanly and the row data stays untouched.
+        if (auto err = apply_updates(resource,
+                                     updates_,
+                                     out_chunk,
+                                     out_chunk,
+                                     index,
+                                     pipeline_context->parameters,
+                                     pipeline_context->session_tz,
+                                     modified_);
+            err.contains_error()) {
+            return err;
+        }
         output_->append_chunk(std::move(out_chunk));
         return core::error_t::no_error();
     }
@@ -239,14 +252,17 @@ namespace components::operators {
         out_chunk.copy(old_chunk, 0);
         index_old_chunks_.emplace_back(std::move(old_chunk));
 
-        apply_updates(resource,
-                      updates_,
-                      out_chunk,
-                      right_chunk,
-                      index,
-                      pipeline_context->parameters,
-                      pipeline_context->session_tz,
-                      modified_);
+        if (auto err = apply_updates(resource,
+                                     updates_,
+                                     out_chunk,
+                                     right_chunk,
+                                     index,
+                                     pipeline_context->parameters,
+                                     pipeline_context->session_tz,
+                                     modified_);
+            err.contains_error()) {
+            return err;
+        }
         output_->append_chunk(std::move(out_chunk));
         // Keep the matched FROM rows aligned with the updated rows so RETURNING can
         // project joined (right-side) columns.

--- a/integration/cpp/test/test_arithmetic.cpp
+++ b/integration/cpp/test/test_arithmetic.cpp
@@ -2102,3 +2102,59 @@ TEST_CASE("integration::cpp::test_arithmetic::datetime") {
         }
     }
 }
+
+// UPDATE SET <col> = <col> << 1 on a DOUBLE (or STRING) column used to report
+// success while writing 0 (resp. '') — the bitwise/shift vector kernel's
+// non-integer branch was an assert-only stub, erased in Release, leaving the
+// destination vector unwritten. Such updates must fail with an error and leave
+// the data untouched.
+TEST_CASE("integration::cpp::test_arithmetic::update_bitshift_non_integer_rejected") {
+    auto config = test_create_config("/tmp/test_arithmetic/update_bitshift_non_integer");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE t;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE t.b (x bigint, f double, s string);")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "INSERT INTO t.b (x, f, s) VALUES (3, 1.5, 'ab');")->is_success());
+    }
+
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "UPDATE t.b SET f = f << 1 WHERE x > 0;");
+        REQUIRE_FALSE(cur->is_success()); // was: reported success
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "UPDATE t.b SET s = s << 1 WHERE x > 0;");
+        REQUIRE_FALSE(cur->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT f, s FROM t.b;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        const double f = cur->value(0, 0).value<double>();
+        CHECK(f > 1.4999); // was: silently overwritten with 0
+        CHECK(f < 1.5001);
+        CHECK(cur->value(1, 0).value<std::string_view>() == "ab"); // was: ''
+    }
+    // Bitshift on a genuinely integer column keeps working.
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "UPDATE t.b SET x = x << 1 WHERE x > 0;")->is_success());
+        auto cur = dispatcher->execute_sql(session, "SELECT x FROM t.b;");
+        REQUIRE(cur->is_success());
+        CHECK(cur->value(0, 0).value<int64_t>() == 6);
+    }
+}


### PR DESCRIPTION
Silent data corruption from one ordinary statement, verified against current `main` (Release build):

```sql
CREATE TABLE db.t (x BIGINT, f DOUBLE, s STRING);
INSERT INTO db.t (x, f, s) VALUES (3, 1.5, 'ab');
UPDATE db.t SET f = f << 1 WHERE x > 0;   -- reports success…
SELECT f FROM db.t;                        -- …f is now 0
UPDATE db.t SET s = s << 1 WHERE x > 0;   -- same: success, s becomes ''
```

## Root cause

The bitwise/shift and unary-arithmetic vector kernels handle their unsupported-type branches with a **bare `assert`** — erased under NDEBUG — after which execution continues with the destination vector **unwritten**. The freshly allocated (zeroed) column then replaces the real values and the UPDATE commits it, so `f << 1` on a `DOUBLE` (or `s << 1` on a `STRING`) reports success while silently zeroing / emptying the column.

## Fix

The unsupported combination is now caught at the update-expression layer, before any kernel runs, and reported through the pipeline error channel — no exceptions:

- `update_expr_calculate_t::execute_impl` validates operand types before dispatching: a bitwise/shift op on a non-integer physical type (float/double/string), or unary arithmetic on a string column, is rejected.
- `update_expr_t::execute()` now returns `core::result_wrapper_t<std::pmr::vector<bool>>` — the repo's value-or-error wrapper (its own header advises surfacing errors "via result_wrapper_t/error_t instead of throwing", and the operators layer already uses it, e.g. `arithmetic_eval.hpp` / `predicate->check()`). Child errors propagate up the expression tree through the wrapper; no error state is kept on the expression nodes.
- `apply_updates` returns a bare `core::error_t` (its payload is void, which `result_wrapper_t` deliberately doesn't allow), and `operator_update` forwards it (`physical_plan_error`) instead of wrapping a throw in `try/catch`.

The statement fails cleanly and the rows stay untouched; a bitshift on a genuinely integer column is unaffected. (This keeps the change scoped to the UPDATE path — `vector_operations.cpp` is untouched.)

## Testing

- `integration::cpp::test_arithmetic::update_bitshift_non_integer_rejected`: both corrupting UPDATEs must error, the data must read back unchanged, and an integer bitshift must keep working. Before the fix the test observed success-plus-corruption (`f` read back `0`).
- The arithmetic, update, SQL-CRUD, RETURNING and list/array suites pass.
