### PR TITLE
fix(dispatcher): watchdog logged routine pokes at warn on healthy runs

### DIFF
--- a/integration/cpp/test/CMakeLists.txt
+++ b/integration/cpp/test/CMakeLists.txt
@@ -15,6 +15,7 @@ set( ${PROJECT_NAME}_SOURCES
         test_unique_constraint_operator.cpp
         test_create_index_backfill_batched.cpp
         test_correctness_bugs.cpp
+        test_dispatcher_watchdog_log.cpp
         test_production_scenarios.cpp
         test_join.cpp
         test_join_raw.cpp

--- a/integration/cpp/test/test_dispatcher_watchdog_log.cpp
+++ b/integration/cpp/test/test_dispatcher_watchdog_log.cpp
@@ -1,0 +1,57 @@
+#include "test_config.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+// The dispatcher-loop watchdog pokes executors whenever an in-flight await
+// stays busy past ~2ms — routine for any multi-row DML — and used to log every
+// firing at WARN, flooding logs on perfectly healthy runs (a 14-statement
+// insert workload produced 24 warnings). Routine firings must be trace-level;
+// only a slot stale across hundreds of consecutive poke rounds (a genuine
+// stall) escalates to warn, with a distinct message.
+TEST_CASE("integration::cpp::dispatcher::watchdog_quiet_on_healthy_runs") {
+    auto config = test_create_config("/tmp/otterbrix/integration/test_dispatcher_watchdog/healthy");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    config.log.level = log_t::level::warn;
+
+    {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+
+        REQUIRE(test_helpers::exec(dispatcher, "CREATE DATABASE db;")->is_success());
+        REQUIRE(test_helpers::exec(dispatcher, "CREATE TABLE db.t (a bigint, b bigint);")->is_success());
+        auto cur = test_helpers::seed_rows(dispatcher, "db.t", "a, b", 5000, [](unsigned i) {
+            return "(" + std::to_string(i) + ", " + std::to_string(i * 2) + ")";
+        });
+        REQUIRE(cur->is_success());
+        auto count = test_helpers::exec(dispatcher, "SELECT count(*) FROM db.t;");
+        REQUIRE(count->is_success());
+        REQUIRE(count->value(0, 0).value<int64_t>() == 5000);
+    }
+
+    // The engine is destructed, so the file sink is flushed. A healthy run must
+    // not surface the routine watchdog firing at warn level.
+    bool found_routine_warn = false;
+    for (const auto& entry : std::filesystem::recursive_directory_iterator(std::string(config.log.path.string()))) {
+        if (!entry.is_regular_file()) {
+            continue;
+        }
+        std::ifstream in(entry.path());
+        std::string line;
+        while (std::getline(in, line)) {
+            if (line.find("stale await detected") != std::string::npos) {
+                found_routine_warn = true;
+                break;
+            }
+        }
+        if (found_routine_warn) {
+            break;
+        }
+    }
+    REQUIRE_FALSE(found_routine_warn);
+}

--- a/services/dispatcher/dispatcher.cpp
+++ b/services/dispatcher/dispatcher.cpp
@@ -157,6 +157,7 @@ namespace services::dispatcher {
                         }
                         if (cont) {
                             ready_slot->stale_ticks = 0;
+                            ready_slot->poke_rounds = 0;
                             cont.resume();
                             poll_pending();
                             progress = true;
@@ -194,9 +195,30 @@ namespace services::dispatcher {
                         break;
                     }
                 if (any_stale) {
-                    warn(log_,
-                         "dispatcher loop: stale await detected — poking executors (see "
-                         "docs/actor-zeta-lost-wakeup.md)");
+                    // Routine firings are EXPECTED: any executor operation longer
+                    // than ~2ms (20 ticks x ~100us loop) trips the threshold, so a
+                    // healthy multi-row DML statement fires this several times.
+                    // Those log at trace. A slot that stays stale across hundreds
+                    // of consecutive poke rounds is a genuine stall (a wedged
+                    // executor, or a lost wakeup no poke can clear) — that one
+                    // escalates to a single warn with a distinct message.
+                    constexpr uint32_t escalate_poke_rounds = 256;
+                    bool escalate = false;
+                    for (auto& e : in_flight) {
+                        if (e.behavior && !e.behavior.done() && e.behavior.is_busy() &&
+                            !e.behavior.is_awaited_ready() && e.stale_ticks > 20) {
+                            if (++e.poke_rounds == escalate_poke_rounds) {
+                                escalate = true;
+                            }
+                        }
+                    }
+                    if (escalate) {
+                        warn(log_,
+                             "dispatcher loop: await stale across {} poke rounds — possible stalled executor",
+                             escalate_poke_rounds);
+                    } else {
+                        trace(log_, "dispatcher loop: stale await detected — poking executors");
+                    }
                     for (auto& ex : executors_) {
                         if (ex) {
                             auto [ns, f] = actor_zeta::send(ex.get(), &collection::executor::executor_t::poke_msg);

--- a/services/dispatcher/dispatcher.hpp
+++ b/services/dispatcher/dispatcher.hpp
@@ -71,6 +71,12 @@ namespace services::dispatcher {
             actor_zeta::mailbox::message_ptr pending_msg{};
             actor_zeta::behavior_t behavior{};
             uint32_t stale_ticks{0};
+            // Consecutive watchdog poke rounds this slot stayed stale (reset when
+            // its await completes). Routine staleness is normal for any executor
+            // operation past ~2ms; a slot surviving hundreds of poke rounds is a
+            // genuine stall and escalates the (otherwise trace-level) watchdog
+            // log to a warning.
+            uint32_t poke_rounds{0};
         };
 
         manager_dispatcher_t(std::pmr::memory_resource*, actor_zeta::scheduler_raw, log_t& log);


### PR DESCRIPTION
The dispatcher-loop watchdog — the mitigation for the documented actor-zeta lost-wakeup parking race (`docs/actor-zeta-lost-wakeup.md`) — fires whenever an in-flight await stays busy past ~2ms (20 loop ticks), which is routine for any multi-row DML. Every firing logged at **warn**: a fully successful 14-statement insert workload produced 24 identical warnings (verified against current `main`), drowning real signals in both stdout and the file sink.

## Fix

The poke cadence is untouched — it is load-bearing. Only the diagnostics change:

- routine firings log at **trace**;
- a new per-slot `poke_rounds` counter (reset when the slot's await completes) escalates to a **single, textually distinct warning** once a slot has stayed stale across 256 consecutive poke rounds — the signature of a genuinely stalled executor, which healthy long operations never approach;
- the poke log messages no longer embed the internal `docs/actor-zeta-lost-wakeup.md` path — that pointer belongs in the source (the code comment still carries it), not in operator-facing log output.

## Testing

New `dispatcher::watchdog_quiet_on_healthy_runs`: runs a 5000-row insert workload at warn-level logging and asserts the log files contain no "stale await detected" lines. Before the fix the test found the warn spam. Dispatcher and parameterized-query suites pass.
