### PR TITLE
fix(jsonb): crashes and wrong results in the flattened jsonb operators

### DIFF
--- a/components/expressions/jsonb_path.hpp
+++ b/components/expressions/jsonb_path.hpp
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <memory_resource>
+#include <string>
+#include <string_view>
+#include <vector>
+
+// Single source of truth for the jsonb path <-> flattened-column-name mapping.
+//
+// otterbrix stores a nested jsonb path as one flat column on a "computing" table:
+// the path a.b is the column named "a/b", segments joined by the reserved
+// separator '/'. Every jsonb operator (navigation ->/->>, path #>/#>>, existence
+// ?/?|/?&, expansion, deletion) and the INSERT target flattener build and match
+// these names, so the read and write sides MUST agree byte-for-byte — this header
+// is the one place that defines the split (operand text -> segments) and the join
+// (segments -> flattened name).
+//
+// NOTE on the '/' separator: because a computing-table column name and a nested
+// path share one namespace, a column whose literal name contains '/' (e.g. a
+// quoted "a/b") is indistinguishable from the two-segment path a.b — both are the
+// storage name "a/b". That is an inherent property of the flattened
+// representation, not something this codec can resolve without escaping every
+// ordinary column identifier system-wide; callers that care must reserve '/'.
+namespace components::expressions::jsonb_path {
+
+    inline constexpr char separator = '/';
+
+    // Join path segments into the flattened storage-column name (segments are used
+    // verbatim; the caller guarantees they do not contain the separator).
+    inline std::pmr::string flatten(const std::pmr::vector<std::pmr::string>& segments,
+                                    std::pmr::memory_resource* resource) {
+        std::pmr::string out(resource);
+        bool first = true;
+        for (const auto& seg : segments) {
+            if (!first) {
+                out += separator;
+            }
+            out += seg;
+            first = false;
+        }
+        return out;
+    }
+
+    // Split a jsonb path OPERAND string into its segments. Two spellings are
+    // accepted, matching PostgreSQL's #> path operators:
+    //   dotted        'a.b'   -> ["a", "b"]
+    //   pg text-array '{a,b}' -> ["a", "b"]   (braces stripped, per-segment spaces trimmed)
+    // Empty / all-space segments are dropped. This is the single splitter used by
+    // every path-taking operator.
+    inline std::pmr::vector<std::pmr::string> split_operand(std::string_view raw,
+                                                            std::pmr::memory_resource* resource) {
+        std::pmr::vector<std::pmr::string> segments(resource);
+        auto push = [&](std::string_view s) {
+            size_t b = s.find_first_not_of(' ');
+            if (b == std::string_view::npos) {
+                return; // empty / all spaces
+            }
+            size_t e = s.find_last_not_of(' ');
+            segments.emplace_back(std::pmr::string{s.substr(b, e - b + 1), resource});
+        };
+        std::string_view body = raw;
+        char delim = '.';
+        if (raw.size() >= 2 && raw.front() == '{' && raw.back() == '}') {
+            body = raw.substr(1, raw.size() - 2);
+            delim = ',';
+        }
+        size_t start = 0;
+        while (true) {
+            size_t next = body.find(delim, start);
+            push(next == std::string_view::npos ? body.substr(start) : body.substr(start, next - start));
+            if (next == std::string_view::npos) {
+                break;
+            }
+            start = next + 1;
+        }
+        return segments;
+    }
+
+} // namespace components::expressions::jsonb_path

--- a/components/expressions/key.hpp
+++ b/components/expressions/key.hpp
@@ -22,7 +22,8 @@ namespace components::expressions {
             , storage_{std::move(key.storage_)}
             , path_{std::move(key.path_)}
             , cast_type_{std::move(key.cast_type_)}
-            , variant_select_{key.variant_select_} {}
+            , variant_select_{key.variant_select_}
+            , absent_ok_{key.absent_ok_} {}
 
         key_t(const key_t& key) = default;
         key_t& operator=(const key_t& key) = default;
@@ -112,6 +113,14 @@ namespace components::expressions {
 
         void set_variant_select(bool v) { variant_select_ = v; }
 
+        // Set for a jsonb navigation / existence key: a key that matches no column
+        // is a legal ABSENT leaf (postgres 3VL — navigation yields SQL NULL,
+        // existence yields false), not the hard "path not found" error a mistyped
+        // regular column deserves. Only such flagged keys get the lenient handling.
+        bool absent_ok() const { return absent_ok_; }
+
+        void set_absent_ok(bool v) { absent_ok_ = v; }
+
         auto is_null() const -> bool { return storage_.empty(); }
 
         auto side() const -> side_t { return side_; }
@@ -146,6 +155,7 @@ namespace components::expressions {
         std::pmr::vector<size_t> path_;
         std::optional<types::complex_logical_type> cast_type_;
         bool variant_select_ = false;
+        bool absent_ok_ = false;
     };
 
     template<class OStream>

--- a/components/physical_plan/operators/operator_insert.cpp
+++ b/components/physical_plan/operators/operator_insert.cpp
@@ -31,6 +31,16 @@ namespace components::operators {
             modified_ = make_operator_write_data(resource());
         }
         if (input.size() > 0) {
+            // INSERT ... SELECT: rename the streamed projection columns to the target
+            // columns (positionally, in target order) so the name-based append routes
+            // each value to the intended column. No-op for VALUES (rename_targets_ is
+            // empty) and for a projection that already carries the target names.
+            if (!rename_targets_.empty()) {
+                const uint64_t n = std::min<uint64_t>(input.column_count(), rename_targets_.size());
+                for (uint64_t i = 0; i < n; ++i) {
+                    input.data[i].set_type_alias(std::string(rename_targets_[i]));
+                }
+            }
             output_->append_chunk(std::move(input));
         }
         return core::error_t::no_error();

--- a/components/physical_plan/operators/operator_insert.hpp
+++ b/components/physical_plan/operators/operator_insert.hpp
@@ -20,6 +20,13 @@ namespace components::operators {
 
         catalog::oid_t table_oid() const noexcept { return table_oid_; }
 
+        // INSERT ... SELECT only: the target column names, in target order. The
+        // streamed SELECT columns are renamed to these before the (name-based)
+        // append, so 'INSERT INTO t (id, a.b) SELECT 5, 55' lands 5,55 in id,a/b
+        // rather than in projection-named columns that leave id/a.b null. Left
+        // empty for INSERT ... VALUES, whose raw-data columns are already named.
+        void set_rename_targets(std::pmr::vector<std::pmr::string> targets) { rename_targets_ = std::move(targets); }
+
         // STREAMING DML (STEP 3b). The insert is a SINK on its input: push() folds
         // each input batch into a bounded accumulator and emits nothing; the executor
         // then drives the async WAL->storage->index commit via await_async_and_resume
@@ -53,6 +60,8 @@ namespace components::operators {
         // Both are materialized into output_ only on the final (is_final) drive.
         chunks_vector_t returning_accum_{resource_};
         uint64_t affected_rows_{0};
+        // Target column names for an INSERT ... SELECT rename (see set_rename_targets).
+        std::pmr::vector<std::pmr::string> rename_targets_{resource_};
     };
 
 } // namespace components::operators

--- a/components/physical_plan_generator/impl/create_plan_insert.cpp
+++ b/components/physical_plan_generator/impl/create_plan_insert.cpp
@@ -31,6 +31,21 @@ namespace services::planner::impl {
                                                                                     context.log.clone(),
                                                                                     node->table_oid(),
                                                                                     std::move(returning)));
+        // INSERT ... SELECT: the SELECT projection column names need not match the
+        // target columns (e.g. SELECT 5, 55 into (id, a.b)), and the append is
+        // name-based, so hand the operator the target names to rename the streamed
+        // columns positionally. INSERT ... VALUES has a raw-data (data_t) child whose
+        // columns fill_row already named, so it is left untouched.
+        const auto& kt = node_insert->key_translation();
+        if (!kt.empty() && !node->children().empty() &&
+            node->children().front()->type() != components::logical_plan::node_type::data_t) {
+            std::pmr::vector<std::pmr::string> names(context.resource);
+            names.reserve(kt.size());
+            for (const auto& k : kt) {
+                names.emplace_back(std::pmr::string{k.as_string().c_str(), context.resource});
+            }
+            plan->set_rename_targets(std::move(names));
+        }
         plan->set_children(create_plan(context,
                                        function_registry,
                                        node->children().front(),

--- a/components/sql/transformer/impl/transform_insert.cpp
+++ b/components/sql/transformer/impl/transform_insert.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 
 #include <components/expressions/aggregate_expression.hpp>
+#include <components/expressions/jsonb_path.hpp>
 #include <components/expressions/scalar_expression.hpp>
 #include <components/logical_plan/node_insert.hpp>
 #include <components/sql/transformer/transformer.hpp>
@@ -299,11 +300,25 @@ namespace components::sql::transform {
             if (target->indirection->lst.empty()) {
                 key_translation.emplace_back(resource_, target->name);
             } else {
-                auto key = expressions::key_t{
-                    std::pmr::vector<std::pmr::string>{{std::pmr::string{target->name, resource_},
-                                                        pmrStrVal(target->indirection->lst.back().data, resource_)},
-                                                       resource_}};
-                key_translation.emplace_back(std::move(key));
+                // Dotted / subscripted target such as `a.b.c` or `arr[0]`: flatten
+                // the WHOLE path — the base name plus EVERY indirection element —
+                // into one computing-table column name, through the shared codec so
+                // the write side agrees byte-for-byte with the read side. Keeping
+                // every interior segment fixes the old two-element build that stored
+                // `a.b.c` as "a/c" (dropping the middle); rendering a subscript with
+                // indices_to_str fixes the crash where an A_Indices node was
+                // dereferenced as a string (`arr[0]` -> "arr/0", not a null deref).
+                std::pmr::vector<std::pmr::string> segments(resource_);
+                segments.emplace_back(std::pmr::string{target->name, resource_});
+                for (const auto& part : target->indirection->lst) {
+                    Node* p = pg_ptr_cast<Node>(part.data);
+                    if (nodeTag(p) == T_A_Indices) {
+                        segments.emplace_back(indices_to_str(resource_, pg_ptr_cast<A_Indices>(p)));
+                    } else {
+                        segments.emplace_back(pmrStrVal(p, resource_));
+                    }
+                }
+                key_translation.emplace_back(resource_, jsonb_path::flatten(segments, resource_));
             }
         }
         // RETURNING projection (references the target table's columns). Parsed

--- a/components/sql/transformer/impl/transform_select.cpp
+++ b/components/sql/transformer/impl/transform_select.cpp
@@ -3,6 +3,7 @@
 
 #include <components/expressions/aggregate_expression.hpp>
 #include <components/expressions/expression.hpp>
+#include <components/expressions/jsonb_path.hpp>
 #include <components/expressions/scalar_expression.hpp>
 #include <components/expressions/sort_expression.hpp>
 #include <components/logical_plan/node_aggregate.hpp>
@@ -989,6 +990,37 @@ namespace components::sql::transform {
                             if (op_str == "#-" ||
                                 (op_str == "-" && a_expr->lexpr && jsonb_lhs_is_table(a_expr->lexpr, names))) {
                                 has_non_star = true;
+                                // '-' with a text-array operand '{a,b}' deletes several
+                                // top-level keys at once (postgres `jsonb - text[]`).
+                                // Each key becomes one delete prefix carried as a param;
+                                // the empty array '{}' deletes nothing. Every other
+                                // spelling ('- key', '#- path') is a single prefix.
+                                if (op_str == "-") {
+                                    std::string rhs = get_str_value(a_expr->rexpr);
+                                    if (has_error()) {
+                                        return nullptr;
+                                    }
+                                    if (rhs.size() >= 2 && rhs.front() == '{' && rhs.back() == '}') {
+                                        expressions::side_t side = expressions::side_t::undefined;
+                                        std::pmr::vector<std::pmr::string> base(resource_);
+                                        if (!resolve_jsonb_base(a_expr->lexpr, names, base, side)) {
+                                            return nullptr;
+                                        }
+                                        if (side == expressions::side_t::undefined && names.right_name.empty() &&
+                                            names.right_alias.empty()) {
+                                            side = expressions::side_t::left;
+                                        }
+                                        auto del = make_scalar_expression(resource_, scalar_type::jsonb_delete);
+                                        for (auto& k : jsonb_path::split_operand(rhs, resource_)) {
+                                            std::pmr::vector<std::pmr::string> segs(base);
+                                            segs.emplace_back(std::move(k));
+                                            del->append_param(
+                                                expressions::key_t(resource_, jsonb_path::flatten(segs, resource_), side));
+                                        }
+                                        select_node->append_expression(del);
+                                        break;
+                                    }
+                                }
                                 expressions::key_t prefix_key{resource_};
                                 if (!resolve_jsonb_prefix_key(a_expr, names, prefix_key)) {
                                     return nullptr;

--- a/components/sql/transformer/impl/transfrom_common.cpp
+++ b/components/sql/transformer/impl/transfrom_common.cpp
@@ -1,5 +1,6 @@
 #include <components/expressions/aggregate_expression.hpp>
 #include <components/expressions/function_expression.hpp>
+#include <components/expressions/jsonb_path.hpp>
 #include <components/expressions/scalar_expression.hpp>
 #include <components/logical_plan/node_function.hpp>
 #include <components/sql/transformer/transformer.hpp>
@@ -944,43 +945,13 @@ namespace components::sql::transform {
         if (has_error()) {
             return false;
         }
-        auto push_segment = [&](const std::string& s) {
-            // trim surrounding spaces (PG-style '{a, b}')
-            size_t b = s.find_first_not_of(' ');
-            size_t e = s.find_last_not_of(' ');
-            if (b == std::string::npos) {
-                return;
-            }
-            std::string trimmed = s.substr(b, e - b + 1);
-            segments.emplace_back(std::pmr::string{trimmed.c_str(), resource_});
-        };
         if (jsonb_op_takes_path(op)) {
             // '#>' / '#>>' / '#-' : a whole path. Accept PG array '{a,b}' or dotted 'a.b'.
-            std::string path = key_str;
-            if (path.size() >= 2 && path.front() == '{' && path.back() == '}') {
-                path = path.substr(1, path.size() - 2);
-                size_t start = 0;
-                while (true) {
-                    size_t comma = path.find(',', start);
-                    push_segment(path.substr(start, comma - start));
-                    if (comma == std::string::npos) {
-                        break;
-                    }
-                    start = comma + 1;
-                }
-            } else {
-                size_t start = 0;
-                while (true) {
-                    size_t dot = path.find('.', start);
-                    push_segment(path.substr(start, dot - start));
-                    if (dot == std::string::npos) {
-                        break;
-                    }
-                    start = dot + 1;
-                }
+            for (auto& seg : jsonb_path::split_operand(key_str, resource_)) {
+                segments.emplace_back(std::move(seg));
             }
         } else {
-            // '->' / '->>' : a single key.
+            // '->' / '->>' : a single key, taken verbatim (no splitting).
             segments.emplace_back(std::pmr::string{key_str.c_str(), resource_});
         }
         return true;
@@ -1010,14 +981,7 @@ namespace components::sql::transform {
                 core::error_t(core::error_code_t::sql_parse_error, std::pmr::string{"empty jsonb path", resource_});
             return false;
         }
-        std::pmr::string joined(resource_);
-        for (size_t i = 0; i < segments.size(); ++i) {
-            if (i != 0) {
-                joined += "/";
-            }
-            joined += segments[i];
-        }
-        out_key = expressions::key_t(resource_, std::move(joined), side);
+        out_key = expressions::key_t(resource_, jsonb_path::flatten(segments, resource_), side);
         if (out_key.side() == expressions::side_t::undefined && names.right_name.empty() && names.right_alias.empty()) {
             out_key.set_side(expressions::side_t::left);
         }
@@ -1037,30 +1001,9 @@ namespace components::sql::transform {
                                                     resource_});
             return false;
         }
-        std::pmr::vector<std::pmr::string> segments(resource_);
-        expressions::side_t side = expressions::side_t::undefined;
-        if (!collect_jsonb_path(node, names, segments, side)) {
-            return false;
-        }
-        if (segments.empty()) {
-            error_ =
-                core::error_t(core::error_code_t::sql_parse_error, std::pmr::string{"empty jsonb path", resource_});
-            return false;
-        }
-        std::pmr::string joined(resource_);
-        for (size_t i = 0; i < segments.size(); ++i) {
-            if (i != 0) {
-                joined += "/";
-            }
-            joined += segments[i];
-        }
-        out_key = expressions::key_t(resource_, std::move(joined), side);
-        // Single-table queries leave side undefined; pin to left so the value
-        // getter can read it (mirrors transform_a_expr_func).
-        if (out_key.side() == expressions::side_t::undefined && names.right_name.empty() && names.right_alias.empty()) {
-            out_key.set_side(expressions::side_t::left);
-        }
-        return true;
+        // The only difference from a prefix key is the scalar-vs-table guard above;
+        // the flattening itself is identical, so share it.
+        return resolve_jsonb_prefix_key(node, names, out_key);
     }
 
     expression_ptr transformer::transform_jsonb_exists(A_Expr* node,
@@ -1130,13 +1073,9 @@ namespace components::sql::transform {
             use_side = expressions::side_t::left;
         }
         auto build_exists = [&](const std::pmr::string& k) -> compare_expression_ptr {
-            std::pmr::string joined(resource_);
-            for (const auto& seg : prefix) {
-                joined += seg;
-                joined += "/";
-            }
-            joined += k;
-            expressions::key_t key(resource_, std::move(joined), use_side);
+            std::pmr::vector<std::pmr::string> segments(prefix);
+            segments.emplace_back(k);
+            expressions::key_t key(resource_, jsonb_path::flatten(segments, resource_), use_side);
             auto dummy = params->add_parameter(
                 types::logical_value_t(resource_, types::complex_logical_type{types::logical_type::NA}));
             return make_compare_expression(params->parameters().resource(), compare_type::is_not_null, key, dummy);

--- a/components/sql/transformer/impl/transfrom_common.cpp
+++ b/components/sql/transformer/impl/transfrom_common.cpp
@@ -164,6 +164,33 @@ namespace components::sql::transform {
                     }
                     return col_ref.field;
                 }
+                // A cast over a scalar jsonb navigation, e.g. (t #>> 'a.c')::bigint:
+                // resolve the navigation to its flattened column key and annotate it,
+                // exactly like a column cast. Without this the cast node fell through
+                // to add_param_value, which tried to fold the navigation A_Expr into a
+                // constant parameter and read uninitialized memory — a per-run garbage
+                // constant, identical on every row.
+                if (cast->arg && nodeTag(cast->arg) == T_A_Expr) {
+                    auto* sub = pg_ptr_cast<A_Expr>(cast->arg);
+                    if (sub->kind == AEXPR_OP && sub->name &&
+                        nodeTag(sub->name->lst.front().data) == T_String &&
+                        is_jsonb_nav_operator(strVal(sub->name->lst.front().data))) {
+                        auto target_type_res = get_type(resource_, cast->typeName);
+                        if (target_type_res.has_error()) {
+                            error_ = target_type_res.error();
+                            return nullptr;
+                        }
+                        expressions::key_t k{resource_};
+                        if (!resolve_jsonb_scalar_key(sub, names, k)) {
+                            return nullptr;
+                        }
+                        k.set_cast_type(target_type_res.value());
+                        if (cast->variant_select) {
+                            k.set_variant_select(true);
+                        }
+                        return k;
+                    }
+                }
                 return add_param_value(node, plan->parameters.get());
             }
             case T_ParamRef:

--- a/components/sql/transformer/impl/transfrom_common.cpp
+++ b/components/sql/transformer/impl/transfrom_common.cpp
@@ -1076,6 +1076,10 @@ namespace components::sql::transform {
             std::pmr::vector<std::pmr::string> segments(prefix);
             segments.emplace_back(k);
             expressions::key_t key(resource_, jsonb_path::flatten(segments, resource_), use_side);
+            // A jsonb existence test: a key that names no column is legally absent
+            // (yields false), and an intermediate object key is present if a child
+            // is — the validator resolves both, so it must not hard-error here.
+            key.set_absent_ok(true);
             auto dummy = params->add_parameter(
                 types::logical_value_t(resource_, types::complex_logical_type{types::logical_type::NA}));
             return make_compare_expression(params->parameters().resource(), compare_type::is_not_null, key, dummy);

--- a/components/sql/transformer/impl/transfrom_common.cpp
+++ b/components/sql/transformer/impl/transfrom_common.cpp
@@ -253,13 +253,21 @@ namespace components::sql::transform {
         }
     }
 
+    // Render a jsonb operator's right-hand key/path operand into its textual form.
+    // The operand is always a literal: a bare string/number, a cast of one, or a
+    // ParamRef; a bare column reference (`t -> x`) contributes the column's *name*.
+    // The switch is exhaustive and never dereferences a node as the wrong type —
+    // every unhandled shape reports a clean parse error instead.
     std::string transformer::get_str_value(Node* node) {
         switch (nodeTag(node)) {
-            case T_TypeCast: {
-                auto cast = pg_ptr_cast<TypeCast>(node);
-                bool is_true = std::string(strVal(&pg_ptr_cast<A_Const>(cast->arg)->val)) == "t";
-                return is_true ? "true" : "false";
-            }
+            case T_TypeCast:
+                // A cast key is just its underlying constant rendered as text:
+                // 'x'::text -> "x", 5::bigint -> "5", TRUE -> "t". Recurse so the
+                // operand's real node type drives the conversion. (This arm used to
+                // collapse EVERY cast to the boolean strings "true"/"false", which
+                // both mis-keyed 'x'::text and dereferenced a non-string cast
+                // argument's integer union member as a char* — a segfault.)
+                return get_str_value(pg_ptr_cast<TypeCast>(node)->arg);
             case T_A_Const: {
                 auto value = &(pg_ptr_cast<A_Const>(node)->val);
                 switch (nodeTag(value)) {
@@ -269,13 +277,26 @@ namespace components::sql::transform {
                         return std::to_string(intVal(value));
                     case T_Float:
                         return strVal(value);
+                    case T_Null:
+                        error_ = core::error_t(
+                            core::error_code_t::sql_parse_error,
+                            std::pmr::string{"jsonb key must be a constant value, not NULL", resource_});
+                        return {};
+                    default:
+                        break;
                 }
+                // No fall-through into the ColumnRef arm below: an unexpected
+                // constant kind is a clean error, not a wild reinterpret-cast.
+                break;
             }
             case T_ColumnRef:
-                assert(false);
+                // `t -> col`: the key is the column's own name (its identifier),
+                // not its per-row value. Kept for compatibility with that spelling.
                 return strVal(pg_ptr_cast<ColumnRef>(node)->fields->lst.back().data);
             case T_ParamRef:
                 return "$" + std::to_string(pg_ptr_cast<ParamRef>(node)->number);
+            default:
+                break;
         }
         error_ = core::error_t(core::error_code_t::sql_parse_error,
                                std::pmr::string{"incorrect string value in get_str_value", resource_});

--- a/integration/cpp/test/CMakeLists.txt
+++ b/integration/cpp/test/CMakeLists.txt
@@ -57,6 +57,7 @@ set( ${PROJECT_NAME}_SOURCES
         test_aggregate_pushdown_e2e.cpp
         test_pushdown_traffic.cpp
         test_pushed_reduce_scan_lateral.cpp
+        test_jsonb_support.cpp
 
         # stress tests with sanitizer are incredibly slow
         $<$<NOT:$<BOOL:${ENABLE_ASAN}>>:stress_test_sql_features.cpp>

--- a/integration/cpp/test/test_jsonb_support.cpp
+++ b/integration/cpp/test/test_jsonb_support.cpp
@@ -48,6 +48,9 @@
 //       no column is a "path not found" error (not a silently vanished select
 //       item), and inside a join expand and delete resolve against the side the
 //       operator named (not blindly across both, which was ambiguous).
+//   [F] a cast over a scalar navigation used in arithmetic ((t #>> 'a.c')::bigint
+//       + 1) reads the navigated column per row, instead of folding the navigation
+//       into an uninitialized constant parameter (per-run garbage on every row).
 
 #include "test_config.hpp"
 #include <catch2/catch_test_macros.hpp>
@@ -659,15 +662,17 @@ TEST_CASE("integration::cpp::test_jsonb_support::sql_json_standard_absent") {
 // BUG characterization — each CHECK below pins behavior that is WRONG.
 // ===========================================================================
 
-// A cast applied to a navigated value, then used in arithmetic, reads
-// uninitialized memory: the result is a per-run-varying constant repeated on
-// every row. Without the cast, or without the arithmetic, the same expression is
-// correct — so the two together corrupt the value.
-TEST_CASE("integration::cpp::test_jsonb_support::bug_cast_nav_in_arithmetic_is_garbage") {
+// [F] A cast applied to a navigated value, then used in arithmetic, reads the
+// navigated column per row like every other operand. It used to fall through to
+// the constant-parameter path, which folded the navigation expression into an
+// uninitialized parameter: a per-run-varying garbage constant repeated on every
+// row. Both halves were individually correct — only the two together corrupted.
+TEST_CASE("integration::cpp::test_jsonb_support::cast_nav_in_arithmetic_reads_the_column") {
     auto config = make_test_config("/tmp/test_jsonb_matrix/cast_arith");
     test_spaces space(config);
     auto* d = space.dispatcher();
     seed(d);
+    // rows: a/c = 20, 40, 60, 70 (present on every row)
 
     // both halves are individually correct
     auto cast_only = exec(d, "SELECT id, (t #>> 'a.c')::bigint AS v FROM jp.t ORDER BY id;");
@@ -678,15 +683,21 @@ TEST_CASE("integration::cpp::test_jsonb_support::bug_cast_nav_in_arithmetic_is_g
     REQUIRE(arith_only->is_success());
     CHECK(i64(arith_only, "v", 0) == 21);
 
-    // together: garbage. Same value on every row, unrelated to the data.
+    // together: now the per-row value, not a repeated garbage constant
     auto both = exec(d, "SELECT id, (t #>> 'a.c')::bigint + 1 AS v FROM jp.t ORDER BY id;");
     REQUIRE(both->is_success());
-    // correct: 21, 41, 61, 71
-    CHECK_FALSE(i64(both, "v", 0) == 21);
-    CHECK(i64(both, "v", 0) == i64(both, "v", 1)); // every row gets the same garbage
-    CHECK(i64(both, "v", 1) == i64(both, "v", 2));
+    CHECK(i64(both, "v", 0) == 21);
+    CHECK(i64(both, "v", 1) == 41);
+    CHECK(i64(both, "v", 2) == 61);
+    CHECK(i64(both, "v", 3) == 71);
 
-    // the same shape over a plain column is fine — this is navigation-specific
+    // the cast composes on either side of the operator, still per row
+    auto both2 = exec(d, "SELECT id, 100 - (t #>> 'a.b')::bigint AS v FROM jp.t WHERE id < 3 ORDER BY id;");
+    REQUIRE(both2->is_success());
+    CHECK(i64(both2, "v", 0) == 90);  // 100 - 10
+    CHECK(i64(both2, "v", 1) == 70);  // 100 - 30
+
+    // the same shape over a plain column was always fine — this was nav-specific
     auto plain = exec(d, "SELECT id, (id)::bigint + 1 AS v FROM jp.t ORDER BY id;");
     REQUIRE(plain->is_success());
     CHECK(i64(plain, "v", 0) == 2);

--- a/integration/cpp/test/test_jsonb_support.cpp
+++ b/integration/cpp/test/test_jsonb_support.cpp
@@ -28,7 +28,6 @@
 //
 // NOT PINNABLE — these SEGFAULT the process, so they cannot live in a test binary.
 // Verified on this commit; kept here as the repro list:
-//   INSERT INTO t (a.b, x) VALUES (NULL, 'z');          -- NULL literal in a dotted target [C3]
 //   SELECT CASE WHEN t #>> 'a.b' = 10 THEN 1 ELSE 0 END -- only when the leaf has a NULL row;
 //     FROM t;                                           --   reproduces on plain columns too (general 3VL bug)
 //
@@ -51,6 +50,9 @@
 //   [F] a cast over a scalar navigation used in arithmetic ((t #>> 'a.c')::bigint
 //       + 1) reads the navigated column per row, instead of folding the navigation
 //       into an uninitialized constant parameter (per-run garbage on every row).
+//   [H] a NULL written to a not-yet-existing column of a computing table is an
+//       absent key: it carries no type, so the column is dropped after schema
+//       reconciliation instead of reaching storage as an all-NA column (segfault).
 
 #include "test_config.hpp"
 #include <catch2/catch_test_macros.hpp>
@@ -754,6 +756,42 @@ TEST_CASE("integration::cpp::test_jsonb_support::subscript_insert_target") {
     CHECK(i64(cur, "arr/1", 0) == 8);
     // and it reads back through the path spelling
     CHECK(i64(exec(d, "SELECT d #>> 'arr.0' AS v FROM jp.d;"), "v", 0) == 7);
+}
+
+// [H] A NULL written to a column that does not yet exist has no type to create
+// the column from. On a schemaless computing table that is simply an absent key:
+// the column is not materialized (it used to build an all-NA column and segfault
+// the insert), and it comes into existence — with the earlier rows null — only
+// once some row supplies a concrete value.
+TEST_CASE("integration::cpp::test_jsonb_support::insert_null_into_new_column_is_absent") {
+    auto config = make_test_config("/tmp/test_jsonb_matrix/null_insert");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(exec(d, "CREATE DATABASE jp;")->is_success());
+    REQUIRE(exec(d, "CREATE TABLE jp.t ();")->is_success());
+
+    // NULL into a brand-new flattened column: no crash, and the value it carried
+    // (x) is stored while the all-null a.b key is simply absent.
+    REQUIRE(exec(d, "INSERT INTO jp.t (a.b, x) VALUES (NULL, 'z');")->is_success());
+    auto only_x = exec(d, "SELECT * FROM jp.t;");
+    REQUIRE(only_x->is_success());
+    CHECK(aliases(only_x) == std::set<std::string>{"x"});
+
+    // NULL then a concrete value in the same insert: the column springs into
+    // existence and every earlier all-null row reads back null, not a zero.
+    REQUIRE(exec(d, "CREATE TABLE jp.u ();")->is_success());
+    REQUIRE(exec(d, "INSERT INTO jp.u (id, v) VALUES (1, NULL), (2, NULL), (3, 7);")->is_success());
+    auto u = exec(d, "SELECT id, v FROM jp.u ORDER BY id;");
+    REQUIRE(u->is_success());
+    CHECK(i64(u, "id", 0) == 1);
+    CHECK(is_null(u, "v", 0));
+    CHECK(is_null(u, "v", 1));
+    CHECK(i64(u, "v", 2) == 7);
+
+    // an all-null single-column insert has nothing to store and no column to make
+    REQUIRE(exec(d, "CREATE TABLE jp.w ();")->is_success());
+    REQUIRE(exec(d, "INSERT INTO jp.w (a.b) VALUES (NULL);")->is_success());
+    CHECK(exec(d, "SELECT * FROM jp.w;")->size() == 0);
 }
 
 // [C] `- '{a,b}'` is the postgres text-array form of key deletion (`jsonb - text[]`):

--- a/integration/cpp/test/test_jsonb_support.cpp
+++ b/integration/cpp/test/test_jsonb_support.cpp
@@ -44,6 +44,10 @@
 //       subtree, not just a single key.
 //   [E] existence over a missing key is absent (false), not a hard error: a truly
 //       absent key folds to constant false and never poisons a '?|' any-of.
+//   [D] table-valued expand/delete are well-behaved: expanding a path that matches
+//       no column is a "path not found" error (not a silently vanished select
+//       item), and inside a join expand and delete resolve against the side the
+//       operator named (not blindly across both, which was ambiguous).
 
 #include "test_config.hpp"
 #include <catch2/catch_test_macros.hpp>
@@ -961,11 +965,12 @@ TEST_CASE("integration::cpp::test_jsonb_support::bug_cast_over_navigation_is_a_n
     CHECK(i64(cur, "v", 0) == 20);
 }
 
-// Inside a join, scalar navigation is side-aware but EXPANSION is not: it
-// resolves the path against one schema only, so the moment both joined tables
-// carry the same subtree name it fails with "path not found" — for a path that
-// exists on both sides. Key deletion inside a join is broken outright.
-TEST_CASE("integration::cpp::test_jsonb_support::bug_expand_inside_join_is_side_blind") {
+// [D] Inside a join a jsonb operator names one table (its base), and the base's
+// side disambiguates a subtree name both joined tables carry. Expansion and key
+// deletion used to be side-blind — they matched columns from both sides, so every
+// produced column was ambiguous ("path not found") — while scalar navigation was
+// already side-aware. Now all three resolve to the side the operator named.
+TEST_CASE("integration::cpp::test_jsonb_support::expand_inside_join_is_side_aware") {
     auto config = make_test_config("/tmp/test_jsonb_matrix/join_expand");
     test_spaces space(config);
     auto* d = space.dispatcher();
@@ -976,19 +981,31 @@ TEST_CASE("integration::cpp::test_jsonb_support::bug_expand_inside_join_is_side_
                 ->is_success());
     REQUIRE(exec(d, "INSERT INTO jp.m (k, mv, d.e, d.f) VALUES (1, 10, 11, 12), (2, 20, 22, 23);")->is_success());
 
-    // Scalar navigation resolves each side correctly — this is the part that works.
+    // Scalar navigation resolves each side correctly — this always worked.
     CHECK(i64_set(exec(d, "SELECT m #>> 'd.e' AS v FROM jp.l JOIN jp.m ON l.k = m.k;"), "v") ==
           std::set<int64_t>{11, 22});
     CHECK(i64_set(exec(d, "SELECT l #>> 'd.e' AS v FROM jp.l JOIN jp.m ON l.k = m.k;"), "v") ==
           std::set<int64_t>{111, 222});
 
-    // Expansion of the very same subtree fails, from either side.
-    // correct: two columns e, f holding 11,12 / 22,23 (resp. 111,112 / 222,223).
-    CHECK_FALSE(exec(d, "SELECT m -> 'd' FROM jp.l JOIN jp.m ON l.k = m.k;")->is_success());
-    CHECK_FALSE(exec(d, "SELECT l -> 'd' FROM jp.l JOIN jp.m ON l.k = m.k;")->is_success());
+    // Expansion of the shared subtree now works from either side, picking that
+    // side's values into the two rerooted columns e, f.
+    auto me = exec(d, "SELECT m -> 'd' FROM jp.l JOIN jp.m ON l.k = m.k;");
+    REQUIRE(me->is_success());
+    CHECK(aliases(me) == std::set<std::string>{"e", "f"});
+    CHECK(i64_set(me, "e") == std::set<int64_t>{11, 22});
+    CHECK(i64_set(me, "f") == std::set<int64_t>{12, 23});
 
-    // Key deletion inside a join cannot resolve any column at all.
-    CHECK_FALSE(exec(d, "SELECT m - 'd' FROM jp.l JOIN jp.m ON l.k = m.k;")->is_success());
+    auto le = exec(d, "SELECT l -> 'd' FROM jp.l JOIN jp.m ON l.k = m.k;");
+    REQUIRE(le->is_success());
+    CHECK(i64_set(le, "e") == std::set<int64_t>{111, 222});
+    CHECK(i64_set(le, "f") == std::set<int64_t>{112, 223});
+
+    // Key deletion resolves against the named side too: m minus subtree d keeps
+    // exactly m's remaining columns (k, mv), not l's.
+    auto md = exec(d, "SELECT m - 'd' FROM jp.l JOIN jp.m ON l.k = m.k;");
+    REQUIRE(md->is_success());
+    CHECK(aliases(md) == std::set<std::string>{"k", "mv"});
+    CHECK(i64_set(md, "mv") == std::set<int64_t>{10, 20});
 }
 
 // Expansion DOES work inside a join as long as the subtree name belongs to only

--- a/integration/cpp/test/test_jsonb_support.cpp
+++ b/integration/cpp/test/test_jsonb_support.cpp
@@ -40,6 +40,10 @@
 //       shared by navigation, existence and the INSERT flattener.
 //   [G] INSERT target flattening keeps every segment (a.b.c -> "a/b/c") and renders
 //       a subscript target (arr[0] -> "arr/0") instead of crashing on it.
+//   [C] delete accepts the text-array form (t - '{a,b}') and removes every listed
+//       subtree, not just a single key.
+//   [E] existence over a missing key is absent (false), not a hard error: a truly
+//       absent key folds to constant false and never poisons a '?|' any-of.
 
 #include "test_config.hpp"
 #include <catch2/catch_test_macros.hpp>
@@ -780,36 +784,32 @@ TEST_CASE("integration::cpp::test_jsonb_support::delete_key_array_form") {
 // Expanding a path that matches no column does not error — the expansion item is
 // silently ERASED from the select list. On its own that yields a zero-column
 // result; alongside other items it silently changes the arity of the answer.
-TEST_CASE("integration::cpp::test_jsonb_support::bug_zero_match_expand_drops_the_select_item") {
+// [D] Expand ('->'/'#>') names a specific object; a key that matches no column is
+// a "path not found" error, exactly like the scalar form. It used to be erased to
+// nothing, so the select item silently vanished and the caller got fewer columns
+// than it asked for, with no indication that anything went wrong.
+TEST_CASE("integration::cpp::test_jsonb_support::zero_match_expand_is_an_error") {
     auto config = make_test_config("/tmp/test_jsonb_matrix/zero_exp");
     test_spaces space(config);
     auto* d = space.dispatcher();
     seed(d);
 
-    // the scalar operator errors, as it should
+    // the scalar operator errors, as it always has
     CHECK_FALSE(exec(d, "SELECT t ->> 'nokey' AS v FROM jp.t;")->is_success());
 
-    // the table-valued one silently produces nothing
-    auto cur = exec(d, "SELECT t -> 'nokey' FROM jp.t;");
-    REQUIRE(cur->is_success()); // correct: this should be an error
-    CHECK(cur->column_count() == 0);
+    // the table-valued one now errors too, instead of producing zero columns
+    CHECK_FALSE(exec(d, "SELECT t -> 'nokey' FROM jp.t;")->is_success());
 
-    // ... and next to other select items it just disappears, so the caller gets
-    // fewer columns than it asked for, with no indication that anything was wrong.
-    auto mixed = exec(d, "SELECT t -> 'nokey', x FROM jp.t;");
-    REQUIRE(mixed->is_success());
-    CHECK(mixed->column_count() == 1); // correct: an error, or 2 columns
-    CHECK(aliases(mixed) == std::set<std::string>{"x"});
+    // ... and it no longer disappears silently from among other select items
+    CHECK_FALSE(exec(d, "SELECT t -> 'nokey', x FROM jp.t;")->is_success());
+    CHECK_FALSE(exec(d, "SELECT id, t -> 'nokey', x FROM jp.t;")->is_success());
 
-    auto mixed3 = exec(d, "SELECT id, t -> 'nokey', x FROM jp.t;");
-    REQUIRE(mixed3->is_success());
-    CHECK(mixed3->column_count() == 2); // correct: an error, or 3 columns
-    CHECK(aliases(mixed3) == std::set<std::string>{"id", "x"});
+    // a dotted path handed to -> (which takes a single key, not a path) names the
+    // literal key "a.b", which no column matches -> error, not a vanished column
+    CHECK_FALSE(exec(d, "SELECT t -> 'a.b' FROM jp.t;")->is_success());
 
-    // same for a dotted path handed to -> (which takes a single key, not a path)
-    auto dotted = exec(d, "SELECT t -> 'a.b' FROM jp.t;");
-    REQUIRE(dotted->is_success()); // correct: error, or expand "a/b"
-    CHECK(dotted->column_count() == 0);
+    // a key that DOES match still expands, so the guard is scoped to true misses
+    CHECK(aliases(exec(d, "SELECT t -> 'a' FROM jp.t;")) == std::set<std::string>{"b", "c"});
 }
 
 // LIMITATION of the flattened representation (documented, not a fix target here).
@@ -939,11 +939,9 @@ TEST_CASE("integration::cpp::test_jsonb_support::key_operand_literals") {
 
     SECTION("a non-string cast key resolves to its value and never crashes") {
         // (1::bool) used to segfault; now the key is the text "1" (no such column).
-        // Scalar form errors cleanly; the table-valued form is covered by the
-        // zero-match-expand case. Either way: no crash.
+        // Both the scalar and the table-valued form error cleanly on the miss.
         CHECK_FALSE(exec(d, "SELECT t ->> (1::bool) AS v FROM jp.t;")->is_success());
-        auto expand = exec(d, "SELECT t -> (1::bool) FROM jp.t;");
-        REQUIRE(expand->is_success()); // key "1" matches nothing -> zero-match expand
+        CHECK_FALSE(exec(d, "SELECT t -> (1::bool) FROM jp.t;")->is_success());
     }
 }
 

--- a/integration/cpp/test/test_jsonb_support.cpp
+++ b/integration/cpp/test/test_jsonb_support.cpp
@@ -53,6 +53,9 @@
 //   [H] a NULL written to a not-yet-existing column of a computing table is an
 //       absent key: it carries no type, so the column is dropped after schema
 //       reconciliation instead of reaching storage as an all-NA column (segfault).
+//   [I] INSERT ... SELECT lands each projected value in its target column: the
+//       target names are stamped onto the streamed columns before the name-based
+//       append, instead of appending a row where the plain columns came out NULL.
 
 #include "test_config.hpp"
 #include <catch2/catch_test_macros.hpp>
@@ -536,28 +539,41 @@ TEST_CASE("integration::cpp::test_jsonb_support::view_over_navigation") {
     // for views over plain tables too), so it is only recorded, not pinned here.
 }
 
-// INSERT ... SELECT reports "1 row inserted" and then discards every value: on a
-// computing table it appends a row in which even the plain columns are NULL.
-// (On a fixed-schema table the same statement inserts nothing at all, so the
-// broken piece is INSERT ... SELECT itself; the flattened-storage variant is
-// pinned here because it is the one that leaves corrupt rows behind.)
-TEST_CASE("integration::cpp::test_jsonb_support::bug_insert_select_appends_a_null_row") {
+// [I] INSERT ... SELECT lands each projected value in its target column. The
+// append is name-based, and a projection need not carry the target names
+// (SELECT 5, 55), so the target names are stamped on the streamed columns in
+// target order. It used to skip that step and append a row in which even the
+// plain columns were NULL (the projection-named columns matched nothing).
+TEST_CASE("integration::cpp::test_jsonb_support::insert_select_maps_projection_to_target_columns") {
     auto config = make_test_config("/tmp/test_jsonb_matrix/insert_select");
     test_spaces space(config);
     auto* d = space.dispatcher();
     seed(d);
+    // rows 1..4: a/b = 10,30,50,(absent); a/c = 20,40,60,70
 
     auto ins = exec(d, "INSERT INTO jp.t (id, a.b) SELECT 5, 55;");
     REQUIRE(ins->is_success());
-    CHECK(ins->size() == 1); // claims one row
+    CHECK(ins->size() == 1);
 
     auto cur = exec(d, "SELECT * FROM jp.t ORDER BY id;");
     REQUIRE(cur->is_success());
-    // correct: 4 rows unchanged plus (id=5, a/b=55). We get a 5th row of all NULLs.
     CHECK(cur->size() == 5);
-    CHECK(is_null(cur, "id", 4));
-    CHECK(is_null(cur, "a/b", 4));
-    CHECK(i64_set(exec(d, "SELECT t #>> 'a.b' AS v FROM jp.t;"), "v") == std::set<int64_t>{10, 30, 50});
+    // the new row carries its values, not NULLs: id=5, a/b=55, and the columns
+    // the projection did not name (a/c, x) are absent/null for it
+    CHECK(i64(cur, "id", 4) == 5);
+    CHECK(i64(cur, "a/b", 4) == 55);
+    CHECK(is_null(cur, "a/c", 4));
+    CHECK(is_null(cur, "x", 4));
+    // navigation sees the appended leaf too (row 4 keeps a/b absent -> null)
+    CHECK(i64_set(exec(d, "SELECT t #>> 'a.b' AS v FROM jp.t;"), "v") == std::set<int64_t>{10, 30, 50, 55});
+
+    // a SELECT from another table, projected out of target order, still routes
+    // each value by target position (a.b <- w, id <- k), not by source name
+    REQUIRE(exec(d, "CREATE TABLE jp.src ();")->is_success());
+    REQUIRE(exec(d, "INSERT INTO jp.src (k, w) VALUES (100, 200);")->is_success());
+    REQUIRE(exec(d, "INSERT INTO jp.t (a.b, id) SELECT w, k FROM jp.src;")->is_success());
+    CHECK(ids(exec(d, "SELECT id FROM jp.t;")) == std::set<int64_t>{1, 2, 3, 4, 5, 100});
+    CHECK(i64(exec(d, "SELECT t #>> 'a.b' AS v FROM jp.t WHERE id = 100;"), "v", 0) == 200);
 }
 
 // Everything that is NOT supported must fail loudly. This case exists so that a

--- a/integration/cpp/test/test_jsonb_support.cpp
+++ b/integration/cpp/test/test_jsonb_support.cpp
@@ -842,27 +842,53 @@ TEST_CASE("integration::cpp::test_jsonb_support::flattened_name_and_nested_path_
     CHECK(i64_set(exec(d, "SELECT s ->> 'a/b' AS v FROM jp.s;"), "v") == std::set<int64_t>{10, 20});
 }
 
-// In postgres a missing key yields NULL (for ->>) or false (for ?). Here it is a
-// hard error, which makes the existence operators unusable for their one purpose:
-// you cannot ask "does this row have key K" unless K is already known to exist.
-TEST_CASE("integration::cpp::test_jsonb_support::bug_missing_key_errors_instead_of_null_or_false") {
+// [E] Existence over a missing key follows postgres 3VL instead of hard-erroring,
+// which is what makes '?'/'?|'/'?&' usable: you can ask "does this row have key K"
+// without K being known to exist. A truly absent key is false; an intermediate
+// object key (a prefix of stored columns) is present iff a child is; and one
+// absent key no longer poisons an any-of another key satisfies.
+TEST_CASE("integration::cpp::test_jsonb_support::existence_over_missing_key") {
     auto config = make_test_config("/tmp/test_jsonb_matrix/missing");
     test_spaces space(config);
     auto* d = space.dispatcher();
     seed(d);
+    // rows: 1(a/b=10,a/c=20,x=p) 2(a/b=30,a/c=40,x=q) 3(a/b=50,a/c=60) 4(a/c=70)
 
-    CHECK_FALSE(exec(d, "SELECT t ->> 'nokey' AS v FROM jp.t;")->is_success()); // correct: NULL for every row
-    CHECK_FALSE(exec(d, "SELECT id FROM jp.t WHERE t ? 'nokey';")->is_success()); // correct: false -> no rows
-    // one absent key poisons an any-of that another key already satisfies
-    CHECK_FALSE(exec(d, "SELECT id FROM jp.t WHERE t ?| '{x,nokey}';")->is_success()); // correct: rows 1,2
-    CHECK_FALSE(exec(d, "SELECT id FROM jp.t WHERE t ?& '{x,nokey}';")->is_success()); // correct: no rows
+    // a key present in some rows
+    CHECK(ids(exec(d, "SELECT id FROM jp.t WHERE t ? 'x';")) == std::set<int64_t>{1, 2});
+    // a truly absent key -> false for every row (no error)
+    CHECK(exec(d, "SELECT id FROM jp.t WHERE t ? 'nokey';")->size() == 0);
+    CHECK(exec(d, "SELECT id FROM jp.t WHERE NOT (t ? 'nokey');")->size() == 4);
 
-    // ? cannot see an intermediate key either, even though it is a real prefix
-    // of two stored columns ("a/b", "a/c") and postgres would report it present.
-    CHECK_FALSE(exec(d, "SELECT id FROM jp.t WHERE t ? 'a';")->is_success()); // correct: all rows
+    // one absent key no longer poisons an any-of / all-of
+    CHECK(ids(exec(d, "SELECT id FROM jp.t WHERE t ?| '{x,nokey}';")) == std::set<int64_t>{1, 2});
+    CHECK(exec(d, "SELECT id FROM jp.t WHERE t ?& '{x,nokey}';")->size() == 0);
+    CHECK(exec(d, "SELECT id FROM jp.t WHERE t ?| '{nokey,nokey2}';")->size() == 0);
 
-    // and IS NULL cannot be used to bridge the gap
-    CHECK_FALSE(exec(d, "SELECT id FROM jp.t WHERE t #>> 'a.b' IS NULL;")->is_success()); // correct: row 4
+    // an intermediate object key 'a' (prefix of a/b, a/c) is PRESENT where a child
+    // is non-null — a/b or a/c is set for every row, so all four rows
+    CHECK(ids(exec(d, "SELECT id FROM jp.t WHERE t ? 'a';")) == std::set<int64_t>{1, 2, 3, 4});
+    CHECK(ids(exec(d, "SELECT id FROM jp.t WHERE t ?& '{a,x}';")) == std::set<int64_t>{1, 2});
+
+    // a mistyped REGULAR column IS NULL still errors — only jsonb keys are lenient
+    REQUIRE(exec(d, "CREATE TABLE jp.r (id BIGINT, v BIGINT);")->is_success());
+    REQUIRE(exec(d, "INSERT INTO jp.r (id, v) VALUES (1, 5);")->is_success());
+    CHECK_FALSE(exec(d, "SELECT id FROM jp.r WHERE nosuchcol IS NULL;")->is_success());
+}
+
+// STILL a hard error, deferred (documented): scalar navigation over an absent key
+// should yield SQL NULL, and `<nav> IS NULL` should be a boolean. Both need the
+// select-list / compare paths to synthesize a typed NULL leaf for a flagged key,
+// a larger change than the existence rewrite; pinned so the deferral is visible.
+TEST_CASE("integration::cpp::test_jsonb_support::navigation_over_missing_key_still_errors") {
+    auto config = make_test_config("/tmp/test_jsonb_matrix/missing_nav");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    seed(d);
+
+    CHECK_FALSE(exec(d, "SELECT t ->> 'nokey' AS v FROM jp.t;")->is_success());   // deferred: NULL every row
+    CHECK_FALSE(exec(d, "SELECT t #>> 'no.key' AS v FROM jp.t;")->is_success());  // deferred: NULL every row
+    CHECK_FALSE(exec(d, "SELECT id FROM jp.t WHERE t #>> 'a.b' IS NULL;")->is_success()); // deferred: row 4
 }
 
 // [A] The key operand of a jsonb operator is a literal: a bare string/number, a

--- a/integration/cpp/test/test_jsonb_support.cpp
+++ b/integration/cpp/test/test_jsonb_support.cpp
@@ -1,0 +1,907 @@
+// JSONB support suite.
+//
+// otterbrix has NO json/jsonb data type, no binary json storage, no SQL/JSON
+// path engine and no SQL/JSON functions (see the sql_json_standard_absent case
+// at the bottom, which pins that). What it *does* have — added by PR #499 with
+// zero grammar changes, purely in the transformer — is nine postgres-spelled
+// jsonb operators that are name-mangling over *flattened columns*:
+//
+//   CREATE TABLE t ();                                 -- "computing" table, relkind 'g'
+//   INSERT INTO t (id, a.b, a.c, x) VALUES (1,10,20,'p');
+//   -- storage is four plain columns: id, "a/b", "a/c", x
+//   SELECT t #>> 'a.b' FROM t;                         -- compiles to a get_field projection on "a/b"
+//
+//   scalar  (one column) : ->>  #>>          .. terminate a chain, return the leaf value
+//   table   (n columns)  : ->   #>           .. expand an object into its child columns
+//   existence (predicate): ?    ?|    ?&     .. per-row "key present and not null"
+//   delete  (projection) : -    #-           .. project every column except the named subtree
+//
+// Paths are spelled either dotted ('a.b') or as a postgres text array ('{a,b}').
+// Keys are case-sensitive; a path that no column matches is a hard ERROR, not NULL.
+//
+// The cases below are split in two:
+//   * SUPPORTED  — value-exact pins of behavior that is correct and worth keeping.
+//   * BUG        — characterization pins of behavior that is WRONG today. Each one
+//                  asserts what the engine currently does and states what it should
+//                  do in a "correct:" comment, so a fix flips a visible assertion
+//                  instead of silently changing an untested result.
+//
+// NOT PINNABLE — these SEGFAULT the process, so they cannot live in a test binary.
+// Verified on this commit; kept here as the repro list:
+//   SELECT t -> (1::bool) FROM t;                       -- bool cast as key -> null deref
+//   SELECT t ->> NULL FROM t;                           -- NULL key -> null deref
+//   INSERT INTO t (a.b, x) VALUES (NULL, 'z');          -- NULL literal in a dotted target
+//   SELECT CASE WHEN t #>> 'a.b' = 10 THEN 1 ELSE 0 END -- only when the leaf has a NULL row;
+//     FROM t;                                           --   reproduces on plain columns too (general 3VL bug)
+// And this one escapes as an uncaught C++ exception rather than a cursor error:
+//   INSERT INTO t (id, arr[0]) VALUES (1, 1);           -- "basic_string: construction from null is not valid"
+
+#include "test_config.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <set>
+#include <string>
+
+using namespace test_helpers;
+using components::cursor::cursor_t_ptr;
+
+namespace {
+
+    // The shared fixture used by most cases. Four rows over a computing table,
+    // deliberately ragged so that per-row-absent keys are covered:
+    //
+    //   id | a/b  | a/c | x
+    //    1 |   10 |  20 | 'p'
+    //    2 |   30 |  40 | 'q'
+    //    3 |   50 |  60 | NULL   <- x absent for this row
+    //    4 | NULL |  70 | NULL   <- a.b absent for this row
+    void seed(otterbrix::wrapper_dispatcher_t* d) {
+        REQUIRE(exec(d, "CREATE DATABASE jp;")->is_success());
+        REQUIRE(exec(d, "CREATE TABLE jp.t ();")->is_success());
+        REQUIRE(exec(d, "INSERT INTO jp.t (id, a.b, a.c, x) VALUES (1, 10, 20, 'p'), (2, 30, 40, 'q');")
+                    ->is_success());
+        REQUIRE(exec(d, "INSERT INTO jp.t (id, a.b, a.c) VALUES (3, 50, 60);")->is_success());
+        REQUIRE(exec(d, "INSERT INTO jp.t (id, a.c) VALUES (4, 70);")->is_success());
+    }
+
+    std::set<std::string> aliases(const cursor_t_ptr& cur) {
+        std::set<std::string> s;
+        if (cur->is_success() && !cur->chunks().empty()) {
+            const auto& chunk = cur->chunks().front();
+            for (size_t c = 0; c < chunk.column_count(); ++c) {
+                s.insert(std::string(chunk.data[c].type().alias()));
+            }
+        }
+        return s;
+    }
+
+    size_t col_of(const cursor_t_ptr& cur, const std::string& alias) {
+        const auto& chunk = cur->chunks().front();
+        for (size_t c = 0; c < chunk.column_count(); ++c) {
+            if (std::string(chunk.data[c].type().alias()) == alias) {
+                return c;
+            }
+        }
+        FAIL("no column aliased '" << alias << "'");
+        return 0;
+    }
+
+    int64_t i64(const cursor_t_ptr& cur, const std::string& alias, size_t row) {
+        return cur->chunks().front().get_value<int64_t>(col_of(cur, alias), row);
+    }
+
+    std::string str(const cursor_t_ptr& cur, const std::string& alias, size_t row) {
+        return cur->chunks().front().value(col_of(cur, alias), row).value<const std::string&>();
+    }
+
+    bool is_null(const cursor_t_ptr& cur, const std::string& alias, size_t row) {
+        return cur->chunks().front().value(col_of(cur, alias), row).is_null();
+    }
+
+    components::types::logical_type type_of(const cursor_t_ptr& cur, const std::string& alias) {
+        return cur->chunks().front().data[col_of(cur, alias)].type().type();
+    }
+
+    // Every non-null integer value of one column, as a set. Used where ORDER BY
+    // cannot be applied — otterbrix does not accept an output alias as a sort key.
+    std::set<int64_t> i64_set(const cursor_t_ptr& cur, const std::string& alias) {
+        std::set<int64_t> s;
+        REQUIRE(cur->is_success());
+        if (!cur->chunks().empty()) {
+            const auto& chunk = cur->chunks().front();
+            const auto col = col_of(cur, alias);
+            for (size_t r = 0; r < chunk.size(); ++r) {
+                if (!chunk.value(col, r).is_null()) {
+                    s.insert(chunk.get_value<int64_t>(col, r));
+                }
+            }
+        }
+        return s;
+    }
+
+    // ids of every returned row, for set-comparison of predicates.
+    std::set<int64_t> ids(const cursor_t_ptr& cur) { return i64_set(cur, "id"); }
+
+} // namespace
+
+// ===========================================================================
+// SUPPORTED
+// ===========================================================================
+
+// The flattened storage model itself: dotted INSERT targets become real columns
+// named with '/' separators, and rows that omit a target leave it NULL.
+TEST_CASE("integration::cpp::test_jsonb_support::flattened_storage_model") {
+    auto config = make_test_config("/tmp/test_jsonb_matrix/storage");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    seed(d);
+
+    auto cur = exec(d, "SELECT * FROM jp.t ORDER BY id;");
+    REQUIRE(cur->is_success());
+    REQUIRE(cur->size() == 4);
+    // The dotted targets a.b / a.c are stored as two ordinary columns "a/b", "a/c" —
+    // there is no nested value anywhere.
+    CHECK(aliases(cur) == std::set<std::string>{"id", "a/b", "a/c", "x"});
+    CHECK(i64(cur, "a/b", 0) == 10);
+    CHECK(i64(cur, "a/c", 0) == 20);
+    CHECK(str(cur, "x", 0) == "p");
+    CHECK(is_null(cur, "x", 2));    // row 3 never supplied x
+    CHECK(is_null(cur, "a/b", 3));  // row 4 never supplied a.b
+    CHECK(i64(cur, "a/c", 3) == 70);
+}
+
+// ->> and #>> : scalar extraction. Every spelling of the same path must agree.
+TEST_CASE("integration::cpp::test_jsonb_support::extract_scalar") {
+    auto config = make_test_config("/tmp/test_jsonb_matrix/extract");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    seed(d);
+
+    SECTION("top-level key") {
+        auto cur = exec(d, "SELECT id, t ->> 'x' AS v FROM jp.t ORDER BY id;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 4);
+        CHECK(str(cur, "v", 0) == "p");
+        CHECK(str(cur, "v", 1) == "q");
+        // A key the row never supplied reads back as NULL (only a key that matches
+        // no column *at all* is an error — see bug_missing_key_errors_instead_of_null).
+        CHECK(is_null(cur, "v", 2));
+        CHECK(is_null(cur, "v", 3));
+    }
+
+    SECTION("nested path: all four spellings agree") {
+        const char* q[] = {"SELECT id, t -> 'a' ->> 'b' AS v FROM jp.t ORDER BY id;",
+                           "SELECT id, t #>> 'a.b' AS v FROM jp.t ORDER BY id;",
+                           "SELECT id, t #>> '{a,b}' AS v FROM jp.t ORDER BY id;",
+                           "SELECT id, t #>> '{ a , b }' AS v FROM jp.t ORDER BY id;"};
+        for (const auto* sql : q) {
+            INFO(sql);
+            auto cur = exec(d, sql);
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 4);
+            CHECK(i64(cur, "v", 0) == 10);
+            CHECK(i64(cur, "v", 1) == 30);
+            CHECK(i64(cur, "v", 2) == 50);
+            CHECK(is_null(cur, "v", 3));
+        }
+    }
+
+    SECTION("the extracted value keeps its native column type — ->> does NOT return text") {
+        auto cur = exec(d, "SELECT t ->> 'x' AS s, t #>> 'a.b' AS n FROM jp.t;");
+        REQUIRE(cur->is_success());
+        CHECK(type_of(cur, "s") == components::types::logical_type::STRING_LITERAL);
+        // In PostgreSQL ->> is text-returning; here an integer leaf stays BIGINT.
+        CHECK(type_of(cur, "n") == components::types::logical_type::BIGINT);
+    }
+
+    SECTION("navigation works through a table alias, and via the base name too") {
+        CHECK(i64(exec(d, "SELECT tt #>> 'a.b' AS v FROM jp.t AS tt ORDER BY id;"), "v", 0) == 10);
+        CHECK(i64(exec(d, "SELECT t #>> 'a.b' AS v FROM jp.t AS tt ORDER BY id;"), "v", 0) == 10);
+    }
+
+    SECTION("keys are case-sensitive") {
+        CHECK_FALSE(exec(d, "SELECT t ->> 'X' AS v FROM jp.t;")->is_success());
+    }
+}
+
+// -> and #> : object expansion. These are table-valued — they widen the projection
+// to one column per child, which is why they cannot terminate a scalar chain.
+TEST_CASE("integration::cpp::test_jsonb_support::expand_object") {
+    auto config = make_test_config("/tmp/test_jsonb_matrix/expand");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    seed(d);
+
+    SECTION("-> expands to the child columns, named by their leaf segment") {
+        auto cur = exec(d, "SELECT t -> 'a' FROM jp.t ORDER BY id;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 4);
+        CHECK(aliases(cur) == std::set<std::string>{"b", "c"});
+        CHECK(i64(cur, "b", 0) == 10);
+        CHECK(i64(cur, "c", 0) == 20);
+        CHECK(is_null(cur, "b", 3));
+        CHECK(i64(cur, "c", 3) == 70);
+    }
+
+    SECTION("#> with a path array expands the same way") {
+        auto cur = exec(d, "SELECT t #> '{a}' FROM jp.t ORDER BY id;");
+        REQUIRE(cur->is_success());
+        CHECK(aliases(cur) == std::set<std::string>{"b", "c"});
+        CHECK(i64(cur, "b", 1) == 30);
+    }
+
+    SECTION("expansion composes with ordinary columns and with a further ->") {
+        auto cur = exec(d, "SELECT id, t -> 'a' FROM jp.t ORDER BY id;");
+        REQUIRE(cur->is_success());
+        CHECK(aliases(cur) == std::set<std::string>{"id", "b", "c"});
+
+        auto chained = exec(d, "SELECT t -> 'a' -> 'b' FROM jp.t ORDER BY id;");
+        REQUIRE(chained->is_success());
+        CHECK(aliases(chained) == std::set<std::string>{"b"});
+        CHECK(i64(chained, "b", 0) == 10);
+    }
+
+    SECTION("-> on a leaf yields that single column") {
+        auto cur = exec(d, "SELECT t -> 'x' FROM jp.t ORDER BY id;");
+        REQUIRE(cur->is_success());
+        CHECK(aliases(cur) == std::set<std::string>{"x"});
+        CHECK(str(cur, "x", 0) == "p");
+    }
+
+    SECTION("a table-valued operator cannot be used as a scalar — and says so") {
+        auto cur = exec(d, "SELECT id FROM jp.t WHERE t #> '{a}' = 1;");
+        REQUIRE_FALSE(cur->is_success());
+        CHECK(std::string(cur->get_error().what).find("cannot be used as a scalar") != std::string::npos);
+    }
+}
+
+// - and #- : project everything EXCEPT the named key/subtree.
+TEST_CASE("integration::cpp::test_jsonb_support::delete_keys") {
+    auto config = make_test_config("/tmp/test_jsonb_matrix/delete");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    seed(d);
+
+    SECTION("- drops a leaf key") {
+        auto cur = exec(d, "SELECT t - 'x' FROM jp.t ORDER BY id;");
+        REQUIRE(cur->is_success());
+        CHECK(aliases(cur) == std::set<std::string>{"id", "a/b", "a/c"});
+        CHECK(i64(cur, "a/b", 0) == 10);
+    }
+
+    SECTION("- drops a whole subtree when given the prefix") {
+        auto cur = exec(d, "SELECT t - 'a' FROM jp.t ORDER BY id;");
+        REQUIRE(cur->is_success());
+        CHECK(aliases(cur) == std::set<std::string>{"id", "x"});
+    }
+
+    SECTION("#- drops one leaf of a subtree, dotted or as a path array") {
+        auto dotted = exec(d, "SELECT t #- 'a.b' FROM jp.t ORDER BY id;");
+        REQUIRE(dotted->is_success());
+        CHECK(aliases(dotted) == std::set<std::string>{"id", "a/c", "x"});
+        CHECK(i64(dotted, "a/c", 0) == 20);
+
+        auto arr = exec(d, "SELECT t #- '{a}' FROM jp.t ORDER BY id;");
+        REQUIRE(arr->is_success());
+        CHECK(aliases(arr) == std::set<std::string>{"id", "x"});
+    }
+
+    SECTION("deleting a key that does not exist is a no-op, as in postgres") {
+        auto cur = exec(d, "SELECT t - 'nokey' FROM jp.t ORDER BY id;");
+        REQUIRE(cur->is_success());
+        CHECK(aliases(cur) == std::set<std::string>{"id", "a/b", "a/c", "x"});
+    }
+}
+
+// ? / ?| / ?& : per-row existence. "Exists" means the column exists in the schema
+// AND this row's value is not null — so a ragged row tests false, as in postgres.
+TEST_CASE("integration::cpp::test_jsonb_support::existence_predicates") {
+    auto config = make_test_config("/tmp/test_jsonb_matrix/exists");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    seed(d);
+
+    // rows 3 and 4 never supplied x.
+    CHECK(ids(exec(d, "SELECT id FROM jp.t WHERE t ? 'x';")) == std::set<int64_t>{1, 2});
+    CHECK(ids(exec(d, "SELECT id FROM jp.t WHERE NOT (t ? 'x');")) == std::set<int64_t>{3, 4});
+    CHECK(ids(exec(d, "SELECT id FROM jp.t WHERE t ? 'x' AND t ? 'id';")) == std::set<int64_t>{1, 2});
+
+    // ?| any-of, ?& all-of.
+    CHECK(ids(exec(d, "SELECT id FROM jp.t WHERE t ?| '{x,id}';")) == std::set<int64_t>{1, 2, 3, 4});
+    CHECK(ids(exec(d, "SELECT id FROM jp.t WHERE t ?& '{x,id}';")) == std::set<int64_t>{1, 2});
+
+    // Degenerate key lists: an empty any-of is false for every row, an empty
+    // all-of is vacuously true for every row.
+    CHECK(exec(d, "SELECT id FROM jp.t WHERE t ?| '{}';")->size() == 0);
+    CHECK(ids(exec(d, "SELECT id FROM jp.t WHERE t ?& '{}';")) == std::set<int64_t>{1, 2, 3, 4});
+
+    // Existence composes with COUNT and with a subquery.
+    auto cnt = exec(d, "SELECT COUNT(*) AS n FROM jp.t WHERE t ? 'x';");
+    REQUIRE(cnt->is_success());
+    CHECK(cnt->chunks().front().get_value<uint64_t>(0, 0) == 2);
+}
+
+// Navigation as a predicate, and as the WHERE of a DML statement.
+TEST_CASE("integration::cpp::test_jsonb_support::predicates_and_dml") {
+    auto config = make_test_config("/tmp/test_jsonb_matrix/dml");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    seed(d);
+
+    SECTION("comparison, BETWEEN, boolean composition") {
+        CHECK(ids(exec(d, "SELECT id FROM jp.t WHERE t #>> 'a.b' = 10;")) == std::set<int64_t>{1});
+        // an integer leaf also compares against a string literal (values are coerced)
+        CHECK(ids(exec(d, "SELECT id FROM jp.t WHERE t #>> 'a.b' = '10';")) == std::set<int64_t>{1});
+        CHECK(ids(exec(d, "SELECT id FROM jp.t WHERE t #>> 'a.b' BETWEEN 5 AND 15;")) == std::set<int64_t>{1});
+        CHECK(ids(exec(d, "SELECT id FROM jp.t WHERE t #>> 'a.b' = 10 OR t #>> 'a.c' = 40;")) ==
+              std::set<int64_t>{1, 2});
+        CHECK(ids(exec(d, "SELECT id FROM jp.t WHERE t #>> 'a.b' = 10 AND t ? 'x';")) == std::set<int64_t>{1});
+        CHECK(ids(exec(d, "SELECT id FROM jp.t WHERE t ->> 'x' = 'p';")) == std::set<int64_t>{1});
+        CHECK(ids(exec(d, "SELECT id FROM jp.t WHERE t ->> 'id' = 1;")) == std::set<int64_t>{1});
+    }
+
+    SECTION("UPDATE ... WHERE <navigation> touches exactly the matching row") {
+        REQUIRE(exec(d, "UPDATE jp.t SET x = 'z' WHERE t #>> 'a.b' = 30;")->is_success());
+        auto cur = exec(d, "SELECT id, x FROM jp.t ORDER BY id;");
+        REQUIRE(cur->is_success());
+        CHECK(str(cur, "x", 0) == "p");
+        CHECK(str(cur, "x", 1) == "z");
+        CHECK(is_null(cur, "x", 2));
+    }
+
+    SECTION("DELETE ... WHERE <navigation> removes exactly the matching row") {
+        REQUIRE(exec(d, "DELETE FROM jp.t WHERE t #>> 'a.c' = 60;")->is_success());
+        CHECK(ids(exec(d, "SELECT id FROM jp.t ORDER BY id;")) == std::set<int64_t>{1, 2, 4});
+    }
+
+    SECTION("a navigating subquery drives an IN predicate") {
+        CHECK(ids(exec(d, "SELECT id FROM jp.t WHERE id IN (SELECT id FROM jp.t WHERE t #>> 'a.b' = 10);")) ==
+              std::set<int64_t>{1});
+    }
+}
+
+// Navigated values inside expressions. The parenthesised form is the supported one.
+TEST_CASE("integration::cpp::test_jsonb_support::navigation_in_expressions") {
+    auto config = make_test_config("/tmp/test_jsonb_matrix/expr");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    seed(d);
+
+    SECTION("arithmetic over a navigated leaf") {
+        auto plus = exec(d, "SELECT id, (t #>> 'a.c') + 1 AS v FROM jp.t ORDER BY id;");
+        REQUIRE(plus->is_success());
+        CHECK(i64(plus, "v", 0) == 21);
+        CHECK(i64(plus, "v", 3) == 71);
+
+        auto mul = exec(d, "SELECT id, (t #>> 'a.c') * 2 AS v FROM jp.t ORDER BY id;");
+        REQUIRE(mul->is_success());
+        CHECK(i64(mul, "v", 1) == 80);
+
+        auto minus = exec(d, "SELECT id, (t #>> 'a.c') - 1 AS v FROM jp.t ORDER BY id;");
+        REQUIRE(minus->is_success());
+        CHECK(i64(minus, "v", 2) == 59);
+    }
+
+    SECTION("aggregates work over a navigated leaf once it is wrapped in arithmetic") {
+        // SUM(t #>> 'a.c') alone fails with "unable to parse value"; + 0 makes it an
+        // ordinary arithmetic expression, which the aggregate accepts.
+        auto s = exec(d, "SELECT SUM((t #>> 'a.c') + 0) AS s FROM jp.t;");
+        REQUIRE(s->is_success());
+        CHECK(i64(s, "s", 0) == 190); // 20 + 40 + 60 + 70
+
+        auto m = exec(d, "SELECT MIN((t #>> 'a.c') + 0) AS s FROM jp.t;");
+        REQUIRE(m->is_success());
+        CHECK(i64(m, "s", 0) == 20);
+    }
+
+    SECTION("CASE over a fully-populated leaf") {
+        auto cur = exec(d, "SELECT id, CASE WHEN t #>> 'a.c' = 20 THEN 1 ELSE 0 END AS v FROM jp.t ORDER BY id;");
+        REQUIRE(cur->is_success());
+        CHECK(i64(cur, "v", 0) == 1);
+        CHECK(i64(cur, "v", 1) == 0);
+    }
+
+    SECTION("DISTINCT and LIMIT over a navigated leaf") {
+        CHECK(exec(d, "SELECT DISTINCT t ->> 'x' AS v FROM jp.t;")->size() == 3); // 'p', 'q', NULL
+        CHECK(exec(d, "SELECT t #>> 'a.c' AS v FROM jp.t LIMIT 2;")->size() == 2);
+    }
+}
+
+// The operators are not gated on relkind: they work over an ordinary fixed-schema
+// table too, where they degrade to plain column access plus an is-not-null test.
+TEST_CASE("integration::cpp::test_jsonb_support::regular_table") {
+    auto config = make_test_config("/tmp/test_jsonb_matrix/regular");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(exec(d, "CREATE DATABASE jp;")->is_success());
+    REQUIRE(exec(d, "CREATE TABLE jp.r (id BIGINT, v BIGINT, s TEXT);")->is_success());
+    REQUIRE(exec(d, "INSERT INTO jp.r (id, v, s) VALUES (1, 10, 'p'), (2, 30, 'q');")->is_success());
+    REQUIRE(exec(d, "INSERT INTO jp.r (id) VALUES (3);")->is_success());
+
+    auto nav = exec(d, "SELECT id, r ->> 'v' AS nv FROM jp.r ORDER BY id;");
+    REQUIRE(nav->is_success());
+    CHECK(i64(nav, "nv", 0) == 10);
+    CHECK(is_null(nav, "nv", 2));
+
+    auto exp = exec(d, "SELECT r -> 'v' FROM jp.r ORDER BY id;");
+    REQUIRE(exp->is_success());
+    CHECK(aliases(exp) == std::set<std::string>{"v"});
+
+    CHECK(ids(exec(d, "SELECT id FROM jp.r WHERE r ->> 'v' = 10;")) == std::set<int64_t>{1});
+    // ? is a not-null test on the column: the row that never got a value is excluded.
+    CHECK(ids(exec(d, "SELECT id FROM jp.r WHERE r ? 'v';")) == std::set<int64_t>{1, 2});
+}
+
+// Navigation on either side of a two-table join.
+TEST_CASE("integration::cpp::test_jsonb_support::two_table_join") {
+    auto config = make_test_config("/tmp/test_jsonb_matrix/join");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(exec(d, "CREATE DATABASE jp;")->is_success());
+    REQUIRE(exec(d, "CREATE TABLE jp.l ();")->is_success());
+    REQUIRE(exec(d, "CREATE TABLE jp.m ();")->is_success());
+    REQUIRE(exec(d, "INSERT INTO jp.l (k, lv, d.e) VALUES (1, 100, 111), (2, 200, 222);")->is_success());
+    REQUIRE(exec(d, "INSERT INTO jp.m (k, mv, d.e) VALUES (1, 10, 11), (2, 20, 22);")->is_success());
+
+    SECTION("navigation into the right-hand table, in the SELECT list") {
+        auto cur = exec(d, "SELECT m #>> 'd.e' AS mde FROM jp.l JOIN jp.m ON l.k = m.k;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 2);
+        CHECK(i64_set(cur, "mde") == std::set<int64_t>{11, 22});
+    }
+
+    SECTION("navigation into either table, in the WHERE clause") {
+        auto right = exec(d, "SELECT l.k AS id FROM jp.l JOIN jp.m ON l.k = m.k WHERE m #>> 'mv' = 10;");
+        CHECK(ids(right) == std::set<int64_t>{1});
+
+        auto left = exec(d, "SELECT l.k AS id FROM jp.l JOIN jp.m ON l.k = m.k WHERE l #>> 'lv' = 200;");
+        CHECK(ids(left) == std::set<int64_t>{2});
+    }
+
+    SECTION("navigation as the join condition itself") {
+        auto cur = exec(d, "SELECT l.k AS id FROM jp.l JOIN jp.m ON l #>> 'k' = m #>> 'k';");
+        CHECK(ids(cur) == std::set<int64_t>{1, 2});
+    }
+}
+
+// Flattened columns survive a WAL/disk round-trip, and navigation still resolves
+// against the restored catalog.
+TEST_CASE("integration::cpp::test_jsonb_support::persistence") {
+    auto config = make_test_config("/tmp/test_jsonb_matrix/persist", true, true);
+    {
+        test_spaces space(config);
+        auto* d = space.dispatcher();
+        seed(d);
+        CHECK(i64(exec(d, "SELECT t #>> 'a.b' AS v FROM jp.t ORDER BY id;"), "v", 0) == 10);
+    }
+    {
+        // reopen the same directory: no clear, disk+wal on
+        test_spaces space(config);
+        auto* d = space.dispatcher();
+
+        auto star = exec(d, "SELECT * FROM jp.t ORDER BY id;");
+        REQUIRE(star->is_success());
+        REQUIRE(star->size() == 4);
+        CHECK(aliases(star) == std::set<std::string>{"id", "a/b", "a/c", "x"});
+
+        auto nav = exec(d, "SELECT id, t #>> 'a.b' AS v, t ->> 'x' AS s FROM jp.t ORDER BY id;");
+        REQUIRE(nav->is_success());
+        CHECK(i64(nav, "v", 0) == 10);
+        CHECK(i64(nav, "v", 2) == 50);
+        CHECK(is_null(nav, "v", 3));
+        CHECK(str(nav, "s", 1) == "q");
+
+        CHECK(ids(exec(d, "SELECT id FROM jp.t WHERE t ? 'x';")) == std::set<int64_t>{1, 2});
+        CHECK(aliases(exec(d, "SELECT t -> 'a' FROM jp.t;")) == std::set<std::string>{"b", "c"});
+    }
+}
+
+// A view can capture a navigation, which is the one way to hand a navigated value
+// to an outer query — the CTE / derived-table route loses the alias (see
+// clean_rejections). INSERT ... SELECT into dotted targets works as well.
+TEST_CASE("integration::cpp::test_jsonb_support::view_over_navigation") {
+    auto config = make_test_config("/tmp/test_jsonb_matrix/view");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    seed(d);
+
+    REQUIRE(exec(d, "CREATE VIEW jp.v AS SELECT id, t #>> 'a.b' AS ab FROM jp.t;")->is_success());
+
+    auto cur = exec(d, "SELECT * FROM jp.v;");
+    REQUIRE(cur->is_success());
+    REQUIRE(cur->size() == 4);
+    CHECK(aliases(cur) == std::set<std::string>{"id", "ab"});
+    CHECK(i64_set(cur, "ab") == std::set<int64_t>{10, 30, 50});
+    CHECK(is_null(cur, "ab", 3));
+
+    // NOTE: a narrowed projection over the view is ignored — "SELECT ab FROM jp.v"
+    // still returns both columns. That is a view bug, not a jsonb one (it happens
+    // for views over plain tables too), so it is only recorded, not pinned here.
+}
+
+// INSERT ... SELECT reports "1 row inserted" and then discards every value: on a
+// computing table it appends a row in which even the plain columns are NULL.
+// (On a fixed-schema table the same statement inserts nothing at all, so the
+// broken piece is INSERT ... SELECT itself; the flattened-storage variant is
+// pinned here because it is the one that leaves corrupt rows behind.)
+TEST_CASE("integration::cpp::test_jsonb_support::bug_insert_select_appends_a_null_row") {
+    auto config = make_test_config("/tmp/test_jsonb_matrix/insert_select");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    seed(d);
+
+    auto ins = exec(d, "INSERT INTO jp.t (id, a.b) SELECT 5, 55;");
+    REQUIRE(ins->is_success());
+    CHECK(ins->size() == 1); // claims one row
+
+    auto cur = exec(d, "SELECT * FROM jp.t ORDER BY id;");
+    REQUIRE(cur->is_success());
+    // correct: 4 rows unchanged plus (id=5, a/b=55). We get a 5th row of all NULLs.
+    CHECK(cur->size() == 5);
+    CHECK(is_null(cur, "id", 4));
+    CHECK(is_null(cur, "a/b", 4));
+    CHECK(i64_set(exec(d, "SELECT t #>> 'a.b' AS v FROM jp.t;"), "v") == std::set<int64_t>{10, 30, 50});
+}
+
+// Everything that is NOT supported must fail loudly. This case exists so that a
+// future change cannot quietly start returning a wrong answer for any of them.
+TEST_CASE("integration::cpp::test_jsonb_support::clean_rejections") {
+    auto config = make_test_config("/tmp/test_jsonb_matrix/reject");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    seed(d);
+
+    const char* rejected[] = {
+        // navigation is not accepted as a sort / group key
+        "SELECT id FROM jp.t ORDER BY t #>> 'a.b' DESC;",
+        "SELECT t #>> 'a.b' AS k, COUNT(*) FROM jp.t GROUP BY t #>> 'a.b';",
+        // nor as an UPDATE SET source, nor as an index expression
+        "UPDATE jp.t SET x = t ->> 'x' WHERE id = 1;",
+        "CREATE INDEX ix ON jp.t (t #>> 'a.b');",
+        // nor on the left of IN / LIKE, nor against another navigation
+        "SELECT id FROM jp.t WHERE t #>> 'a.b' IN (10, 30);",
+        "SELECT id FROM jp.t WHERE t ->> 'x' LIKE 'p%';",
+        "SELECT id FROM jp.t WHERE t #>> 'a.b' = t #>> 'a.c';",
+        // functions cannot take a navigated argument
+        "SELECT upper(t ->> 'x') AS v FROM jp.t;",
+        "SELECT SUM(t #>> 'a.b') FROM jp.t;",
+        // the delete operators are SELECT-list only
+        "SELECT id FROM jp.t WHERE t #- 'a.b' = 1;",
+        // no navigation or deletion in a RETURNING clause
+        "DELETE FROM jp.t WHERE id = 3 RETURNING t ->> 'x';",
+        "DELETE FROM jp.t WHERE id = 3 RETURNING t - 'x';",
+        // UNION over expansions is only as valid as the two arities happen to be
+        "SELECT t -> 'a' FROM jp.t UNION SELECT t -> 'nokey' FROM jp.t;",
+        // a navigated alias is not visible to an enclosing CTE (a VIEW does work —
+        // see view_over_navigation)
+        "WITH c AS (SELECT id, t #>> 'a.b' AS ab FROM jp.t) SELECT ab FROM c;",
+        // a parameter cannot supply the key: $1 is taken as the literal path "$1"
+        "SELECT t ->> $1 AS v FROM jp.t;",
+        // ARRAY[...] is not accepted as a path (only 'a.b' and '{a,b}' are)
+        "SELECT t #>> ARRAY['a','b'] AS v FROM jp.t;",
+        // navigation in the SELECT list of a GROUP BY query
+        "SELECT t #>> 'a.b' AS v FROM jp.t GROUP BY id;",
+        // path segments are not dequoted
+        "SELECT t #>> '{\"a\",\"b\"}' AS v FROM jp.t;",
+        // an intermediate (non-leaf) key is not a scalar
+        "SELECT t #>> 'a' AS v FROM jp.t;",
+        // postgres jsonpath / containment / concatenation operators do not exist
+        "SELECT id FROM jp.t WHERE t @> '{\"x\":1}';",
+        "SELECT id FROM jp.t WHERE t <@ '{\"x\":1}';",
+        "SELECT id FROM jp.t WHERE t @? '$.x';",
+        "SELECT id FROM jp.t WHERE t @@ '$.x == 1';",
+    };
+    for (const auto* sql : rejected) {
+        INFO(sql);
+        auto cur = exec(d, sql);
+        REQUIRE(cur);
+        CHECK_FALSE(cur->is_success());
+    }
+}
+
+// The wiki's SQL-Standards matrix marks every SQL:2016 JSON row ❌ for otterbrix.
+// That is accurate, and this case keeps it honest: none of it may start silently
+// half-working. (The failure MODE differs per feature — type rejection, unknown
+// function, or plain syntax error — but none of them execute.)
+TEST_CASE("integration::cpp::test_jsonb_support::sql_json_standard_absent") {
+    auto config = make_test_config("/tmp/test_jsonb_matrix/std");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(exec(d, "CREATE DATABASE jp;")->is_success());
+    REQUIRE(exec(d, "CREATE TABLE jp.r (id BIGINT, s TEXT);")->is_success());
+    REQUIRE(exec(d, "INSERT INTO jp.r (id, s) VALUES (1, '{\"a\":1}');")->is_success());
+
+    SECTION("4.1 there is no JSON / JSONB column type") {
+        auto j = exec(d, "CREATE TABLE jp.j1 (id BIGINT, j JSON);");
+        REQUIRE_FALSE(j->is_success());
+        CHECK(std::string(j->get_error().what).find("json") != std::string::npos);
+        CHECK_FALSE(exec(d, "CREATE TABLE jp.j2 (id BIGINT, j JSONB);")->is_success());
+    }
+
+    SECTION("4.2/4.4 the SQL/JSON functions do not exist") {
+        const char* fns[] = {"SELECT JSON_QUERY(s, '$.a') FROM jp.r;",
+                             "SELECT JSON_VALUE(s, '$.a') FROM jp.r;",
+                             "SELECT JSON_EXISTS(s, '$.a') FROM jp.r;",
+                             "SELECT JSON_OBJECT('a', 1);",
+                             "SELECT JSON_ARRAY(1, 2);",
+                             "SELECT JSON_ARRAYAGG(id) FROM jp.r;",
+                             "SELECT to_json(id) FROM jp.r;"};
+        for (const auto* sql : fns) {
+            INFO(sql);
+            CHECK_FALSE(exec(d, sql)->is_success());
+        }
+    }
+
+    SECTION("4.3/4.5 JSON_TABLE, IS JSON and MATCH_RECOGNIZE are syntax errors") {
+        const char* syn[] = {"SELECT * FROM JSON_TABLE('{\"a\":1}', '$' COLUMNS (a INT PATH '$.a'));",
+                             "SELECT s IS JSON FROM jp.r;",
+                             "SELECT * FROM jp.r MATCH_RECOGNIZE (PATTERN (A) DEFINE A AS id > 0);"};
+        for (const auto* sql : syn) {
+            INFO(sql);
+            CHECK_FALSE(exec(d, sql)->is_success());
+        }
+    }
+}
+
+// ===========================================================================
+// BUG characterization — each CHECK below pins behavior that is WRONG.
+// ===========================================================================
+
+// A cast applied to a navigated value, then used in arithmetic, reads
+// uninitialized memory: the result is a per-run-varying constant repeated on
+// every row. Without the cast, or without the arithmetic, the same expression is
+// correct — so the two together corrupt the value.
+TEST_CASE("integration::cpp::test_jsonb_support::bug_cast_nav_in_arithmetic_is_garbage") {
+    auto config = make_test_config("/tmp/test_jsonb_matrix/cast_arith");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    seed(d);
+
+    // both halves are individually correct
+    auto cast_only = exec(d, "SELECT id, (t #>> 'a.c')::bigint AS v FROM jp.t ORDER BY id;");
+    REQUIRE(cast_only->is_success());
+    CHECK(i64(cast_only, "v", 0) == 20);
+
+    auto arith_only = exec(d, "SELECT id, (t #>> 'a.c') + 1 AS v FROM jp.t ORDER BY id;");
+    REQUIRE(arith_only->is_success());
+    CHECK(i64(arith_only, "v", 0) == 21);
+
+    // together: garbage. Same value on every row, unrelated to the data.
+    auto both = exec(d, "SELECT id, (t #>> 'a.c')::bigint + 1 AS v FROM jp.t ORDER BY id;");
+    REQUIRE(both->is_success());
+    // correct: 21, 41, 61, 71
+    CHECK_FALSE(i64(both, "v", 0) == 21);
+    CHECK(i64(both, "v", 0) == i64(both, "v", 1)); // every row gets the same garbage
+    CHECK(i64(both, "v", 1) == i64(both, "v", 2));
+
+    // the same shape over a plain column is fine — this is navigation-specific
+    auto plain = exec(d, "SELECT id, (id)::bigint + 1 AS v FROM jp.t ORDER BY id;");
+    REQUIRE(plain->is_success());
+    CHECK(i64(plain, "v", 0) == 2);
+}
+
+// An INSERT target three or more segments deep silently loses its middle
+// segments: only the first and last survive. The value is stored — under a path
+// nobody asked for — and the path that was written is then unreadable.
+TEST_CASE("integration::cpp::test_jsonb_support::bug_deep_path_insert_drops_middle_segments") {
+    auto config = make_test_config("/tmp/test_jsonb_matrix/depth");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(exec(d, "CREATE DATABASE jp;")->is_success());
+    REQUIRE(exec(d, "CREATE TABLE jp.d ();")->is_success());
+    REQUIRE(exec(d, "INSERT INTO jp.d (id, a.b.c) VALUES (1, 111);")->is_success());
+    REQUIRE(exec(d, "INSERT INTO jp.d (id, p.q.r.s) VALUES (2, 222);")->is_success());
+
+    auto cur = exec(d, "SELECT * FROM jp.d ORDER BY id;");
+    REQUIRE(cur->is_success());
+    // correct: {"id", "a/b/c", "p/q/r/s"}
+    CHECK(aliases(cur) == std::set<std::string>{"id", "a/c", "p/s"});
+    CHECK(i64(cur, "a/c", 0) == 111); // the value landed under the truncated path
+    CHECK(i64(cur, "p/s", 1) == 222); // two segments dropped here
+
+    // consequence: the path that was inserted cannot be read back
+    CHECK_FALSE(exec(d, "SELECT d #>> 'a.b.c' AS v FROM jp.d;")->is_success());   // correct: 111
+    CHECK_FALSE(exec(d, "SELECT d #>> '{a,b,c}' AS v FROM jp.d;")->is_success()); // correct: 111
+    CHECK(exec(d, "SELECT d #>> 'a.c' AS v FROM jp.d;")->is_success());           // the path nobody wrote
+}
+
+// `- '{key}'` (the postgres text-array form of key deletion) is silently ignored:
+// no column is removed and no error is raised. Only the bare `- 'key'` form works.
+TEST_CASE("integration::cpp::test_jsonb_support::bug_array_form_of_delete_is_silent_noop") {
+    auto config = make_test_config("/tmp/test_jsonb_matrix/del_arr");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    seed(d);
+
+    auto ok = exec(d, "SELECT t - 'x' FROM jp.t;");
+    REQUIRE(ok->is_success());
+    CHECK(aliases(ok) == std::set<std::string>{"id", "a/b", "a/c"});
+
+    auto arr = exec(d, "SELECT t - '{x}' FROM jp.t;");
+    REQUIRE(arr->is_success());
+    // correct: {"id", "a/b", "a/c"} — x should have been deleted, or the form rejected.
+    CHECK(aliases(arr) == std::set<std::string>{"id", "a/b", "a/c", "x"});
+}
+
+// Expanding a path that matches no column does not error — the expansion item is
+// silently ERASED from the select list. On its own that yields a zero-column
+// result; alongside other items it silently changes the arity of the answer.
+TEST_CASE("integration::cpp::test_jsonb_support::bug_zero_match_expand_drops_the_select_item") {
+    auto config = make_test_config("/tmp/test_jsonb_matrix/zero_exp");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    seed(d);
+
+    // the scalar operator errors, as it should
+    CHECK_FALSE(exec(d, "SELECT t ->> 'nokey' AS v FROM jp.t;")->is_success());
+
+    // the table-valued one silently produces nothing
+    auto cur = exec(d, "SELECT t -> 'nokey' FROM jp.t;");
+    REQUIRE(cur->is_success()); // correct: this should be an error
+    CHECK(cur->column_count() == 0);
+
+    // ... and next to other select items it just disappears, so the caller gets
+    // fewer columns than it asked for, with no indication that anything was wrong.
+    auto mixed = exec(d, "SELECT t -> 'nokey', x FROM jp.t;");
+    REQUIRE(mixed->is_success());
+    CHECK(mixed->column_count() == 1); // correct: an error, or 2 columns
+    CHECK(aliases(mixed) == std::set<std::string>{"x"});
+
+    auto mixed3 = exec(d, "SELECT id, t -> 'nokey', x FROM jp.t;");
+    REQUIRE(mixed3->is_success());
+    CHECK(mixed3->column_count() == 2); // correct: an error, or 3 columns
+    CHECK(aliases(mixed3) == std::set<std::string>{"id", "x"});
+
+    // same for a dotted path handed to -> (which takes a single key, not a path)
+    auto dotted = exec(d, "SELECT t -> 'a.b' FROM jp.t;");
+    REQUIRE(dotted->is_success()); // correct: error, or expand "a/b"
+    CHECK(dotted->column_count() == 0);
+}
+
+// The '/' that joins path segments internally is not reserved, so a top-level key
+// spelled with a slash and a nested path are the SAME column: "a/b" and a.b
+// collide. Either spelling reads back both rows.
+TEST_CASE("integration::cpp::test_jsonb_support::bug_path_separator_collides_with_a_literal_key") {
+    auto config = make_test_config("/tmp/test_jsonb_matrix/sep");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(exec(d, "CREATE DATABASE jp;")->is_success());
+    REQUIRE(exec(d, "CREATE TABLE jp.s ();")->is_success());
+    REQUIRE(exec(d, "INSERT INTO jp.s (id, a.b) VALUES (1, 10);")->is_success());
+    REQUIRE(exec(d, "INSERT INTO jp.s (id, \"a/b\") VALUES (2, 20);")->is_success());
+
+    auto star = exec(d, "SELECT * FROM jp.s ORDER BY id;");
+    REQUIRE(star->is_success());
+    // correct: two distinct columns — the nested path a.b, and the flat key "a/b"
+    CHECK(aliases(star) == std::set<std::string>{"id", "a/b"});
+
+    // both spellings address that one column, so each sees the other's row
+    CHECK(i64_set(exec(d, "SELECT s #>> 'a.b' AS v FROM jp.s;"), "v") == std::set<int64_t>{10, 20});
+    CHECK(i64_set(exec(d, "SELECT s ->> 'a/b' AS v FROM jp.s;"), "v") == std::set<int64_t>{10, 20});
+}
+
+// In postgres a missing key yields NULL (for ->>) or false (for ?). Here it is a
+// hard error, which makes the existence operators unusable for their one purpose:
+// you cannot ask "does this row have key K" unless K is already known to exist.
+TEST_CASE("integration::cpp::test_jsonb_support::bug_missing_key_errors_instead_of_null_or_false") {
+    auto config = make_test_config("/tmp/test_jsonb_matrix/missing");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    seed(d);
+
+    CHECK_FALSE(exec(d, "SELECT t ->> 'nokey' AS v FROM jp.t;")->is_success()); // correct: NULL for every row
+    CHECK_FALSE(exec(d, "SELECT id FROM jp.t WHERE t ? 'nokey';")->is_success()); // correct: false -> no rows
+    // one absent key poisons an any-of that another key already satisfies
+    CHECK_FALSE(exec(d, "SELECT id FROM jp.t WHERE t ?| '{x,nokey}';")->is_success()); // correct: rows 1,2
+    CHECK_FALSE(exec(d, "SELECT id FROM jp.t WHERE t ?& '{x,nokey}';")->is_success()); // correct: no rows
+
+    // ? cannot see an intermediate key either, even though it is a real prefix
+    // of two stored columns ("a/b", "a/c") and postgres would report it present.
+    CHECK_FALSE(exec(d, "SELECT id FROM jp.t WHERE t ? 'a';")->is_success()); // correct: all rows
+
+    // and IS NULL cannot be used to bridge the gap
+    CHECK_FALSE(exec(d, "SELECT id FROM jp.t WHERE t #>> 'a.b' IS NULL;")->is_success()); // correct: row 4
+}
+
+// Any cast on the right of a navigation operator is treated as a boolean cast:
+// the key becomes the string "false" (or "true"), so `t ->> ('x'::text)` looks
+// for a column named "false". The bool cast itself segfaults (see header).
+TEST_CASE("integration::cpp::test_jsonb_support::bug_cast_key_is_treated_as_boolean") {
+    auto config = make_test_config("/tmp/test_jsonb_matrix/cast_key");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    seed(d);
+
+    auto cur = exec(d, "SELECT t ->> ('x'::text) AS v FROM jp.t;");
+    REQUIRE_FALSE(cur->is_success()); // correct: same as t ->> 'x'
+    // the key was rewritten to the literal "false"
+    CHECK(std::string(cur->get_error().what).find("false") != std::string::npos);
+}
+
+// A cast over a navigated value does not convert it: ::text on an integer leaf
+// leaves it BIGINT. (Compare with bug_cast_nav_in_arithmetic_is_garbage, where
+// the same no-op cast additionally corrupts the arithmetic that follows.)
+TEST_CASE("integration::cpp::test_jsonb_support::bug_cast_over_navigation_is_a_noop") {
+    auto config = make_test_config("/tmp/test_jsonb_matrix/cast_noop");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    seed(d);
+
+    auto cur = exec(d, "SELECT (t #>> 'a.c')::text AS v FROM jp.t ORDER BY id;");
+    REQUIRE(cur->is_success());
+    // correct: STRING_LITERAL holding "20"
+    CHECK(type_of(cur, "v") == components::types::logical_type::BIGINT);
+    CHECK(i64(cur, "v", 0) == 20);
+}
+
+// Inside a join, scalar navigation is side-aware but EXPANSION is not: it
+// resolves the path against one schema only, so the moment both joined tables
+// carry the same subtree name it fails with "path not found" — for a path that
+// exists on both sides. Key deletion inside a join is broken outright.
+TEST_CASE("integration::cpp::test_jsonb_support::bug_expand_inside_join_is_side_blind") {
+    auto config = make_test_config("/tmp/test_jsonb_matrix/join_expand");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(exec(d, "CREATE DATABASE jp;")->is_success());
+    REQUIRE(exec(d, "CREATE TABLE jp.l ();")->is_success());
+    REQUIRE(exec(d, "CREATE TABLE jp.m ();")->is_success());
+    REQUIRE(exec(d, "INSERT INTO jp.l (k, lv, d.e, d.f) VALUES (1, 100, 111, 112), (2, 200, 222, 223);")
+                ->is_success());
+    REQUIRE(exec(d, "INSERT INTO jp.m (k, mv, d.e, d.f) VALUES (1, 10, 11, 12), (2, 20, 22, 23);")->is_success());
+
+    // Scalar navigation resolves each side correctly — this is the part that works.
+    CHECK(i64_set(exec(d, "SELECT m #>> 'd.e' AS v FROM jp.l JOIN jp.m ON l.k = m.k;"), "v") ==
+          std::set<int64_t>{11, 22});
+    CHECK(i64_set(exec(d, "SELECT l #>> 'd.e' AS v FROM jp.l JOIN jp.m ON l.k = m.k;"), "v") ==
+          std::set<int64_t>{111, 222});
+
+    // Expansion of the very same subtree fails, from either side.
+    // correct: two columns e, f holding 11,12 / 22,23 (resp. 111,112 / 222,223).
+    CHECK_FALSE(exec(d, "SELECT m -> 'd' FROM jp.l JOIN jp.m ON l.k = m.k;")->is_success());
+    CHECK_FALSE(exec(d, "SELECT l -> 'd' FROM jp.l JOIN jp.m ON l.k = m.k;")->is_success());
+
+    // Key deletion inside a join cannot resolve any column at all.
+    CHECK_FALSE(exec(d, "SELECT m - 'd' FROM jp.l JOIN jp.m ON l.k = m.k;")->is_success());
+}
+
+// Expansion DOES work inside a join as long as the subtree name belongs to only
+// one of the joined tables — which is what makes the failure above a resolution
+// bug rather than a missing feature.
+TEST_CASE("integration::cpp::test_jsonb_support::expand_in_join_with_unique_subtree") {
+    auto config = make_test_config("/tmp/test_jsonb_matrix/join_expand_ok");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(exec(d, "CREATE DATABASE jp;")->is_success());
+    REQUIRE(exec(d, "CREATE TABLE jp.l ();")->is_success());
+    REQUIRE(exec(d, "CREATE TABLE jp.m ();")->is_success());
+    REQUIRE(exec(d, "INSERT INTO jp.l (k, lv) VALUES (1, 100), (2, 200);")->is_success());
+    REQUIRE(exec(d, "INSERT INTO jp.m (k, d.e, d.f) VALUES (1, 11, 12), (2, 22, 23);")->is_success());
+
+    auto cur = exec(d, "SELECT m -> 'd' FROM jp.l JOIN jp.m ON l.k = m.k;");
+    REQUIRE(cur->is_success());
+    CHECK(aliases(cur) == std::set<std::string>{"e", "f"});
+    CHECK(i64_set(cur, "e") == std::set<int64_t>{11, 22});
+    CHECK(i64_set(cur, "f") == std::set<int64_t>{12, 23});
+}
+
+// With three or more joined tables, a column name shared by several of them
+// silently resolves to the LEFTMOST table — so a navigation that names the third
+// table returns the first table's values. (The same holds for a plain qualified
+// column, so the root cause is join name resolution rather than jsonb; it is
+// pinned here because navigation has no way to disambiguate at all.)
+TEST_CASE("integration::cpp::test_jsonb_support::bug_three_table_join_takes_leftmost_value") {
+    auto config = make_test_config("/tmp/test_jsonb_matrix/join3");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(exec(d, "CREATE DATABASE jp;")->is_success());
+    REQUIRE(exec(d, "CREATE TABLE jp.l ();")->is_success());
+    REQUIRE(exec(d, "CREATE TABLE jp.m ();")->is_success());
+    REQUIRE(exec(d, "CREATE TABLE jp.n ();")->is_success());
+    REQUIRE(exec(d, "INSERT INTO jp.l (k, v) VALUES (1, 100), (2, 200);")->is_success());
+    REQUIRE(exec(d, "INSERT INTO jp.m (k, v) VALUES (1, 10), (2, 20);")->is_success());
+    REQUIRE(exec(d, "INSERT INTO jp.n (k, v) VALUES (1, 1000), (2, 2000);")->is_success());
+
+    auto cur = exec(d, "SELECT m #>> 'v' AS v FROM jp.l JOIN jp.m ON l.k = m.k JOIN jp.n ON m.k = n.k;");
+    REQUIRE(cur->is_success());
+    // correct: {10, 20} (the values of m). We get l's values instead.
+    CHECK(i64_set(cur, "v") == std::set<int64_t>{100, 200});
+}

--- a/integration/cpp/test/test_jsonb_support.cpp
+++ b/integration/cpp/test/test_jsonb_support.cpp
@@ -578,6 +578,35 @@ TEST_CASE("integration::cpp::test_jsonb_support::insert_select_maps_projection_t
     CHECK(i64(exec(d, "SELECT t #>> 'a.b' AS v FROM jp.t WHERE id = 100;"), "v", 0) == 200);
 }
 
+// A jsonb scalar navigation lowers to a plain read of its flattened column, so a
+// same-table comparison of two navigations is an ordinary column-vs-column
+// predicate: it returns exactly the rows whose two leaves are equal, with SQL
+// NULL semantics (an absent leaf never matches). A path naming no column at all
+// is still a clean error, as for any other navigation (see
+// navigation_over_missing_key_still_errors). This was pinned as an unsupported
+// rejection until the predicate/scan layer was generalized upstream.
+TEST_CASE("integration::cpp::test_jsonb_support::compare_two_navigations") {
+    auto config = make_test_config("/tmp/test_jsonb_matrix/nav_cmp");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(exec(d, "CREATE DATABASE jp;")->is_success());
+    REQUIRE(exec(d, "CREATE TABLE jp.t ();")->is_success());
+    // rows 2 and 3 have a.b == a.c; row 4 leaves a.b absent (NULL)
+    REQUIRE(exec(d, "INSERT INTO jp.t (id, a.b, a.c) VALUES (1, 10, 20), (2, 30, 30), (3, 99, 99);")
+                ->is_success());
+    REQUIRE(exec(d, "INSERT INTO jp.t (id, a.c) VALUES (4, 70);")->is_success());
+
+    SECTION("returns exactly the equal-leaf rows; a NULL leaf never matches") {
+        auto cur = exec(d, "SELECT id FROM jp.t WHERE t #>> 'a.b' = t #>> 'a.c';");
+        REQUIRE(cur->is_success());
+        CHECK(ids(cur) == std::set<int64_t>{2, 3});
+    }
+
+    SECTION("a navigation naming no column is still a clean error, not a wrong answer") {
+        CHECK_FALSE(exec(d, "SELECT id FROM jp.t WHERE t #>> 'a.b' = t #>> 'nokey';")->is_success());
+    }
+}
+
 // Everything that is NOT supported must fail loudly. This case exists so that a
 // future change cannot quietly start returning a wrong answer for any of them.
 TEST_CASE("integration::cpp::test_jsonb_support::clean_rejections") {
@@ -593,10 +622,9 @@ TEST_CASE("integration::cpp::test_jsonb_support::clean_rejections") {
         // nor as an UPDATE SET source, nor as an index expression
         "UPDATE jp.t SET x = t ->> 'x' WHERE id = 1;",
         "CREATE INDEX ix ON jp.t (t #>> 'a.b');",
-        // nor on the left of IN / LIKE, nor against another navigation
+        // nor on the left of IN / LIKE
         "SELECT id FROM jp.t WHERE t #>> 'a.b' IN (10, 30);",
         "SELECT id FROM jp.t WHERE t ->> 'x' LIKE 'p%';",
-        "SELECT id FROM jp.t WHERE t #>> 'a.b' = t #>> 'a.c';",
         // functions cannot take a navigated argument
         "SELECT upper(t ->> 'x') AS v FROM jp.t;",
         "SELECT SUM(t #>> 'a.b') FROM jp.t;",

--- a/integration/cpp/test/test_jsonb_support.cpp
+++ b/integration/cpp/test/test_jsonb_support.cpp
@@ -737,22 +737,44 @@ TEST_CASE("integration::cpp::test_jsonb_support::subscript_insert_target") {
     CHECK(i64(exec(d, "SELECT d #>> 'arr.0' AS v FROM jp.d;"), "v", 0) == 7);
 }
 
-// `- '{key}'` (the postgres text-array form of key deletion) is silently ignored:
-// no column is removed and no error is raised. Only the bare `- 'key'` form works.
-TEST_CASE("integration::cpp::test_jsonb_support::bug_array_form_of_delete_is_silent_noop") {
+// [C] `- '{a,b}'` is the postgres text-array form of key deletion (`jsonb - text[]`):
+// it removes SEVERAL top-level keys at once. The bare `- 'key'` form still removes
+// one key, and `#- 'a.b'` still deletes a nested path — the three are distinct.
+TEST_CASE("integration::cpp::test_jsonb_support::delete_key_array_form") {
     auto config = make_test_config("/tmp/test_jsonb_matrix/del_arr");
     test_spaces space(config);
     auto* d = space.dispatcher();
-    seed(d);
+    REQUIRE(exec(d, "CREATE DATABASE jp;")->is_success());
+    REQUIRE(exec(d, "CREATE TABLE jp.t ();")->is_success());
+    REQUIRE(exec(d, "INSERT INTO jp.t (id, a.b, a.c, x, y) VALUES (1, 10, 20, 'p', 'q');")->is_success());
 
-    auto ok = exec(d, "SELECT t - 'x' FROM jp.t;");
-    REQUIRE(ok->is_success());
-    CHECK(aliases(ok) == std::set<std::string>{"id", "a/b", "a/c"});
+    // single key (unchanged)
+    CHECK(aliases(exec(d, "SELECT t - 'x' FROM jp.t;")) == std::set<std::string>{"id", "a/b", "a/c", "y"});
 
-    auto arr = exec(d, "SELECT t - '{x}' FROM jp.t;");
-    REQUIRE(arr->is_success());
-    // correct: {"id", "a/b", "a/c"} — x should have been deleted, or the form rejected.
-    CHECK(aliases(arr) == std::set<std::string>{"id", "a/b", "a/c", "x"});
+    // one-element array removes that one key
+    CHECK(aliases(exec(d, "SELECT t - '{x}' FROM jp.t;")) == std::set<std::string>{"id", "a/b", "a/c", "y"});
+
+    // several keys removed together
+    CHECK(aliases(exec(d, "SELECT t - '{x,y}' FROM jp.t;")) == std::set<std::string>{"id", "a/b", "a/c"});
+
+    // a key that names a subtree removes the whole subtree, mixed with a leaf key
+    CHECK(aliases(exec(d, "SELECT t - '{x,a}' FROM jp.t;")) == std::set<std::string>{"id", "y"});
+
+    // the empty array deletes nothing; an unknown key deletes nothing (no error)
+    CHECK(aliases(exec(d, "SELECT t - '{}' FROM jp.t;")) ==
+          std::set<std::string>{"id", "a/b", "a/c", "x", "y"});
+    CHECK(aliases(exec(d, "SELECT t - '{nokey}' FROM jp.t;")) ==
+          std::set<std::string>{"id", "a/b", "a/c", "x", "y"});
+
+    // #- with an array is still a single nested PATH delete, not multi-key
+    CHECK(aliases(exec(d, "SELECT t #- '{a,b}' FROM jp.t;")) == std::set<std::string>{"id", "a/c", "x", "y"});
+
+    // values of the surviving columns are intact after a multi-key delete
+    auto surv = exec(d, "SELECT t - '{a}' FROM jp.t;");
+    REQUIRE(surv->is_success());
+    CHECK(aliases(surv) == std::set<std::string>{"id", "x", "y"});
+    CHECK(str(surv, "x", 0) == "p");
+    CHECK(str(surv, "y", 0) == "q");
 }
 
 // Expanding a path that matches no column does not error — the expansion item is

--- a/integration/cpp/test/test_jsonb_support.cpp
+++ b/integration/cpp/test/test_jsonb_support.cpp
@@ -45,8 +45,10 @@
 //       absent key folds to constant false and never poisons a '?|' any-of.
 //   [D] table-valued expand/delete are well-behaved: expanding a path that matches
 //       no column is a "path not found" error (not a silently vanished select
-//       item), and inside a join expand and delete resolve against the side the
-//       operator named (not blindly across both, which was ambiguous).
+//       item); inside a join expand and delete resolve against the side the
+//       operator named (not blindly across both, which was ambiguous); and under
+//       GROUP BY / an aggregate they are a clean rejection, not a segfault (the
+//       group branch never expands them).
 //   [F] a cast over a scalar navigation used in arithmetic ((t #>> 'a.c')::bigint
 //       + 1) reads the navigated column per row, instead of folding the navigation
 //       into an uninitialized constant parameter (per-run garbage on every row).
@@ -630,6 +632,34 @@ TEST_CASE("integration::cpp::test_jsonb_support::clean_rejections") {
         REQUIRE(cur);
         CHECK_FALSE(cur->is_success());
     }
+}
+
+// A table-valued operator (expand '->'/'#>', delete '-'/'#-') is lowered to
+// per-column get_field only on the plain SELECT path. Under GROUP BY — or a bare
+// aggregate, which routes through the same group branch — it is never expanded, so
+// an un-expanded node used to reach physical execution and SEGFAULT the process.
+// It must be a clean rejection instead (expanding one row into several columns has
+// no meaning under grouping).
+TEST_CASE("integration::cpp::test_jsonb_support::table_valued_op_rejected_under_grouping") {
+    auto config = make_test_config("/tmp/test_jsonb_matrix/gb_reject");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(exec(d, "CREATE DATABASE jp;")->is_success());
+    REQUIRE(exec(d, "CREATE TABLE jp.gb ();")->is_success());
+    REQUIRE(exec(d, "INSERT INTO jp.gb (g, a.b, x) VALUES (1, 1, 9), (1, 2, 90);")->is_success());
+
+    // clean errors, not crashes — with an explicit GROUP BY ...
+    CHECK_FALSE(exec(d, "SELECT g, gb -> 'a' FROM jp.gb GROUP BY g;")->is_success());
+    CHECK_FALSE(exec(d, "SELECT gb #> 'a' FROM jp.gb GROUP BY g;")->is_success());
+    CHECK_FALSE(exec(d, "SELECT gb - 'x' FROM jp.gb GROUP BY g;")->is_success());
+    CHECK_FALSE(exec(d, "SELECT gb #- 'a.b' FROM jp.gb GROUP BY g;")->is_success());
+    // ... and with a bare aggregate (routes through the group branch too)
+    CHECK_FALSE(exec(d, "SELECT gb -> 'a', COUNT(x) FROM jp.gb;")->is_success());
+
+    // a genuine aggregate over the same table is unaffected
+    auto ok = exec(d, "SELECT g, COUNT(x) AS n FROM jp.gb GROUP BY g;");
+    REQUIRE(ok->is_success());
+    CHECK(ok->size() == 1);
 }
 
 // The wiki's SQL-Standards matrix marks every SQL:2016 JSON row ❌ for otterbrix.

--- a/integration/cpp/test/test_jsonb_support.cpp
+++ b/integration/cpp/test/test_jsonb_support.cpp
@@ -31,12 +31,15 @@
 //   INSERT INTO t (a.b, x) VALUES (NULL, 'z');          -- NULL literal in a dotted target [C3]
 //   SELECT CASE WHEN t #>> 'a.b' = 10 THEN 1 ELSE 0 END -- only when the leaf has a NULL row;
 //     FROM t;                                           --   reproduces on plain columns too (general 3VL bug)
-// And this one escapes as an uncaught C++ exception rather than a cursor error:
-//   INSERT INTO t (id, arr[0]) VALUES (1, 1);           -- "basic_string: construction from null is not valid" [C4]
 //
 // FIXED (were crashes/wrong results, now pinned as correct below):
 //   [A] get_str_value hardening — a cast key is transparent, a NULL key is a clean
 //       error, and neither `t -> (1::bool)` nor `t ->> NULL` crashes any more.
+//   [B] one path<->column codec (components/expressions/jsonb_path.hpp) — the split
+//       (operand -> segments) and join (segments -> "a/b" name) live in one place,
+//       shared by navigation, existence and the INSERT flattener.
+//   [G] INSERT target flattening keeps every segment (a.b.c -> "a/b/c") and renders
+//       a subscript target (arr[0] -> "arr/0") instead of crashing on it.
 
 #include "test_config.hpp"
 #include <catch2/catch_test_macros.hpp>
@@ -681,29 +684,57 @@ TEST_CASE("integration::cpp::test_jsonb_support::bug_cast_nav_in_arithmetic_is_g
     CHECK(i64(plain, "v", 0) == 2);
 }
 
-// An INSERT target three or more segments deep silently loses its middle
-// segments: only the first and last survive. The value is stored — under a path
-// nobody asked for — and the path that was written is then unreadable.
-TEST_CASE("integration::cpp::test_jsonb_support::bug_deep_path_insert_drops_middle_segments") {
+// [G] An INSERT target of arbitrary depth flattens to the full slash-joined
+// column name — every interior segment is kept, and the path written is the path
+// read back. The write side and the read side share one codec, so any depth and
+// either spelling (dotted or pg-array) round-trip.
+TEST_CASE("integration::cpp::test_jsonb_support::deep_path_insert_keeps_all_segments") {
     auto config = make_test_config("/tmp/test_jsonb_matrix/depth");
     test_spaces space(config);
     auto* d = space.dispatcher();
     REQUIRE(exec(d, "CREATE DATABASE jp;")->is_success());
     REQUIRE(exec(d, "CREATE TABLE jp.d ();")->is_success());
     REQUIRE(exec(d, "INSERT INTO jp.d (id, a.b.c) VALUES (1, 111);")->is_success());
-    REQUIRE(exec(d, "INSERT INTO jp.d (id, p.q.r.s) VALUES (2, 222);")->is_success());
+    REQUIRE(exec(d, "INSERT INTO jp.d (id, p.q.r.s.t) VALUES (2, 222);")->is_success());
 
     auto cur = exec(d, "SELECT * FROM jp.d ORDER BY id;");
     REQUIRE(cur->is_success());
-    // correct: {"id", "a/b/c", "p/q/r/s"}
-    CHECK(aliases(cur) == std::set<std::string>{"id", "a/c", "p/s"});
-    CHECK(i64(cur, "a/c", 0) == 111); // the value landed under the truncated path
-    CHECK(i64(cur, "p/s", 1) == 222); // two segments dropped here
+    CHECK(aliases(cur) == std::set<std::string>{"id", "a/b/c", "p/q/r/s/t"});
+    CHECK(i64(cur, "a/b/c", 0) == 111);
+    CHECK(i64(cur, "p/q/r/s/t", 1) == 222);
 
-    // consequence: the path that was inserted cannot be read back
-    CHECK_FALSE(exec(d, "SELECT d #>> 'a.b.c' AS v FROM jp.d;")->is_success());   // correct: 111
-    CHECK_FALSE(exec(d, "SELECT d #>> '{a,b,c}' AS v FROM jp.d;")->is_success()); // correct: 111
-    CHECK(exec(d, "SELECT d #>> 'a.c' AS v FROM jp.d;")->is_success());           // the path nobody wrote
+    // the exact path that was written reads back, both spellings, both operators
+    CHECK(i64(exec(d, "SELECT d #>> 'a.b.c' AS v FROM jp.d WHERE id = 1;"), "v", 0) == 111);
+    CHECK(i64(exec(d, "SELECT d #>> '{a,b,c}' AS v FROM jp.d WHERE id = 1;"), "v", 0) == 111);
+    CHECK(i64(exec(d, "SELECT d #>> 'p.q.r.s.t' AS v FROM jp.d WHERE id = 2;"), "v", 0) == 222);
+    // the truncated path nobody wrote is (correctly) absent now
+    CHECK_FALSE(exec(d, "SELECT d #>> 'a.c' AS v FROM jp.d;")->is_success());
+
+    // partial expansion through the deep path
+    auto expand = exec(d, "SELECT d -> 'a' -> 'b' FROM jp.d WHERE id = 1;");
+    REQUIRE(expand->is_success());
+    CHECK(aliases(expand) == std::set<std::string>{"c"});
+    CHECK(i64(expand, "c", 0) == 111);
+}
+
+// [G] A subscript target such as arr[0] flattens like any other segment
+// (arr[0] -> "arr/0") instead of dereferencing the A_Indices node as a string,
+// which used to throw an uncaught std::exception.
+TEST_CASE("integration::cpp::test_jsonb_support::subscript_insert_target") {
+    auto config = make_test_config("/tmp/test_jsonb_matrix/subscript");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(exec(d, "CREATE DATABASE jp;")->is_success());
+    REQUIRE(exec(d, "CREATE TABLE jp.d ();")->is_success());
+
+    REQUIRE(exec(d, "INSERT INTO jp.d (id, arr[0], arr[1]) VALUES (1, 7, 8);")->is_success());
+    auto cur = exec(d, "SELECT * FROM jp.d ORDER BY id;");
+    REQUIRE(cur->is_success());
+    CHECK(aliases(cur) == std::set<std::string>{"id", "arr/0", "arr/1"});
+    CHECK(i64(cur, "arr/0", 0) == 7);
+    CHECK(i64(cur, "arr/1", 0) == 8);
+    // and it reads back through the path spelling
+    CHECK(i64(exec(d, "SELECT d #>> 'arr.0' AS v FROM jp.d;"), "v", 0) == 7);
 }
 
 // `- '{key}'` (the postgres text-array form of key deletion) is silently ignored:
@@ -759,10 +790,18 @@ TEST_CASE("integration::cpp::test_jsonb_support::bug_zero_match_expand_drops_the
     CHECK(dotted->column_count() == 0);
 }
 
-// The '/' that joins path segments internally is not reserved, so a top-level key
-// spelled with a slash and a nested path are the SAME column: "a/b" and a.b
-// collide. Either spelling reads back both rows.
-TEST_CASE("integration::cpp::test_jsonb_support::bug_path_separator_collides_with_a_literal_key") {
+// LIMITATION of the flattened representation (documented, not a fix target here).
+// A computing-table column name and a nested path share one namespace, and the
+// path separator '/' is a legal identifier character, so the nested path a.b and a
+// column whose literal name is "a/b" are the same storage column "a/b" — a value
+// written one way is visible the other way. Making them distinct (postgres keeps
+// the jsonb key "a/b" separate from a nested a->b) would require percent-escaping
+// EVERY column identifier on read and write system-wide — including regular tables
+// and DDL, well outside jsonb — so we do not do it here. The one codec that owns
+// the mapping (jsonb_path.hpp) documents the same reservation. This case pins the
+// behavior so a future escaping change is a deliberate, visible flip rather than a
+// silent one.
+TEST_CASE("integration::cpp::test_jsonb_support::flattened_name_and_nested_path_share_storage") {
     auto config = make_test_config("/tmp/test_jsonb_matrix/sep");
     test_spaces space(config);
     auto* d = space.dispatcher();
@@ -773,7 +812,7 @@ TEST_CASE("integration::cpp::test_jsonb_support::bug_path_separator_collides_wit
 
     auto star = exec(d, "SELECT * FROM jp.s ORDER BY id;");
     REQUIRE(star->is_success());
-    // correct: two distinct columns — the nested path a.b, and the flat key "a/b"
+    // one shared column "a/b", not two
     CHECK(aliases(star) == std::set<std::string>{"id", "a/b"});
 
     // both spellings address that one column, so each sees the other's row

--- a/integration/cpp/test/test_jsonb_support.cpp
+++ b/integration/cpp/test/test_jsonb_support.cpp
@@ -28,13 +28,15 @@
 //
 // NOT PINNABLE — these SEGFAULT the process, so they cannot live in a test binary.
 // Verified on this commit; kept here as the repro list:
-//   SELECT t -> (1::bool) FROM t;                       -- bool cast as key -> null deref
-//   SELECT t ->> NULL FROM t;                           -- NULL key -> null deref
-//   INSERT INTO t (a.b, x) VALUES (NULL, 'z');          -- NULL literal in a dotted target
+//   INSERT INTO t (a.b, x) VALUES (NULL, 'z');          -- NULL literal in a dotted target [C3]
 //   SELECT CASE WHEN t #>> 'a.b' = 10 THEN 1 ELSE 0 END -- only when the leaf has a NULL row;
 //     FROM t;                                           --   reproduces on plain columns too (general 3VL bug)
 // And this one escapes as an uncaught C++ exception rather than a cursor error:
-//   INSERT INTO t (id, arr[0]) VALUES (1, 1);           -- "basic_string: construction from null is not valid"
+//   INSERT INTO t (id, arr[0]) VALUES (1, 1);           -- "basic_string: construction from null is not valid" [C4]
+//
+// FIXED (were crashes/wrong results, now pinned as correct below):
+//   [A] get_str_value hardening — a cast key is transparent, a NULL key is a clean
+//       error, and neither `t -> (1::bool)` nor `t ->> NULL` crashes any more.
 
 #include "test_config.hpp"
 #include <catch2/catch_test_macros.hpp>
@@ -802,19 +804,60 @@ TEST_CASE("integration::cpp::test_jsonb_support::bug_missing_key_errors_instead_
     CHECK_FALSE(exec(d, "SELECT id FROM jp.t WHERE t #>> 'a.b' IS NULL;")->is_success()); // correct: row 4
 }
 
-// Any cast on the right of a navigation operator is treated as a boolean cast:
-// the key becomes the string "false" (or "true"), so `t ->> ('x'::text)` looks
-// for a column named "false". The bool cast itself segfaults (see header).
-TEST_CASE("integration::cpp::test_jsonb_support::bug_cast_key_is_treated_as_boolean") {
-    auto config = make_test_config("/tmp/test_jsonb_matrix/cast_key");
+// [A] The key operand of a jsonb operator is a literal: a bare string/number, a
+// cast of one, or NULL. A cast is transparent (it names the same key as the bare
+// literal), a numeric key is stringified, a NULL key is a clean error, and none
+// of these crash the process — the three things get_str_value used to get wrong.
+TEST_CASE("integration::cpp::test_jsonb_support::key_operand_literals") {
+    auto config = make_test_config("/tmp/test_jsonb_matrix/key_operand");
     test_spaces space(config);
     auto* d = space.dispatcher();
     seed(d);
 
-    auto cur = exec(d, "SELECT t ->> ('x'::text) AS v FROM jp.t;");
-    REQUIRE_FALSE(cur->is_success()); // correct: same as t ->> 'x'
-    // the key was rewritten to the literal "false"
-    CHECK(std::string(cur->get_error().what).find("false") != std::string::npos);
+    SECTION("a cast on a scalar key names the same column as the bare key") {
+        // ->> takes a single key: ('x'::text) is exactly 'x'.
+        auto cast = exec(d, "SELECT id, t ->> ('x'::text) AS v FROM jp.t ORDER BY id;");
+        REQUIRE(cast->is_success());
+        CHECK(str(cast, "v", 0) == "p");
+        CHECK(str(cast, "v", 1) == "q");
+        CHECK(is_null(cast, "v", 2));
+        // identical to the un-cast spelling
+        auto plain = exec(d, "SELECT id, t ->> 'x' AS v FROM jp.t ORDER BY id;");
+        REQUIRE(plain->is_success());
+        CHECK(str(plain, "v", 0) == "p");
+    }
+
+    SECTION("a cast on a path key splits into segments just like the bare path") {
+        // #>> takes a whole path: ('a.b'::text) splits to a/b.
+        auto cast = exec(d, "SELECT id, t #>> ('a.b'::text) AS v FROM jp.t ORDER BY id;");
+        REQUIRE(cast->is_success());
+        CHECK(i64(cast, "v", 0) == 10);
+        CHECK(i64(cast, "v", 1) == 30);
+        // ->> is single-key, so ('a.b'::text) is the literal key "a.b" (no such column)
+        CHECK_FALSE(exec(d, "SELECT t ->> ('a.b'::text) AS v FROM jp.t;")->is_success());
+    }
+
+    SECTION("a cast key composes in every clause the bare key does") {
+        CHECK(ids(exec(d, "SELECT id FROM jp.t WHERE t ? ('x'::text);")) == std::set<int64_t>{1, 2});
+        CHECK(ids(exec(d, "SELECT id FROM jp.t WHERE t #>> ('a.b'::text) = 10;")) == std::set<int64_t>{1});
+    }
+
+    SECTION("a NULL key is a clean error, not a crash") {
+        auto cur = exec(d, "SELECT t ->> NULL FROM jp.t;");
+        REQUIRE_FALSE(cur->is_success());
+        CHECK(std::string(cur->get_error().what).find("NULL") != std::string::npos);
+        CHECK_FALSE(exec(d, "SELECT t #>> NULL FROM jp.t;")->is_success());
+        CHECK_FALSE(exec(d, "SELECT id FROM jp.t WHERE t ? NULL;")->is_success());
+    }
+
+    SECTION("a non-string cast key resolves to its value and never crashes") {
+        // (1::bool) used to segfault; now the key is the text "1" (no such column).
+        // Scalar form errors cleanly; the table-valued form is covered by the
+        // zero-match-expand case. Either way: no crash.
+        CHECK_FALSE(exec(d, "SELECT t ->> (1::bool) AS v FROM jp.t;")->is_success());
+        auto expand = exec(d, "SELECT t -> (1::bool) FROM jp.t;");
+        REQUIRE(expand->is_success()); // key "1" matches nothing -> zero-match expand
+    }
 }
 
 // A cast over a navigated value does not convert it: ::text on an integer leaf

--- a/services/dispatcher/validate_logical_plan.cpp
+++ b/services/dispatcher/validate_logical_plan.cpp
@@ -1842,6 +1842,19 @@ namespace services::dispatcher {
                                         cols.emplace_back(std::move(out), std::move(alias));
                                     }
                                 }
+                                // Expand names a specific object: a key matching no
+                                // column is a "path not found" error, the same as the
+                                // scalar form ('->>'/'#>>'), never a select item that
+                                // silently vanishes and hands the caller fewer columns.
+                                // (Delete-to-empty is legal — it yields the empty object
+                                // '{}' — so this guard is expand-only.)
+                                if (is_expand && cols.empty()) {
+                                    return core::error_t(core::error_code_t::schema_error,
+                                                         std::pmr::string{(std::string{"jsonb expand: path '"} +
+                                                                           prefix + "' matches no column")
+                                                                              .c_str(),
+                                                                          resource});
+                                }
                                 exprs.erase(exprs.begin() + static_cast<ptrdiff_t>(ei));
                                 for (size_t j = 0; j < cols.size(); j++) {
                                     components::expressions::key_t out_key(resource, cols[j].first.c_str());

--- a/services/dispatcher/validate_logical_plan.cpp
+++ b/services/dispatcher/validate_logical_plan.cpp
@@ -1802,6 +1802,26 @@ namespace services::dispatcher {
                                 }
                                 const std::string prefix = se->key().as_string();
                                 const std::string prefix_slash = prefix + "/";
+                                // A jsonb operator 'base OP path' works on the columns of
+                                // ONE table — the base. In a join the two sides share
+                                // subtree names (both l and m may carry "d/e"), so the
+                                // base's side is what disambiguates: without it the loop
+                                // matched columns from both sides and every produced
+                                // get_field became ambiguous ("path not found"). The array
+                                // delete form keeps its side on the params, not key().
+                                components::expressions::side_t op_side = se->key().side();
+                                if (se->key().is_null()) {
+                                    for (const auto& p : se->params()) {
+                                        if (std::holds_alternative<components::expressions::key_t>(p)) {
+                                            op_side = std::get<components::expressions::key_t>(p).side();
+                                            break;
+                                        }
+                                    }
+                                }
+                                auto on_op_side = [&](const type_from_t& sc) {
+                                    return op_side == side_t::undefined || sc.side == side_t::undefined ||
+                                           sc.side == op_side;
+                                };
                                 // Delete may carry several prefixes: key() plus any
                                 // key_t params (the multi-key form `jsonb - text[]`).
                                 // A column survives only if it is under NONE of them.
@@ -1828,7 +1848,7 @@ namespace services::dispatcher {
                                 // (output_name, source_alias) pairs
                                 std::vector<std::pair<std::string, std::string>> cols;
                                 for (const auto& sc : incoming_schema) {
-                                    if (!sc.type.has_alias()) {
+                                    if (!sc.type.has_alias() || !on_op_side(sc)) {
                                         continue;
                                     }
                                     std::string alias(sc.type.alias());
@@ -1859,6 +1879,9 @@ namespace services::dispatcher {
                                 for (size_t j = 0; j < cols.size(); j++) {
                                     components::expressions::key_t out_key(resource, cols[j].first.c_str());
                                     components::expressions::key_t src_key(resource, cols[j].second.c_str());
+                                    // Carry the base's side so the shared subtree name
+                                    // resolves back to the side the operator named.
+                                    src_key.set_side(op_side);
                                     exprs.insert(
                                         exprs.begin() + static_cast<ptrdiff_t>(ei + j),
                                         make_scalar_expression(resource, scalar_type::get_field, out_key, src_key));

--- a/services/dispatcher/validate_logical_plan.cpp
+++ b/services/dispatcher/validate_logical_plan.cpp
@@ -1349,6 +1349,9 @@ namespace services::dispatcher {
         std::pmr::vector<complex_logical_type> encountered_types{resource};
         std::set<std::string> table_dbnames;
         core::error_t result = core::error_t::no_error();
+        // 'g' once the VALUES target is a schemaless computing table (see the
+        // NA-column drop after chunk reconciliation below).
+        char insert_target_relkind = 0;
 
         auto check_node = [&](node_t* node) {
             // Drop-nodes skip existence + type collection here.
@@ -1367,6 +1370,7 @@ namespace services::dispatcher {
                                            std::pmr::string{"collection does not exist", resource});
                     return false;
                 }
+                insert_target_relkind = tbl->relkind;
                 if (tbl->relkind != 'g') {
                     for (const auto& column : tbl->columns) {
                         encountered_types.emplace_back(column.type);
@@ -1515,6 +1519,21 @@ namespace services::dispatcher {
                                            "missing type conversion in dispatcher_t::check_collections_format_");
                                 }
                             }
+                        }
+                        // A column still typed NA after reconciliation carries no
+                        // storable type. On a schemaless computing table that is an
+                        // absent key (every row null), not a real column, and handing
+                        // an all-NA column to storage segfaults the append. A declared
+                        // table never reaches here NA — its columns are typed by the
+                        // schema — so drop such columns only for a computing target.
+                        if (insert_target_relkind == 'g') {
+                            auto& cols = chunk.data;
+                            cols.erase(std::remove_if(cols.begin(),
+                                                      cols.end(),
+                                                      [](const components::vector::vector_t& c) {
+                                                          return c.type().type() == logical_type::NA;
+                                                      }),
+                                       cols.end());
                         }
                     }
                 }

--- a/services/dispatcher/validate_logical_plan.cpp
+++ b/services/dispatcher/validate_logical_plan.cpp
@@ -428,6 +428,34 @@ namespace services::dispatcher {
                     variants.push_back(c.type);
                 }
             }
+            if (variants.empty() && key.absent_ok()) {
+                // A jsonb existence key ('?'/'?|'/'?&') that matches no column
+                // exactly. Postgres 3VL, over the flattened representation:
+                //   - an INTERMEDIATE object key (a prefix of one or more stored
+                //     columns, e.g. 'a' with columns a/b, a/c) is PRESENT iff a
+                //     child is non-null -> OR/AND of the per-child null checks;
+                //   - a truly ABSENT key is present for no row -> constant false
+                //     (is_not_null) / true (is_null), so one missing key can never
+                //     poison a '?|' any-of that another key already satisfies.
+                const std::string prefix_slash = name + "/";
+                std::vector<components::expressions::key_t> children;
+                for (const auto& c : schema) {
+                    if (c.type.has_alias() && std::string(c.type.alias()).rfind(prefix_slash, 0) == 0) {
+                        components::expressions::key_t ckey(resource, std::string(c.type.alias()));
+                        ckey.set_side(key.side());
+                        children.push_back(std::move(ckey));
+                    }
+                }
+                if (children.empty()) {
+                    return make_compare_expression(resource, is_nn ? compare_type::all_false : compare_type::all_true);
+                }
+                auto combined =
+                    make_compare_union_expression(resource, is_nn ? compare_type::union_or : compare_type::union_and);
+                for (auto& ckey : children) {
+                    combined->append_child(make_compare_expression(resource, cmp->type(), ckey, cmp->right()));
+                }
+                return combined;
+            }
             if (variants.size() <= 1) {
                 return expr; // single-type (or unknown) — leave as-is
             }

--- a/services/dispatcher/validate_logical_plan.cpp
+++ b/services/dispatcher/validate_logical_plan.cpp
@@ -1774,6 +1774,29 @@ namespace services::dispatcher {
                                 }
                                 const std::string prefix = se->key().as_string();
                                 const std::string prefix_slash = prefix + "/";
+                                // Delete may carry several prefixes: key() plus any
+                                // key_t params (the multi-key form `jsonb - text[]`).
+                                // A column survives only if it is under NONE of them.
+                                std::vector<std::string> del_prefixes;
+                                if (is_delete) {
+                                    if (!se->key().is_null()) {
+                                        del_prefixes.push_back(prefix);
+                                    }
+                                    for (const auto& p : se->params()) {
+                                        if (std::holds_alternative<components::expressions::key_t>(p)) {
+                                            del_prefixes.push_back(
+                                                std::get<components::expressions::key_t>(p).as_string());
+                                        }
+                                    }
+                                }
+                                auto under_any = [&](const std::string& alias) {
+                                    for (const auto& pfx : del_prefixes) {
+                                        if (alias == pfx || alias.rfind(pfx + "/", 0) == 0) {
+                                            return true;
+                                        }
+                                    }
+                                    return false;
+                                };
                                 // (output_name, source_alias) pairs
                                 std::vector<std::pair<std::string, std::string>> cols;
                                 for (const auto& sc : incoming_schema) {
@@ -1781,12 +1804,11 @@ namespace services::dispatcher {
                                         continue;
                                     }
                                     std::string alias(sc.type.alias());
-                                    const bool under = alias == prefix || alias.rfind(prefix_slash, 0) == 0;
                                     if (is_delete) {
-                                        if (!under) {
+                                        if (!under_any(alias)) {
                                             cols.emplace_back(alias, alias);
                                         }
-                                    } else if (under) {
+                                    } else if (alias == prefix || alias.rfind(prefix_slash, 0) == 0) {
                                         std::string out = alias == prefix ? prefix.substr(prefix.find_last_of('/') + 1)
                                                                           : alias.substr(prefix_slash.size());
                                         cols.emplace_back(std::move(out), std::move(alias));

--- a/services/dispatcher/validate_logical_plan.cpp
+++ b/services/dispatcher/validate_logical_plan.cpp
@@ -1628,6 +1628,28 @@ namespace services::dispatcher {
                     }
                 }
 
+                // Table-valued jsonb operators ('->'/'#>' expand, '-'/'#-' delete)
+                // are lowered to per-column get_field only on the non-GROUP-BY path.
+                // With a GROUP BY (or a bare aggregate, which also routes here) they
+                // are never expanded, so an un-expanded jsonb_expand/jsonb_delete would
+                // reach physical execution and crash. Reject them cleanly instead —
+                // expanding one row into several columns has no meaning under grouping.
+                if (node_group && node_select) {
+                    for (const auto& expr : node_select->expressions()) {
+                        if (expr->group() != expression_group::scalar) {
+                            continue;
+                        }
+                        auto* se = reinterpret_cast<scalar_expression_t*>(expr.get());
+                        if (se->type() == scalar_type::jsonb_expand || se->type() == scalar_type::jsonb_delete) {
+                            return core::error_t(
+                                core::error_code_t::schema_error,
+                                std::pmr::string{"table-valued jsonb operator ('->'/'#>'/'-'/'#-') "
+                                                 "is not supported with GROUP BY or aggregation",
+                                                 resource});
+                        }
+                    }
+                }
+
                 if (node_data) {
                     auto node_data_res = validate_schema(resource, idx, node_data, parameters);
                     if (node_data_res.has_error()) {


### PR DESCRIPTION
## Summary

The jsonb operators added in #499 (`->` `->>` `#>` `#>>` `?` `?|` `?&` `-` `#-`)
are implemented in the transformer as name-mangling over the flattened columns of
a schemaless *computing* table:

```sql
CREATE TABLE db.t ();                                  -- computing table, relkind 'g'
INSERT INTO db.t (id, a.b, a.c, x) VALUES (1, 10, 20, 'p'), (2, 30, 40, 'q');
-- storage is four plain columns: id, "a/b", "a/c", x
SELECT t #>> 'a.b' FROM db.t;                          -- get_field projection on "a/b"
```

This surface had several crashes, silent wrong results and a shared design flaw
(the path↔column mapping was re-implemented in three disagreeing places). This PR
fixes ten of them. Each fix flips a pinned assertion in
`integration/cpp/test/test_jsonb_support.cpp` (29 cases / 641 assertions, green),
and the full insert / update / index / sql / params / projection / streaming /
subqueries / list_array / computed_schema regression stays green.

Unless noted, examples assume the table above.

---

### 1. Operator key/path operand crashes and mis-parses

```sql
SELECT t ->> NULL FROM db.t;            -- SIGSEGV
SELECT t -> (1::bool) FROM db.t;        -- SIGSEGV
SELECT t ->> ('x'::text) FROM db.t;     -- looks for a column named "false"
```

The operand reader collapsed *every* cast to a boolean and dereferenced a
non-string cast argument as a `char*`; a `NULL` operand was dereferenced too.

**Fix:** `get_str_value` now recurses through a cast to its underlying literal
(`'x'::text` → the key `x`, `5::bigint` → `"5"`), stringifies a numeric key, and
returns a clean error for a `NULL` key. No operand shape is reinterpreted as the
wrong node type.

### 2. INSERT dropped interior path segments (one path↔column codec)

```sql
INSERT INTO db.d (p.q.r.s) VALUES (222);   -- stored as "p/s", not "p/q/r/s"
SELECT d #>> 'p.q.r.s' FROM db.d;          -- the path just written is unreadable
```

The write side and the read side used different, disagreeing path-flattening code,
and the write side kept only the first and last segment.

**Fix:** introduce a single path↔column codec (`components/expressions/jsonb_path.hpp`)
that owns both the split (operand → segments) and the join (segments → `a/b/c`
name), shared by navigation, existence and the INSERT flattener. Every interior
segment is kept and the path written round-trips. A subscript target
(`arr[0]` → `arr/0`) is rendered instead of throwing.

### 3. Text-array key deletion was a silent no-op

```sql
SELECT t - '{x,a}' FROM db.t;    -- removed nothing; only `- 'x'` (single key) worked
```

**Fix:** support the postgres `jsonb - text[]` form; each listed key becomes a
delete prefix and all of them are removed.

### 4. Existence over a missing key was a hard error

```sql
SELECT id FROM db.t WHERE t ? 'nokey';        -- error "path not found" (want: no rows)
SELECT id FROM db.t WHERE t ?| '{x,nokey}';   -- error: one absent key poisons the any-of
```

Existence reused the navigation resolver, so a key naming no column errored instead
of answering the existence question, and one absent key poisoned a `?|` that another
key already satisfied.

**Fix:** SQL three-valued logic. A key that matches no column folds to constant
false, so it can never poison a `?|`; an intermediate object key (a prefix of one or
more stored columns) is present iff a child is non-null. Scoped to existence keys —
a mistyped regular column in `IS NULL` still errors.

### 5. Zero-match expand silently dropped the select item

```sql
SELECT t -> 'nokey', x FROM db.t;    -- returns ONE column (x); the expand vanished
```

An expand that matched no column erased its select item and inserted nothing, so the
caller got fewer columns than it asked for, with no error.

**Fix:** a zero-match expand is the same "path not found" error the scalar form
(`->>`/`#>>`) already raises. (Deleting every key still yields the empty object, so
the guard is expand-only.)

### 6. Expand and delete were side-blind inside a join

```sql
-- l and m both carry a subtree "d"
SELECT m -> 'd' FROM db.l JOIN db.m ON l.k = m.k;   -- error "path not found"
SELECT m - 'd' FROM db.l JOIN db.m ON l.k = m.k;    -- cannot resolve any column
```

Scalar navigation was already side-aware, but expand and delete matched columns by
name across the whole merged join schema, so a subtree name present on both sides was
ambiguous.

**Fix:** scope the pre-expansion to the operator's base side and stamp the produced
columns with it, so a shared subtree name resolves back to the table the operator
named. Single-table queries are unaffected.

### 7. A cast over navigation in arithmetic read uninitialized memory

```sql
SELECT (t #>> 'a.c')::bigint + 1 FROM db.t;   -- per-run garbage, identical on every row
SELECT (t #>> 'a.c')::bigint FROM db.t;       -- correct alone
SELECT (t #>> 'a.c') + 1 FROM db.t;           -- correct alone
```

A cast whose argument was a navigation fell through to the constant-parameter path,
which folded the navigation into an uninitialized parameter.

**Fix:** resolve a cast over a scalar navigation to the same flattened column key a
column cast produces, so the value is read per row.

### 8. NULL into a new computing-table column crashed the insert

```sql
INSERT INTO db.t (a.b, x) VALUES (NULL, 'z');   -- SIGSEGV
```

A `NULL` for a not-yet-existing column built an untyped (NA) column. A declared table
types such a column from its schema, but a computing table has none, so the all-NA
column reached storage and segfaulted the append.

**Fix:** after schema reconciliation, a column still typed NA on a computing-table
target carries no storable type — it is an absent key (every row null) — so drop it.
A column any row gives a concrete value is promoted before this point and kept;
declared tables never reach here NA and are untouched.

### 9. INSERT ... SELECT appended an all-NULL row

```sql
INSERT INTO db.t (id, a.b) SELECT 5, 55;   -- appends a row where id and a/b are NULL
```

The append routes values to columns by name and only worked when the projection
happened to carry the target names. `SELECT 5, 55` produced projection-named columns
that matched no target, so every value was lost.

**Fix:** stamp the target column names onto the streamed columns in target order,
before the append. Scoped to the `SELECT` source; a `VALUES` insert whose columns are
already named is untouched.

### 10. Table-valued operator under GROUP BY segfaulted

```sql
SELECT g, gb -> 'a' FROM db.gb GROUP BY g;   -- SIGSEGV
SELECT gb -> 'a', COUNT(x) FROM db.gb;       -- SIGSEGV (bare aggregate routes here too)
```

Expand and delete are lowered to per-column `get_field` only on the plain SELECT
path. A grouped query (explicit `GROUP BY`, or a bare aggregate) never ran that
lowering, so an un-expanded node reached physical execution and crashed.

**Fix:** reject a table-valued jsonb operator in the select list when the plan has
a group node — expanding one row into several columns has no meaning under
grouping. Scalar navigation, plain `get_field` and genuine aggregates are
unaffected.
