### PR TITLE
fix(buffer_pool): start eviction-queue freelist empty; order schedulers before actors

### DIFF
--- a/components/table/storage/buffer_pool.hpp
+++ b/components/table/storage/buffer_pool.hpp
@@ -27,7 +27,15 @@ namespace components::table::storage {
         eviction_queue_t(const file_buffer_type file_buffer_type, std::pmr::memory_resource* resource)
             : buffer_type(file_buffer_type)
             , resource_(resource)
-            , q(INITIAL_QUEUE_CAPACITY)
+            // Start the freelist empty. boost::lockfree::queue eagerly reserves
+            // capacity+1 nodes at construction via an over-aligned allocator
+            // (aligned_alloc/posix_memalign) that bypasses both operator new and
+            // the pmr resource_tracer, so a non-zero capacity here reserves
+            // ~257 untracked nodes per queue at bootstrap. enqueue() uses
+            // q.push(), which grows the dynamic freelist on demand, so starting
+            // empty is functionally identical and pays a malloc only on the first
+            // evictions (restores the lazy a13 std::queue behaviour).
+            , q(0)
             , approx_q_size_(0)
             , evict_queue_insertions_(0)
             , total_dead_nodes_(0) {}
@@ -56,7 +64,6 @@ namespace components::table::storage {
         constexpr static uint64_t PURGE_SIZE_MULTIPLIER = 2;
         constexpr static uint64_t EARLY_OUT_MULTIPLIER = 4;
         constexpr static uint64_t ALIVE_NODE_MULTIPLIER = 4;
-        constexpr static uint64_t INITIAL_QUEUE_CAPACITY = 256;
 
         std::pmr::memory_resource* resource_;
         // lock-free MPMC queue of heap nodes: producers (unpin on scan/disk

--- a/components/table/test/CMakeLists.txt
+++ b/components/table/test/CMakeLists.txt
@@ -5,6 +5,7 @@ set(${PROJECT_NAME}_SOURCES
         test_table.cpp
         test_block_manager.cpp
         test_eviction_guard.cpp
+        test_eviction_queue_leak_repro.cpp
         test_metadata.cpp
         test_checkpoint_load.cpp
         test_transaction_manager.cpp

--- a/components/table/test/test_eviction_queue_leak_repro.cpp
+++ b/components/table/test/test_eviction_queue_leak_repro.cpp
@@ -1,0 +1,129 @@
+// Reproduction / regression guard for the boost::lockfree eviction-queue
+// bootstrap allocation footprint (the b1/b2 regression vs a13).
+//
+// eviction_queue_t::q is a `boost::lockfree::queue<buffer_eviction_node_t*>`
+// constructed with a runtime capacity. boost's variable-sized freelist EAGERLY
+// reserves `capacity + 1` heap nodes at construction (freelist_stack ctor loops
+// `n+1` times), each via an over-aligned allocator (the node is
+// `alignas(cacheline)`, so allocation bypasses `operator new` and the pmr
+// resource_tracer — it goes straight to aligned_alloc/posix_memalign, i.e. it is
+// UNTRACKED and unmaskable). Building the queue with capacity 256 therefore
+// reserves 257 nodes up front; those nodes only leak if the owning queue is
+// never destroyed (a destroyed queue frees them all — asserted below).
+//
+// This test injects a counting allocator (via the public `boost::lockfree::allocator<>`
+// policy) into a queue with the SAME element type as production
+// (`buffer_eviction_node_t*`) to make the otherwise-invisible node reservation
+// observable, deterministically and cross-platform (no ASAN, no interposition).
+//
+// LIMITATION (intentional): the production `eviction_queue_t::q` uses boost's
+// DEFAULT allocator, which is not injectable, so this exercises the same node
+// type and freelist mechanism, not the live engine instance. The engine-level
+// teardown gate lives in integration/cpp/test/test_engine_lifecycle.cpp.
+
+#include <atomic>
+#include <cstddef>
+#include <new>
+
+#include <boost/lockfree/policies.hpp>
+#include <boost/lockfree/queue.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <components/table/storage/buffer_pool.hpp>
+
+namespace {
+
+    // Process-global node allocation/free counters for the counting allocator.
+    // Only our counting_queue below routes through this allocator, so these
+    // counters are unaffected by any other queue in the test binary (which use
+    // boost's default allocator). Reset at the top of each TEST_CASE.
+    std::atomic<long> g_node_allocs{0};
+    std::atomic<long> g_node_frees{0};
+
+    // Standard-allocator-shaped counter that returns OVER-ALIGNED memory. boost
+    // rebinds this to the freelist `node` type, which is `alignas(cacheline_bytes)`
+    // (64 on x86_64 Linux, 128 on arm64 macOS); over-aligning every allocation to
+    // 128 is a safe superset that satisfies either. Each freelist node is allocated
+    // one at a time, so one allocate() call == one node.
+    constexpr std::size_t kNodeAlign = 128;
+
+    template <class T>
+    struct counting_alloc {
+        using value_type = T;
+
+        counting_alloc() = default;
+        template <class U>
+        counting_alloc(const counting_alloc<U>&) noexcept {}
+
+        template <class U>
+        struct rebind {
+            using other = counting_alloc<U>;
+        };
+
+        T* allocate(std::size_t n) {
+            g_node_allocs.fetch_add(1, std::memory_order_relaxed);
+            return static_cast<T*>(::operator new(n * sizeof(T), std::align_val_t(kNodeAlign)));
+        }
+        void deallocate(T* p, std::size_t n) noexcept {
+            g_node_frees.fetch_add(1, std::memory_order_relaxed);
+            ::operator delete(p, n * sizeof(T), std::align_val_t(kNodeAlign));
+        }
+
+        template <class U>
+        bool operator==(const counting_alloc<U>&) const noexcept {
+            return true;
+        }
+        template <class U>
+        bool operator!=(const counting_alloc<U>&) const noexcept {
+            return false;
+        }
+    };
+
+    using node_ptr = components::table::storage::buffer_eviction_node_t*;
+    using counting_queue =
+        boost::lockfree::queue<node_ptr, boost::lockfree::allocator<counting_alloc<char>>>;
+
+} // namespace
+
+TEST_CASE("eviction queue: capacity 256 eagerly reserves 257 nodes (b1/b2 regression signature)",
+          "[buffer_pool][leak-repro]") {
+    g_node_allocs = 0;
+    g_node_frees = 0;
+    {
+        counting_queue q(256);
+        // boost freelist reserves capacity+1 nodes at construction, all up front.
+        CHECK(g_node_allocs.load() == 257);
+        CHECK(g_node_frees.load() == 0);
+    }
+    // A destroyed queue frees every reserved node — this is WHY otterbrix's own
+    // ASAN/LSan CI is green, and why the reported leak requires a never-destroyed
+    // owner rather than mere over-reservation.
+    CHECK(g_node_frees.load() == g_node_allocs.load());
+    CHECK(g_node_allocs.load() == 257);
+}
+
+TEST_CASE("eviction queue: capacity 0 reserves nothing eagerly and grows lazily (a13 / Edit 1)",
+          "[buffer_pool][leak-repro]") {
+    components::table::storage::buffer_eviction_node_t node_obj;
+
+    g_node_allocs = 0;
+    g_node_frees = 0;
+    {
+        counting_queue q(0);
+        // Only the single dummy/sentinel node is reserved (capacity 0 + 1).
+        CHECK(g_node_allocs.load() == 1);
+
+        // push() on an empty freelist lazily allocates exactly one node on demand
+        // (production enqueue uses q.push(), not bounded_push()), so capacity 0 is
+        // functionally safe — it just defers the first malloc to the first eviction.
+        REQUIRE(q.push(&node_obj));
+        CHECK(g_node_allocs.load() == 2);
+
+        node_ptr out = nullptr;
+        REQUIRE(q.pop(out));
+        CHECK(out == &node_obj);
+    }
+    // Net zero: everything reserved/grown is freed on destruction.
+    CHECK(g_node_frees.load() == g_node_allocs.load());
+    CHECK(g_node_allocs.load() == 2);
+}

--- a/integration/cpp/base_spaces.cpp
+++ b/integration/cpp/base_spaces.cpp
@@ -27,12 +27,12 @@ namespace otterbrix {
         , resource()
         , scheduler_(new actor_zeta::shared_work(3, 1000))
         , scheduler_dispatcher_(new actor_zeta::shared_work(3, 1000))
+        , scheduler_disk_(new actor_zeta::shared_work(3, 1000))
         , manager_dispatcher_(nullptr, actor_zeta::pmr::deleter_t(&resource))
         , manager_disk_(nullptr, actor_zeta::pmr::deleter_t(&resource))
         , manager_wal_(nullptr, actor_zeta::pmr::deleter_t(&resource))
         , manager_index_(nullptr, actor_zeta::pmr::deleter_t(&resource))
-        , wrapper_dispatcher_(nullptr, actor_zeta::pmr::deleter_t(&resource))
-        , scheduler_disk_(new actor_zeta::shared_work(3, 1000)) {
+        , wrapper_dispatcher_(nullptr, actor_zeta::pmr::deleter_t(&resource)) {
         log_ = initialization_logger("python", config.log.path.c_str());
         log_.set_level(config.log.level);
         trace(log_, "spaces::spaces()");

--- a/integration/cpp/base_spaces.hpp
+++ b/integration/cpp/base_spaces.hpp
@@ -72,12 +72,15 @@ namespace otterbrix {
         log_t log_;
         actor_zeta::scheduler_ptr scheduler_;
         actor_zeta::scheduler_ptr scheduler_dispatcher_;
+        // Declared before every manager so all three schedulers are destroyed
+        // AFTER the actors under implicit reverse-declaration destruction
+        // (manager_disk_ holds a raw pointer to scheduler_disk_).
+        actor_zeta::scheduler_ptr scheduler_disk_;
         services::dispatcher::manager_dispatcher_ptr manager_dispatcher_;
         services::disk::manager_disk_ptr manager_disk_;
         services::wal::manager_wal_ptr manager_wal_;
         services::index::manager_index_ptr manager_index_;
         std::unique_ptr<otterbrix::wrapper_dispatcher_t, actor_zeta::pmr::deleter_t> wrapper_dispatcher_;
-        actor_zeta::scheduler_ptr scheduler_disk_;
 
         // Catalog-driven index bootstrap. Called once during construction, after
         // WAL replay and before scheduler.start, while single-threaded. Scans

--- a/integration/cpp/test/test_engine_lifecycle.cpp
+++ b/integration/cpp/test/test_engine_lifecycle.cpp
@@ -526,3 +526,41 @@ TEST_CASE("integration::cpp::test_engine_lifecycle::concurrent_insert_scan_evict
         }
     }
 }
+
+// Teardown leak gate for the boost::lockfree freelist nodes (eviction_queue_t::q
+// and the four manager inbox_{128} queues). Construct an engine (disk on) so the
+// system-table buffer pools are instantiated at bootstrap, add a user table with
+// rows and scan it (exercising the eviction queue), then destroy at scope exit.
+//
+// On Linux ASAN+LeakSanitizer (the CI gate) a clean teardown must report ZERO
+// leaked blocks — a destroyed queue frees every freelist node, so any residual
+// means an owner survived teardown. On macOS LSan does not run, so this also
+// serves as an ASan use-after-free smoke test that exercises the scheduler_disk_
+// teardown ordering (Edit 3).
+TEST_CASE("integration::cpp::test_engine_lifecycle::construct_destroy_clean_teardown",
+          "[engine-lifecycle][leak-repro]") {
+    auto config = test_create_config("/tmp/test_engine_lifecycle/teardown_leak");
+    test_clear_directory(config);
+    config.disk.on = true;
+    components::compute::function_registry_t::reset_default();
+
+    {
+        auto inst = otterbrix::make_otterbrix(config);
+        auto* dispatcher = inst->dispatcher();
+
+        REQUIRE(dispatcher->execute_sql(otterbrix::session_id_t(), "CREATE DATABASE leakreprodb;")
+                    ->is_success());
+        REQUIRE(dispatcher->execute_sql(otterbrix::session_id_t(),
+                                        "CREATE TABLE leakreprodb.t (g bigint, v bigint);")
+                    ->is_success());
+        REQUIRE(dispatcher
+                    ->execute_sql(otterbrix::session_id_t(),
+                                  "INSERT INTO leakreprodb.t (g, v) VALUES "
+                                  "(1, 10), (1, 20), (2, 30), (2, 40), (2, 50);")
+                    ->is_success());
+        REQUIRE(dispatcher->execute_sql(otterbrix::session_id_t(), "SELECT g, v FROM leakreprodb.t;")
+                    ->is_success());
+    } // engine destroyed here; a clean teardown must free every boost freelist node
+
+    SUCCEED("engine constructed, populated, and destroyed without an ASan/LSan error");
+}

--- a/integration/cpp/test/test_engine_lifecycle.cpp
+++ b/integration/cpp/test/test_engine_lifecycle.cpp
@@ -2,10 +2,13 @@
 #include <catch2/catch_test_macros.hpp>
 #include <integration/cpp/otterbrix.hpp>
 
+#include <algorithm>
 #include <array>
 #include <mutex>
 #include <sstream>
+#include <string>
 #include <thread>
+#include <vector>
 
 // Engine lifecycle invariants:
 //
@@ -563,4 +566,118 @@ TEST_CASE("integration::cpp::test_engine_lifecycle::construct_destroy_clean_tear
     } // engine destroyed here; a clean teardown must free every boost freelist node
 
     SUCCEED("engine constructed, populated, and destroyed without an ASan/LSan error");
+}
+
+// Stress variant of the teardown gate: repeatedly construct and destroy the
+// engine so any intermittent teardown-ordering leak or use-after-free is
+// amplified under ASAN+LeakSanitizer. Each cycle instantiates the system-table
+// buffer pools plus a user table (more boost::lockfree eviction queues + the
+// four manager inbox queues), then tears the whole graph down. If Edit 3's
+// implicit teardown were unsound, N cycles make a stray freelist node or a
+// dangling scheduler far more likely to surface than a single construct/destroy.
+TEST_CASE("integration::cpp::test_engine_lifecycle::repeated_construct_destroy_no_leak",
+          "[engine-lifecycle][leak-repro]") {
+    constexpr int kCycles = 12;
+    for (int i = 0; i < kCycles; ++i) {
+        auto config = test_create_config("/tmp/test_engine_lifecycle/stress_" + std::to_string(i));
+        test_clear_directory(config);
+        config.disk.on = true;
+        components::compute::function_registry_t::reset_default();
+
+        auto inst = otterbrix::make_otterbrix(config);
+        auto* dispatcher = inst->dispatcher();
+        REQUIRE(dispatcher->execute_sql(otterbrix::session_id_t(), "CREATE DATABASE stressdb;")
+                    ->is_success());
+        REQUIRE(dispatcher->execute_sql(otterbrix::session_id_t(),
+                                        "CREATE TABLE stressdb.t (g bigint, v bigint);")
+                    ->is_success());
+        REQUIRE(dispatcher
+                    ->execute_sql(otterbrix::session_id_t(),
+                                  "INSERT INTO stressdb.t (g, v) VALUES (1, 10), (2, 20);")
+                    ->is_success());
+        // inst destroyed at the end of the iteration.
+    }
+    SUCCEED("engine survived repeated construct/destroy cycles without an ASan/LSan error");
+}
+
+namespace {
+
+    // Records the order in which subobjects are destroyed. Each recorder appends
+    // its name to a shared log from its destructor, so the log ends up in
+    // reverse-construction (= reverse-declaration) order.
+    struct destruction_order_recorder_t {
+        std::vector<std::string>* log;
+        std::string name;
+        ~destruction_order_recorder_t() { log->push_back(name); }
+    };
+
+    // Mirrors the data-member layout of base_otterbrix_t AFTER Edit 3: the three
+    // schedulers are declared BEFORE the managers, and manager_dispatcher_ is the
+    // first manager (so it is destroyed last among the managers). C++ destroys
+    // members in reverse declaration order, so this model makes the teardown
+    // ordering Edit 3 establishes observable and assertable. Kept in lockstep
+    // with integration/cpp/base_spaces.hpp:73-80.
+    struct base_spaces_layout_model_t {
+        explicit base_spaces_layout_model_t(std::vector<std::string>* log)
+            : scheduler_{log, "scheduler"}
+            , scheduler_dispatcher_{log, "scheduler_dispatcher"}
+            , scheduler_disk_{log, "scheduler_disk"}
+            , manager_dispatcher_{log, "manager_dispatcher"}
+            , manager_disk_{log, "manager_disk"}
+            , manager_wal_{log, "manager_wal"}
+            , manager_index_{log, "manager_index"}
+            , wrapper_dispatcher_{log, "wrapper_dispatcher"} {}
+
+        destruction_order_recorder_t scheduler_;
+        destruction_order_recorder_t scheduler_dispatcher_;
+        destruction_order_recorder_t scheduler_disk_;
+        destruction_order_recorder_t manager_dispatcher_;
+        destruction_order_recorder_t manager_disk_;
+        destruction_order_recorder_t manager_wal_;
+        destruction_order_recorder_t manager_index_;
+        destruction_order_recorder_t wrapper_dispatcher_;
+    };
+
+} // namespace
+
+// Proves the destruction-order invariant Edit 3 establishes (and that the
+// dropped Edit 2 is unnecessary): under implicit reverse-declaration
+// destruction, all three schedulers are destroyed AFTER every manager
+// (manager_disk_ holds a raw pointer to scheduler_disk_), and the dispatcher —
+// the cyclic-graph sink every manager holds an address to — is destroyed LAST
+// among the managers. This is the exact ordering guarantee that makes the
+// implicit teardown safe without an explicit ordered reset.
+TEST_CASE("integration::cpp::test_engine_lifecycle::teardown_order_schedulers_outlive_managers",
+          "[engine-lifecycle][leak-repro]") {
+    std::vector<std::string> order;
+    { base_spaces_layout_model_t model(&order); }
+
+    REQUIRE(order.size() == 8);
+    const auto pos = [&](const std::string& n) {
+        return std::find(order.begin(), order.end(), n) - order.begin();
+    };
+
+    const std::array<const char*, 3> schedulers{"scheduler", "scheduler_dispatcher", "scheduler_disk"};
+    const std::array<const char*, 5> managers{"manager_dispatcher",
+                                              "manager_disk",
+                                              "manager_wal",
+                                              "manager_index",
+                                              "wrapper_dispatcher"};
+
+    // Every scheduler is destroyed after every manager (schedulers outlive actors).
+    for (const char* s : schedulers) {
+        for (const char* m : managers) {
+            INFO(s << " must destruct after " << m);
+            CHECK(pos(s) > pos(m));
+        }
+    }
+
+    // The dispatcher is destroyed last among the managers (cyclic-graph sink).
+    for (const char* m : {"manager_disk", "manager_wal", "manager_index", "wrapper_dispatcher"}) {
+        INFO("manager_dispatcher must destruct after " << m);
+        CHECK(pos("manager_dispatcher") > pos(m));
+    }
+
+    // scheduler_disk_ specifically outlives manager_disk_ (the raw-pointer holder).
+    CHECK(pos("scheduler_disk") > pos("manager_disk"));
 }


### PR DESCRIPTION
## What

- **Edit 1 — `components/table/storage/buffer_pool.hpp`**: build `eviction_queue_t::q` with capacity `0` instead of `256`. `boost::lockfree::queue` eagerly reserves `capacity+1 = 257` freelist nodes at construction via an over-aligned allocator (`aligned_alloc`/`posix_memalign`) that bypasses **both** `operator new` and the pmr `resource_tracer` — ~257 untracked nodes × 8 queues × 13 bootstrap system-table buffer pools at startup. `enqueue()` uses `q.push()` (not `bounded_push`), which grows the dynamic freelist on demand, so `q(0)` is functionally identical and restores the lazy a13 `std::queue` behaviour.
- **Edit 3 — `integration/cpp/base_spaces.{hpp,cpp}`**: move `scheduler_disk_`'s declaration up next to `scheduler_`/`scheduler_dispatcher_` so all three schedulers are declared before every manager and thus destroyed **after** the actors under implicit reverse-declaration destruction (`manager_disk_` holds a raw pointer to `scheduler_disk_`), closing a latent use-after-free. Declaration + ctor initializer moved together so init-order == decl-order (no `-Wreorder` under `-Werror`).

## Tests

- `components/table/test/test_eviction_queue_leak_repro.cpp` — deterministic, cross-platform proof (via the public `boost::lockfree::allocator<>` policy on the production node type `buffer_eviction_node_t*`) that capacity 256 reserves 257 nodes, capacity 0 reserves 1 and grows lazily on `push()`, and a destroyed queue frees every node.
- `integration/cpp/test/test_engine_lifecycle.cpp::construct_destroy_clean_teardown` — Linux ASAN+LeakSanitizer teardown gate (construct engine with disk on + table + rows + scan → destroy at scope exit).

## Verification

The real gate is the `ubuntu-22-04-address-sanitizer.yaml` job (Linux gcc, `ENABLE_ASAN`, LeakSanitizer on by default). LSan does **not** run on macOS, so this cannot be verified locally on Darwin.

## Notes

- The reported ~29187-block leak was **not reproduced in otterbrix's own ASAN CI** (green on `main` and `1.0.0b2-rc-1`). A destroyed queue frees all its freelist nodes, so the leak requires a never-destroyed owner (an otterstax-side condition). Edit 1 still removes the eager untracked bootstrap reservation and restores a13 behaviour; Edit 3 hardens teardown ordering.
- **Edit 2 (explicit ordered manager reset) was intentionally dropped**: with Edit 3 the implicit teardown is already provably safe, and the originally-proposed disk-last reset order is riskier for the cyclic routing graph (it would destroy the dispatcher — which every manager holds an address to — before its referrers). Re-add (in dispatcher-last order) only if the CI teardown gate shows a leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)