### PR TITLE
fix(dispatcher): table/database-not-exists errors surfaced with empty messages

### DIFF
--- a/integration/cpp/test/test_parameterized_queries.cpp
+++ b/integration/cpp/test/test_parameterized_queries.cpp
@@ -577,14 +577,51 @@ TEST_CASE("integration::cpp::params::error_code_contracts") {
         REQUIRE_FALSE(cur->get_error().what.empty());
     }
 
-    INFO("SELECT from nonexistent table -> table_not_exists");
+    INFO("SELECT from nonexistent table -> table_not_exists with a message naming it");
     {
         auto session = otterbrix::session_id_t();
         auto cur = dispatcher->execute_sql(session, "SELECT * FROM ErrDb.NoSuchTable;");
         REQUIRE(cur->is_error());
         REQUIRE(cur->get_error().type == core::error_code_t::table_not_exists);
-        // Unlike the DDL error paths above (which carry a descriptive .what), the
-        // SELECT-from-nonexistent-table path surfaces table_not_exists with an empty
-        // message, so we assert only the error code contract here.
+        REQUIRE_FALSE(cur->get_error().what.empty());
+        // Identifiers are case-folded by the parser, so the message carries the
+        // lowercase name.
+        REQUIRE(std::string(cur->get_error().what).find("nosuchtable") != std::string::npos);
+    }
+
+    INFO("aggregate over nonexistent table -> table_not_exists with a message");
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT count(*) FROM ErrDb.NoSuchTable;");
+        REQUIRE(cur->is_error());
+        REQUIRE(cur->get_error().type == core::error_code_t::table_not_exists);
+        REQUIRE_FALSE(cur->get_error().what.empty());
+    }
+
+    INFO("INSERT into nonexistent table -> table_not_exists with a message");
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "INSERT INTO ErrDb.NoSuchTable (a) VALUES (1);");
+        REQUIRE(cur->is_error());
+        REQUIRE(cur->get_error().type == core::error_code_t::table_not_exists);
+        REQUIRE_FALSE(cur->get_error().what.empty());
+    }
+
+    INFO("CREATE INDEX on nonexistent table -> table_not_exists with a message");
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "CREATE INDEX ix ON ErrDb.NoSuchTable (a);");
+        REQUIRE(cur->is_error());
+        REQUIRE(cur->get_error().type == core::error_code_t::table_not_exists);
+        REQUIRE_FALSE(cur->get_error().what.empty());
+    }
+
+    INFO("aggregate over a table in a nonexistent database -> database_not_exists with a message");
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT count(*) FROM NoSuchDb.NoSuchTable;");
+        REQUIRE(cur->is_error());
+        REQUIRE(cur->get_error().type == core::error_code_t::database_not_exists);
+        REQUIRE_FALSE(cur->get_error().what.empty());
     }
 }

--- a/services/dispatcher/validate_logical_plan.cpp
+++ b/services/dispatcher/validate_logical_plan.cpp
@@ -1074,7 +1074,11 @@ namespace services::dispatcher {
                     }
                     return result;
                 } else {
-                    return core::error_t(core::error_code_t::table_not_exists, std::pmr::string{"", resource});
+                    std::pmr::string msg{"collection does not exist: ", resource};
+                    msg.append(node->dbname().begin(), node->dbname().end());
+                    msg += '.';
+                    msg.append(node->relname().begin(), node->relname().end());
+                    return core::error_t(core::error_code_t::table_not_exists, std::move(msg));
                 }
             } else {
                 assert(node->expressions().size() == 1);
@@ -1595,10 +1599,15 @@ namespace services::dispatcher {
                         // so callers (and tests) get the right error code.
                         if (impl::ns_oid_for_dbname(idx, std::string_view(agg_dbname_s)) ==
                             components::catalog::INVALID_OID) {
-                            return core::error_t(core::error_code_t::database_not_exists,
-                                                 std::pmr::string{"", resource});
+                            std::pmr::string msg{"database does not exist: ", resource};
+                            msg.append(agg_dbname_s.begin(), agg_dbname_s.end());
+                            return core::error_t(core::error_code_t::database_not_exists, std::move(msg));
                         }
-                        return core::error_t(core::error_code_t::table_not_exists, std::pmr::string{"", resource});
+                        std::pmr::string msg{"collection does not exist: ", resource};
+                        msg.append(agg_dbname_s.begin(), agg_dbname_s.end());
+                        msg += '.';
+                        msg.append(agg_relname_s.begin(), agg_relname_s.end());
+                        return core::error_t(core::error_code_t::table_not_exists, std::move(msg));
                     }
                 }
                 if (table_schema.empty() && incoming_schema.empty()) {
@@ -2499,7 +2508,9 @@ namespace services::dispatcher {
                 auto* insert_node = reinterpret_cast<node_insert_t*>(node);
                 const auto* tbl_ins = impl::tbl_md_for_oid(idx, insert_node->table_oid());
                 if (!tbl_ins) {
-                    return core::error_t(core::error_code_t::table_not_exists, std::pmr::string{"", resource});
+                    // node_insert_t carries only the (unresolved) table oid, no names.
+                    return core::error_t(core::error_code_t::table_not_exists,
+                                         std::pmr::string{"INSERT target collection does not exist", resource});
                 }
 
                 auto incoming_schema = validate_schema(resource, idx, node->children().front().get(), parameters);
@@ -2825,7 +2836,9 @@ namespace services::dispatcher {
                 auto* idx_node = static_cast<node_create_index_t*>(node);
                 const auto* tbl_idx = impl::tbl_md_for_oid(idx, idx_node->table_oid());
                 if (!tbl_idx) {
-                    return core::error_t(core::error_code_t::table_not_exists, std::pmr::string{"", resource});
+                    // node_create_index_t carries only the index name, no table names.
+                    return core::error_t(core::error_code_t::table_not_exists,
+                                         std::pmr::string{"CREATE INDEX target collection does not exist", resource});
                 }
 
                 named_schema table_schema{resource};


### PR DESCRIPTION
Five validation sites construct `table_not_exists` / `database_not_exists` errors with an **empty message string**, so the most common error a user can hit surfaces as a bare code with `what == ""` through every API (verified against current `main` via the C API):

```
SELECT * FROM errdb.no_such;                -- code=16, msg=''
SELECT count(*) FROM errdb.no_such;         -- code=16, msg=''
INSERT INTO errdb.no_such (a) VALUES (1);   -- code=16, msg=''
CREATE INDEX ix ON errdb.no_such (a);       -- code=16, msg=''
SELECT count(*) FROM no_such_db.t;          -- code=14, msg=''
```

The C-API marshalling is innocent — paths that do carry text (DROP TABLE, UPDATE/DELETE validation) deliver it verbatim; these five sites in `validate_logical_plan.cpp` are the only empty-message constructions in the tree.

## Fix

- Scan and aggregate paths (which have the names in scope) now name the missing object: `collection does not exist: <db>.<table>` / `database does not exist: <db>`.
- INSERT and CREATE INDEX paths carry only the resolved oid on their nodes, so they get descriptive static text (`INSERT target collection does not exist`, `CREATE INDEX target collection does not exist`).

## Testing

The `params::error_code_contracts` test now asserts a non-empty message (and, for the scan path, that it names the missing table) for all five statements — those assertions failed on the previously empty messages. The stale comment in the test documenting the empty-message behavior is gone. Full parameterized-queries and dispatcher suites pass.

Note: identifiers are case-folded by the parser, so messages carry the folded (lowercase) names.
