### PR TITLE
fix(table): NULL must not satisfy a pushed-down value comparison (SQL three-valued logic)

### DIFF
--- a/components/table/column_data.cpp
+++ b/components/table/column_data.cpp
@@ -500,13 +500,28 @@ namespace components::table {
         transient.revert_append(static_cast<uint64_t>(start_row));
     }
 
-    bool column_data_t::check_predicate(int64_t row_id, const table_filter_t* filter, core::error_t& error) {
+    filter_match_t column_data_t::check_predicate(int64_t row_id, const table_filter_t* filter, core::error_t& error) {
+        // SQL three-valued logic, enforced once for every column type and every storage
+        // layout. A NULL operand makes any value comparison UNKNOWN — the row is neither
+        // selected nor eligible to be flipped back in by NOT.
+        //
+        // This gate must come first: the compressed and raw-buffer paths below read the
+        // value bytes only, and a NULL row's payload is a meaningless 0 (validity lives in a
+        // separate sibling column), so they would otherwise report `0 == 0` and match.
+        // check_validity() goes through fetch_row, which applies the update overlay, so a row
+        // updated to NULL is seen as NULL here too.
+        //
+        // IS NULL / IS NOT NULL never reach this function — row_group_t::check_predicate
+        // answers them from the validity mask directly — so gating here cannot break them.
+        if (!check_validity(row_id)) {
+            return filter_match_t::unknown;
+        }
         if (updates_ &&
             updates_->has_updates(static_cast<uint64_t>(row_id - start_) / vector::DEFAULT_VECTOR_CAPACITY)) {
             // The vector has some updated rows. Check if THIS specific row is updated.
             if (updates_->row_is_updated(row_id)) {
                 // Row is in the update overlay — check against the updated value only
-                return updates_->check_row(row_id, filter);
+                return updates_->check_row(row_id, filter) ? filter_match_t::yes : filter_match_t::no;
             }
         }
         // STRUCT columns store child data in sub_columns, not in data_ segments — fetch the full value
@@ -522,15 +537,13 @@ namespace components::table {
             fetch_row(fetch_state, row_id, result, 0);
             if (fetch_state.fetch_error.contains_error()) {
                 error = fetch_state.fetch_error;
-                return false;
-            }
-            if (!result.validity().row_is_valid(0)) {
-                return false;
+                return filter_match_t::no;
             }
             if (auto* set = dynamic_cast<const set_membership_filter_t*>(filter)) {
-                return set->contains(result.value(0));
+                return set->contains(result.value(0)) ? filter_match_t::yes : filter_match_t::no;
             }
-            return filter->cast<constant_filter_t>().compare(result.value(0));
+            return filter->cast<constant_filter_t>().compare(result.value(0)) ? filter_match_t::yes
+                                                                              : filter_match_t::no;
         }
         auto segment = data_.get_segment(row_id);
         // For compressed segments, fetch the actual decompressed value
@@ -541,24 +554,21 @@ namespace components::table {
             fetch_row(fetch_state, row_id, result, 0);
             if (fetch_state.fetch_error.contains_error()) {
                 error = fetch_state.fetch_error;
-                return false;
-            }
-            if (!result.validity().row_is_valid(0)) {
-                return false;
+                return filter_match_t::no;
             }
             // Dispatch handles both constant_filter_t and set_membership_filter_t.
             if (auto* set = dynamic_cast<const set_membership_filter_t*>(filter)) {
-                return set->contains(result.value(0));
+                return set->contains(result.value(0)) ? filter_match_t::yes : filter_match_t::no;
             }
             const auto& const_filter = filter->cast<constant_filter_t>();
-            return const_filter.compare(result.value(0));
+            return const_filter.compare(result.value(0)) ? filter_match_t::yes : filter_match_t::no;
         }
         auto checked = segment->check_predicate(row_id, filter);
         if (checked.has_error()) {
             error = checked.error();
-            return false;
+            return filter_match_t::no;
         }
-        return checked.value();
+        return checked.value() ? filter_match_t::yes : filter_match_t::no;
     }
 
     bool column_data_t::check_validity(int64_t row_id) {

--- a/components/table/column_data.hpp
+++ b/components/table/column_data.hpp
@@ -23,6 +23,28 @@ namespace components::table {
         TRUE_OR_NULL = 3,
         FALSE_OR_NULL = 4
     };
+    // SQL three-valued logic. A value comparison against a NULL operand is UNKNOWN, not
+    // FALSE: the two differ under NOT (`NOT UNKNOWN` is UNKNOWN, while `NOT FALSE` is TRUE),
+    // so a filter tree that collapses UNKNOWN into FALSE lets NOT resurrect NULL rows.
+    // Only rows that evaluate to `yes` are selected.
+    enum class filter_match_t : uint8_t
+    {
+        no = 0,
+        yes = 1,
+        unknown = 2
+    };
+
+    constexpr filter_match_t filter_match_not(filter_match_t v) {
+        switch (v) {
+            case filter_match_t::yes:
+                return filter_match_t::no;
+            case filter_match_t::no:
+                return filter_match_t::yes;
+            default:
+                return filter_match_t::unknown;
+        }
+    }
+
     constexpr uint64_t MAX_ROW_ID = 1ULL << 55; // 2^55
 
     class column_data_t {
@@ -117,7 +139,9 @@ namespace components::table {
 
         // `error` carries an out_of_memory error_t when a pin fails during the predicate check;
         // on error the bool return is meaningless and the scan loop stops.
-        virtual bool check_predicate(int64_t row_id, const table_filter_t* filter, core::error_t& error);
+        // Returns `unknown` when the row's value is NULL — a NULL operand never satisfies a
+        // value comparison, and must stay distinguishable from a genuine `no` (see filter_match_t).
+        virtual filter_match_t check_predicate(int64_t row_id, const table_filter_t* filter, core::error_t& error);
         virtual bool check_validity(int64_t row_id);
         virtual uint64_t fetch(column_scan_state& state, int64_t row_id, vector::vector_t& result);
         virtual void

--- a/components/table/row_group.cpp
+++ b/components/table/row_group.cpp
@@ -203,75 +203,97 @@ namespace components::table {
 
     // A trailing subscript index into an ARRAY/LIST column (e.g. WHERE v[k] = x)
     // addresses an element, not a STRUCT sub-column. Materialize the row's list
-    // value and compare the addressed (0-based) element against the filter. A
-    // NULL list, an out-of-range index, or a NULL element does not match.
-    static bool check_array_element_predicate(column_data_t& column,
-                                              int64_t row_id,
-                                              uint64_t element_index,
-                                              const table_filter_t* filter,
-                                              core::error_t& error) {
+    // value and compare the addressed (0-based) element against the filter.
+    //
+    // A NULL list, an out-of-range subscript, or a NULL element all yield a NULL
+    // operand, so the comparison is UNKNOWN — not FALSE (see filter_match_t).
+    static filter_match_t check_array_element_predicate(column_data_t& column,
+                                                        int64_t row_id,
+                                                        uint64_t element_index,
+                                                        const table_filter_t* filter,
+                                                        core::error_t& error) {
         column_fetch_state fetch_state;
         vector::vector_t result(column.resource(), column.type(), 1);
         column.fetch_row(fetch_state, row_id, result, 0);
         if (fetch_state.fetch_error.contains_error()) {
             error = fetch_state.fetch_error;
-            return false;
+            return filter_match_t::no;
         }
         if (!result.validity().row_is_valid(0)) {
-            return false;
+            return filter_match_t::unknown;
         }
         auto list_value = result.value(0);
         const auto& elements = list_value.children();
         if (element_index >= elements.size()) {
-            return false;
+            return filter_match_t::unknown;
         }
         const auto& element_value = elements[element_index];
         if (element_value.is_null()) {
-            return false;
+            return filter_match_t::unknown;
         }
         if (auto* set = dynamic_cast<const set_membership_filter_t*>(filter)) {
-            return set->contains(element_value);
+            return set->contains(element_value) ? filter_match_t::yes : filter_match_t::no;
         }
-        return filter->cast<constant_filter_t>().compare(element_value);
+        return filter->cast<constant_filter_t>().compare(element_value) ? filter_match_t::yes : filter_match_t::no;
     }
 
-    bool row_group_t::check_predicate(int64_t row_id, const table_filter_t* filter, core::error_t& error) {
+    filter_match_t row_group_t::check_predicate(int64_t row_id, const table_filter_t* filter, core::error_t& error) {
         switch (filter->filter_type) {
             case expressions::compare_type::union_or: {
+                // TRUE if any child is TRUE; otherwise UNKNOWN if any child is UNKNOWN.
+                // (UNKNOWN OR TRUE = TRUE, so a TRUE disjunct still rescues a NULL row.)
                 auto& conjunction_or = filter->cast<conjunction_or_filter_t>();
+                bool saw_unknown = false;
                 for (auto& child_filter : conjunction_or.child_filters) {
-                    if (check_predicate(row_id, child_filter.get(), error)) {
-                        return true;
-                    }
+                    auto child = check_predicate(row_id, child_filter.get(), error);
                     if (error.contains_error()) {
-                        return false;
+                        return filter_match_t::no;
                     }
+                    if (child == filter_match_t::yes) {
+                        return filter_match_t::yes;
+                    }
+                    saw_unknown |= (child == filter_match_t::unknown);
                 }
-                return false;
+                return saw_unknown ? filter_match_t::unknown : filter_match_t::no;
             }
             case expressions::compare_type::union_and: {
+                // FALSE if any child is FALSE; otherwise UNKNOWN if any child is UNKNOWN.
+                // (UNKNOWN AND FALSE = FALSE, so a FALSE conjunct still excludes decisively.)
                 auto& conjunction_and = filter->cast<conjunction_and_filter_t>();
+                bool saw_unknown = false;
                 for (auto& child_filter : conjunction_and.child_filters) {
-                    if (!check_predicate(row_id, child_filter.get(), error)) {
-                        return false;
-                    }
+                    auto child = check_predicate(row_id, child_filter.get(), error);
                     if (error.contains_error()) {
-                        return false;
+                        return filter_match_t::no;
                     }
+                    if (child == filter_match_t::no) {
+                        return filter_match_t::no;
+                    }
+                    saw_unknown |= (child == filter_match_t::unknown);
                 }
-                return true;
+                return saw_unknown ? filter_match_t::unknown : filter_match_t::yes;
             }
             case expressions::compare_type::union_not: {
+                // NOT over the disjunction of the children: negate the OR result.
+                // Crucially NOT UNKNOWN is UNKNOWN — a row excluded because its operand was
+                // NULL must not be flipped back in. This is what makes the validity gate in
+                // column_data_t::check_predicate safe to add.
                 auto& conjunction_not = filter->cast<conjunction_not_filter_t>();
+                auto acc = filter_match_t::no;
                 for (auto& child_filter : conjunction_not.child_filters) {
-                    if (check_predicate(row_id, child_filter.get(), error)) {
-                        return false;
-                    }
+                    auto child = check_predicate(row_id, child_filter.get(), error);
                     if (error.contains_error()) {
-                        return false;
+                        return filter_match_t::no;
+                    }
+                    if (child == filter_match_t::yes) {
+                        acc = filter_match_t::yes;
+                        break;
+                    }
+                    if (child == filter_match_t::unknown) {
+                        acc = filter_match_t::unknown;
                     }
                 }
-                return true;
+                return filter_match_not(acc);
             }
             case expressions::compare_type::invalid: {
                 assert(false && "invalid type for filter selection");
@@ -285,8 +307,11 @@ namespace components::table {
                     column =
                         static_cast<struct_column_data_t*>(column)->sub_columns[null_filter.table_indices[i]].get();
                 }
+                // IS NULL / IS NOT NULL are the two predicates that interrogate nullness
+                // itself: they are always TRUE or FALSE, never UNKNOWN.
                 bool is_valid = column->check_validity(row_id);
-                return filter->filter_type == expressions::compare_type::is_null ? !is_valid : is_valid;
+                bool matches = filter->filter_type == expressions::compare_type::is_null ? !is_valid : is_valid;
+                return matches ? filter_match_t::yes : filter_match_t::no;
             }
             default: {
                 // Works for both constant_filter_t and set_membership_filter_t.
@@ -342,9 +367,11 @@ namespace components::table {
         for (uint64_t i = 0; i < approved_tuple_count; i++) {
             auto idx = indexing.get_index(i);
             new_indexing.set_index(result_count, idx);
-            result_count += check_predicate(static_cast<int64_t>(idx + vector_index * vector::DEFAULT_VECTOR_CAPACITY),
-                                            filter,
-                                            error);
+            // Only TRUE selects a row: UNKNOWN (a NULL operand) is excluded, exactly as FALSE is.
+            auto match = check_predicate(static_cast<int64_t>(idx + vector_index * vector::DEFAULT_VECTOR_CAPACITY),
+                                         filter,
+                                         error);
+            result_count += (match == filter_match_t::yes) ? 1 : 0;
             if (error.contains_error()) {
                 // OOM during predicate evaluation: stop; caller copies to scan_error.
                 return;

--- a/components/table/row_group.hpp
+++ b/components/table/row_group.hpp
@@ -58,7 +58,7 @@ namespace components::table {
         void scan_committed(collection_scan_state& state, vector::data_chunk_t& result, table_scan_type type);
 
         // `error` carries an out_of_memory error_t when a pin fails mid-check.
-        bool check_predicate(int64_t row_id, const table_filter_t* filter, core::error_t& error);
+        filter_match_t check_predicate(int64_t row_id, const table_filter_t* filter, core::error_t& error);
 
         void fetch_row(column_fetch_state& state,
                        const std::vector<storage_index_t>& column_ids,

--- a/integration/cpp/test/CMakeLists.txt
+++ b/integration/cpp/test/CMakeLists.txt
@@ -17,6 +17,7 @@ set( ${PROJECT_NAME}_SOURCES
         test_create_index_backfill_batched.cpp
         test_correctness_bugs.cpp
         test_dispatcher_watchdog_log.cpp
+        test_null_three_valued_logic.cpp
         test_production_scenarios.cpp
         test_join.cpp
         test_join_raw.cpp

--- a/integration/cpp/test/test_null_three_valued_logic.cpp
+++ b/integration/cpp/test/test_null_three_valued_logic.cpp
@@ -1,0 +1,273 @@
+#include "test_config.hpp"
+#include <catch2/catch_test_macros.hpp>
+
+// SQL three-valued logic over NULL operands.
+//
+// A NULL operand makes a value comparison UNKNOWN, not FALSE, and UNKNOWN rows are excluded
+// from WHERE / DELETE / UPDATE. The distinction matters under NOT: `NOT UNKNOWN` is UNKNOWN
+// (the row stays excluded), whereas `NOT FALSE` is TRUE (the row would be wrongly included).
+//
+// Before the fix, a pure comparison was pushed down into the storage scan, whose fast path
+// compared the raw data buffer without consulting the validity mask. Validity lives in a
+// separate sibling column, so a NULL row's payload bytes are a meaningless 0 — every NULL row
+// therefore matched `= 0` / `>= 0` / `< 1` ..., and DELETE/UPDATE mutated those rows.
+//
+// Both surfaces are covered here because they are the same bug: a jsonb nav (`t ->> 'x'`) is
+// resolved at transform time into a plain column reference, and an absent key is stored as a
+// NULL. A plain NULL and an absent jsonb key reach the identical scan path.
+
+namespace {
+
+    struct probe_t {
+        bool ok{false};
+        size_t rows{0};
+    };
+
+    template<typename Dispatcher>
+    probe_t run(Dispatcher* dispatcher, const std::string& sql) {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, sql);
+        if (!cur || !cur->is_success()) {
+            return {false, 0};
+        }
+        return {true, cur->size()};
+    }
+
+    // id=1 -> x=5 ; id=2 -> x NULL ; id=3 -> x=0
+    template<typename Dispatcher>
+    void seed_plain(Dispatcher* d, const std::string& table) {
+        REQUIRE(run(d, "CREATE TABLE " + table + " (id INT, x BIGINT);").ok);
+        REQUIRE(run(d, "INSERT INTO " + table + " (id, x) VALUES (1, 5);").ok);
+        REQUIRE(run(d, "INSERT INTO " + table + " (id, x) VALUES (2, NULL);").ok);
+        REQUIRE(run(d, "INSERT INTO " + table + " (id, x) VALUES (3, 0);").ok);
+    }
+
+    // The same three rows on a computing table, where id=2 simply has no 'x' key at all.
+    template<typename Dispatcher>
+    void seed_computed(Dispatcher* d, const std::string& table) {
+        REQUIRE(run(d, "CREATE TABLE " + table + " ();").ok);
+        REQUIRE(run(d, "INSERT INTO " + table + " (id, x) VALUES (1, 5);").ok);
+        REQUIRE(run(d, "INSERT INTO " + table + " (id) VALUES (2);").ok);
+        REQUIRE(run(d, "INSERT INTO " + table + " (id, x) VALUES (3, 0);").ok);
+    }
+
+} // namespace
+
+TEST_CASE("integration::cpp::null_3vl::comparisons_exclude_null") {
+    auto config = test_create_config("/tmp/test_null_3vl/cmp");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE n3;").ok);
+    seed_plain(d, "n3.t");
+
+    // The NULL row (id=2) must satisfy NO value comparison.
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x = 0;").rows == 1);   // id=3
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x <> 0;").rows == 1);  // id=1
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x >= 0;").rows == 2);  // id=1,3
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x > -1;").rows == 2);  // id=1,3
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x < 1;").rows == 1);   // id=3
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x <= 5;").rows == 2);  // id=1,3
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x = 5;").rows == 1);   // id=1
+
+    // IS NULL / IS NOT NULL keep working — they are TRUE/FALSE, never UNKNOWN.
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x IS NULL;").rows == 1);     // id=2
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x IS NOT NULL;").rows == 2); // id=1,3
+}
+
+TEST_CASE("integration::cpp::null_3vl::not_does_not_resurrect_null") {
+    // The guard against a naive fix. Merely excluding NULL from a comparison is not enough:
+    // if the filter tree is two-valued, NOT flips that exclusion into an inclusion.
+    // NOT UNKNOWN must stay UNKNOWN.
+    auto config = test_create_config("/tmp/test_null_3vl/not");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE n3;").ok);
+    seed_plain(d, "n3.t");
+
+    CHECK(run(d, "SELECT id FROM n3.t WHERE NOT (x = 0);").rows == 1);  // id=1 only
+    CHECK(run(d, "SELECT id FROM n3.t WHERE NOT (x >= 0);").rows == 0); // nobody
+    CHECK(run(d, "SELECT id FROM n3.t WHERE NOT (x = 5);").rows == 1);  // id=3 only
+    CHECK(run(d, "SELECT id FROM n3.t WHERE NOT (x <> 0);").rows == 1); // id=3 only
+}
+
+TEST_CASE("integration::cpp::null_3vl::and_or_propagate_unknown") {
+    auto config = test_create_config("/tmp/test_null_3vl/andor");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE n3;").ok);
+    seed_plain(d, "n3.t");
+
+    // OR: UNKNOWN or TRUE = TRUE; UNKNOWN or FALSE = UNKNOWN (excluded).
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x = 0 OR x = 5;").rows == 2);       // id=1,3
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x = 999 OR x = 5;").rows == 1);     // id=1
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x = 0 OR id = 2;").rows == 2);      // id=2,3 — TRUE rescues it
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x IS NULL OR x = 0;").rows == 2);   // id=2,3
+
+    // AND: UNKNOWN and TRUE = UNKNOWN (excluded); UNKNOWN and FALSE = FALSE.
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x >= 0 AND x <= 9;").rows == 2);    // id=1,3
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x >= 0 AND id = 2;").rows == 0);    // nobody
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x IS NULL AND id = 2;").rows == 1); // id=2
+}
+
+TEST_CASE("integration::cpp::null_3vl::dml_does_not_touch_null_rows") {
+    auto config = test_create_config("/tmp/test_null_3vl/dml");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE n3;").ok);
+
+    // DELETE must not remove the NULL row.
+    seed_plain(d, "n3.del");
+    CHECK(run(d, "DELETE FROM n3.del WHERE x = 0;").ok);
+    CHECK(run(d, "SELECT id FROM n3.del;").rows == 2);                 // id=1,2 survive
+    CHECK(run(d, "SELECT id FROM n3.del WHERE x IS NULL;").rows == 1); // id=2 still there
+
+    // UPDATE must not clobber the NULL row.
+    seed_plain(d, "n3.upd");
+    CHECK(run(d, "UPDATE n3.upd SET id = 99 WHERE x > -1;").ok);
+    CHECK(run(d, "SELECT id FROM n3.upd WHERE id = 99;").rows == 2); // only id=1,3 -> 99
+    CHECK(run(d, "SELECT id FROM n3.upd WHERE id = 2;").rows == 1);  // the NULL row is untouched
+}
+
+TEST_CASE("integration::cpp::null_3vl::update_overlay_keeps_null_excluded") {
+    // The update-overlay branch of column_data_t::check_predicate: once a vector carries
+    // updates, matching is answered from the overlay. The NULL row must stay excluded there
+    // too — the validity gate runs before the overlay is consulted.
+    auto config = test_create_config("/tmp/test_null_3vl/overlay");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE n3;").ok);
+    seed_plain(d, "n3.t");
+
+    CHECK(run(d, "UPDATE n3.t SET x = 7 WHERE id = 1;").ok); // put this vector into the overlay
+
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x = 7;").rows == 1);     // id=1, read from the overlay
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x = 5;").rows == 0);     // old value is gone
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x = 0;").rows == 1);     // id=3 only — NOT the NULL row
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x >= 0;").rows == 2);    // id=1(7),3(0) — NOT the NULL row
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x IS NULL;").rows == 1); // id=2 still NULL
+}
+
+TEST_CASE("integration::cpp::null_3vl::string_column_null") {
+    // The string fast path (string_check_row) has the same raw-buffer shape as the fixed-size
+    // one: an empty string must not be conflated with a NULL.
+    auto config = test_create_config("/tmp/test_null_3vl/str");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE n3;").ok);
+    REQUIRE(run(d, "CREATE TABLE n3.s (id INT, name TEXT);").ok);
+    REQUIRE(run(d, "INSERT INTO n3.s (id, name) VALUES (1, 'ann');").ok);
+    REQUIRE(run(d, "INSERT INTO n3.s (id, name) VALUES (2, NULL);").ok);
+    REQUIRE(run(d, "INSERT INTO n3.s (id, name) VALUES (3, '');").ok);
+
+    CHECK(run(d, "SELECT id FROM n3.s WHERE name = '';").rows == 1);     // id=3, NOT the NULL
+    CHECK(run(d, "SELECT id FROM n3.s WHERE name <> 'ann';").rows == 1); // id=3
+    CHECK(run(d, "SELECT id FROM n3.s WHERE name IS NULL;").rows == 1);  // id=2
+}
+
+// NOTE — two adjacent gaps are deliberately NOT covered here. They are separate pre-existing
+// bugs that this change neither causes nor fixes (verified: identical results with and without
+// it), and pinning them would misattribute them to this fix:
+//
+//   * INDEX SCAN route. `CREATE INDEX idx_x ON t (x)` then `WHERE x = 0` returns 0 rows — it
+//     loses id=3, whose value genuinely IS 0. A pure compare on an indexed column is planned
+//     as an index_scan (create_plan_match.cpp:112-127), bypassing the scan filter entirely,
+//     and the index mishandles a column containing NULLs.
+//   * `UPDATE t SET x = NULL` does not mark the row NULL: afterwards, `x IS NULL` still does
+//     not see it.
+//
+// Both are silent-wrong-result bugs and deserve their own fix and tests.
+
+// ---------------------------------------------------------------------------
+// JSONB surface: the same bug, reached through a nav operator over an absent key.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("integration::cpp::null_3vl::jsonb_absent_key_comparisons") {
+    auto config = test_create_config("/tmp/test_null_3vl/jsonb_cmp");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE n3;").ok);
+    seed_computed(d, "n3.co");
+
+    // An absent key projects as NULL (this was already correct before the fix).
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = d->execute_sql(session, "SELECT co ->> 'x' AS v FROM n3.co WHERE id = 2;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        CHECK(cur->value(0, 0).is_null());
+    }
+
+    // ...and it must now be excluded from every value comparison through the nav operand.
+    CHECK(run(d, "SELECT id FROM n3.co WHERE co ->> 'x' = 0;").rows == 1);  // id=3
+    CHECK(run(d, "SELECT id FROM n3.co WHERE co ->> 'x' > -1;").rows == 2); // id=1,3
+    CHECK(run(d, "SELECT id FROM n3.co WHERE co ->> 'x' < 1;").rows == 1);  // id=3
+    CHECK(run(d, "SELECT id FROM n3.co WHERE co ->> 'x' >= 0;").rows == 2); // id=1,3
+    CHECK(run(d, "SELECT id FROM n3.co WHERE co ->> 'x' <> 0;").rows == 1); // id=1
+
+    // The same rows, addressed as a plain column on the same computing table.
+    CHECK(run(d, "SELECT id FROM n3.co WHERE x = 0;").rows == 1);
+    CHECK(run(d, "SELECT id FROM n3.co WHERE x >= 0;").rows == 2);
+}
+
+TEST_CASE("integration::cpp::null_3vl::jsonb_not_and_dml") {
+    auto config = test_create_config("/tmp/test_null_3vl/jsonb_dml");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE n3;").ok);
+
+    seed_computed(d, "n3.co");
+    CHECK(run(d, "SELECT id FROM n3.co WHERE NOT (co ->> 'x' = 0);").rows == 1); // id=1 only
+
+    // DELETE through a nav operand must not remove the keyless row.
+    seed_computed(d, "n3.cod");
+    CHECK(run(d, "DELETE FROM n3.cod WHERE cod ->> 'x' = 0;").ok);
+    CHECK(run(d, "SELECT id FROM n3.cod;").rows == 2); // id=1,2 survive
+
+    // UPDATE through a nav operand must not clobber it.
+    seed_computed(d, "n3.cou");
+    CHECK(run(d, "UPDATE n3.cou SET id = 99 WHERE cou ->> 'x' > -1;").ok);
+    CHECK(run(d, "SELECT id FROM n3.cou WHERE id = 99;").rows == 2); // id=1,3 only
+    CHECK(run(d, "SELECT id FROM n3.cou WHERE id = 2;").rows == 1);  // keyless row untouched
+}
+
+TEST_CASE("integration::cpp::null_3vl::jsonb_nested_absent_key") {
+    // A dotted/nested key flattens to the column "a/b"; an absent nested key is a NULL there.
+    auto config = test_create_config("/tmp/test_null_3vl/jsonb_nested");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE n3;").ok);
+    REQUIRE(run(d, "CREATE TABLE n3.nd ();").ok);
+    REQUIRE(run(d, "INSERT INTO n3.nd (id, a.b) VALUES (1, 5);").ok);
+    REQUIRE(run(d, "INSERT INTO n3.nd (id) VALUES (2);").ok); // no a.b
+    REQUIRE(run(d, "INSERT INTO n3.nd (id, a.b) VALUES (3, 0);").ok);
+
+    CHECK(run(d, "SELECT id FROM n3.nd WHERE nd #>> '{a,b}' = 0;").rows == 1);  // id=3
+    CHECK(run(d, "SELECT id FROM n3.nd WHERE nd #>> '{a,b}' >= 0;").rows == 2); // id=1,3
+}


### PR DESCRIPTION
## The bug

A `NULL` silently matches every value comparison that `0` satisfies, and `DELETE`/`UPDATE` act on those rows. Plain table, declared columns, one honest NULL:

```sql
CREATE TABLE hr.emp (id INT, name TEXT, bonus BIGINT);
INSERT INTO hr.emp VALUES (1, 'ann', 500);   -- got a bonus
INSERT INTO hr.emp VALUES (2, 'bob', NULL);  -- bonus not yet decided
INSERT INTO hr.emp VALUES (3, 'cid', 0);     -- got nothing

SELECT name FROM hr.emp WHERE bonus IS NULL;  -- bob        (correct: the NULL is really there)
SELECT name FROM hr.emp WHERE bonus = 0;      -- bob, cid   WRONG, expected: cid
SELECT name FROM hr.emp WHERE bonus < 1;      -- bob, cid   WRONG, expected: cid
SELECT name FROM hr.emp WHERE bonus >= 0;     -- ann,bob,cid WRONG, expected: ann, cid

DELETE FROM hr.emp WHERE bonus = 0;           -- "clear out everyone who got no bonus"
SELECT name FROM hr.emp;                      -- ann        WRONG: bob is gone
```

Bob's bonus was undecided, not zero. No error, no warning — the statement reported success and deleted him.

## Root cause

A pure comparison is planned as a **pushdown filter into the storage scan** (`create_plan_match.cpp:107-136`), not as `operator_match`/`simple_predicate`. The scan's fast path (`column_data_t::check_predicate`) pins the raw block and compares the **data buffer**, never consulting the validity mask. Validity lives in a physically separate sibling column (`standard_column_data_t`), so a NULL row's payload bytes are a meaningless `0` — hence `0 == 0` matches.

The same function guards this in its STRUCT/ARRAY/LIST branch and its RLE/DICTIONARY branch, and omits it in the plain fixed-size/string branch — the one every ordinary column takes. `simple_predicate`, `IS NULL`, and the projection path all handle NULL correctly; only the pushed-down scan filter departed from SQL semantics.

## Why the fix is not just a validity guard

Adding the missing guard fixes the comparisons and then **breaks `NOT`**:

```sql
SELECT id FROM t WHERE NOT (x = 0);   -- guard alone: returns the NULL row. Expected: it must not.
```

The filter tree was two-valued (`bool`), so `union_not` simply negated its child: a row excluded because its operand was NULL got flipped back in. The two bugs had been cancelling out under `NOT`. Fixing only the comparison trades data loss for wrong results — and no existing test would have caught it.

So the evaluator is made three-valued, per standard SQL:

* `filter_match_t {no, yes, unknown}` replaces `bool` in `column_data_t::check_predicate` and `row_group_t::check_predicate`.
* A NULL operand yields `unknown`, gated **once** at the top of `column_data_t::check_predicate` — so raw buffers, RLE/dictionary, struct/array/list and the update overlay are covered by one check instead of three ad-hoc ones. It routes through `fetch_row`, which applies the update overlay, so a row updated to NULL is seen as NULL.
* `AND`/`OR`/`NOT` propagate UNKNOWN: FALSE dominates AND, TRUE dominates OR, and `NOT UNKNOWN` stays UNKNOWN.
* `IS NULL` / `IS NOT NULL` are always TRUE or FALSE, never UNKNOWN — they are answered from the validity mask before this gate, so they are unaffected.
* Only `yes` selects a row.

## JSONB: the same bug, not a second one

`t ->> 'x'` is resolved at transform time into a plain column reference, and an absent key is stored as a NULL — so an absent-key row reaches the identical scan path. Verified: one guard fixes all three spellings at once.

```sql
CREATE TABLE z.doc ();
INSERT INTO z.doc (id, x) VALUES (1, 5);
INSERT INTO z.doc (id)    VALUES (2);      -- no 'x' key at all
INSERT INTO z.doc (id, x) VALUES (3, 0);

SELECT co ->> 'x' FROM z.doc WHERE id = 2;        -- NULL   (projection was always correct)
SELECT id FROM z.doc WHERE doc ->> 'x' = 0;       -- was: 2 rows, now: 1 (id=3)
DELETE FROM z.doc WHERE doc ->> 'x' = 0;          -- no longer deletes the keyless row
UPDATE z.doc SET id = 99 WHERE doc ->> 'x' > -1;  -- no longer clobbers it
```

This is the `absent_key_coerced_to_zero` bug characterized in #560, but it is a core engine bug that jsonb merely provides another door into — not a jsonb quirk. Note that #560's pins assert the current (broken) behaviour, so they will need flipping once this lands.

## Tests

`integration/cpp/test/test_null_three_valued_logic.cpp` — 9 cases, 110 assertions over both surfaces: comparisons, `NOT`, AND/OR propagation, `DELETE`/`UPDATE`, the update overlay, string columns (empty string must not be conflated with NULL), and the jsonb navs (`->>`, `#>>`, nested `a.b`, plus DML through a nav).

* All 9 cases **fail before** this change (29 failing assertions) and **pass after**. `not_does_not_resurrect_null` exists specifically to fail against the naive validity-guard-only fix.
* Full integration suite on this branch: **410 tests, 0 failures**.

## Known gaps, deliberately not fixed here

Verified identical with and without this change (documented in the test file):

* **Index scan silently drops rows** when the column contains a NULL: with an index on `x`, `WHERE x = 0` returns **0 rows** — losing the row whose value genuinely is `0`. A pure compare on an indexed column is planned as an `index_scan`, bypassing the scan filter entirely. Comparable severity; worth its own fix.
* `UPDATE t SET x = NULL` does not mark the row NULL (`x IS NULL` still does not see it afterwards).
* `WHERE a.b = 0` does not resolve on a computing table (the nested test navigates via `#>> '{a,b}'` instead).

## Follow-up

The validity gate calls `check_validity`, which goes through `fetch_row` and allocates per row on the hot scan path. Correct, but the plain fast path exists to avoid exactly that. Column stats already track `null_count()`, so the clean optimisation is to skip the check on null-free columns — not built on that here, because stale stats would silently reintroduce the bug. Not benchmarked.