### PR TITLE
fix: SQL three-valued logic for NULL; aggregate FILTER (WHERE p)

### DIFF
--- a/components/index/index.cpp
+++ b/components/index/index.cpp
@@ -78,15 +78,44 @@ namespace components::index {
         assert(resource != nullptr);
     }
 
+    // An index stores exactly the NON-NULL keys of the live rows.
+    //
+    // A NULL key is never stored and is never looked up. This is enforced here, in index_t, rather
+    // than in any single caller, because it is an invariant of the index — not a policy of one write
+    // path. Every mutation and lookup funnels through these entry points, including the two
+    // rehydrate paths that reconstruct an index from disk and bypass index_engine_t entirely.
+    //
+    // The invariant is what SQL requires: a NULL satisfies no value comparison, and the only
+    // predicates the planner routes to an index are eq/lt/lte/gt/gte (IS NULL is answered from the
+    // validity mask, never from an index). So a NULL-free index is a COMPLETE index for every
+    // question an index scan can be asked.
+    //
+    // It is also what keeps the b-tree sound. A NULL key carries logical_type::NA rather than the
+    // column's type, and the concrete indexes cast every key to the column type before storing it —
+    // a cast that throws for NA, inside an actor coroutine that swallows the exception. Admitting a
+    // NULL key therefore corrupts the index (a truncated batch, or, when the NULL arrives first, a
+    // tree of mixed NA/typed keys ordered by a comparator that is not a strict weak ordering).
+    // Keeping NULLs out means the concrete indexes only ever see a key of the column's own type.
+    static bool is_null_key(const value_t& key) { return key.is_null(); }
+
     index_t::range index_t::find(const value_t& value, core::date::timezone_offset_t local_timezone) const {
+        if (is_null_key(value)) {
+            return std::make_pair(cend_impl(), cend_impl()); // NULL matches nothing
+        }
         return find_impl(value, local_timezone);
     }
 
     index_t::range index_t::lower_bound(const value_t& value, core::date::timezone_offset_t local_timezone) const {
+        if (is_null_key(value)) {
+            return std::make_pair(cend_impl(), cend_impl());
+        }
         return lower_bound_impl(value, local_timezone);
     }
 
     index_t::range index_t::upper_bound(const value_t& value, core::date::timezone_offset_t local_timezone) const {
+        if (is_null_key(value)) {
+            return std::make_pair(cend_impl(), cend_impl());
+        }
         return upper_bound_impl(value, local_timezone);
     }
 
@@ -95,14 +124,23 @@ namespace components::index {
     index_t::iterator index_t::cend() const { return cend_impl(); }
 
     auto index_t::insert(value_t key, index_value_t value, core::date::timezone_offset_t local_timezone) -> void {
+        if (is_null_key(key)) {
+            return;
+        }
         return insert_impl(key, std::move(value), local_timezone);
     }
 
     auto index_t::insert(value_t key, int64_t row_index, core::date::timezone_offset_t local_timezone) -> void {
+        if (is_null_key(key)) {
+            return;
+        }
         return insert_impl(key, index_value_t(row_index), local_timezone);
     }
 
     auto index_t::remove(value_t key, core::date::timezone_offset_t local_timezone) -> void {
+        if (is_null_key(key)) {
+            return;
+        }
         remove_impl(key, local_timezone);
     }
 
@@ -133,6 +171,12 @@ namespace components::index {
                                               uint64_t txn_id,
                                               core::date::timezone_offset_t local_timezone) const {
         std::pmr::vector<int64_t> result(resource_);
+
+        // `WHERE indexed_col <op> NULL` is UNKNOWN for every row, so it selects nothing. Answering
+        // it here also keeps a NULL key out of the concrete index's cast, which would throw.
+        if (is_null_key(value)) {
+            return result;
+        }
 
         auto filter = [&](auto begin, auto end) {
             for (auto iter = begin; iter != end; ++iter) {
@@ -196,12 +240,22 @@ namespace components::index {
 
     auto index_t::insert(value_t key, int64_t row_index, uint64_t txn_id, core::date::timezone_offset_t local_timezone)
         -> void {
+        if (is_null_key(key)) {
+            return;
+        }
         insert_txn_impl(std::move(key), row_index, txn_id, local_timezone);
     }
 
     auto
     index_t::mark_delete(value_t key, int64_t row_index, uint64_t txn_id, core::date::timezone_offset_t local_timezone)
         -> void {
+        // Symmetric with insert: a NULL key was never stored, so there is nothing to delete. The
+        // skip must happen here and not below, because the disk-backed hash index records a pending
+        // delete without first looking the key up — it would otherwise queue a delete for a key that
+        // was never written.
+        if (is_null_key(key)) {
+            return;
+        }
         mark_delete_impl(std::move(key), row_index, txn_id, local_timezone);
     }
 

--- a/components/physical_plan/operators/aggregate/grouped_aggregate.cpp
+++ b/components/physical_plan/operators/aggregate/grouped_aggregate.cpp
@@ -250,12 +250,16 @@ namespace components::operators::aggregate {
                                           builtin_agg agg,
                                           const raw_agg_state_t& state,
                                           types::logical_type col_type) {
-        if (!state.initialized) {
-            return types::logical_value_t(resource, types::complex_logical_type{types::logical_type::NA});
+        // COUNT is defined for an empty or all-NULL group: it is 0, never NULL. It must be
+        // answered before the uninitialized-state NULL that every value aggregate returns.
+        // Guard the read explicitly: a state that never counted a row has u64 == 0 by the
+        // union's default initializer, but do not rely on that alone.
+        if (agg == builtin_agg::COUNT) {
+            return types::logical_value_t(resource, state.initialized ? state.u64 : uint64_t{0});
         }
 
-        if (agg == builtin_agg::COUNT) {
-            return types::logical_value_t(resource, state.u64);
+        if (!state.initialized) {
+            return types::logical_value_t(resource, types::complex_logical_type{types::logical_type::NA});
         }
 
         if (agg == builtin_agg::AVG) {

--- a/components/physical_plan/operators/aggregate/grouped_aggregate.hpp
+++ b/components/physical_plan/operators/aggregate/grouped_aggregate.hpp
@@ -18,9 +18,12 @@ namespace components::operators::aggregate {
     builtin_agg classify(const std::string& func_name);
 
     struct raw_agg_state_t {
+        // Exactly one union member may carry a default initializer; it zero-initializes the
+        // shared storage so an aggregate that finalizes without ever seeing a value (e.g. COUNT
+        // over an all-NULL group) reads a deterministic 0 rather than indeterminate bytes.
         union {
             int64_t i64;
-            uint64_t u64;
+            uint64_t u64{0};
             double f64;
         };
         uint64_t count{0};

--- a/components/physical_plan/operators/arithmetic_eval.cpp
+++ b/components/physical_plan/operators/arithmetic_eval.cpp
@@ -1,5 +1,6 @@
 #include "arithmetic_eval.hpp"
 
+#include "compare_3vl.hpp"
 #include <core/result_wrapper.hpp>
 
 namespace components::operators {
@@ -296,10 +297,11 @@ namespace components::operators {
                 return right_rw.convert_error<bool>();
             auto left_val = std::move(left_rw.value());
             auto right_val = std::move(right_rw.value());
-            // A NULL operand makes the comparison UNKNOWN; treat it as false (three-valued
-            // logic, mirroring simple_predicate). This is also what keeps a NULL out of the
-            // type-mismatch cast below: casting to/from an NA-typed NULL is a conversion_failure,
-            // and a CASE-WHEN condition over a nullable column must fall through, not error.
+            // A NULL operand makes the comparison UNKNOWN -- which, as a condition, does not match
+            // (three-valued logic, mirroring simple_predicate). Short-circuit before the
+            // type-coercion below: a NULL carries the NA type, and casting to/from NA is a
+            // conversion_failure -- a CASE-WHEN condition over a nullable column must fall
+            // through, not error.
             if (left_val.is_null() || right_val.is_null()) {
                 return false;
             }
@@ -320,20 +322,16 @@ namespace components::operators {
                     }
                 }
             }
-            auto cmp_result = left_val.compare(right_val);
             switch (cmp->type()) {
                 case expressions::compare_type::gt:
-                    return cmp_result == types::compare_t::more;
                 case expressions::compare_type::gte:
-                    return cmp_result >= types::compare_t::equals;
                 case expressions::compare_type::lt:
-                    return cmp_result == types::compare_t::less;
                 case expressions::compare_type::lte:
-                    return cmp_result <= types::compare_t::equals;
                 case expressions::compare_type::eq:
-                    return cmp_result == types::compare_t::equals;
                 case expressions::compare_type::ne:
-                    return cmp_result != types::compare_t::equals;
+                    // A NULL operand makes the comparison UNKNOWN; a CASE WHEN condition that is
+                    // UNKNOWN does not match (it falls through), so it is not selected.
+                    return types::selects(eval_compare_3vl(cmp->type(), left_val, right_val));
                 default:
                     return false;
             }

--- a/components/physical_plan/operators/arithmetic_eval.cpp
+++ b/components/physical_plan/operators/arithmetic_eval.cpp
@@ -202,7 +202,7 @@ namespace components::operators {
                                 if (matched.has_error()) {
                                     return matched.convert_error<types::logical_value_t>();
                                 }
-                                if (matched.value()) {
+                                if (types::selects(matched.value())) {
                                     return resolve_row_value(resource,
                                                              ops[w * 2 + 1],
                                                              chunk,
@@ -265,57 +265,89 @@ namespace components::operators {
             }
         }
 
-        core::result_wrapper_t<bool> evaluate_row_condition(std::pmr::memory_resource* resource,
-                                                            const expressions::expression_ptr& condition,
-                                                            const vector::data_chunk_t& chunk,
-                                                            const logical_plan::storage_parameters& params,
-                                                            size_t row_idx,
-                                                            core::date::timezone_offset_t session_tz) {
-            if (condition->group() != expressions::expression_group::compare)
-                return false;
+        // Evaluate a CASE WHEN condition in SQL three-valued logic. A WHEN fires only when the
+        // result is definitely TRUE (the caller applies selects()); UNKNOWN and FALSE fall through.
+        core::result_wrapper_t<types::tri_bool_t> evaluate_row_condition(
+            std::pmr::memory_resource* resource,
+            const expressions::expression_ptr& condition,
+            const vector::data_chunk_t& chunk,
+            const logical_plan::storage_parameters& params,
+            size_t row_idx,
+            core::date::timezone_offset_t session_tz) {
+            using types::tri_bool_t;
+            if (!condition || condition->group() != expressions::expression_group::compare)
+                return tri_bool_t::unknown;
             auto* cmp = static_cast<const expressions::compare_expression_t*>(condition.get());
 
+            // Boolean combinators fold with three-valued logic. Crucially a NOT (union_not) NEGATES
+            // its child rather than behaving like an OR, and UNKNOWN under NOT stays UNKNOWN -- so a
+            // NULL operand under NOT does not resurrect a match.
             if (cmp->is_union()) {
-                bool is_and = (cmp->type() == expressions::compare_type::union_and);
-                for (auto& child : cmp->children()) {
-                    auto child_result = evaluate_row_condition(resource, child, chunk, params, row_idx, session_tz);
-                    if (child_result.has_error())
-                        return child_result;
-                    if (is_and && !child_result.value())
-                        return false;
-                    if (!is_and && child_result.value())
-                        return true;
+                switch (cmp->type()) {
+                    case expressions::compare_type::union_and: {
+                        tri_bool_t acc = tri_bool_t::yes;
+                        for (const auto& child : cmp->children()) {
+                            auto r = evaluate_row_condition(resource, child, chunk, params, row_idx, session_tz);
+                            if (r.has_error())
+                                return r;
+                            acc = types::tri_and(acc, r.value());
+                            if (acc == tri_bool_t::no)
+                                return acc;
+                        }
+                        return acc;
+                    }
+                    case expressions::compare_type::union_or: {
+                        tri_bool_t acc = tri_bool_t::no;
+                        for (const auto& child : cmp->children()) {
+                            auto r = evaluate_row_condition(resource, child, chunk, params, row_idx, session_tz);
+                            if (r.has_error())
+                                return r;
+                            acc = types::tri_or(acc, r.value());
+                            if (acc == tri_bool_t::yes)
+                                return acc;
+                        }
+                        return acc;
+                    }
+                    case expressions::compare_type::union_not: {
+                        if (cmp->children().empty())
+                            return tri_bool_t::unknown;
+                        auto r =
+                            evaluate_row_condition(resource, cmp->children().front(), chunk, params, row_idx, session_tz);
+                        if (r.has_error())
+                            return r;
+                        return types::tri_not(r.value());
+                    }
+                    default:
+                        return tri_bool_t::unknown;
                 }
-                return is_and;
             }
 
             auto left_rw = resolve_row_value(resource, cmp->left(), chunk, params, row_idx, session_tz);
             if (left_rw.has_error())
-                return left_rw.convert_error<bool>();
+                return left_rw.convert_error<types::tri_bool_t>();
             auto right_rw = resolve_row_value(resource, cmp->right(), chunk, params, row_idx, session_tz);
             if (right_rw.has_error())
-                return right_rw.convert_error<bool>();
+                return right_rw.convert_error<types::tri_bool_t>();
             auto left_val = std::move(left_rw.value());
             auto right_val = std::move(right_rw.value());
-            // A NULL operand makes the comparison UNKNOWN -- which, as a condition, does not match
-            // (three-valued logic, mirroring simple_predicate). Short-circuit before the
-            // type-coercion below: a NULL carries the NA type, and casting to/from NA is a
-            // conversion_failure -- a CASE-WHEN condition over a nullable column must fall
-            // through, not error.
+            // A NULL operand makes the comparison UNKNOWN (three-valued logic, mirroring
+            // simple_predicate). Short-circuit before the type-coercion below: a NULL carries the
+            // NA type, and casting to/from NA is a conversion_failure -- a CASE-WHEN condition
+            // over a nullable column must fall through, not error.
             if (left_val.is_null() || right_val.is_null()) {
-                return false;
+                return tri_bool_t::unknown;
             }
             if (left_val.type() != right_val.type()) {
                 auto cast_right = right_val.cast_as(left_val.type(), session_tz);
                 if (cast_right.has_error()) {
-                    return cast_right.convert_error<bool>();
+                    return cast_right.convert_error<types::tri_bool_t>();
                 }
                 if (!cast_right.value().is_null()) {
                     right_val = std::move(cast_right.value());
                 } else {
                     auto cast_left = left_val.cast_as(right_val.type(), session_tz);
                     if (cast_left.has_error()) {
-                        return cast_left.convert_error<bool>();
+                        return cast_left.convert_error<types::tri_bool_t>();
                     }
                     if (!cast_left.value().is_null()) {
                         left_val = std::move(cast_left.value());
@@ -329,12 +361,90 @@ namespace components::operators {
                 case expressions::compare_type::lte:
                 case expressions::compare_type::eq:
                 case expressions::compare_type::ne:
-                    // A NULL operand makes the comparison UNKNOWN; a CASE WHEN condition that is
-                    // UNKNOWN does not match (it falls through), so it is not selected.
-                    return types::selects(eval_compare_3vl(cmp->type(), left_val, right_val));
+                    return eval_compare_3vl(cmp->type(), left_val, right_val);
                 default:
-                    return false;
+                    return tri_bool_t::unknown;
             }
+        }
+
+        // Best-effort STATIC type of a CASE branch (a THEN or ELSE operand), resolved from the
+        // chunk's column types / bound parameters -- WITHOUT evaluating any row. Needed to type the
+        // output vector when NO row produces a value (an all-NULL CASE column must still carry the
+        // branch's type; the unsized NA sentinel would bad_alloc on vector construction). Returns NA
+        // only when the type genuinely cannot be determined.
+        static types::complex_logical_type branch_static_type(const expressions::param_storage& param,
+                                                              const vector::data_chunk_t& chunk,
+                                                              const logical_plan::storage_parameters& params) {
+            using types::complex_logical_type;
+            using types::logical_type;
+            if (std::holds_alternative<expressions::key_t>(param)) {
+                auto& key = std::get<expressions::key_t>(param);
+                if (!key.path().empty()) {
+                    if (auto* vec = chunk.at(key.path())) {
+                        return vec->type();
+                    }
+                }
+                return complex_logical_type(logical_type::NA);
+            } else if (std::holds_alternative<core::parameter_id_t>(param)) {
+                auto it = params.parameters.find(std::get<core::parameter_id_t>(param));
+                if (it != params.parameters.end()) {
+                    return it->second.type();
+                }
+                return complex_logical_type(logical_type::NA);
+            }
+            auto& expr_ptr = std::get<expressions::expression_ptr>(param);
+            if (expr_ptr && expr_ptr->group() == expressions::expression_group::scalar) {
+                auto* scalar = static_cast<const expressions::scalar_expression_t*>(expr_ptr.get());
+                if (scalar->type() == expressions::scalar_type::case_expr) {
+                    // Nested CASE: take the first branch (THEN, then ELSE) whose type is knowable.
+                    auto& ops = scalar->params();
+                    bool nested_default = (ops.size() % 2 == 1);
+                    size_t nested_whens = ops.size() / 2;
+                    for (size_t w = 0; w < nested_whens; ++w) {
+                        auto t = branch_static_type(ops[w * 2 + 1], chunk, params);
+                        if (t.type() != logical_type::NA) {
+                            return t;
+                        }
+                    }
+                    if (nested_default && !ops.empty()) {
+                        auto t = branch_static_type(ops.back(), chunk, params);
+                        if (t.type() != logical_type::NA) {
+                            return t;
+                        }
+                    }
+                    return complex_logical_type(logical_type::NA);
+                }
+                // unary_minus preserves its operand's type.
+                if (scalar->type() == expressions::scalar_type::unary_minus && !scalar->params().empty()) {
+                    auto t = branch_static_type(scalar->params()[0], chunk, params);
+                    if (t.type() != logical_type::NA) {
+                        return t;
+                    }
+                }
+                // Binary arithmetic (add/subtract/multiply/divide/mod): the result type follows the
+                // SAME numeric-promotion / temporal rules the arithmetic kernels apply
+                // (types::arithmetic_result_type), so e.g. INT * DOUBLE resolves to DOUBLE rather
+                // than the first operand's INT.
+                vector::arithmetic_op aop;
+                if (scalar_to_arithmetic_op(scalar->type(), aop) && scalar->params().size() >= 2) {
+                    auto lt = branch_static_type(scalar->params()[0], chunk, params);
+                    auto rt = branch_static_type(scalar->params()[1], chunk, params);
+                    auto res = types::arithmetic_result_type(lt.type(), rt.type(), aop);
+                    if (res != logical_type::NA) {
+                        return complex_logical_type(res);
+                    }
+                }
+                // Fallback for any other scalar shape: the first typeable operand, else BIGINT (the
+                // arithmetic evaluator's own default).
+                if (!scalar->params().empty()) {
+                    auto t = branch_static_type(scalar->params()[0], chunk, params);
+                    if (t.type() != logical_type::NA) {
+                        return t;
+                    }
+                }
+                return complex_logical_type(logical_type::BIGINT);
+            }
+            return complex_logical_type(logical_type::NA);
         }
 
         core::result_wrapper_t<vector::vector_t>
@@ -347,32 +457,26 @@ namespace components::operators {
             bool has_default = (operands.size() % 2 == 1);
             size_t num_whens = operands.size() / 2;
 
-            // Determine result type from first matching value for row 0
+            // The CASE output type is the type of its THEN/ELSE branches, determined STATICALLY from
+            // column / parameter types -- so it is independent of WHICH row matches (and thus stable
+            // whether or not row 0 happens to take the ELSE), and well-defined even when a matched
+            // value is NULL. Prefer the THEN branches, then ELSE. (The previous code typed from the
+            // first THEN evaluated at row 0; resolving it statically reproduces that type while also
+            // covering the NULL-row-0 and all-NULL cases that would otherwise bad_alloc on an unsized
+            // NA-typed vector.)
             types::complex_logical_type result_type(types::logical_type::NA);
-            if (count > 0) {
-                // Try first THEN result
-                auto val = resolve_row_value(resource, operands[1], chunk, params, 0, session_tz);
-                if (val.has_error()) {
-                    return val.convert_error<vector::vector_t>();
-                }
-                result_type = val.value().type();
+            for (size_t w = 0; w < num_whens && result_type.type() == types::logical_type::NA; ++w) {
+                result_type = branch_static_type(operands[w * 2 + 1], chunk, params);
+            }
+            if (result_type.type() == types::logical_type::NA && has_default) {
+                result_type = branch_static_type(operands.back(), chunk, params);
             }
 
-            vector::vector_t output(resource, result_type, count);
-
-            auto coerce_to_result = [&](types::logical_value_t val) -> types::logical_value_t {
-                if (!val.is_null() && val.type() != result_type) {
-                    auto casted = val.cast_as(result_type, session_tz);
-                    // No error channel here (the lambda yields a value); a non-castable pair falls back to
-                    // the uncoerced value instead of aborting.
-                    if (!casted.has_error() && !casted.value().is_null()) {
-                        return std::move(casted.value());
-                    }
-                }
-                return val;
-            };
-
+            // First pass: compute each row's result value.
+            std::pmr::vector<types::logical_value_t> results(resource);
+            results.reserve(count);
             for (uint64_t i = 0; i < count; i++) {
+                types::logical_value_t row_val(resource, types::complex_logical_type{types::logical_type::NA});
                 bool matched = false;
                 for (size_t w = 0; w < num_whens; w++) {
                     auto& cond_param = operands[w * 2];
@@ -382,13 +486,14 @@ namespace components::operators {
                         if (cond.has_error()) {
                             return cond.convert_error<vector::vector_t>();
                         }
-                        if (cond.value()) {
+                        // A WHEN fires only on a definite TRUE; UNKNOWN / FALSE fall through.
+                        if (types::selects(cond.value())) {
                             auto resolved =
                                 resolve_row_value(resource, operands[w * 2 + 1], chunk, params, i, session_tz);
                             if (resolved.has_error()) {
                                 return resolved.convert_error<vector::vector_t>();
                             }
-                            output.set_value(i, coerce_to_result(std::move(resolved.value())));
+                            row_val = std::move(resolved.value());
                             matched = true;
                             break;
                         }
@@ -399,9 +504,44 @@ namespace components::operators {
                     if (resolved.has_error()) {
                         return resolved.convert_error<vector::vector_t>();
                     }
-                    output.set_value(i, coerce_to_result(std::move(resolved.value())));
-                } else if (!matched) {
+                    row_val = std::move(resolved.value());
+                }
+                // Refinement: if the branches were statically untypeable (NA), learn the type from
+                // the first row that produces one. A typed NULL (e.g. a NULL read from a BIGINT
+                // column) still carries its type, so learn from row_val.type() rather than gating on
+                // is_null().
+                if (result_type.type() == types::logical_type::NA &&
+                    row_val.type().type() != types::logical_type::NA) {
+                    result_type = row_val.type();
+                }
+                results.emplace_back(std::move(row_val));
+            }
+
+            // Last resort (e.g. a bare `THEN NULL` over an empty/all-NULL set): a concrete,
+            // allocatable, nullable type so vector construction never faults on the unsized NA
+            // sentinel. Every value is NULL here, so the choice is immaterial to results.
+            if (result_type.type() == types::logical_type::NA) {
+                result_type = types::complex_logical_type(types::logical_type::BIGINT);
+            }
+
+            // Second pass: build the typed output, coercing each value to the common result type.
+            vector::vector_t output(resource, result_type, count);
+            for (uint64_t i = 0; i < count; i++) {
+                if (results[i].is_null()) {
                     output.set_null(i, true);
+                    continue;
+                }
+                if (results[i].type() != result_type) {
+                    auto casted = results[i].cast_as(result_type, session_tz);
+                    // No error channel would help here (the row already produced a value); a
+                    // non-castable pair keeps the uncoerced value instead of aborting.
+                    if (!casted.has_error() && !casted.value().is_null()) {
+                        output.set_value(i, std::move(casted.value()));
+                    } else {
+                        output.set_value(i, results[i]);
+                    }
+                } else {
+                    output.set_value(i, results[i]);
                 }
             }
             return output;

--- a/components/physical_plan/operators/arithmetic_eval.hpp
+++ b/components/physical_plan/operators/arithmetic_eval.hpp
@@ -5,6 +5,7 @@
 #include <components/expressions/compare_expression.hpp>
 #include <components/expressions/scalar_expression.hpp>
 #include <components/logical_plan/param_storage.hpp>
+#include <components/types/tri_bool.hpp>
 #include <components/vector/arithmetic.hpp>
 #include <deque>
 
@@ -38,9 +39,10 @@ namespace components::operators {
                           size_t row_idx,
                           core::date::timezone_offset_t session_tz);
 
-        // Evaluate a compare_expression for a specific row.
+        // Evaluate a CASE WHEN condition for a specific row in SQL three-valued logic (TRUE / FALSE /
+        // UNKNOWN); the caller applies selects() -- a WHEN fires only on a definite TRUE.
         // On failure returns the error via result_wrapper_t (never throws).
-        [[nodiscard]] core::result_wrapper_t<bool>
+        [[nodiscard]] core::result_wrapper_t<types::tri_bool_t>
         evaluate_row_condition(std::pmr::memory_resource* resource,
                                const expressions::expression_ptr& condition,
                                const vector::data_chunk_t& chunk,

--- a/components/physical_plan/operators/compare_3vl.hpp
+++ b/components/physical_plan/operators/compare_3vl.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <components/expressions/forward.hpp>
+#include <components/types/logical_value.hpp>
+#include <components/types/tri_bool.hpp>
+
+namespace components::operators {
+
+    // Evaluate a scalar SQL comparison in three-valued logic. A NULL operand makes the comparison
+    // UNKNOWN -- distinct from FALSE -- so a CASE WHEN / HAVING / CHECK over a NULL falls through
+    // (UNKNOWN does not select, and NOT cannot flip it in). This is the shared spelling that keeps
+    // every non-predicate comparison site answering SQL the same way; it must be used instead of
+    // logical_value_t::compare(), whose total order (NULLs last) is for sorting and indexing.
+    inline types::tri_bool_t eval_compare_3vl(expressions::compare_type op,
+                                              const types::logical_value_t& lhs,
+                                              const types::logical_value_t& rhs) {
+        const auto c = lhs.compare_sql(rhs);
+        if (!c) {
+            return types::tri_bool_t::unknown;
+        }
+        switch (op) {
+            case expressions::compare_type::eq:
+                return types::tri_of(*c == types::compare_t::equals);
+            case expressions::compare_type::ne:
+                return types::tri_of(*c != types::compare_t::equals);
+            case expressions::compare_type::gt:
+                return types::tri_of(*c == types::compare_t::more);
+            case expressions::compare_type::gte:
+                return types::tri_of(*c != types::compare_t::less);
+            case expressions::compare_type::lt:
+                return types::tri_of(*c == types::compare_t::less);
+            case expressions::compare_type::lte:
+                return types::tri_of(*c != types::compare_t::more);
+            default:
+                return types::tri_bool_t::unknown;
+        }
+    }
+
+} // namespace components::operators

--- a/components/physical_plan/operators/operator_check_constraint.cpp
+++ b/components/physical_plan/operators/operator_check_constraint.cpp
@@ -109,7 +109,8 @@ namespace components::operators {
             if (expr.empty())
                 return {new predicates::simple_predicate(
                     r,
-                    [](const vector::data_chunk_t&, const vector::data_chunk_t&, size_t, size_t) { return true; })};
+                    [](const vector::data_chunk_t&, const vector::data_chunk_t&, size_t, size_t)
+                        -> core::result_wrapper_t<types::tri_bool_t> { return types::tri_bool_t::yes; })};
 
             // NOT (...)
             if (expr.size() > 5 && expr.substr(0, 5) == "NOT (") {
@@ -170,9 +171,10 @@ namespace components::operators {
                     [col, absent_is_valid](const vector::data_chunk_t& chunk,
                                            const vector::data_chunk_t&,
                                            size_t idx,
-                                           size_t) -> bool {
+                                           size_t) -> core::result_wrapper_t<types::tri_bool_t> {
                         const auto* v = find_col(chunk, col);
-                        return v ? v->validity().row_is_valid(idx) : absent_is_valid;
+                        // IS NOT NULL is a total predicate: a definite TRUE / FALSE, never UNKNOWN.
+                        return types::tri_of(v ? v->validity().row_is_valid(idx) : absent_is_valid);
                     })};
             }
             if (expr.size() > kIsNull.size() && expr.substr(expr.size() - kIsNull.size()) == kIsNull) {
@@ -187,9 +189,9 @@ namespace components::operators {
                     [col, absent_is_null](const vector::data_chunk_t& chunk,
                                           const vector::data_chunk_t&,
                                           size_t idx,
-                                          size_t) -> bool {
+                                          size_t) -> core::result_wrapper_t<types::tri_bool_t> {
                         const auto* v = find_col(chunk, col);
-                        return v ? !v->validity().row_is_valid(idx) : absent_is_null;
+                        return types::tri_of(v ? !v->validity().row_is_valid(idx) : absent_is_null);
                     })};
             }
 
@@ -229,47 +231,50 @@ namespace components::operators {
                     [col_name, const_val, col_is_rhs, op_str, has_def, def_val](const vector::data_chunk_t& chunk,
                                                                                 const vector::data_chunk_t&,
                                                                                 size_t idx,
-                                                                                size_t) -> bool {
-                        // Returns whether the CHECK is satisfied. A CHECK is violated only by a
-                        // definitely-FALSE comparison; a NULL operand makes it UNKNOWN, which passes
-                        // (compare_sql yields nullopt for a NULL operand).
-                        auto satisfied = [&op_str](const types::logical_value_t& lhs,
-                                                   const types::logical_value_t& rhs) -> bool {
+                                                                                size_t)
+                        -> core::result_wrapper_t<types::tri_bool_t> {
+                        // Raw three-valued result of the comparison: a NULL operand is UNKNOWN (not
+                        // pre-folded to "passes"), so that a NOT wrapping it stays UNKNOWN rather
+                        // than flipping to a violation. The consumer applies permits() -- a CHECK is
+                        // violated only by a definitely-FALSE (tri_bool_t::no) result.
+                        auto compare_tri = [&op_str](const types::logical_value_t& lhs,
+                                                     const types::logical_value_t& rhs) -> types::tri_bool_t {
                             const auto c = lhs.compare_sql(rhs);
                             if (!c)
-                                return true;
+                                return types::tri_bool_t::unknown;
                             using Cmp = types::compare_t;
                             if (op_str == ">")
-                                return *c == Cmp::more;
+                                return types::tri_of(*c == Cmp::more);
                             if (op_str == "<")
-                                return *c == Cmp::less;
+                                return types::tri_of(*c == Cmp::less);
                             if (op_str == ">=")
-                                return *c == Cmp::more || *c == Cmp::equals;
+                                return types::tri_of(*c == Cmp::more || *c == Cmp::equals);
                             if (op_str == "<=")
-                                return *c == Cmp::less || *c == Cmp::equals;
+                                return types::tri_of(*c == Cmp::less || *c == Cmp::equals);
                             if (op_str == "=")
-                                return *c == Cmp::equals;
+                                return types::tri_of(*c == Cmp::equals);
                             if (op_str == "<>")
-                                return *c != Cmp::equals;
-                            return true;
+                                return types::tri_of(*c != Cmp::equals);
+                            return types::tri_bool_t::yes; // unreachable operator: do not reject
                         };
                         const auto* vec = find_col(chunk, col_name);
                         if (!vec) {
+                            // Absent column with no default stores NULL -> UNKNOWN (permits passes).
                             if (!has_def)
-                                return true;
-                            return col_is_rhs ? satisfied(const_val, def_val) : satisfied(def_val, const_val);
+                                return types::tri_bool_t::unknown;
+                            return col_is_rhs ? compare_tri(const_val, def_val) : compare_tri(def_val, const_val);
                         }
-                        // vec->value reports NA for a NULL row, so the comparison is UNKNOWN and the
-                        // CHECK passes -- SQL rejects only definitely-FALSE checks.
+                        // vec->value reports NA for a NULL row, so compare_sql yields UNKNOWN.
                         auto col_val = vec->value(idx);
-                        return col_is_rhs ? satisfied(const_val, col_val) : satisfied(col_val, const_val);
+                        return col_is_rhs ? compare_tri(const_val, col_val) : compare_tri(col_val, const_val);
                     })};
             }
 
             // Unrecognised expression — pass.
             return {new predicates::simple_predicate(
                 r,
-                [](const vector::data_chunk_t&, const vector::data_chunk_t&, size_t, size_t) { return true; })};
+                [](const vector::data_chunk_t&, const vector::data_chunk_t&, size_t, size_t)
+                    -> core::result_wrapper_t<types::tri_bool_t> { return types::tri_bool_t::yes; })};
         }
 
     } // anonymous namespace
@@ -391,7 +396,9 @@ namespace components::operators {
             for (const auto& [name, pred] : check_predicates_) {
                 for (uint64_t row = 0; row < chunk.size(); ++row) {
                     auto check_result = pred->check(chunk, row);
-                    if (check_result.has_error() || !check_result.value()) {
+                    // A CHECK is violated only by a definitely-FALSE result; UNKNOWN (a NULL operand,
+                    // even under NOT) permits the row -- SQL rejects only definitely-FALSE checks.
+                    if (check_result.has_error() || !types::permits(check_result.value())) {
                         set_error(
                             core::error_t{core::error_code_t::other_error,
                                           std::pmr::string{"CHECK constraint \"" + name + "\" violated", resource_}});

--- a/components/physical_plan/operators/operator_check_constraint.cpp
+++ b/components/physical_plan/operators/operator_check_constraint.cpp
@@ -230,32 +230,39 @@ namespace components::operators {
                                                                                 const vector::data_chunk_t&,
                                                                                 size_t idx,
                                                                                 size_t) -> bool {
-                        auto apply = [&op_str](types::compare_t cmp) -> bool {
+                        // Returns whether the CHECK is satisfied. A CHECK is violated only by a
+                        // definitely-FALSE comparison; a NULL operand makes it UNKNOWN, which passes
+                        // (compare_sql yields nullopt for a NULL operand).
+                        auto satisfied = [&op_str](const types::logical_value_t& lhs,
+                                                   const types::logical_value_t& rhs) -> bool {
+                            const auto c = lhs.compare_sql(rhs);
+                            if (!c)
+                                return true;
                             using Cmp = types::compare_t;
                             if (op_str == ">")
-                                return cmp == Cmp::more;
+                                return *c == Cmp::more;
                             if (op_str == "<")
-                                return cmp == Cmp::less;
+                                return *c == Cmp::less;
                             if (op_str == ">=")
-                                return cmp == Cmp::more || cmp == Cmp::equals;
+                                return *c == Cmp::more || *c == Cmp::equals;
                             if (op_str == "<=")
-                                return cmp == Cmp::less || cmp == Cmp::equals;
+                                return *c == Cmp::less || *c == Cmp::equals;
                             if (op_str == "=")
-                                return cmp == Cmp::equals;
+                                return *c == Cmp::equals;
                             if (op_str == "<>")
-                                return cmp != Cmp::equals;
+                                return *c != Cmp::equals;
                             return true;
                         };
                         const auto* vec = find_col(chunk, col_name);
                         if (!vec) {
                             if (!has_def)
                                 return true;
-                            return apply(col_is_rhs ? const_val.compare(def_val) : def_val.compare(const_val));
+                            return col_is_rhs ? satisfied(const_val, def_val) : satisfied(def_val, const_val);
                         }
-                        if (!vec->validity().row_is_valid(idx))
-                            return false;
+                        // vec->value reports NA for a NULL row, so the comparison is UNKNOWN and the
+                        // CHECK passes -- SQL rejects only definitely-FALSE checks.
                         auto col_val = vec->value(idx);
-                        return apply(col_is_rhs ? const_val.compare(col_val) : col_val.compare(const_val));
+                        return col_is_rhs ? satisfied(const_val, col_val) : satisfied(col_val, const_val);
                     })};
             }
 

--- a/components/physical_plan/operators/operator_delete.cpp
+++ b/components/physical_plan/operators/operator_delete.cpp
@@ -77,7 +77,8 @@ namespace components::operators {
             if (check_result.has_error()) {
                 return check_result.error();
             }
-            if (!check_result.value()) {
+            // Only a definitely-TRUE predicate deletes the row; UNKNOWN (NULL operand) keeps it.
+            if (!types::selects(check_result.value())) {
                 continue;
             }
             int64_t abs_id;
@@ -211,7 +212,7 @@ namespace components::operators {
                     if (check_result.has_error()) {
                         return check_result.error();
                     }
-                    if (!check_result.value()) {
+                    if (!types::selects(check_result.value())) {
                         continue;
                     }
                     // Storage / index delete keys on the ABSOLUTE table row id of the

--- a/components/physical_plan/operators/operator_group.cpp
+++ b/components/physical_plan/operators/operator_group.cpp
@@ -1,6 +1,7 @@
 #include "operator_group.hpp"
 
 #include "arithmetic_eval.hpp"
+#include "compare_3vl.hpp"
 #include <cassert>
 #include <components/compute/function.hpp>
 #include <components/expressions/compare_expression.hpp>
@@ -60,26 +61,17 @@ namespace components::operators {
                 case group_key_t::kind::case_when: {
                     for (const auto& clause : key.case_clauses) {
                         auto cond_val = chunk.value(clause.condition_col, row_idx);
-                        auto cmp_result = cond_val.compare(clause.condition_value);
-                        bool matches = false;
+                        bool matches;
                         switch (clause.cmp) {
                             case expressions::compare_type::eq:
-                                matches = cmp_result == types::compare_t::equals;
-                                break;
                             case expressions::compare_type::ne:
-                                matches = cmp_result != types::compare_t::equals;
-                                break;
                             case expressions::compare_type::gt:
-                                matches = cmp_result == types::compare_t::more;
-                                break;
                             case expressions::compare_type::gte:
-                                matches = cmp_result >= types::compare_t::equals;
-                                break;
                             case expressions::compare_type::lt:
-                                matches = cmp_result == types::compare_t::less;
-                                break;
                             case expressions::compare_type::lte:
-                                matches = cmp_result <= types::compare_t::equals;
+                                // A NULL operand makes the WHEN condition UNKNOWN -> fall through.
+                                matches = types::selects(
+                                    eval_compare_3vl(clause.cmp, cond_val, clause.condition_value));
                                 break;
                             default:
                                 matches = true;

--- a/components/physical_plan/operators/operator_having.cpp
+++ b/components/physical_plan/operators/operator_having.cpp
@@ -63,15 +63,18 @@ namespace components::operators {
         if (results.has_error()) {
             return results.error();
         }
-        const std::vector<bool>& mask = results.value();
+        const std::vector<types::tri_bool_t>& mask = results.value();
 
         // Build the selection of surviving (predicate-true) rows. The selection MUST be sized to the
         // full input length (set_index is unchecked); only the first out_count slots are filled/read.
+        // HAVING keeps a group only when the predicate is definitely TRUE -- a NULL operand (e.g. an
+        // aggregate over an all-NULL group) yields UNKNOWN, which drops the group, exactly as WHERE
+        // drops an UNKNOWN row.
         vector::indexing_vector_t sel(resource_);
         sel.reset(input.size());
         uint64_t out_count = 0;
         for (uint64_t i = 0; i < input.size(); i++) {
-            if (mask[i]) {
+            if (types::selects(mask[i])) {
                 sel.set_index(out_count, i);
                 out_count++;
             }

--- a/components/physical_plan/operators/operator_join.cpp
+++ b/components/physical_plan/operators/operator_join.cpp
@@ -92,7 +92,9 @@ namespace components::operators {
                 }
                 const auto& mask = results.value();
                 for (uint64_t rj = 0; rj < B.size(); ++rj) {
-                    if (mask[rj]) {
+                    // A join emits a pair only when the ON predicate is definitely TRUE; a NULL join
+                    // key yields UNKNOWN, which does not match.
+                    if (types::selects(mask[rj])) {
                         builder.emit_matched(probe, li, B, rj);
                         matched = true;
                         if (mark_matched) {

--- a/components/physical_plan/operators/operator_lateral_join.cpp
+++ b/components/physical_plan/operators/operator_lateral_join.cpp
@@ -210,7 +210,9 @@ namespace components::operators {
                     }
                     const auto& mask = mask_res.value();
                     for (uint64_t inner_row = 0; inner_row < inner_chunk.size(); ++inner_row) {
-                        if (mask[inner_row]) {
+                        // selects(): only a definite TRUE joins the pair — an UNKNOWN (NULL
+                        // operand) ON result matches nothing, exactly as in operator_join.
+                        if (types::selects(mask[inner_row])) {
                             matched = true;
                             // inner/left emit every matched (outer ++ inner) pair; semi/anti
                             // only need the EXISTENCE of a match, not the matched rows —

--- a/components/physical_plan/operators/operator_match.cpp
+++ b/components/physical_plan/operators/operator_match.cpp
@@ -106,7 +106,9 @@ namespace components::operators {
         }
         int64_t out_count = 0;
         for (size_t i = 0; i < chunk.size(); i++) {
-            if (results.value()[i]) {
+            // WHERE filter: a row is emitted only when the predicate is definitely TRUE. A NULL
+            // operand yields UNKNOWN, which does not select (and NOT does not turn it into TRUE).
+            if (types::selects(results.value()[i])) {
                 for (size_t j : populated_cols) {
                     out_chunk.set_value(j, static_cast<uint64_t>(out_count), chunk.data[j].value(i));
                 }

--- a/components/physical_plan/operators/operator_select.cpp
+++ b/components/physical_plan/operators/operator_select.cpp
@@ -1,6 +1,7 @@
 #include "operator_select.hpp"
 
 #include "arithmetic_eval.hpp"
+#include "compare_3vl.hpp"
 #include <components/expressions/compare_expression.hpp>
 
 namespace components::operators {
@@ -63,29 +64,21 @@ namespace components::operators {
                 case group_key_t::kind::case_when: {
                     for (const auto& clause : key.case_clauses) {
                         const auto cond_val = src.value(clause.condition_col, row_idx);
-                        auto cmp_result = cond_val.compare(clause.condition_value);
-                        bool matches = false;
+                        bool matches;
                         switch (clause.cmp) {
                             case expressions::compare_type::eq:
-                                matches = cmp_result == types::compare_t::equals;
-                                break;
                             case expressions::compare_type::ne:
-                                matches = cmp_result != types::compare_t::equals;
-                                break;
                             case expressions::compare_type::gt:
-                                matches = cmp_result == types::compare_t::more;
-                                break;
                             case expressions::compare_type::gte:
-                                matches = cmp_result >= types::compare_t::equals;
-                                break;
                             case expressions::compare_type::lt:
-                                matches = cmp_result == types::compare_t::less;
-                                break;
                             case expressions::compare_type::lte:
-                                matches = cmp_result <= types::compare_t::equals;
+                                // A NULL operand makes the WHEN condition UNKNOWN, which (like FALSE)
+                                // falls through to the next clause / ELSE.
+                                matches = types::selects(
+                                    eval_compare_3vl(clause.cmp, cond_val, clause.condition_value));
                                 break;
                             default:
-                                matches = true;
+                                matches = true; // an unconditional clause (preserve prior behaviour)
                                 break;
                         }
                         if (matches) {

--- a/components/physical_plan/operators/operator_update.cpp
+++ b/components/physical_plan/operators/operator_update.cpp
@@ -114,7 +114,8 @@ namespace components::operators {
             if (res.has_error()) {
                 return res.error();
             }
-            if (!res.value()) {
+            // Only a definitely-TRUE predicate updates the row; UNKNOWN (NULL operand) skips it.
+            if (!types::selects(res.value())) {
                 continue;
             }
             if (chunk.data.front().get_vector_type() == vector::vector_type::DICTIONARY) {
@@ -216,7 +217,7 @@ namespace components::operators {
                     return results.error();
                 }
                 for (size_t j = 0; j < chunk_right.size(); ++j) {
-                    if (!results.value()[j]) {
+                    if (!types::selects(results.value()[j])) {
                         continue;
                     }
                     // Storage / index update keys on the ABSOLUTE table row id of the

--- a/components/physical_plan/operators/predicates/expression_filter_bridge.cpp
+++ b/components/physical_plan/operators/predicates/expression_filter_bridge.cpp
@@ -65,7 +65,8 @@ namespace components::operators::predicates {
                     create_predicate(resource, &registry_->registry, expression, no_types, no_types, &params_, session_tz);
             }
 
-            core::result_wrapper_t<bool> evaluate(const vector::data_chunk_t& row, size_t index) const override {
+            core::result_wrapper_t<types::tri_bool_t> evaluate(const vector::data_chunk_t& row,
+                                                               size_t index) const override {
                 // predicate::check is non-const; a const intrusive_ptr still yields a mutable pointee
                 // (like a raw pointer), so this stays a const evaluate().
                 return predicate_->check(row, index);

--- a/components/physical_plan/operators/predicates/function_predicate.cpp
+++ b/components/physical_plan/operators/predicates/function_predicate.cpp
@@ -5,59 +5,80 @@ using namespace components;
 using namespace components::operators::predicates;
 
 namespace {
-    // build a chunk of N rows where column c of row k holds the value returned
-    // by arg_getter[c](left, right, left_indices[k], right_indices[k]), types are inferred from the first row.
+    // build a chunk of N rows where column c of row k holds the value returned by
+    // arg_getter[c](left, right, left_indices[k], right_indices[k]). Each column's type is inferred
+    // from its first NON-NULL value across the batch (a NULL row 0 must not poison the column type),
+    // falling back to whatever row 0 reports when the whole column is NULL. `any_arg_null[k]` is set
+    // when any argument of row k is NULL, so the caller can force that row's predicate to UNKNOWN
+    // (predicate functions -- LIKE / regex / comparisons -- are strict: NULL in, UNKNOWN out).
     core::result_wrapper_t<vector::data_chunk_t> build_batch_chunk(std::pmr::memory_resource* resource,
                                                                    const std::pmr::vector<impl::value_getter>& getters,
                                                                    const vector::data_chunk_t& left,
                                                                    const vector::data_chunk_t& right,
                                                                    const vector::indexing_vector_t& left_indices,
                                                                    const vector::indexing_vector_t& right_indices,
-                                                                   uint64_t count) {
+                                                                   uint64_t count,
+                                                                   std::vector<bool>& any_arg_null) {
         const size_t num_args = getters.size();
 
-        std::pmr::vector<types::logical_value_t> first_vals(resource);
-        first_vals.reserve(num_args);
-        for (const auto& getter : getters) {
-            auto res = getter(left, right, left_indices.get_index(0), right_indices.get_index(0));
-            if (res.has_error()) {
-                return res.convert_error<vector::data_chunk_t>();
-            } else {
-                first_vals.emplace_back(std::move(res.value()));
+        // Materialize every argument value first so a column can be typed from its first non-NULL.
+        // The outer container is a plain std::vector (a pmr vector-of-pmr-vectors would drag the
+        // allocator into each element's construction and fail uses-allocator resolution).
+        std::vector<std::pmr::vector<types::logical_value_t>> cols;
+        cols.reserve(num_args);
+        for (size_t c = 0; c < num_args; ++c) {
+            cols.emplace_back(resource);
+            cols[c].reserve(count);
+        }
+        any_arg_null.assign(count, false);
+        for (uint64_t k = 0; k < count; ++k) {
+            for (size_t c = 0; c < num_args; ++c) {
+                auto res = getters[c](left, right, left_indices.get_index(k), right_indices.get_index(k));
+                if (res.has_error()) {
+                    return res.convert_error<vector::data_chunk_t>();
+                }
+                if (res.value().is_null()) {
+                    any_arg_null[k] = true;
+                }
+                cols[c].emplace_back(std::move(res.value()));
             }
         }
 
         std::pmr::vector<types::complex_logical_type> col_types(resource);
         col_types.reserve(num_args);
-        for (const auto& v : first_vals) {
-            col_types.emplace_back(v.type());
+        for (size_t c = 0; c < num_args; ++c) {
+            const types::logical_value_t* typed = nullptr;
+            for (const auto& v : cols[c]) {
+                if (!v.is_null()) {
+                    typed = &v;
+                    break;
+                }
+            }
+            col_types.emplace_back(typed ? typed->type() : cols[c].front().type());
         }
 
         vector::data_chunk_t batch(resource, col_types, count);
-        for (size_t c = 0; c < num_args; ++c) {
-            batch.set_value(static_cast<uint64_t>(c), 0, first_vals[c]);
-        }
-        for (uint64_t k = 1; k < count; ++k) {
+        for (uint64_t k = 0; k < count; ++k) {
             for (size_t c = 0; c < num_args; ++c) {
-                auto res = getters[c](left, right, left_indices.get_index(k), right_indices.get_index(k));
-                if (res.has_error()) {
-                    return res.convert_error<vector::data_chunk_t>();
-                } else {
-                    batch.set_value(static_cast<uint64_t>(c), k, res.value());
-                }
+                batch.set_value(static_cast<uint64_t>(c), k, cols[c][k]);
             }
         }
         batch.set_cardinality(count);
         return batch;
     }
 
-    core::result_wrapper_t<std::vector<bool>>
-    run_batch_and_extract_bools(const compute::function* function, vector::data_chunk_t& batch, size_t N) {
+    // Extract the function's boolean output as a tri-state, forcing UNKNOWN for rows whose input was
+    // NULL (strict predicate) or whose result the function itself returned as NULL.
+    core::result_wrapper_t<std::vector<types::tri_bool_t>> run_batch_and_extract_tri(
+        const compute::function* function,
+        vector::data_chunk_t& batch,
+        size_t N,
+        const std::vector<bool>& any_arg_null) {
         auto res = function->execute(batch);
         if (res.has_error()) {
-            return res.convert_error<std::vector<bool>>();
+            return res.convert_error<std::vector<types::tri_bool_t>>();
         }
-        std::vector<bool> results(N);
+        std::vector<types::tri_bool_t> results(N);
         if (std::holds_alternative<std::pmr::vector<types::logical_value_t>>(res.value())) {
             const auto& values = std::get<std::pmr::vector<types::logical_value_t>>(res.value());
             if (values.size() < N) {
@@ -67,7 +88,8 @@ namespace {
                                      batch.resource()});
             }
             for (size_t k = 0; k < N; ++k) {
-                results[k] = values[k].value<bool>();
+                results[k] = (any_arg_null[k] || values[k].is_null()) ? types::tri_bool_t::unknown
+                                                                      : types::tri_of(values[k].value<bool>());
             }
         } else {
             // vector_function returns data_chunk_t; result column is data[0]
@@ -78,8 +100,10 @@ namespace {
                     std::pmr::string{"batch function predicate: function returned fewer results than inputs",
                                      batch.resource()});
             }
+            const auto& out_col = chunk.data.front();
             for (size_t k = 0; k < N; ++k) {
-                results[k] = chunk.data.front().get_value<bool>(k);
+                const bool null_out = any_arg_null[k] || !out_col.validity().row_is_valid(k);
+                results[k] = null_out ? types::tri_bool_t::unknown : types::tri_of(out_col.get_value<bool>(k));
             }
         }
         return results;
@@ -93,15 +117,17 @@ namespace {
                    const vector::data_chunk_t& right,
                    const vector::indexing_vector_t& left_indices,
                    const vector::indexing_vector_t& right_indices,
-                   uint64_t count) -> core::result_wrapper_t<std::vector<bool>> {
+                   uint64_t count) -> core::result_wrapper_t<std::vector<types::tri_bool_t>> {
             if (count == 0) {
-                return std::vector<bool>{};
+                return std::vector<types::tri_bool_t>{};
             }
-            auto batch = build_batch_chunk(resource, getters, left, right, left_indices, right_indices, count);
+            std::vector<bool> any_arg_null;
+            auto batch =
+                build_batch_chunk(resource, getters, left, right, left_indices, right_indices, count, any_arg_null);
             if (batch.has_error()) {
-                return batch.convert_error<std::vector<bool>>();
+                return batch.convert_error<std::vector<types::tri_bool_t>>();
             } else {
-                return run_batch_and_extract_bools(function, batch.value(), count);
+                return run_batch_and_extract_tri(function, batch.value(), count, any_arg_null);
             }
         };
     }
@@ -115,14 +141,14 @@ namespace components::operators::predicates {
         : func_(std::move(func))
         , batch_func_(std::move(batch_func)) {}
 
-    core::result_wrapper_t<bool> function_predicate::check_impl(const vector::data_chunk_t& chunk_left,
-                                                                const vector::data_chunk_t& chunk_right,
-                                                                size_t index_left,
-                                                                size_t index_right) {
+    core::result_wrapper_t<types::tri_bool_t> function_predicate::check_impl(const vector::data_chunk_t& chunk_left,
+                                                                             const vector::data_chunk_t& chunk_right,
+                                                                             size_t index_left,
+                                                                             size_t index_right) {
         return func_(chunk_left, chunk_right, index_left, index_right);
     }
 
-    core::result_wrapper_t<std::vector<bool>>
+    core::result_wrapper_t<std::vector<types::tri_bool_t>>
     function_predicate::batch_check_impl(const vector::data_chunk_t& left,
                                          const vector::data_chunk_t& right,
                                          const vector::indexing_vector_t& left_indices,
@@ -132,11 +158,11 @@ namespace components::operators::predicates {
             return batch_func_(left, right, left_indices, right_indices, count);
         }
 
-        std::vector<bool> results(count); // fallback: row-by-row via existing closure
+        std::vector<types::tri_bool_t> results(count); // fallback: row-by-row via existing closure
         for (uint64_t k = 0; k < count; ++k) {
             auto res = func_(left, right, left_indices.get_index(k), right_indices.get_index(k));
             if (res.has_error()) {
-                return res.convert_error<std::vector<bool>>();
+                return res.convert_error<std::vector<types::tri_bool_t>>();
             } else {
                 results[k] = res.value();
             }
@@ -158,26 +184,31 @@ namespace components::operators::predicates {
         // copy for batch (original moved into row closure below)
         auto batch_func = make_batch_func(resource, arg_getters, function);
 
-        function_predicate::row_check_fn_t row_func = [resource, arg_getters = std::move(arg_getters), function](
-                                                          const vector::data_chunk_t& left,
-                                                          const vector::data_chunk_t& right,
-                                                          size_t left_index,
-                                                          size_t right_index) -> core::result_wrapper_t<bool> {
+        function_predicate::row_check_fn_t row_func =
+            [resource, arg_getters = std::move(arg_getters), function](
+                const vector::data_chunk_t& left,
+                const vector::data_chunk_t& right,
+                size_t left_index,
+                size_t right_index) -> core::result_wrapper_t<types::tri_bool_t> {
             std::pmr::vector<types::logical_value_t> args(resource);
             args.reserve(arg_getters.size());
             for (const auto& getter : arg_getters) {
                 auto res = getter(left, right, left_index, right_index);
                 if (res.has_error()) {
-                    return res.convert_error<bool>();
-                } else {
-                    args.emplace_back(std::move(res.value()));
+                    return res.convert_error<types::tri_bool_t>();
                 }
+                // Strict predicate: a NULL argument makes the result UNKNOWN, without executing.
+                if (res.value().is_null()) {
+                    return types::tri_bool_t::unknown;
+                }
+                args.emplace_back(std::move(res.value()));
             }
             auto res = function->execute(args);
             if (res.has_error()) {
-                return res.convert_error<bool>();
+                return res.convert_error<types::tri_bool_t>();
             }
-            return std::get<std::pmr::vector<types::logical_value_t>>(res.value())[0].value<bool>();
+            const auto& out = std::get<std::pmr::vector<types::logical_value_t>>(res.value())[0];
+            return out.is_null() ? types::tri_bool_t::unknown : types::tri_of(out.value<bool>());
         };
         return {new function_predicate(std::move(row_func), std::move(batch_func))};
     }
@@ -209,7 +240,7 @@ namespace components::operators::predicates {
             [resource, expr, function, parameters](const vector::data_chunk_t& left,
                                                    const vector::data_chunk_t& right,
                                                    size_t left_index,
-                                                   size_t right_index) -> core::result_wrapper_t<bool> {
+                                                   size_t right_index) -> core::result_wrapper_t<types::tri_bool_t> {
             std::pmr::vector<types::logical_value_t> args(resource);
             args.reserve(expr->args().size());
             for (const auto& arg : expr->args()) {
@@ -221,12 +252,17 @@ namespace components::operators::predicates {
                 } else {
                     args.emplace_back(parameters->parameters.at(std::get<core::parameter_id_t>(arg)));
                 }
+                // Strict predicate: a NULL argument makes the result UNKNOWN, without executing.
+                if (args.back().is_null()) {
+                    return types::tri_bool_t::unknown;
+                }
             }
             auto res = function->execute(args);
             if (res.has_error()) {
-                return res.convert_error<bool>();
+                return res.convert_error<types::tri_bool_t>();
             }
-            return std::get<std::pmr::vector<types::logical_value_t>>(res.value())[0].value<bool>();
+            const auto& out = std::get<std::pmr::vector<types::logical_value_t>>(res.value())[0];
+            return out.is_null() ? types::tri_bool_t::unknown : types::tri_of(out.value<bool>());
         };
         return {
             new function_predicate(std::move(row_func), make_batch_func(resource, std::move(arg_getters), function))};

--- a/components/physical_plan/operators/predicates/function_predicate.cpp
+++ b/components/physical_plan/operators/predicates/function_predicate.cpp
@@ -88,8 +88,7 @@ namespace {
                                      batch.resource()});
             }
             for (size_t k = 0; k < N; ++k) {
-                results[k] = (any_arg_null[k] || values[k].is_null()) ? types::tri_bool_t::unknown
-                                                                      : types::tri_of(values[k].value<bool>());
+                results[k] = types::tri_of(values[k].value<bool>(), any_arg_null[k] || values[k].is_null());
             }
         } else {
             // vector_function returns data_chunk_t; result column is data[0]
@@ -102,6 +101,8 @@ namespace {
             }
             const auto& out_col = chunk.data.front();
             for (size_t k = 0; k < N; ++k) {
+                // Not the two-arg tri_of: an invalid row's slot may be uninitialized, so the
+                // get_value read must stay behind the short-circuiting guard.
                 const bool null_out = any_arg_null[k] || !out_col.validity().row_is_valid(k);
                 results[k] = null_out ? types::tri_bool_t::unknown : types::tri_of(out_col.get_value<bool>(k));
             }
@@ -208,7 +209,7 @@ namespace components::operators::predicates {
                 return res.convert_error<types::tri_bool_t>();
             }
             const auto& out = std::get<std::pmr::vector<types::logical_value_t>>(res.value())[0];
-            return out.is_null() ? types::tri_bool_t::unknown : types::tri_of(out.value<bool>());
+            return types::tri_of(out.value<bool>(), out.is_null());
         };
         return {new function_predicate(std::move(row_func), std::move(batch_func))};
     }
@@ -262,7 +263,7 @@ namespace components::operators::predicates {
                 return res.convert_error<types::tri_bool_t>();
             }
             const auto& out = std::get<std::pmr::vector<types::logical_value_t>>(res.value())[0];
-            return out.is_null() ? types::tri_bool_t::unknown : types::tri_of(out.value<bool>());
+            return types::tri_of(out.value<bool>(), out.is_null());
         };
         return {
             new function_predicate(std::move(row_func), make_batch_func(resource, std::move(arg_getters), function))};

--- a/components/physical_plan/operators/predicates/function_predicate.hpp
+++ b/components/physical_plan/operators/predicates/function_predicate.hpp
@@ -8,26 +8,27 @@ namespace components::operators::predicates {
     class function_predicate final : public predicate {
     public:
         using batch_check_fn_t =
-            std::function<core::result_wrapper_t<std::vector<bool>>(const vector::data_chunk_t&,
-                                                                    const vector::data_chunk_t&,
-                                                                    const vector::indexing_vector_t&,
-                                                                    const vector::indexing_vector_t&,
-                                                                    uint64_t count)>;
+            std::function<core::result_wrapper_t<std::vector<types::tri_bool_t>>(const vector::data_chunk_t&,
+                                                                                 const vector::data_chunk_t&,
+                                                                                 const vector::indexing_vector_t&,
+                                                                                 const vector::indexing_vector_t&,
+                                                                                 uint64_t count)>;
 
         explicit function_predicate(row_check_fn_t func);
         explicit function_predicate(row_check_fn_t func, batch_check_fn_t batch_func);
 
     private:
-        core::result_wrapper_t<bool> check_impl(const vector::data_chunk_t& chunk_left,
-                                                const vector::data_chunk_t& chunk_right,
-                                                size_t index_left,
-                                                size_t index_right) override;
+        core::result_wrapper_t<types::tri_bool_t> check_impl(const vector::data_chunk_t& chunk_left,
+                                                             const vector::data_chunk_t& chunk_right,
+                                                             size_t index_left,
+                                                             size_t index_right) override;
 
-        core::result_wrapper_t<std::vector<bool>> batch_check_impl(const vector::data_chunk_t& left,
-                                                                   const vector::data_chunk_t& right,
-                                                                   const vector::indexing_vector_t& left_indices,
-                                                                   const vector::indexing_vector_t& right_indices,
-                                                                   uint64_t count) override;
+        core::result_wrapper_t<std::vector<types::tri_bool_t>>
+        batch_check_impl(const vector::data_chunk_t& left,
+                         const vector::data_chunk_t& right,
+                         const vector::indexing_vector_t& left_indices,
+                         const vector::indexing_vector_t& right_indices,
+                         uint64_t count) override;
 
         row_check_fn_t func_;
         batch_check_fn_t batch_func_;

--- a/components/physical_plan/operators/predicates/predicate.cpp
+++ b/components/physical_plan/operators/predicates/predicate.cpp
@@ -5,35 +5,36 @@
 
 namespace components::operators::predicates {
 
-    core::result_wrapper_t<bool> predicate::check(const vector::data_chunk_t& chunk, size_t index) {
+    core::result_wrapper_t<types::tri_bool_t> predicate::check(const vector::data_chunk_t& chunk, size_t index) {
         return check_impl(chunk, chunk, index, index);
     }
-    core::result_wrapper_t<bool> predicate::check(const vector::data_chunk_t& chunk_left,
-                                                  const vector::data_chunk_t& chunk_right,
-                                                  size_t index_left,
-                                                  size_t index_right) {
+    core::result_wrapper_t<types::tri_bool_t> predicate::check(const vector::data_chunk_t& chunk_left,
+                                                               const vector::data_chunk_t& chunk_right,
+                                                               size_t index_left,
+                                                               size_t index_right) {
         return check_impl(chunk_left, chunk_right, index_left, index_right);
     }
 
-    core::result_wrapper_t<std::vector<bool>> predicate::batch_check(const vector::data_chunk_t& left,
-                                                                     const vector::data_chunk_t& right,
-                                                                     const vector::indexing_vector_t& left_indices,
-                                                                     const vector::indexing_vector_t& right_indices,
-                                                                     uint64_t count) {
+    core::result_wrapper_t<std::vector<types::tri_bool_t>>
+    predicate::batch_check(const vector::data_chunk_t& left,
+                           const vector::data_chunk_t& right,
+                           const vector::indexing_vector_t& left_indices,
+                           const vector::indexing_vector_t& right_indices,
+                           uint64_t count) {
         return batch_check_impl(left, right, left_indices, right_indices, count);
     }
 
-    core::result_wrapper_t<std::vector<bool>>
+    core::result_wrapper_t<std::vector<types::tri_bool_t>>
     predicate::batch_check_impl(const vector::data_chunk_t& left,
                                 const vector::data_chunk_t& right,
                                 const vector::indexing_vector_t& left_indices,
                                 const vector::indexing_vector_t& right_indices,
                                 uint64_t count) {
-        std::vector<bool> results(count);
+        std::vector<types::tri_bool_t> results(count);
         for (uint64_t k = 0; k < count; ++k) {
             auto res = check_impl(left, right, left_indices.get_index(k), right_indices.get_index(k));
             if (res.has_error()) {
-                return res.convert_error<std::vector<bool>>();
+                return res.convert_error<std::vector<types::tri_bool_t>>();
             } else {
                 results[k] = res.value();
             }
@@ -74,11 +75,11 @@ namespace components::operators::predicates {
                                        core::date::timezone_offset_t{});
     }
 
-    core::result_wrapper_t<std::vector<bool>> batch_check_1vN(const predicate_ptr& pred,
-                                                              const vector::data_chunk_t& left,
-                                                              const vector::data_chunk_t& right,
-                                                              size_t left_index,
-                                                              uint64_t right_count) {
+    core::result_wrapper_t<std::vector<types::tri_bool_t>> batch_check_1vN(const predicate_ptr& pred,
+                                                                           const vector::data_chunk_t& left,
+                                                                           const vector::data_chunk_t& right,
+                                                                           size_t left_index,
+                                                                           uint64_t right_count) {
         if (right_count == 0) {
             return {};
         }
@@ -90,11 +91,11 @@ namespace components::operators::predicates {
         return pred->batch_check(left, right, broadcast, seq, right_count);
     }
 
-    core::result_wrapper_t<std::vector<bool>> batch_check_Nv1(const predicate_ptr& pred,
-                                                              const vector::data_chunk_t& left,
-                                                              const vector::data_chunk_t& right,
-                                                              uint64_t left_count,
-                                                              size_t right_index) {
+    core::result_wrapper_t<std::vector<types::tri_bool_t>> batch_check_Nv1(const predicate_ptr& pred,
+                                                                           const vector::data_chunk_t& left,
+                                                                           const vector::data_chunk_t& right,
+                                                                           uint64_t left_count,
+                                                                           size_t right_index) {
         if (left_count == 0) {
             return {};
         }

--- a/components/physical_plan/operators/predicates/predicate.hpp
+++ b/components/physical_plan/operators/predicates/predicate.hpp
@@ -3,45 +3,53 @@
 #include <components/compute/function.hpp>
 #include <components/expressions/compare_expression.hpp>
 #include <components/logical_plan/param_storage.hpp>
+#include <components/types/tri_bool.hpp>
 #include <components/vector/data_chunk.hpp>
 #include <components/vector/indexing_vector.hpp>
 #include <core/date/date_types.hpp>
 
 namespace components::operators::predicates {
 
+    // A predicate evaluates to SQL three-valued logic: TRUE / FALSE / UNKNOWN (types::tri_bool_t).
+    // A NULL operand makes a comparison UNKNOWN, which is distinct from FALSE -- the two diverge
+    // under NOT. Each consumer collapses the tri-state to a bool at the very end with the rule that
+    // fits its context: selects() for a WHERE / join / DML filter (only TRUE admits a row),
+    // permits() for a CHECK constraint (only FALSE violates; UNKNOWN passes).
     class predicate : public boost::intrusive_ref_counter<predicate> {
     public:
-        using row_check_fn_t = std::function<core::result_wrapper_t<bool>(const vector::data_chunk_t& chunk_left,
-                                                                          const vector::data_chunk_t& chunk_right,
-                                                                          size_t index_left,
-                                                                          size_t index_right)>;
+        using row_check_fn_t =
+            std::function<core::result_wrapper_t<types::tri_bool_t>(const vector::data_chunk_t& chunk_left,
+                                                                    const vector::data_chunk_t& chunk_right,
+                                                                    size_t index_left,
+                                                                    size_t index_right)>;
         predicate() = default;
         predicate(const predicate&) = delete;
         predicate& operator=(const predicate&) = delete;
         virtual ~predicate() = default;
 
-        core::result_wrapper_t<bool> check(const vector::data_chunk_t& chunk, size_t index);
-        core::result_wrapper_t<bool> check(const vector::data_chunk_t& chunk_left,
-                                           const vector::data_chunk_t& chunk_right,
-                                           size_t index_left,
-                                           size_t index_right);
+        core::result_wrapper_t<types::tri_bool_t> check(const vector::data_chunk_t& chunk, size_t index);
+        core::result_wrapper_t<types::tri_bool_t> check(const vector::data_chunk_t& chunk_left,
+                                                        const vector::data_chunk_t& chunk_right,
+                                                        size_t index_left,
+                                                        size_t index_right);
 
         // evaluate predicate for a batch of (left_indices[k], right_indices[k]) pairs
         // returns result[k] = predicate(left[left_indices[k]], right[right_indices[k]])
-        core::result_wrapper_t<std::vector<bool>> batch_check(const vector::data_chunk_t& left,
-                                                              const vector::data_chunk_t& right,
-                                                              const vector::indexing_vector_t& left_indices,
-                                                              const vector::indexing_vector_t& right_indices,
-                                                              uint64_t count);
+        core::result_wrapper_t<std::vector<types::tri_bool_t>>
+        batch_check(const vector::data_chunk_t& left,
+                    const vector::data_chunk_t& right,
+                    const vector::indexing_vector_t& left_indices,
+                    const vector::indexing_vector_t& right_indices,
+                    uint64_t count);
 
     protected:
-        virtual core::result_wrapper_t<bool> check_impl(const vector::data_chunk_t& chunk_left,
-                                                        const vector::data_chunk_t& chunk_right,
-                                                        size_t index_left,
-                                                        size_t index_right) = 0;
+        virtual core::result_wrapper_t<types::tri_bool_t> check_impl(const vector::data_chunk_t& chunk_left,
+                                                                     const vector::data_chunk_t& chunk_right,
+                                                                     size_t index_left,
+                                                                     size_t index_right) = 0;
 
         // default implementation loops over with check_impl, batch-capable subclasses can override
-        virtual core::result_wrapper_t<std::vector<bool>>
+        virtual core::result_wrapper_t<std::vector<types::tri_bool_t>>
         batch_check_impl(const vector::data_chunk_t& left,
                          const vector::data_chunk_t& right,
                          const vector::indexing_vector_t& left_indices,
@@ -62,17 +70,17 @@ namespace components::operators::predicates {
     predicate_ptr create_all_true_predicate(std::pmr::memory_resource* resource);
 
     // check left[left_index] against right[0..right_count).
-    core::result_wrapper_t<std::vector<bool>> batch_check_1vN(const predicate_ptr& pred,
-                                                              const vector::data_chunk_t& left,
-                                                              const vector::data_chunk_t& right,
-                                                              size_t left_index,
-                                                              uint64_t right_count);
+    core::result_wrapper_t<std::vector<types::tri_bool_t>> batch_check_1vN(const predicate_ptr& pred,
+                                                                           const vector::data_chunk_t& left,
+                                                                           const vector::data_chunk_t& right,
+                                                                           size_t left_index,
+                                                                           uint64_t right_count);
 
     // check left[0..left_count) against right[right_index].
-    core::result_wrapper_t<std::vector<bool>> batch_check_Nv1(const predicate_ptr& pred,
-                                                              const vector::data_chunk_t& left,
-                                                              const vector::data_chunk_t& right,
-                                                              uint64_t left_count,
-                                                              size_t right_index);
+    core::result_wrapper_t<std::vector<types::tri_bool_t>> batch_check_Nv1(const predicate_ptr& pred,
+                                                                           const vector::data_chunk_t& left,
+                                                                           const vector::data_chunk_t& right,
+                                                                           uint64_t left_count,
+                                                                           size_t right_index);
 
 } // namespace components::operators::predicates

--- a/components/physical_plan/operators/predicates/simple_predicate.cpp
+++ b/components/physical_plan/operators/predicates/simple_predicate.cpp
@@ -36,17 +36,19 @@ namespace components::operators::predicates {
                        const vector::data_chunk_t& chunk_left,
                        const vector::data_chunk_t& chunk_right,
                        size_t index_left,
-                       size_t index_right) -> core::result_wrapper_t<bool> {
+                       size_t index_right) -> core::result_wrapper_t<types::tri_bool_t> {
                 auto left_val = left_getter(chunk_left, chunk_right, index_left, index_right);
                 auto right_val = right_getter(chunk_left, chunk_right, index_left, index_right);
                 if (left_val.has_error()) {
-                    return left_val.convert_error<bool>();
+                    return left_val.convert_error<types::tri_bool_t>();
                 }
                 if (right_val.has_error()) {
-                    return right_val.convert_error<bool>();
+                    return right_val.convert_error<types::tri_bool_t>();
                 }
+                // SQL 3VL: a comparison with a NULL operand is UNKNOWN (not FALSE) -- the two
+                // diverge under NOT, so collapsing to FALSE here would let NOT resurrect the row.
                 if (left_val.value().is_null() || right_val.value().is_null()) {
-                    return false;
+                    return types::tri_bool_t::unknown;
                 }
                 const auto& subject_val = left_val.value();
                 const auto& pattern_val = right_val.value();
@@ -61,7 +63,7 @@ namespace components::operators::predicates {
                 if (compiled.has_error()) {
                     return compiled.error();
                 }
-                return compiled.value().match(subject_val.value<std::string_view>());
+                return types::tri_of(compiled.value().match(subject_val.value<std::string_view>()));
             };
         }
 
@@ -80,14 +82,14 @@ namespace components::operators::predicates {
                     session_tz](const vector::data_chunk_t& chunk_left,
                                 const vector::data_chunk_t& chunk_right,
                                 size_t index_left,
-                                size_t index_right) -> core::result_wrapper_t<bool> {
+                                size_t index_right) -> core::result_wrapper_t<types::tri_bool_t> {
                 auto left_val = left_getter(chunk_left, chunk_right, index_left, index_right);
                 auto right_val = right_getter(chunk_left, chunk_right, index_left, index_right);
                 if (left_val.has_error()) {
-                    return left_val.convert_error<bool>();
+                    return left_val.convert_error<types::tri_bool_t>();
                 }
                 if (right_val.has_error()) {
-                    return right_val.convert_error<bool>();
+                    return right_val.convert_error<types::tri_bool_t>();
                 }
                 // PostgreSQL rejects an IMPLICIT boolean <-> numeric comparison ("operator
                 // does not exist: boolean = integer"). is_numeric(BOOLEAN) is true, so without
@@ -96,7 +98,7 @@ namespace components::operators::predicates {
                 // BOOLEAN and the other is a non-boolean numeric, so `bool_col = 1` errors.
                 // Same-type bool=bool and numeric=numeric (neither trips l_bool != r_bool), and
                 // any string / temporal / NULL pairing, are untouched. NULL operands skip the
-                // guard (UNKNOWN -> false inside the shared comparator).
+                // guard (gated to UNKNOWN just below).
                 if (!left_val.value().is_null() && !right_val.value().is_null()) {
                     // Detect a boolean operand by PHYSICAL type (BOOL) so it fires whether the
                     // value's logical type is BOOL or BOOLEAN. The other side is numeric-non-bool
@@ -110,10 +112,21 @@ namespace components::operators::predicates {
                             std::pmr::string{"operator does not exist: boolean = numeric type", resource}};
                     }
                 }
-                // THE canonical NULL + bidirectional-promotion + compare semantics live in ONE
-                // place — table::compare_values_promoting — shared with the pushed col-vs-col
-                // disk filter (row_group_t::check_predicate), so the two paths cannot diverge.
-                return table::compare_values_promoting(left_val.value(), right_val.value(), op, session_tz);
+                // SQL 3VL: a comparison with a NULL operand is UNKNOWN (not FALSE) -- the two
+                // diverge under NOT, so collapsing to FALSE here would let NOT resurrect the row.
+                if (left_val.value().is_null() || right_val.value().is_null()) {
+                    return types::tri_bool_t::unknown;
+                }
+                // THE canonical bidirectional-promotion + compare semantics live in ONE place —
+                // table::compare_values_promoting — shared with the pushed col-vs-col disk filter
+                // (row_group_t::check_predicate), so the two paths cannot diverge. NULL operands
+                // never reach it (gated to UNKNOWN above; the disk filter gates on validity the
+                // same way before calling it).
+                auto cmp = table::compare_values_promoting(left_val.value(), right_val.value(), op, session_tz);
+                if (cmp.has_error()) {
+                    return cmp.convert_error<types::tri_bool_t>();
+                }
+                return types::tri_of(cmp.value());
             };
         }
 
@@ -121,8 +134,9 @@ namespace components::operators::predicates {
         // with RE2 — crash-safe (a bad pattern is stored as an error and returned at eval, never thrown).
         // The subject is read through the shared value_getter. NOT LIKE / NOT ILIKE arrive wrapped in a
         // union_not predicate, so this only performs a positive match. A NULL subject (or a NULL pattern)
-        // yields false (SQL unknown). No per-comparator std::function: this is a real predicate subclass so
-        // the move-only compiled regex can live as a member.
+        // yields UNKNOWN (SQL 3VL), which stays distinct from FALSE under that NOT. No per-comparator
+        // std::function: this is a real predicate subclass so the move-only compiled regex can live as a
+        // member.
         class regex_predicate final : public predicate {
         public:
             regex_predicate(std::pmr::memory_resource* resource,
@@ -139,22 +153,22 @@ namespace components::operators::predicates {
                 , subject_(std::move(subject)) {}
 
         private:
-            core::result_wrapper_t<bool> check_impl(const vector::data_chunk_t& chunk_left,
-                                                    const vector::data_chunk_t& chunk_right,
-                                                    size_t index_left,
-                                                    size_t index_right) override {
+            core::result_wrapper_t<types::tri_bool_t> check_impl(const vector::data_chunk_t& chunk_left,
+                                                                 const vector::data_chunk_t& chunk_right,
+                                                                 size_t index_left,
+                                                                 size_t index_right) override {
                 if (error_) {
                     return *error_;
                 }
                 if (!re_) {
-                    return false; // NULL pattern
+                    return types::tri_bool_t::unknown; // NULL pattern: `x LIKE NULL` is UNKNOWN
                 }
                 auto subject = subject_(chunk_left, chunk_right, index_left, index_right);
                 if (subject.has_error()) {
-                    return subject.convert_error<bool>();
+                    return subject.convert_error<types::tri_bool_t>();
                 }
                 if (subject.value().is_null()) {
-                    return false;
+                    return types::tri_bool_t::unknown; // NULL subject: UNKNOWN, not FALSE
                 }
                 const auto& subject_val = subject.value();
                 // Non-string subject (`int_col LIKE 'p'` — the validator does not type-check regex):
@@ -163,7 +177,7 @@ namespace components::operators::predicates {
                     return core::error_t{core::error_code_t::comparison_failure,
                                          std::pmr::string{"incorrect argument type for regex", resource_}};
                 }
-                return re_->match(subject_val.value<std::string_view>());
+                return types::tri_of(re_->match(subject_val.value<std::string_view>()));
             }
 
             std::pmr::memory_resource* resource_;
@@ -211,21 +225,23 @@ namespace components::operators::predicates {
                 , cache_(resource) {}
 
         private:
-            core::result_wrapper_t<bool> check_impl(const vector::data_chunk_t& chunk_left,
-                                                    const vector::data_chunk_t& chunk_right,
-                                                    size_t index_left,
-                                                    size_t index_right) override {
+            core::result_wrapper_t<types::tri_bool_t> check_impl(const vector::data_chunk_t& chunk_left,
+                                                                 const vector::data_chunk_t& chunk_right,
+                                                                 size_t index_left,
+                                                                 size_t index_right) override {
                 auto left_val = left_getter_(chunk_left, chunk_right, index_left, index_right);
                 if (left_val.has_error()) {
-                    return left_val.convert_error<bool>();
-                }
-                if (left_val.value().is_null()) {
-                    return false;
+                    return left_val.convert_error<types::tri_bool_t>();
                 }
                 const auto& arr_param = parameters_->parameters.at(param_id_);
-                // Empty sub-query list: `x = ANY(empty)` is false, `x <> ALL(empty)` is true (loop-exhausted).
+                // Empty sub-query list: `x = ANY(empty)` is FALSE, `x <> ALL(empty)` is TRUE
+                // (loop-exhausted) — a total answer even for a NULL x, so checked first.
                 if (arr_param.is_null()) {
-                    return !is_any_;
+                    return is_any_ ? types::tri_bool_t::no : types::tri_bool_t::yes;
+                }
+                // A NULL subject makes every element comparison UNKNOWN, so the whole fold is UNKNOWN.
+                if (left_val.value().is_null()) {
+                    return types::tri_bool_t::unknown;
                 }
                 const auto& subject_val = left_val.value();
                 // Non-string subject (`int_col LIKE ANY(...)` — the validator does not type-check
@@ -256,7 +272,7 @@ namespace components::operators::predicates {
                     } else {
                         auto casted = element.cast_as(subject_val.type(), session_tz_);
                         if (casted.has_error()) {
-                            return casted.convert_error<bool>();
+                            return casted.convert_error<types::tri_bool_t>();
                         }
                         if (casted.value().is_null()) {
                             has_null_element = true;
@@ -276,19 +292,19 @@ namespace components::operators::predicates {
                         matched = !matched;
                     }
                     if (is_any_ && matched) {
-                        return true;
+                        return types::tri_bool_t::yes;
                     }
                     if (!is_any_ && !matched) {
-                        return false;
+                        return types::tri_bool_t::no;
                     }
                 }
-                // Loop exhausted with no decisive element. For `x [NOT] LIKE ALL(S)` a NULL element
-                // makes the still-undecided row UNKNOWN, not TRUE, so it must be dropped. ANY is
-                // unaffected: no match is FALSE, and UNKNOWN drops the row too.
-                if (!is_any_ && has_null_element) {
-                    return false;
+                // Loop exhausted with no decisive element. A NULL pattern element made a
+                // comparison UNKNOWN, so the fold is UNKNOWN for ANY and ALL alike — the row is
+                // dropped either way, and NOT cannot resurrect it.
+                if (has_null_element) {
+                    return types::tri_bool_t::unknown;
                 }
-                return !is_any_;
+                return is_any_ ? types::tri_bool_t::no : types::tri_bool_t::yes;
             }
 
             // Compile-once: look the element pattern up in the cache (heterogeneous string_view
@@ -334,56 +350,60 @@ namespace components::operators::predicates {
         , nested_(std::move(nested))
         , nested_type_(nested_type) {}
 
-    core::result_wrapper_t<std::vector<bool>>
+    core::result_wrapper_t<std::vector<types::tri_bool_t>>
     simple_predicate::batch_check_impl(const vector::data_chunk_t& left,
                                        const vector::data_chunk_t& right,
                                        const vector::indexing_vector_t& left_indices,
                                        const vector::indexing_vector_t& right_indices,
                                        uint64_t count) {
+        using types::tri_bool_t;
         switch (nested_type_) {
             case expressions::compare_type::union_and: {
-                std::vector<bool> result(count, true);
+                // 3VL AND: identity is TRUE; FALSE dominates, else UNKNOWN if any child is UNKNOWN.
+                std::vector<tri_bool_t> result(count, tri_bool_t::yes);
                 for (const auto& child : nested_) {
                     auto child_res = child->batch_check(left, right, left_indices, right_indices, count);
                     if (child_res.has_error()) {
                         return child_res;
                     }
                     for (uint64_t k = 0; k < count; ++k) {
-                        result[k] = result[k] && child_res.value()[k];
+                        result[k] = types::tri_and(result[k], child_res.value()[k]);
                     }
                 }
                 return result;
             }
             case expressions::compare_type::union_or: {
-                std::vector<bool> result(count, false);
+                // 3VL OR: identity is FALSE; TRUE dominates, else UNKNOWN if any child is UNKNOWN.
+                std::vector<tri_bool_t> result(count, tri_bool_t::no);
                 for (const auto& child : nested_) {
                     auto child_res = child->batch_check(left, right, left_indices, right_indices, count);
                     if (child_res.has_error()) {
                         return child_res;
                     }
                     for (uint64_t k = 0; k < count; ++k) {
-                        result[k] = result[k] || child_res.value()[k];
+                        result[k] = types::tri_or(result[k], child_res.value()[k]);
                     }
                 }
                 return result;
             }
             case expressions::compare_type::union_not: {
+                // 3VL NOT: TRUE<->FALSE, UNKNOWN unchanged (so NOT does not resurrect a NULL row).
                 auto result = nested_.front()->batch_check(left, right, left_indices, right_indices, count);
                 if (result.has_error()) {
                     return result;
                 }
-                for (size_t i = 0; i < result.value().size(); ++i) {
-                    result.value()[i] = !result.value()[i];
+                for (auto& v : result.value()) {
+                    v = types::tri_not(v);
                 }
                 return result;
             }
             default:
                 // fallback to row-by-row via func_
-                std::vector<bool> result(count);
+                std::vector<tri_bool_t> result(count);
                 for (uint64_t k = 0; k < count; ++k) {
                     if (auto res = func_(left, right, left_indices.get_index(k), right_indices.get_index(k));
                         res.has_error()) {
-                        return res.convert_error<std::vector<bool>>();
+                        return res.convert_error<std::vector<tri_bool_t>>();
                     } else {
                         result[k] = res.value();
                     }
@@ -392,31 +412,47 @@ namespace components::operators::predicates {
         }
     }
 
-    core::result_wrapper_t<bool> simple_predicate::check_impl(const vector::data_chunk_t& chunk_left,
-                                                              const vector::data_chunk_t& chunk_right,
-                                                              size_t index_left,
-                                                              size_t index_right) {
+    core::result_wrapper_t<types::tri_bool_t> simple_predicate::check_impl(const vector::data_chunk_t& chunk_left,
+                                                                           const vector::data_chunk_t& chunk_right,
+                                                                           size_t index_left,
+                                                                           size_t index_right) {
+        using types::tri_bool_t;
         switch (nested_type_) {
-            case expressions::compare_type::union_and:
+            case expressions::compare_type::union_and: {
+                // 3VL AND: FALSE dominates (short-circuit); a later FALSE can still override an
+                // accumulated UNKNOWN, so only FALSE ends the fold early.
+                tri_bool_t acc = tri_bool_t::yes;
                 for (const auto& predicate : nested_) {
-                    if (auto res = predicate->check(chunk_left, chunk_right, index_left, index_right);
-                        res.has_error() || !res.value()) {
+                    auto res = predicate->check(chunk_left, chunk_right, index_left, index_right);
+                    if (res.has_error()) {
                         return res;
                     }
-                }
-                return true;
-            case expressions::compare_type::union_or:
-                for (const auto& predicate : nested_) {
-                    if (auto res = predicate->check(chunk_left, chunk_right, index_left, index_right);
-                        res.has_error() || res.value()) {
-                        return res;
+                    acc = types::tri_and(acc, res.value());
+                    if (acc == tri_bool_t::no) {
+                        return acc;
                     }
                 }
-                return false;
+                return acc;
+            }
+            case expressions::compare_type::union_or: {
+                // 3VL OR: TRUE dominates (short-circuit); only TRUE ends the fold early.
+                tri_bool_t acc = tri_bool_t::no;
+                for (const auto& predicate : nested_) {
+                    auto res = predicate->check(chunk_left, chunk_right, index_left, index_right);
+                    if (res.has_error()) {
+                        return res;
+                    }
+                    acc = types::tri_or(acc, res.value());
+                    if (acc == tri_bool_t::yes) {
+                        return acc;
+                    }
+                }
+                return acc;
+            }
             case expressions::compare_type::union_not: {
                 auto res = nested_.front()->check(chunk_left, chunk_right, index_left, index_right);
                 if (!res.has_error()) {
-                    res.value() = !res.value();
+                    res.value() = types::tri_not(res.value());
                 }
                 return res;
             }
@@ -495,27 +531,27 @@ namespace components::operators::predicates {
                      session_tz](const vector::data_chunk_t& chunk_left,
                                  const vector::data_chunk_t& chunk_right,
                                  size_t index_left,
-                                 size_t index_right) -> core::result_wrapper_t<bool> {
+                                 size_t index_right) -> core::result_wrapper_t<types::tri_bool_t> {
                         auto left_val = left_getter(chunk_left, chunk_right, index_left, index_right);
                         if (left_val.has_error()) {
-                            return left_val.convert_error<bool>();
+                            return left_val.convert_error<types::tri_bool_t>();
                         }
                         const auto& arr_param = parameters->parameters.at(param_id);
                         // Empty sub-query list: compact_to_array_value returns the NA-null
                         // sentinel for a zero-row `x [NOT] IN (SELECT ...)`. PostgreSQL:
-                        // `x = ANY(empty)` is false (IN () matches nothing) and
-                        // `x <> ALL(empty)` is true (NOT IN () matches everything) — exactly
+                        // `x = ANY(empty)` is FALSE (IN () matches nothing) and
+                        // `x <> ALL(empty)` is TRUE (NOT IN () matches everything) — exactly
                         // the loop-exhausted result, so short-circuit before dereferencing
                         // the (null) array's children. This precedes the NULL-left check
                         // below: over an empty set the answer is total regardless of x, so
                         // even a NULL x yields `NULL NOT IN (empty)` = TRUE / `NULL IN (empty)` = FALSE.
                         if (arr_param.is_null()) {
-                            return !is_any;
+                            return is_any ? types::tri_bool_t::no : types::tri_bool_t::yes;
                         }
-                        // A NULL left value can neither match nor mismatch any element: UNKNOWN for
-                        // every comparison -> the row is dropped for both IN and ANY/ALL in a WHERE.
+                        // A NULL left operand makes every element comparison UNKNOWN, so the whole
+                        // ANY / ALL is UNKNOWN.
                         if (left_val.value().is_null()) {
-                            return false;
+                            return types::tri_bool_t::unknown;
                         }
                         const auto& arr = arr_param.children();
                         // Three-valued (SQL NULL) membership: a NULL element (or one whose cast to the left
@@ -529,7 +565,7 @@ namespace components::operators::predicates {
                             }
                             auto rhs_rw = element.cast_as(left_val.value().type(), session_tz);
                             if (rhs_rw.has_error()) {
-                                return rhs_rw.convert_error<bool>();
+                                return rhs_rw.convert_error<types::tri_bool_t>();
                             }
                             if (rhs_rw.value().is_null()) {
                                 has_null_element = true;
@@ -560,23 +596,24 @@ namespace components::operators::predicates {
                                     break;
                             }
                             if (cmp.has_error()) {
-                                return cmp;
+                                return cmp.convert_error<types::tri_bool_t>();
                             }
                             if (is_any && cmp.value()) {
-                                return true;
+                                return types::tri_bool_t::yes;
                             }
                             if (!is_any && !cmp.value()) {
-                                return false;
+                                return types::tri_bool_t::no;
                             }
                         }
-                        // Loop exhausted with no decisive element. For `x op ALL(S)` (NOT IN is
-                        // `x <> ALL(S)`) a NULL element makes the still-undecided row UNKNOWN, not TRUE,
-                        // so it must be dropped — `x NOT IN (SELECT ... with a NULL)` yields no rows.
-                        // ANY / IN is unaffected: no match is FALSE, and UNKNOWN drops the row too.
-                        if (!is_any && has_null_element) {
-                            return false;
+                        // Loop exhausted with no decisive element. A NULL element (or one whose
+                        // cast yielded NULL) made a comparison UNKNOWN, so the fold is UNKNOWN for
+                        // ANY and ALL alike: `x = ANY(S with a NULL)` on a miss is UNKNOWN, not
+                        // FALSE, and `x <> ALL(S with a NULL)` (NOT IN) is UNKNOWN, not TRUE --
+                        // either way the row is dropped, and NOT cannot resurrect it.
+                        if (has_null_element) {
+                            return types::tri_bool_t::unknown;
                         }
-                        return !is_any;
+                        return is_any ? types::tri_bool_t::no : types::tri_bool_t::yes;
                     })};
             }
             case compare_type::regex: {
@@ -610,34 +647,42 @@ namespace components::operators::predicates {
                                              make_regex_comparator(resource, function_registry, expr, parameters))};
             }
             case compare_type::all_false:
-                return {new simple_predicate(
-                    resource,
-                    [](const vector::data_chunk_t&, const vector::data_chunk_t&, size_t, size_t) { return false; })};
+                return {new simple_predicate(resource,
+                                             [](const vector::data_chunk_t&, const vector::data_chunk_t&, size_t, size_t)
+                                                 -> core::result_wrapper_t<types::tri_bool_t> {
+                                                 return types::tri_bool_t::no;
+                                             })};
             case compare_type::is_null: {
+                // IS NULL / IS NOT NULL are themselves total predicates (never UNKNOWN): they ask
+                // about validity directly and answer a definite TRUE / FALSE.
                 return {new simple_predicate(
                     resource,
                     [column_path = std::get<expressions::key_t>(expr->left()).path()](
                         const vector::data_chunk_t& chunk_left,
                         const vector::data_chunk_t&,
                         size_t index_left,
-                        size_t) { return !chunk_left.at(column_path)->validity().row_is_valid(index_left); })};
+                        size_t) -> core::result_wrapper_t<types::tri_bool_t> {
+                        return types::tri_of(!chunk_left.at(column_path)->validity().row_is_valid(index_left));
+                    })};
             }
             case compare_type::is_not_null: {
-                return {new simple_predicate(resource,
-                                             [column_path = std::get<expressions::key_t>(expr->left()).path()](
-                                                 const vector::data_chunk_t& chunk_left,
-                                                 const vector::data_chunk_t&,
-                                                 size_t index_left,
-                                                 size_t) -> core::result_wrapper_t<bool> {
-                                                 return chunk_left.at(column_path)->validity().row_is_valid(index_left);
-                                             })};
+                return {new simple_predicate(
+                    resource,
+                    [column_path = std::get<expressions::key_t>(expr->left()).path()](
+                        const vector::data_chunk_t& chunk_left,
+                        const vector::data_chunk_t&,
+                        size_t index_left,
+                        size_t) -> core::result_wrapper_t<types::tri_bool_t> {
+                        return types::tri_of(chunk_left.at(column_path)->validity().row_is_valid(index_left));
+                    })};
             }
             case compare_type::all_true:
             default:
-                return {
-                    new simple_predicate(resource,
-                                         [](const vector::data_chunk_t&, const vector::data_chunk_t&, size_t, size_t)
-                                             -> core::result_wrapper_t<bool> { return true; })};
+                return {new simple_predicate(resource,
+                                             [](const vector::data_chunk_t&, const vector::data_chunk_t&, size_t, size_t)
+                                                 -> core::result_wrapper_t<types::tri_bool_t> {
+                                                 return types::tri_bool_t::yes;
+                                             })};
         }
     }
 

--- a/components/physical_plan/operators/predicates/simple_predicate.hpp
+++ b/components/physical_plan/operators/predicates/simple_predicate.hpp
@@ -13,16 +13,17 @@ namespace components::operators::predicates {
                          expressions::compare_type nested_type);
 
     private:
-        core::result_wrapper_t<bool> check_impl(const vector::data_chunk_t& chunk_left,
-                                                const vector::data_chunk_t& chunk_right,
-                                                size_t index_left,
-                                                size_t index_right) override;
+        core::result_wrapper_t<types::tri_bool_t> check_impl(const vector::data_chunk_t& chunk_left,
+                                                             const vector::data_chunk_t& chunk_right,
+                                                             size_t index_left,
+                                                             size_t index_right) override;
 
-        core::result_wrapper_t<std::vector<bool>> batch_check_impl(const vector::data_chunk_t& left,
-                                                                   const vector::data_chunk_t& right,
-                                                                   const vector::indexing_vector_t& left_indices,
-                                                                   const vector::indexing_vector_t& right_indices,
-                                                                   uint64_t count) override;
+        core::result_wrapper_t<std::vector<types::tri_bool_t>>
+        batch_check_impl(const vector::data_chunk_t& left,
+                         const vector::data_chunk_t& right,
+                         const vector::indexing_vector_t& left_indices,
+                         const vector::indexing_vector_t& right_indices,
+                         uint64_t count) override;
 
         std::pmr::memory_resource* resource_;
         row_check_fn_t func_;

--- a/components/sql/test/test_constraints_ddl.cpp
+++ b/components/sql/test/test_constraints_ddl.cpp
@@ -274,6 +274,18 @@ TEST_CASE("components::sql::check_constraint_whitelist") {
         REQUIRE_FALSE(data->constraints()[0].check_expression.empty());
     }
 
+    SECTION("NOT of a comparison is allowed") {
+        auto stmt = linitial(raw_parser(&arena_resource, "CREATE TABLE t (x INTEGER, CHECK(NOT (x > 0)))"));
+        auto result = ([](auto _w) {
+            REQUIRE_FALSE(_w.has_error());
+            return _w.value();
+        }(transformer.transform(pg_cell_to_node_cast(stmt)).finalize()));
+        auto node = ddl_consumer(result.sub_queries.back());
+        auto data = reinterpret_cast<node_create_collection_ptr&>(node);
+        REQUIRE(data->constraints().size() == 1);
+        REQUIRE(data->constraints()[0].check_expression == "NOT (x > 0)");
+    }
+
     // Forbidden node kinds must throw parser_exception_t.
     SECTION("function call in CHECK is rejected") {
         auto stmt = linitial(raw_parser(&arena_resource, "CREATE TABLE t (x INTEGER, CHECK(abs(x) > 0))"));

--- a/components/sql/transformer/impl/transform_select.cpp
+++ b/components/sql/transformer/impl/transform_select.cpp
@@ -829,6 +829,13 @@ namespace components::sql::transform {
                             }
                         }
 
+                        // FILTER (WHERE p): lower to a CASE over each argument (or COUNT(CASE ...)
+                        // for a bare aggregate) so only qualifying rows reach the aggregate.
+                        args = apply_aggregate_filter(func->agg_filter, std::move(args), names, plan);
+                        if (has_error()) {
+                            return nullptr;
+                        }
+
                         std::string expr_name;
                         if (res->name) {
                             expr_name = res->name;

--- a/components/sql/transformer/impl/transfrom_common.cpp
+++ b/components/sql/transformer/impl/transfrom_common.cpp
@@ -287,6 +287,10 @@ namespace components::sql::transform {
                     }
                 }
 
+                // FILTER (WHERE p): lower to a CASE over each argument (or COUNT(CASE ...) for a
+                // bare aggregate) so only qualifying rows reach the aggregate.
+                args = apply_aggregate_filter(func->agg_filter, std::move(args), names, plan);
+
                 // Create aggregate with auto-generated alias
                 // TODO: default aggregate aliases should come from function registry, not hardcoded here
                 std::string auto_alias = "__agg_" + funcname + "_" + std::to_string(aggregate_counter_++);
@@ -1456,6 +1460,47 @@ namespace components::sql::transform {
         return expr;
     }
 
+    std::pmr::vector<param_storage>
+    transformer::apply_aggregate_filter(Node* agg_filter,
+                                        std::pmr::vector<param_storage> args,
+                                        const name_collection_t& names,
+                                        logical_plan::execution_plan_t* plan) {
+        if (!agg_filter) {
+            return args;
+        }
+        // Wrap one aggregate argument `x` into `CASE WHEN p THEN x END`. The predicate is
+        // re-transformed per argument so each CASE owns an independent condition tree (constant
+        // folding mutates compare nodes in place, so a shared one would be unsafe); aggregates
+        // almost always take a single argument, so the duplication is immaterial.
+        auto wrap = [&](param_storage result) -> param_storage {
+            auto cond = transform_predicate(agg_filter, names, plan);
+            if (has_error()) {
+                return result;
+            }
+            auto case_expr =
+                make_scalar_expression(resource_,
+                                       scalar_type::case_expr,
+                                       expressions::key_t{resource_,
+                                                          "__aggfilter_" + std::to_string(aggregate_counter_++)});
+            case_expr->append_param(cond);              // WHEN p
+            case_expr->append_param(std::move(result)); // THEN <arg>   (no ELSE -> NULL when p not TRUE)
+            return expressions::expression_ptr(case_expr);
+        };
+
+        if (args.empty()) {
+            // count(*) / a parameterless aggregate: count the rows where p by counting the non-NULL
+            // results of CASE WHEN p THEN 1 END.
+            auto one = plan->parameters->add_parameter(static_cast<int64_t>(1));
+            std::pmr::vector<param_storage> filtered(resource_);
+            filtered.emplace_back(wrap(one));
+            return filtered;
+        }
+        for (auto& arg : args) {
+            arg = wrap(std::move(arg));
+        }
+        return args;
+    }
+
     void transformer::transform_select_case_expr(CaseExpr* node,
                                                  const char* alias,
                                                  const name_collection_t& names,
@@ -1500,6 +1545,9 @@ namespace components::sql::transform {
                         }
                     }
                 }
+                // FILTER (WHERE p): lower to a CASE over each argument (or COUNT(CASE ...) for a
+                // bare aggregate) so only qualifying rows reach the aggregate.
+                args = apply_aggregate_filter(func->agg_filter, std::move(args), names, plan);
                 std::string alias = "__having_" + funcname + "_" + std::to_string(aggregate_counter_++);
                 auto agg_expr = make_aggregate_expression(resource_, funcname, expressions::key_t{resource_, alias});
                 for (auto& arg : args) {

--- a/components/sql/transformer/transformer.hpp
+++ b/components/sql/transformer/transformer.hpp
@@ -161,6 +161,19 @@ namespace components::sql::transform {
         expressions::expression_ptr
         transform_a_expr_func(FuncCall* node, const name_collection_t& names, logical_plan::parameter_node_t* params);
 
+        // Lower an aggregate FILTER (WHERE p) clause by wrapping each aggregate argument in a CASE:
+        //   agg(x)   FILTER (WHERE p)  ->  agg(CASE WHEN p THEN x END)
+        //   count(*) FILTER (WHERE p)  ->  count(CASE WHEN p THEN 1 END)
+        // Every supported aggregate skips NULLs, so rows where p is not TRUE (the CASE yields NULL)
+        // are excluded -- exactly FILTER semantics -- and the predicate reuses the three-valued
+        // CASE-WHEN evaluator (UNKNOWN excludes the row). `agg_filter` is FuncCall.agg_filter; a null
+        // one returns `args` unchanged. On a parse error inside p, sets error_ and returns args as-is.
+        std::pmr::vector<expressions::param_storage> apply_aggregate_filter(
+            Node* agg_filter,
+            std::pmr::vector<expressions::param_storage> args,
+            const name_collection_t& names,
+            logical_plan::execution_plan_t* plan);
+
         // HAVING clause: resolve aggregate references to aliases from group node
         expressions::expression_ptr transform_having_expr(Node* node,
                                                           const name_collection_t& names,

--- a/components/sql/transformer/utils.cpp
+++ b/components/sql/transformer/utils.cpp
@@ -727,6 +727,16 @@ namespace components::sql::transform {
                     }
                     return "(" + std::move(left.value()) + ")" + sep + "(" + std::move(right.value()) + ")";
                 }
+                if (e->kind == AEXPR_NOT) {
+                    // Unary NOT in A_Expr form: the operand is rexpr (lexpr is null). Emit the same
+                    // "NOT (...)" shape that the BoolExpr NOT branch produces so build_check_predicate
+                    // recognises it.
+                    auto inner = deparse_check_expr(resource, e->rexpr);
+                    if (inner.has_error() || inner.value().empty()) {
+                        return inner;
+                    }
+                    return "NOT (" + std::move(inner.value()) + ")";
+                }
                 return "";
             }
             case T_BoolExpr: {

--- a/components/table/column_data.cpp
+++ b/components/table/column_data.cpp
@@ -71,6 +71,12 @@ namespace components::table {
             filter.filter_type == expressions::compare_type::lte) {
             auto& constant_filter = filter.cast<constant_filter_t>();
             const auto& constant = constant_filter.constant;
+            // A NULL constant makes the comparison UNKNOWN for every row (`WHERE x > NULL` selects
+            // nothing). Ordering a NULL against min/max would be meaningless, so do not prune on it;
+            // the per-row evaluator resolves it to UNKNOWN and excludes the rows.
+            if (constant.is_null()) {
+                return filter_propagate_result_t::NO_PRUNING_POSSIBLE;
+            }
             const auto& min = statistics_.min_value();
             const auto& max = statistics_.max_value();
             switch (filter.filter_type) {
@@ -153,6 +159,10 @@ namespace components::table {
             filter.filter_type == expressions::compare_type::lte) {
             auto& constant_filter = filter.cast<constant_filter_t>();
             const auto& constant = constant_filter.constant;
+            // See check_zonemap: a NULL constant is UNKNOWN for every row, never a prunable bound.
+            if (constant.is_null()) {
+                return filter_propagate_result_t::NO_PRUNING_POSSIBLE;
+            }
             const auto& min = seg_stats.min_value();
             const auto& max = seg_stats.max_value();
             switch (filter.filter_type) {

--- a/components/table/column_data.cpp
+++ b/components/table/column_data.cpp
@@ -520,13 +520,28 @@ namespace components::table {
         transient.revert_append(static_cast<uint64_t>(start_row));
     }
 
-    bool column_data_t::check_predicate(int64_t row_id, const table_filter_t* filter, core::error_t& error) {
+    filter_match_t column_data_t::check_predicate(int64_t row_id, const table_filter_t* filter, core::error_t& error) {
+        // SQL three-valued logic, enforced once for every column type and every storage
+        // layout. A NULL operand makes any value comparison UNKNOWN — the row is neither
+        // selected nor eligible to be flipped back in by NOT.
+        //
+        // This gate must come first: the compressed and raw-buffer paths below read the
+        // value bytes only, and a NULL row's payload is a meaningless 0 (validity lives in a
+        // separate sibling column), so they would otherwise report `0 == 0` and match.
+        // check_validity() goes through fetch_row, which applies the update overlay, so a row
+        // updated to NULL is seen as NULL here too.
+        //
+        // IS NULL / IS NOT NULL never reach this function — row_group_t::check_predicate
+        // answers them from the validity mask directly — so gating here cannot break them.
+        if (!check_validity(row_id)) {
+            return filter_match_t::unknown;
+        }
         if (updates_ &&
             updates_->has_updates(static_cast<uint64_t>(row_id - start_) / vector::DEFAULT_VECTOR_CAPACITY)) {
             // The vector has some updated rows. Check if THIS specific row is updated.
             if (updates_->row_is_updated(row_id)) {
                 // Row is in the update overlay — check against the updated value only
-                return updates_->check_row(row_id, filter);
+                return updates_->check_row(row_id, filter) ? filter_match_t::yes : filter_match_t::no;
             }
         }
         // STRUCT columns store child data in sub_columns, not in data_ segments — fetch the full value
@@ -542,15 +557,13 @@ namespace components::table {
             fetch_row(fetch_state, row_id, result, 0);
             if (fetch_state.fetch_error.contains_error()) {
                 error = fetch_state.fetch_error;
-                return false;
-            }
-            if (!result.validity().row_is_valid(0)) {
-                return false;
+                return filter_match_t::no;
             }
             if (auto* set = dynamic_cast<const set_membership_filter_t*>(filter)) {
-                return set->contains(result.value(0));
+                return set->contains(result.value(0)) ? filter_match_t::yes : filter_match_t::no;
             }
-            return filter->cast<constant_filter_t>().compare(result.value(0));
+            return filter->cast<constant_filter_t>().compare(result.value(0)) ? filter_match_t::yes
+                                                                              : filter_match_t::no;
         }
         auto segment = data_.get_segment(row_id);
         // For compressed segments, fetch the actual decompressed value
@@ -561,28 +574,26 @@ namespace components::table {
             fetch_row(fetch_state, row_id, result, 0);
             if (fetch_state.fetch_error.contains_error()) {
                 error = fetch_state.fetch_error;
-                return false;
-            }
-            if (!result.validity().row_is_valid(0)) {
-                return false;
+                return filter_match_t::no;
             }
             // Dispatch handles constant_filter_t, set_membership_filter_t, and the string-only regex_filter_t.
             if (auto* set = dynamic_cast<const set_membership_filter_t*>(filter)) {
-                return set->contains(result.value(0));
+                return set->contains(result.value(0)) ? filter_match_t::yes : filter_match_t::no;
             }
             if (filter->filter_type == expressions::compare_type::regex) {
                 auto cell = result.value(0); // bind before value<string_view>() (chunk value is a temporary)
-                return filter->cast<regex_filter_t>().matches(cell.value<std::string_view>());
+                return filter->cast<regex_filter_t>().matches(cell.value<std::string_view>()) ? filter_match_t::yes
+                                                                                              : filter_match_t::no;
             }
             const auto& const_filter = filter->cast<constant_filter_t>();
-            return const_filter.compare(result.value(0));
+            return const_filter.compare(result.value(0)) ? filter_match_t::yes : filter_match_t::no;
         }
         auto checked = segment->check_predicate(row_id, filter);
         if (checked.has_error()) {
             error = checked.error();
-            return false;
+            return filter_match_t::no;
         }
-        return checked.value();
+        return checked.value() ? filter_match_t::yes : filter_match_t::no;
     }
 
     bool column_data_t::check_validity(int64_t row_id) {

--- a/components/table/column_data.hpp
+++ b/components/table/column_data.hpp
@@ -23,6 +23,28 @@ namespace components::table {
         TRUE_OR_NULL = 3,
         FALSE_OR_NULL = 4
     };
+    // SQL three-valued logic. A value comparison against a NULL operand is UNKNOWN, not
+    // FALSE: the two differ under NOT (`NOT UNKNOWN` is UNKNOWN, while `NOT FALSE` is TRUE),
+    // so a filter tree that collapses UNKNOWN into FALSE lets NOT resurrect NULL rows.
+    // Only rows that evaluate to `yes` are selected.
+    enum class filter_match_t : uint8_t
+    {
+        no = 0,
+        yes = 1,
+        unknown = 2
+    };
+
+    constexpr filter_match_t filter_match_not(filter_match_t v) {
+        switch (v) {
+            case filter_match_t::yes:
+                return filter_match_t::no;
+            case filter_match_t::no:
+                return filter_match_t::yes;
+            default:
+                return filter_match_t::unknown;
+        }
+    }
+
     constexpr uint64_t MAX_ROW_ID = 1ULL << 55; // 2^55
 
     class column_data_t {
@@ -117,7 +139,9 @@ namespace components::table {
 
         // `error` carries an out_of_memory error_t when a pin fails during the predicate check;
         // on error the bool return is meaningless and the scan loop stops.
-        virtual bool check_predicate(int64_t row_id, const table_filter_t* filter, core::error_t& error);
+        // Returns `unknown` when the row's value is NULL — a NULL operand never satisfies a
+        // value comparison, and must stay distinguishable from a genuine `no` (see filter_match_t).
+        virtual filter_match_t check_predicate(int64_t row_id, const table_filter_t* filter, core::error_t& error);
         virtual bool check_validity(int64_t row_id);
         virtual uint64_t fetch(column_scan_state& state, int64_t row_id, vector::vector_t& result);
         virtual void

--- a/components/table/column_data.hpp
+++ b/components/table/column_data.hpp
@@ -31,8 +31,6 @@ namespace components::table {
     // under NOT, so collapsing UNKNOWN into FALSE would let NOT resurrect NULL rows.
     using filter_match_t = types::tri_bool_t;
 
-    inline constexpr filter_match_t filter_match_not(filter_match_t v) noexcept { return types::tri_not(v); }
-
     constexpr uint64_t MAX_ROW_ID = 1ULL << 55; // 2^55
 
     class column_data_t {

--- a/components/table/column_data.hpp
+++ b/components/table/column_data.hpp
@@ -5,6 +5,7 @@
 #include "column_state.hpp"
 #include "segment_tree.hpp"
 #include "update_segment.hpp"
+#include <components/types/tri_bool.hpp>
 
 namespace components::table {
 
@@ -23,27 +24,14 @@ namespace components::table {
         TRUE_OR_NULL = 3,
         FALSE_OR_NULL = 4
     };
-    // SQL three-valued logic. A value comparison against a NULL operand is UNKNOWN, not
-    // FALSE: the two differ under NOT (`NOT UNKNOWN` is UNKNOWN, while `NOT FALSE` is TRUE),
-    // so a filter tree that collapses UNKNOWN into FALSE lets NOT resurrect NULL rows.
-    // Only rows that evaluate to `yes` are selected.
-    enum class filter_match_t : uint8_t
-    {
-        no = 0,
-        yes = 1,
-        unknown = 2
-    };
+    // The storage-scan filter answers in SQL three-valued logic. filter_match_t is the table
+    // component's spelling of the shared types::tri_bool_t vocabulary (tri_bool.hpp), so the scan
+    // filter and the in-memory predicate evaluator share one definition of TRUE/FALSE/UNKNOWN and
+    // cannot drift. A value comparison against a NULL operand is UNKNOWN, not FALSE: the two differ
+    // under NOT, so collapsing UNKNOWN into FALSE would let NOT resurrect NULL rows.
+    using filter_match_t = types::tri_bool_t;
 
-    constexpr filter_match_t filter_match_not(filter_match_t v) {
-        switch (v) {
-            case filter_match_t::yes:
-                return filter_match_t::no;
-            case filter_match_t::no:
-                return filter_match_t::yes;
-            default:
-                return filter_match_t::unknown;
-        }
-    }
+    inline constexpr filter_match_t filter_match_not(filter_match_t v) noexcept { return types::tri_not(v); }
 
     constexpr uint64_t MAX_ROW_ID = 1ULL << 55; // 2^55
 

--- a/components/table/column_state.hpp
+++ b/components/table/column_state.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <components/types/tri_bool.hpp>
 #include <components/types/types.hpp>
 #include <core/date/date_types.hpp>
 #include <core/operations_helper.hpp>
@@ -390,7 +391,10 @@ namespace components::table {
         virtual ~expression_evaluator_t() = default;
         // Evaluate the whole compare over `row` at `index`; `row` presents each referenced column
         // at its ORIGINAL storage column index (path[0]) so the value_getters resolve correctly.
-        virtual core::result_wrapper_t<bool> evaluate(const vector::data_chunk_t& row, size_t index) const = 0;
+        // Three-valued (SQL): a NULL operand yields UNKNOWN, which must stay distinct from FALSE
+        // so a NOT above the filter cannot resurrect the row (see filter_match_t).
+        virtual core::result_wrapper_t<types::tri_bool_t> evaluate(const vector::data_chunk_t& row,
+                                                                   size_t index) const = 0;
     };
 
     // A comparison whose one operand is a function/arithmetic expression over column(s) and whose

--- a/components/table/row_group.cpp
+++ b/components/table/row_group.cpp
@@ -365,7 +365,8 @@ namespace components::table {
         if (!result.validity().row_is_valid(0)) {
             element_is_null = true;
         } else {
-            const auto& elements = result.value(0).children();
+            auto array_value = result.value(0);
+            const auto& elements = array_value.children();
             element_is_null = element_index >= elements.size() || elements[element_index].is_null();
         }
         const bool matches = want_null ? element_is_null : !element_is_null;

--- a/components/table/row_group.cpp
+++ b/components/table/row_group.cpp
@@ -234,52 +234,56 @@ namespace components::table {
 
     // A trailing subscript index into an ARRAY/LIST column (e.g. WHERE v[k] = x)
     // addresses an element, not a STRUCT sub-column. Materialize the row's list
-    // value and compare the addressed (0-based) element against the filter. A
-    // NULL list, an out-of-range index, or a NULL element does not match.
-    static bool check_array_element_predicate(column_data_t& column,
-                                              int64_t row_id,
-                                              uint64_t element_index,
-                                              const table_filter_t* filter,
-                                              core::error_t& error) {
+    // value and compare the addressed (0-based) element against the filter.
+    //
+    // A NULL list, an out-of-range subscript, or a NULL element all yield a NULL
+    // operand, so the comparison is UNKNOWN — not FALSE (see filter_match_t).
+    static filter_match_t check_array_element_predicate(column_data_t& column,
+                                                        int64_t row_id,
+                                                        uint64_t element_index,
+                                                        const table_filter_t* filter,
+                                                        core::error_t& error) {
         column_fetch_state fetch_state;
         vector::vector_t result(column.resource(), column.type(), 1);
         column.fetch_row(fetch_state, row_id, result, 0);
         if (fetch_state.fetch_error.contains_error()) {
             error = fetch_state.fetch_error;
-            return false;
+            return filter_match_t::no;
         }
         if (!result.validity().row_is_valid(0)) {
-            return false;
+            return filter_match_t::unknown;
         }
         auto list_value = result.value(0);
         const auto& elements = list_value.children();
         if (element_index >= elements.size()) {
-            return false;
+            return filter_match_t::unknown;
         }
         const auto& element_value = elements[element_index];
         if (element_value.is_null()) {
-            return false;
+            return filter_match_t::unknown;
         }
         if (auto* set = dynamic_cast<const set_membership_filter_t*>(filter)) {
-            return set->contains(element_value);
+            return set->contains(element_value) ? filter_match_t::yes : filter_match_t::no;
         }
         if (filter->filter_type == expressions::compare_type::regex) {
-            return filter->cast<regex_filter_t>().matches(element_value.value<std::string_view>());
+            return filter->cast<regex_filter_t>().matches(element_value.value<std::string_view>())
+                       ? filter_match_t::yes
+                       : filter_match_t::no;
         }
-        return filter->cast<constant_filter_t>().compare(element_value);
+        return filter->cast<constant_filter_t>().compare(element_value) ? filter_match_t::yes : filter_match_t::no;
     }
 
-    bool row_group_t::check_expression_predicate(int64_t row_id,
-                                                 const expression_filter_t& filter,
-                                                 expression_filter_layout_cache_t& expression_layouts,
-                                                 core::error_t& error) {
+    filter_match_t row_group_t::check_expression_predicate(int64_t row_id,
+                                                           const expression_filter_t& filter,
+                                                           expression_filter_layout_cache_t& expression_layouts,
+                                                           core::error_t& error) {
         if (!filter.evaluator) {
             // Reached the per-row check without an agent-attached evaluator (see
             // expression_evaluator_t). Fail cleanly with an error instead of dereferencing null.
             error = core::error_t{core::error_code_t::physical_plan_error,
                                   std::pmr::string{"expression_filter_t reached check_predicate without an evaluator",
                                                    collection_->resource()}};
-            return false;
+            return filter_match_t::no;
         }
         auto* res = collection_->resource();
         auto* layout = expression_layouts.find(&filter);
@@ -328,22 +332,24 @@ namespace components::table {
             get_column(top).fetch_row(fetch_state, row_id, layout->row.data[top], 0);
             if (fetch_state.fetch_error.contains_error()) {
                 error = fetch_state.fetch_error;
-                return false;
+                return filter_match_t::no;
             }
         }
         layout->row.set_cardinality(1);
         auto checked = filter.evaluator->evaluate(layout->row, 0);
         if (checked.has_error()) {
             error = checked.error();
-            return false;
+            return filter_match_t::no;
         }
-        return checked.value();
+        // The expression evaluator is two-valued: it folds an UNKNOWN (NULL-operand) result
+        // into false itself, so there is no unknown to surface here.
+        return checked.value() ? filter_match_t::yes : filter_match_t::no;
     }
 
-    bool row_group_t::check_predicate(int64_t row_id,
-                                      const table_filter_t* filter,
-                                      expression_filter_layout_cache_t& expression_layouts,
-                                      core::error_t& error) {
+    filter_match_t row_group_t::check_predicate(int64_t row_id,
+                                                const table_filter_t* filter,
+                                                expression_filter_layout_cache_t& expression_layouts,
+                                                core::error_t& error) {
         // An expression_filter_t (WHERE f(col) OP const) aliases a constant comparison filter_type
         // but has a different layout and its own multi-column evaluation, so intercept it BEFORE the
         // filter_type switch (which would mis-cast it to constant_filter_t in the default arm).
@@ -352,40 +358,60 @@ namespace components::table {
         }
         switch (filter->filter_type) {
             case expressions::compare_type::union_or: {
+                // TRUE if any child is TRUE; otherwise UNKNOWN if any child is UNKNOWN.
+                // (UNKNOWN OR TRUE = TRUE, so a TRUE disjunct still rescues a NULL row.)
                 auto& conjunction_or = filter->cast<conjunction_or_filter_t>();
+                bool saw_unknown = false;
                 for (auto& child_filter : conjunction_or.child_filters) {
-                    if (check_predicate(row_id, child_filter.get(), expression_layouts, error)) {
-                        return true;
-                    }
+                    auto child = check_predicate(row_id, child_filter.get(), expression_layouts, error);
                     if (error.contains_error()) {
-                        return false;
+                        return filter_match_t::no;
                     }
+                    if (child == filter_match_t::yes) {
+                        return filter_match_t::yes;
+                    }
+                    saw_unknown |= (child == filter_match_t::unknown);
                 }
-                return false;
+                return saw_unknown ? filter_match_t::unknown : filter_match_t::no;
             }
             case expressions::compare_type::union_and: {
+                // FALSE if any child is FALSE; otherwise UNKNOWN if any child is UNKNOWN.
+                // (UNKNOWN AND FALSE = FALSE, so a FALSE conjunct still excludes decisively.)
                 auto& conjunction_and = filter->cast<conjunction_and_filter_t>();
+                bool saw_unknown = false;
                 for (auto& child_filter : conjunction_and.child_filters) {
-                    if (!check_predicate(row_id, child_filter.get(), expression_layouts, error)) {
-                        return false;
-                    }
+                    auto child = check_predicate(row_id, child_filter.get(), expression_layouts, error);
                     if (error.contains_error()) {
-                        return false;
+                        return filter_match_t::no;
                     }
+                    if (child == filter_match_t::no) {
+                        return filter_match_t::no;
+                    }
+                    saw_unknown |= (child == filter_match_t::unknown);
                 }
-                return true;
+                return saw_unknown ? filter_match_t::unknown : filter_match_t::yes;
             }
             case expressions::compare_type::union_not: {
+                // NOT over the disjunction of the children: negate the OR result.
+                // Crucially NOT UNKNOWN is UNKNOWN — a row excluded because its operand was
+                // NULL must not be flipped back in. This is what makes the validity gate in
+                // column_data_t::check_predicate safe to add.
                 auto& conjunction_not = filter->cast<conjunction_not_filter_t>();
+                auto acc = filter_match_t::no;
                 for (auto& child_filter : conjunction_not.child_filters) {
-                    if (check_predicate(row_id, child_filter.get(), expression_layouts, error)) {
-                        return false;
-                    }
+                    auto child = check_predicate(row_id, child_filter.get(), expression_layouts, error);
                     if (error.contains_error()) {
-                        return false;
+                        return filter_match_t::no;
+                    }
+                    if (child == filter_match_t::yes) {
+                        acc = filter_match_t::yes;
+                        break;
+                    }
+                    if (child == filter_match_t::unknown) {
+                        acc = filter_match_t::unknown;
                     }
                 }
-                return true;
+                return filter_match_not(acc);
             }
             case expressions::compare_type::invalid: {
                 assert(false && "invalid type for filter selection");
@@ -399,13 +425,16 @@ namespace components::table {
                     column =
                         static_cast<struct_column_data_t*>(column)->sub_columns[null_filter.table_indices[i]].get();
                 }
+                // IS NULL / IS NOT NULL are the two predicates that interrogate nullness
+                // itself: they are always TRUE or FALSE, never UNKNOWN.
                 bool is_valid = column->check_validity(row_id);
-                return filter->filter_type == expressions::compare_type::is_null ? !is_valid : is_valid;
+                bool matches = filter->filter_type == expressions::compare_type::is_null ? !is_valid : is_valid;
+                return matches ? filter_match_t::yes : filter_match_t::no;
             }
             default: {
                 // Column-vs-column (`a.x OP a.y`): fetch both column values for this row and compare. A NULL
-                // operand yields false (SQL three-valued logic). Checked before the single-column dispatch
-                // below (a distinct multi-column filter type).
+                // operand makes the comparison UNKNOWN (see filter_match_t). Checked before the
+                // single-column dispatch below (a distinct multi-column filter type).
                 if (auto* cc = dynamic_cast<const column_column_filter_t*>(filter)) {
                     auto resolve = [&](const std::pmr::vector<uint64_t>& path) -> column_data_t* {
                         column_data_t* c = &get_column(path.front());
@@ -422,28 +451,29 @@ namespace components::table {
                     lcol->fetch_row(lstate, row_id, lvec, 0);
                     if (lstate.fetch_error.contains_error()) {
                         error = lstate.fetch_error;
-                        return false;
+                        return filter_match_t::no;
                     }
                     rcol->fetch_row(rstate, row_id, rvec, 0);
                     if (rstate.fetch_error.contains_error()) {
                         error = rstate.fetch_error;
-                        return false;
+                        return filter_match_t::no;
                     }
                     if (!lvec.validity().row_is_valid(0) || !rvec.validity().row_is_valid(0)) {
-                        return false;
+                        return filter_match_t::unknown;
                     }
                     auto lval = lvec.value(0);
                     auto rval = rvec.value(0);
                     // Canonical comparator semantics (the shared helper simple_predicate's
                     // make_comparator also runs): bidirectional promotion with the session timezone
                     // the filter captured at plan time — never a one-way zero-tz cast that drops a
-                    // row whose value merely overflows the narrower side's type.
+                    // row whose value merely overflows the narrower side's type. NULL operands never
+                    // reach it (gated to unknown above).
                     auto matched = compare_values_promoting(lval, rval, cc->filter_type, cc->session_tz);
                     if (matched.has_error()) {
                         error = matched.error();
-                        return false;
+                        return filter_match_t::no;
                     }
-                    return matched.value();
+                    return matched.value() ? filter_match_t::yes : filter_match_t::no;
                 }
                 // Works for both constant_filter_t and set_membership_filter_t.
                 const auto& indices = table_filter_table_indices(filter);
@@ -505,10 +535,12 @@ namespace components::table {
         for (uint64_t i = 0; i < approved_tuple_count; i++) {
             auto idx = indexing.get_index(i);
             new_indexing.set_index(result_count, idx);
-            result_count += check_predicate(static_cast<int64_t>(idx + vector_index * vector::DEFAULT_VECTOR_CAPACITY),
-                                            filter,
-                                            expression_layouts,
-                                            error);
+            // Only TRUE selects a row: UNKNOWN (a NULL operand) is excluded, exactly as FALSE is.
+            auto match = check_predicate(static_cast<int64_t>(idx + vector_index * vector::DEFAULT_VECTOR_CAPACITY),
+                                         filter,
+                                         expression_layouts,
+                                         error);
+            result_count += (match == filter_match_t::yes) ? 1 : 0;
             if (error.contains_error()) {
                 // OOM during predicate evaluation: stop; caller copies to scan_error.
                 return;

--- a/components/table/row_group.cpp
+++ b/components/table/row_group.cpp
@@ -476,6 +476,15 @@ namespace components::table {
                     return matched.value() ? filter_match_t::yes : filter_match_t::no;
                 }
                 // Works for both constant_filter_t and set_membership_filter_t.
+
+                // A NULL on the CONSTANT side is UNKNOWN for every row, exactly as a NULL column
+                // value is: `WHERE x > NULL` selects nothing, and must not be flipped in by NOT.
+                // This is decided before the column is even read.
+                if (const auto* const_filter = dynamic_cast<const constant_filter_t*>(filter);
+                    const_filter && const_filter->constant.is_null()) {
+                    return filter_match_t::unknown;
+                }
+
                 const auto& indices = table_filter_table_indices(filter);
                 column_data_t* column = &get_column(indices.front());
                 for (size_t i = 1; i < indices.size(); i++) {
@@ -485,7 +494,20 @@ namespace components::table {
                     }
                     column = static_cast<struct_column_data_t*>(column)->sub_columns[indices[i]].get();
                 }
-                return column->check_predicate(row_id, filter, error);
+                auto match = column->check_predicate(row_id, filter, error);
+
+                // `x IN (1, NULL)`: a hit is TRUE, but a miss is UNKNOWN rather than FALSE, because
+                // the NULL element might have been the match.
+                if (match == filter_match_t::no) {
+                    if (const auto* set = dynamic_cast<const set_membership_filter_t*>(filter)) {
+                        for (const auto& v : set->values) {
+                            if (v.is_null()) {
+                                return filter_match_t::unknown;
+                            }
+                        }
+                    }
+                }
+                return match;
             }
         }
     }

--- a/components/table/row_group.cpp
+++ b/components/table/row_group.cpp
@@ -346,6 +346,32 @@ namespace components::table {
         return checked.value() ? filter_match_t::yes : filter_match_t::no;
     }
 
+    // IS NULL / IS NOT NULL over an ARRAY/LIST element. Nullness is always TRUE or FALSE, never
+    // UNKNOWN: an element is NULL when the whole cell is NULL, when the subscript is out of range,
+    // or when that element itself is NULL.
+    static filter_match_t check_array_element_is_null(column_data_t& column,
+                                                      int64_t row_id,
+                                                      uint64_t element_index,
+                                                      bool want_null,
+                                                      core::error_t& error) {
+        column_fetch_state fetch_state;
+        vector::vector_t result(column.resource(), column.type(), 1);
+        column.fetch_row(fetch_state, row_id, result, 0);
+        if (fetch_state.fetch_error.contains_error()) {
+            error = fetch_state.fetch_error;
+            return filter_match_t::no;
+        }
+        bool element_is_null;
+        if (!result.validity().row_is_valid(0)) {
+            element_is_null = true;
+        } else {
+            const auto& elements = result.value(0).children();
+            element_is_null = element_index >= elements.size() || elements[element_index].is_null();
+        }
+        const bool matches = want_null ? element_is_null : !element_is_null;
+        return matches ? filter_match_t::yes : filter_match_t::no;
+    }
+
     filter_match_t row_group_t::check_predicate(int64_t row_id,
                                                 const table_filter_t* filter,
                                                 expression_filter_layout_cache_t& expression_layouts,
@@ -420,15 +446,24 @@ namespace components::table {
             case expressions::compare_type::is_null:
             case expressions::compare_type::is_not_null: {
                 auto& null_filter = filter->cast<is_null_filter_t>();
+                const bool want_null = filter->filter_type == expressions::compare_type::is_null;
                 column_data_t* column = &get_column(null_filter.table_indices.front());
                 for (size_t i = 1; i < null_filter.table_indices.size(); i++) {
+                    // An intermediate ARRAY/LIST index addresses an element, not a STRUCT
+                    // sub-column: descend it through the element accessor rather than casting the
+                    // array column to a struct (which would dereference a bogus sub-columns entry).
+                    if (column->type().type() == types::logical_type::ARRAY ||
+                        column->type().type() == types::logical_type::LIST) {
+                        return check_array_element_is_null(*column, row_id, null_filter.table_indices[i], want_null,
+                                                           error);
+                    }
                     column =
                         static_cast<struct_column_data_t*>(column)->sub_columns[null_filter.table_indices[i]].get();
                 }
                 // IS NULL / IS NOT NULL are the two predicates that interrogate nullness
                 // itself: they are always TRUE or FALSE, never UNKNOWN.
                 bool is_valid = column->check_validity(row_id);
-                bool matches = filter->filter_type == expressions::compare_type::is_null ? !is_valid : is_valid;
+                bool matches = want_null ? !is_valid : is_valid;
                 return matches ? filter_match_t::yes : filter_match_t::no;
             }
             default: {

--- a/components/table/row_group.cpp
+++ b/components/table/row_group.cpp
@@ -341,9 +341,9 @@ namespace components::table {
             error = checked.error();
             return filter_match_t::no;
         }
-        // The expression evaluator is two-valued: it folds an UNKNOWN (NULL-operand) result
-        // into false itself, so there is no unknown to surface here.
-        return checked.value() ? filter_match_t::yes : filter_match_t::no;
+        // The evaluator is three-valued (filter_match_t aliases types::tri_bool_t): an UNKNOWN
+        // from a NULL operand flows through, so a NOT above this filter cannot resurrect the row.
+        return checked.value();
     }
 
     // IS NULL / IS NOT NULL over an ARRAY/LIST element. Nullness is always TRUE or FALSE, never

--- a/components/table/row_group.cpp
+++ b/components/table/row_group.cpp
@@ -385,41 +385,41 @@ namespace components::table {
         }
         switch (filter->filter_type) {
             case expressions::compare_type::union_or: {
-                // TRUE if any child is TRUE; otherwise UNKNOWN if any child is UNKNOWN.
-                // (UNKNOWN OR TRUE = TRUE, so a TRUE disjunct still rescues a NULL row.)
+                // OR fold via tri_or: TRUE dominates (a TRUE disjunct still rescues a NULL row),
+                // UNKNOWN otherwise absorbs.
                 auto& conjunction_or = filter->cast<conjunction_or_filter_t>();
-                bool saw_unknown = false;
+                auto acc = filter_match_t::no;
                 for (auto& child_filter : conjunction_or.child_filters) {
                     auto child = check_predicate(row_id, child_filter.get(), expression_layouts, error);
                     if (error.contains_error()) {
                         return filter_match_t::no;
                     }
-                    if (child == filter_match_t::yes) {
-                        return filter_match_t::yes;
+                    acc = types::tri_or(acc, child);
+                    if (acc == filter_match_t::yes) {
+                        break; // TRUE dominates OR — no later child can change it
                     }
-                    saw_unknown |= (child == filter_match_t::unknown);
                 }
-                return saw_unknown ? filter_match_t::unknown : filter_match_t::no;
+                return acc;
             }
             case expressions::compare_type::union_and: {
-                // FALSE if any child is FALSE; otherwise UNKNOWN if any child is UNKNOWN.
-                // (UNKNOWN AND FALSE = FALSE, so a FALSE conjunct still excludes decisively.)
+                // AND fold via tri_and: FALSE dominates (a FALSE conjunct excludes decisively),
+                // UNKNOWN otherwise absorbs.
                 auto& conjunction_and = filter->cast<conjunction_and_filter_t>();
-                bool saw_unknown = false;
+                auto acc = filter_match_t::yes;
                 for (auto& child_filter : conjunction_and.child_filters) {
                     auto child = check_predicate(row_id, child_filter.get(), expression_layouts, error);
                     if (error.contains_error()) {
                         return filter_match_t::no;
                     }
-                    if (child == filter_match_t::no) {
-                        return filter_match_t::no;
+                    acc = types::tri_and(acc, child);
+                    if (acc == filter_match_t::no) {
+                        break; // FALSE dominates AND — no later child can change it
                     }
-                    saw_unknown |= (child == filter_match_t::unknown);
                 }
-                return saw_unknown ? filter_match_t::unknown : filter_match_t::yes;
+                return acc;
             }
             case expressions::compare_type::union_not: {
-                // NOT over the disjunction of the children: negate the OR result.
+                // NOT over the disjunction of the children: tri_or the children, then tri_not.
                 // Crucially NOT UNKNOWN is UNKNOWN — a row excluded because its operand was
                 // NULL must not be flipped back in. This is what makes the validity gate in
                 // column_data_t::check_predicate safe to add.
@@ -430,15 +430,12 @@ namespace components::table {
                     if (error.contains_error()) {
                         return filter_match_t::no;
                     }
-                    if (child == filter_match_t::yes) {
-                        acc = filter_match_t::yes;
-                        break;
-                    }
-                    if (child == filter_match_t::unknown) {
-                        acc = filter_match_t::unknown;
+                    acc = types::tri_or(acc, child);
+                    if (acc == filter_match_t::yes) {
+                        break; // the negation is already settled to FALSE
                     }
                 }
-                return filter_match_not(acc);
+                return types::tri_not(acc);
             }
             case expressions::compare_type::invalid: {
                 assert(false && "invalid type for filter selection");

--- a/components/table/row_group.hpp
+++ b/components/table/row_group.hpp
@@ -61,18 +61,20 @@ namespace components::table {
 
         // `error` carries an out_of_memory error_t when a pin fails mid-check. `expression_layouts`
         // caches per-expression_filter_t chunk layouts across the rows of one scan.
-        bool check_predicate(int64_t row_id,
-                             const table_filter_t* filter,
-                             expression_filter_layout_cache_t& expression_layouts,
-                             core::error_t& error);
+        filter_match_t check_predicate(int64_t row_id,
+                                       const table_filter_t* filter,
+                                       expression_filter_layout_cache_t& expression_layouts,
+                                       core::error_t& error);
 
         // Evaluate an expression_filter_t (WHERE f(col) OP const) for one row: materialize the
         // referenced columns into a row-wide chunk (each at its original storage column index) and
         // run the attached per-row evaluator. `error` carries a pin OOM or an evaluation failure.
-        bool check_expression_predicate(int64_t row_id,
-                                        const expression_filter_t& filter,
-                                        expression_filter_layout_cache_t& expression_layouts,
-                                        core::error_t& error);
+        // The evaluator itself folds an UNKNOWN (NULL-operand) result into false, so this
+        // returns yes/no only.
+        filter_match_t check_expression_predicate(int64_t row_id,
+                                                  const expression_filter_t& filter,
+                                                  expression_filter_layout_cache_t& expression_layouts,
+                                                  core::error_t& error);
 
         void fetch_row(column_fetch_state& state,
                        const std::vector<storage_index_t>& column_ids,

--- a/components/table/row_group.hpp
+++ b/components/table/row_group.hpp
@@ -69,8 +69,7 @@ namespace components::table {
         // Evaluate an expression_filter_t (WHERE f(col) OP const) for one row: materialize the
         // referenced columns into a row-wide chunk (each at its original storage column index) and
         // run the attached per-row evaluator. `error` carries a pin OOM or an evaluation failure.
-        // The evaluator itself folds an UNKNOWN (NULL-operand) result into false, so this
-        // returns yes/no only.
+        // Three-valued: an UNKNOWN (NULL-operand) evaluation flows through as unknown.
         filter_match_t check_expression_predicate(int64_t row_id,
                                                   const expression_filter_t& filter,
                                                   expression_filter_layout_cache_t& expression_layouts,

--- a/components/types/logical_value.cpp
+++ b/components/types/logical_value.cpp
@@ -1064,24 +1064,27 @@ namespace components::types {
     * TODO: absl::int128 does not have implementations for all operations
     * Add them in operations_helper.hpp
     */
+    // SQL three-valued logic: an arithmetic operation with any NULL operand is NULL. This is
+    // the single chokepoint every scalar sum/subtract/mult/divide/modulus dispatches through,
+    // so guarding NULL here keeps a NULL operand from being read as a zero payload — which is
+    // both wrong (NULL + 1 would be 1) and unsafe (NULL used as a divisor would divide by zero).
     template<typename OP, typename GET>
     logical_value_t op(const logical_value_t& value, GET getter_function) {
+        if (value.is_null()) {
+            return logical_value_t{value.resource(), complex_logical_type{logical_type::NA}};
+        }
         OP operation{};
         return logical_value_t{value.resource(), operation((value.*getter_function)())};
     }
 
     template<typename OP, typename GET>
     logical_value_t op(const logical_value_t& value1, const logical_value_t& value2, GET getter_function) {
-        using T = typename std::invoke_result<decltype(getter_function), logical_value_t>::type;
-        OP operation{};
         auto* r = value1.resource() ? value1.resource() : value2.resource();
-        if (value1.is_null()) {
-            return logical_value_t{r, operation(T{}, (value2.*getter_function)())};
-        } else if (value2.is_null()) {
-            return logical_value_t{r, operation((value1.*getter_function)(), T{})};
-        } else {
-            return logical_value_t{r, operation((value1.*getter_function)(), (value2.*getter_function)())};
+        if (value1.is_null() || value2.is_null()) {
+            return logical_value_t{r, complex_logical_type{logical_type::NA}};
         }
+        OP operation{};
+        return logical_value_t{r, operation((value1.*getter_function)(), (value2.*getter_function)())};
     }
 
     // session timezone cancels out in arithmetics, so we don't have to pass it
@@ -1111,8 +1114,9 @@ namespace components::types {
     } // namespace
 
     logical_value_t logical_value_t::sum(const logical_value_t& value1, const logical_value_t& value2) {
-        if (value1.is_null() && value2.is_null()) {
-            return value1;
+        if (value1.is_null() || value2.is_null()) {
+            auto* r = value1.resource() ? value1.resource() : value2.resource();
+            return logical_value_t{r, complex_logical_type{logical_type::NA}};
         }
 
         if (needs_numeric_promotion(value1, value2)) {
@@ -1226,8 +1230,9 @@ namespace components::types {
     }
 
     logical_value_t logical_value_t::subtract(const logical_value_t& value1, const logical_value_t& value2) {
-        if (value1.is_null() && value2.is_null()) {
-            return value1;
+        if (value1.is_null() || value2.is_null()) {
+            auto* r = value1.resource() ? value1.resource() : value2.resource();
+            return logical_value_t{r, complex_logical_type{logical_type::NA}};
         }
 
         if (needs_numeric_promotion(value1, value2)) {
@@ -1352,8 +1357,9 @@ namespace components::types {
     }
 
     logical_value_t logical_value_t::mult(const logical_value_t& value1, const logical_value_t& value2) {
-        if (value1.is_null() && value2.is_null()) {
-            return value1;
+        if (value1.is_null() || value2.is_null()) {
+            auto* r = value1.resource() ? value1.resource() : value2.resource();
+            return logical_value_t{r, complex_logical_type{logical_type::NA}};
         }
 
         if (needs_numeric_promotion(value1, value2)) {
@@ -1440,8 +1446,9 @@ namespace components::types {
     }
 
     logical_value_t logical_value_t::divide(const logical_value_t& value1, const logical_value_t& value2) {
-        if (value1.is_null() && value2.is_null()) {
-            return value1;
+        if (value1.is_null() || value2.is_null()) {
+            auto* r = value1.resource() ? value1.resource() : value2.resource();
+            return logical_value_t{r, complex_logical_type{logical_type::NA}};
         }
 
         // Division by zero: return 0 of the appropriate type
@@ -1534,8 +1541,9 @@ namespace components::types {
     }
 
     logical_value_t logical_value_t::modulus(const logical_value_t& value1, const logical_value_t& value2) {
-        if (value1.is_null() && value2.is_null()) {
-            return value1;
+        if (value1.is_null() || value2.is_null()) {
+            auto* r = value1.resource() ? value1.resource() : value2.resource();
+            return logical_value_t{r, complex_logical_type{logical_type::NA}};
         }
 
         if (needs_numeric_promotion(value1, value2)) {
@@ -1573,8 +1581,9 @@ namespace components::types {
     }
 
     logical_value_t logical_value_t::exponent(const logical_value_t& value1, const logical_value_t& value2) {
-        if (value1.is_null() && value2.is_null()) {
-            return value1;
+        if (value1.is_null() || value2.is_null()) {
+            auto* r = value1.resource() ? value1.resource() : value2.resource();
+            return logical_value_t{r, complex_logical_type{logical_type::NA}};
         }
 
         auto type = value1.is_null() ? value2.type().type() : value1.type().type();
@@ -1738,8 +1747,9 @@ namespace components::types {
         }
     }
     logical_value_t logical_value_t::bit_and(const logical_value_t& value1, const logical_value_t& value2) {
-        if (value1.is_null() && value2.is_null()) {
-            return value1;
+        if (value1.is_null() || value2.is_null()) {
+            auto* r = value1.resource() ? value1.resource() : value2.resource();
+            return logical_value_t{r, complex_logical_type{logical_type::NA}};
         }
 
         auto type = value1.is_null() ? value2.type().type() : value1.type().type();
@@ -1772,8 +1782,9 @@ namespace components::types {
     }
 
     logical_value_t logical_value_t::bit_or(const logical_value_t& value1, const logical_value_t& value2) {
-        if (value1.is_null() && value2.is_null()) {
-            return value1;
+        if (value1.is_null() || value2.is_null()) {
+            auto* r = value1.resource() ? value1.resource() : value2.resource();
+            return logical_value_t{r, complex_logical_type{logical_type::NA}};
         }
 
         auto type = value1.is_null() ? value2.type().type() : value1.type().type();
@@ -1806,8 +1817,9 @@ namespace components::types {
     }
 
     logical_value_t logical_value_t::bit_xor(const logical_value_t& value1, const logical_value_t& value2) {
-        if (value1.is_null() && value2.is_null()) {
-            return value1;
+        if (value1.is_null() || value2.is_null()) {
+            auto* r = value1.resource() ? value1.resource() : value2.resource();
+            return logical_value_t{r, complex_logical_type{logical_type::NA}};
         }
 
         auto type = value1.is_null() ? value2.type().type() : value1.type().type();
@@ -1873,8 +1885,9 @@ namespace components::types {
     }
 
     logical_value_t logical_value_t::bit_shift_l(const logical_value_t& value1, const logical_value_t& value2) {
-        if (value1.is_null() && value2.is_null()) {
-            return value1;
+        if (value1.is_null() || value2.is_null()) {
+            auto* r = value1.resource() ? value1.resource() : value2.resource();
+            return logical_value_t{r, complex_logical_type{logical_type::NA}};
         }
 
         auto type = value1.is_null() ? value2.type().type() : value1.type().type();
@@ -1907,8 +1920,9 @@ namespace components::types {
     }
 
     logical_value_t logical_value_t::bit_shift_r(const logical_value_t& value1, const logical_value_t& value2) {
-        if (value1.is_null() && value2.is_null()) {
-            return value1;
+        if (value1.is_null() || value2.is_null()) {
+            auto* r = value1.resource() ? value1.resource() : value2.resource();
+            return logical_value_t{r, complex_logical_type{logical_type::NA}};
         }
 
         auto type = value1.is_null() ? value2.type().type() : value1.type().type();

--- a/components/types/logical_value.cpp
+++ b/components/types/logical_value.cpp
@@ -746,6 +746,23 @@ namespace components::types {
     bool logical_value_t::operator!=(const logical_value_t& rhs) const { return !(*this == rhs); }
 
     bool logical_value_t::operator<(const logical_value_t& rhs) const {
+        // A NULL carries logical_type::NA, not the column's type, so the type-directed switch below
+        // cannot order it: it would fall to `default: return false` for an NA on the left, and for
+        // an NA on the RIGHT it would read the NA's payload as if it were the left type — which
+        // dereferences a null pointer for STRING/LIST/STRUCT/MAP.
+        //
+        // Worse, returning false in both directions makes a NULL "equivalent" to every value while
+        // the values stay ordered among themselves (less(NA,5) and less(5,NA) are both false, yet
+        // less(5,7) is true). Equivalence is then not transitive, so this is not a strict weak
+        // ordering, and every std::sort / std::map / b-tree keyed on it is undefined behaviour.
+        //
+        // Order NULLs LAST, matching the ORDER BY convention already used by sort.cpp, so the
+        // engine has one NULL-ordering rule rather than two.
+        const bool lhs_null = is_null();
+        const bool rhs_null = rhs.is_null();
+        if (lhs_null || rhs_null) {
+            return !lhs_null && rhs_null; // value < NULL; NULL < anything is false
+        }
         // Array/list ordering is length-aware: compare element-wise, a shorter array that is a prefix sorts
         // first (lexicographic). Handled before the size-inclusive type assert so different-length arrays
         // do not trip it.

--- a/components/types/logical_value.cpp
+++ b/components/types/logical_value.cpp
@@ -677,6 +677,13 @@ namespace components::types {
     }
 
     bool logical_value_t::operator==(const logical_value_t& rhs) const {
+        // Structural equality, for container keys / DISTINCT / sort: two NULLs are equal, and a
+        // NULL equals no value. (SQL value equality over a NULL is UNKNOWN, not FALSE -- that is
+        // compare_sql(), which the predicate evaluators use.) Guarded first so a NULL operand never
+        // reaches the type switch below with a mismatched type.
+        if (is_null() || rhs.is_null()) {
+            return is_null() && rhs.is_null();
+        }
         // Array/list equality is length-aware (PostgreSQL): arrays of different length are simply unequal —
         // never reconciled, never an assert. Element types are coerced by cast_as before comparison; a
         // residual per-element type mismatch (e.g. an NA pad against a typed element) also counts as
@@ -691,8 +698,6 @@ namespace components::types {
         }
         assert(type_ == rhs.type_ && "logical_value_t has to be casted to the same type before comparison");
         switch (type_.type()) {
-            case logical_type::NA:
-                return true;
             case logical_type::BOOLEAN:
             case logical_type::TINYINT:
             case logical_type::SMALLINT:
@@ -852,6 +857,15 @@ namespace components::types {
         } else {
             return compare_t::more;
         }
+    }
+
+    std::optional<compare_t> logical_value_t::compare_sql(const logical_value_t& rhs) const {
+        // A comparison with a NULL operand is UNKNOWN in SQL three-valued logic; there is no
+        // TRUE/FALSE answer to map an ordering onto.
+        if (is_null() || rhs.is_null()) {
+            return std::nullopt;
+        }
+        return compare(rhs);
     }
 
     const std::vector<logical_value_t>& logical_value_t::children() const {

--- a/components/types/logical_value.hpp
+++ b/components/types/logical_value.hpp
@@ -5,6 +5,7 @@
 #include <cstring>
 #include <memory>
 #include <memory_resource>
+#include <optional>
 
 #include "types.hpp"
 #include <core/date/date_types.hpp>
@@ -43,7 +44,13 @@ namespace components::types {
         bool operator<=(const logical_value_t& rhs) const;
         bool operator>=(const logical_value_t& rhs) const;
 
+        // Total-order comparison used for sorting, indexing and container keys (NULLs order last;
+        // NULL == NULL). operator</operator== implement it. Never use it to answer a SQL predicate.
         compare_t compare(const logical_value_t& rhs) const;
+
+        // SQL value comparison: nullopt when either operand is NULL (the comparison is UNKNOWN in
+        // three-valued logic). Use this — not compare() — to evaluate a predicate over values.
+        std::optional<compare_t> compare_sql(const logical_value_t& rhs) const;
 
         const std::vector<logical_value_t>& children() const;
 

--- a/components/types/tests/CMakeLists.txt
+++ b/components/types/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ add_definitions(-DDEV_MODE)
 set( ${PROJECT_NAME}_SOURCES
         test_types.cpp
         test_type_switch.cpp
+        test_tri_bool.cpp
 )
 
 add_executable(${PROJECT_NAME} ${${PROJECT_NAME}_SOURCES})

--- a/components/types/tests/test_tri_bool.cpp
+++ b/components/types/tests/test_tri_bool.cpp
@@ -1,0 +1,74 @@
+#include <catch2/catch_test_macros.hpp>
+#include <components/types/tri_bool.hpp>
+
+using components::types::permits;
+using components::types::selects;
+using components::types::tri_and;
+using components::types::tri_bool_t;
+using components::types::tri_not;
+using components::types::tri_of;
+using components::types::tri_or;
+
+namespace {
+    constexpr auto T = tri_bool_t::yes;
+    constexpr auto F = tri_bool_t::no;
+    constexpr auto U = tri_bool_t::unknown;
+
+    // The whole point of three-valued logic is that UNKNOWN is not FALSE: NOT UNKNOWN stays
+    // UNKNOWN. These truth tables are the contract every 3VL consumer relies on, pinned at
+    // compile time so a refactor of the combinators cannot silently change them.
+
+    static_assert(tri_of(true) == T);
+    static_assert(tri_of(false) == F);
+
+    static_assert(tri_not(T) == F);
+    static_assert(tri_not(F) == T);
+    static_assert(tri_not(U) == U); // the load-bearing case
+
+    // AND: FALSE dominates; UNKNOWN otherwise absorbs.
+    static_assert(tri_and(T, T) == T);
+    static_assert(tri_and(T, F) == F);
+    static_assert(tri_and(F, T) == F);
+    static_assert(tri_and(F, F) == F);
+    static_assert(tri_and(T, U) == U);
+    static_assert(tri_and(U, T) == U);
+    static_assert(tri_and(F, U) == F); // FALSE wins over UNKNOWN
+    static_assert(tri_and(U, F) == F);
+    static_assert(tri_and(U, U) == U);
+
+    // OR: TRUE dominates; UNKNOWN otherwise absorbs.
+    static_assert(tri_or(T, T) == T);
+    static_assert(tri_or(T, F) == T);
+    static_assert(tri_or(F, T) == T);
+    static_assert(tri_or(F, F) == F);
+    static_assert(tri_or(T, U) == T); // TRUE wins over UNKNOWN
+    static_assert(tri_or(U, T) == T);
+    static_assert(tri_or(F, U) == U);
+    static_assert(tri_or(U, F) == U);
+    static_assert(tri_or(U, U) == U);
+
+    // A WHERE / join / DML predicate admits a row only on TRUE.
+    static_assert(selects(T));
+    static_assert(!selects(F));
+    static_assert(!selects(U));
+
+    // A CHECK constraint is violated only on FALSE; UNKNOWN passes.
+    static_assert(permits(T));
+    static_assert(!permits(F));
+    static_assert(permits(U));
+} // namespace
+
+TEST_CASE("types::tri_bool::truth_tables") {
+    // The contract is enforced by the static_asserts above; this run-time case makes the
+    // coverage visible to the test harness and guards De Morgan / double-negation identities.
+    for (auto a : {T, F, U}) {
+        CHECK(tri_not(tri_not(a)) == a);
+        for (auto b : {T, F, U}) {
+            CHECK(tri_and(a, b) == tri_and(b, a)); // commutative
+            CHECK(tri_or(a, b) == tri_or(b, a));
+            // De Morgan: NOT(a AND b) == (NOT a) OR (NOT b)
+            CHECK(tri_not(tri_and(a, b)) == tri_or(tri_not(a), tri_not(b)));
+            CHECK(tri_not(tri_or(a, b)) == tri_and(tri_not(a), tri_not(b)));
+        }
+    }
+}

--- a/components/types/tests/test_tri_bool.cpp
+++ b/components/types/tests/test_tri_bool.cpp
@@ -21,6 +21,12 @@ namespace {
     static_assert(tri_of(true) == T);
     static_assert(tri_of(false) == F);
 
+    // Nullable-boolean seam: NULL is UNKNOWN regardless of what the (meaningless) payload holds.
+    static_assert(tri_of(true, false) == T);
+    static_assert(tri_of(false, false) == F);
+    static_assert(tri_of(true, true) == U);
+    static_assert(tri_of(false, true) == U);
+
     static_assert(tri_not(T) == F);
     static_assert(tri_not(F) == T);
     static_assert(tri_not(U) == U); // the load-bearing case

--- a/components/types/tri_bool.hpp
+++ b/components/types/tri_bool.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <cstdint>
+
+namespace components::types {
+
+    // SQL three-valued logic.
+    //
+    // A predicate evaluated over a NULL operand is UNKNOWN, which is distinct from FALSE: the two
+    // diverge under NOT (`NOT UNKNOWN` is UNKNOWN, while `NOT FALSE` is TRUE). A filter tree that
+    // collapses UNKNOWN into FALSE therefore lets NOT resurrect a NULL row. This is the single
+    // vocabulary for that logic, shared by the storage-scan filter and the in-memory predicate
+    // evaluator so the two engines cannot drift.
+    //
+    // Only `yes` (TRUE) admits a row through a WHERE / join / DML predicate; only `no` (FALSE)
+    // violates a CHECK constraint. UNKNOWN excludes from a WHERE but satisfies a CHECK.
+    enum class tri_bool_t : uint8_t
+    {
+        no = 0,
+        yes = 1,
+        unknown = 2
+    };
+
+    constexpr tri_bool_t tri_of(bool b) noexcept { return b ? tri_bool_t::yes : tri_bool_t::no; }
+
+    // NOT: TRUE<->FALSE, UNKNOWN is unchanged.
+    constexpr tri_bool_t tri_not(tri_bool_t v) noexcept {
+        switch (v) {
+            case tri_bool_t::yes:
+                return tri_bool_t::no;
+            case tri_bool_t::no:
+                return tri_bool_t::yes;
+            default:
+                return tri_bool_t::unknown;
+        }
+    }
+
+    // AND: FALSE dominates (FALSE AND anything = FALSE); otherwise UNKNOWN if either is UNKNOWN.
+    constexpr tri_bool_t tri_and(tri_bool_t a, tri_bool_t b) noexcept {
+        if (a == tri_bool_t::no || b == tri_bool_t::no) {
+            return tri_bool_t::no;
+        }
+        if (a == tri_bool_t::unknown || b == tri_bool_t::unknown) {
+            return tri_bool_t::unknown;
+        }
+        return tri_bool_t::yes;
+    }
+
+    // OR: TRUE dominates (TRUE OR anything = TRUE); otherwise UNKNOWN if either is UNKNOWN.
+    constexpr tri_bool_t tri_or(tri_bool_t a, tri_bool_t b) noexcept {
+        if (a == tri_bool_t::yes || b == tri_bool_t::yes) {
+            return tri_bool_t::yes;
+        }
+        if (a == tri_bool_t::unknown || b == tri_bool_t::unknown) {
+            return tri_bool_t::unknown;
+        }
+        return tri_bool_t::no;
+    }
+
+    // A row passes a WHERE / join / DML predicate only when the predicate is definitely TRUE.
+    constexpr bool selects(tri_bool_t v) noexcept { return v == tri_bool_t::yes; }
+
+    // A CHECK constraint is satisfied unless the predicate is definitely FALSE (UNKNOWN passes).
+    constexpr bool permits(tri_bool_t v) noexcept { return v != tri_bool_t::no; }
+
+} // namespace components::types

--- a/components/types/tri_bool.hpp
+++ b/components/types/tri_bool.hpp
@@ -23,6 +23,16 @@ namespace components::types {
 
     constexpr tri_bool_t tri_of(bool b) noexcept { return b ? tri_bool_t::yes : tri_bool_t::no; }
 
+    // Lift a nullable boolean — the one named seam between the engine's (value, validity)
+    // representation and three-valued logic: NULL is UNKNOWN, a present value lifts its truth.
+    // An ordinary function, so `value` is evaluated even when `is_null` is true: use it only
+    // where that read is defined regardless of nullness (e.g. a NULL logical_value_t's payload
+    // is a zeroed member); keep an explicit short-circuiting guard where the value read itself
+    // is only valid for non-NULL data (e.g. a vector slot whose row is invalid).
+    constexpr tri_bool_t tri_of(bool value, bool is_null) noexcept {
+        return is_null ? tri_bool_t::unknown : tri_of(value);
+    }
+
     // NOT: TRUE<->FALSE, UNKNOWN is unchanged.
     constexpr tri_bool_t tri_not(tri_bool_t v) noexcept {
         switch (v) {

--- a/components/types/tri_bool.hpp
+++ b/components/types/tri_bool.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <type_traits>
 
 namespace components::types {
 
@@ -20,6 +21,17 @@ namespace components::types {
         yes = 1,
         unknown = 2
     };
+
+    // tri_bool_t deliberately has no operator bool, no operator&&/||/!, and no implicit bool
+    // interop: in three-valued logic `if (v)` and `a && b` have no single right meaning, and the
+    // classic library pitfalls (boost::tribool's implicit conversions, its always-indeterminate
+    // `== indeterminate`) stem exactly from pretending they do. Combining goes through
+    // tri_and/tri_or/tri_not; collapsing to a bool goes through selects()/permits(), which name
+    // the SQL rule being applied. (`unknown` is the SQL standard's name for the third truth
+    // value — keep it, not boost's `indeterminate`.) These asserts pin the absence of implicit
+    // interop so a convenience operator cannot be added without tripping them.
+    static_assert(!std::is_convertible_v<tri_bool_t, bool>, "tri_bool_t must never implicitly become bool");
+    static_assert(!std::is_convertible_v<bool, tri_bool_t>, "bool must never implicitly become tri_bool_t");
 
     constexpr tri_bool_t tri_of(bool b) noexcept { return b ? tri_bool_t::yes : tri_bool_t::no; }
 

--- a/components/vector/arithmetic.cpp
+++ b/components/vector/arithmetic.cpp
@@ -1129,36 +1129,46 @@ namespace components::vector {
         if (count == 0) {
             return vector_t(resource, types::complex_logical_type(types::logical_type::DOUBLE), 0);
         }
-        if (types::is_duration(left.type().type()) || types::is_duration(right.type().type())) {
-            return compute_temporal_binary(resource, op, left, right, count);
-        }
-        auto result_logical = types::arithmetic_result_type(left.type().type(), right.type().type(), op);
-        if (result_logical == types::logical_type::FLOAT) {
-            result_logical = types::logical_type::DOUBLE;
-        }
-        auto result_type = types::complex_logical_type(result_logical);
-        vector_t output(resource, result_type, count);
-        if (result_type.type() == types::logical_type::NA) {
-            return output;
-        }
-
-        switch (op) {
-            case arithmetic_op::add:
-                dispatch_binary<std::plus>(left, right, output, count);
-                break;
-            case arithmetic_op::subtract:
-                dispatch_binary<std::minus>(left, right, output, count);
-                break;
-            case arithmetic_op::multiply:
-                dispatch_binary<std::multiplies>(left, right, output, count);
-                break;
-            case arithmetic_op::divide:
-                dispatch_binary_div<checked_divides>(left, right, output, count);
-                break;
-            case arithmetic_op::mod:
-                dispatch_binary_div<checked_modulus>(left, right, output, count);
-                break;
-        }
+        // Compute the result values first (numeric or temporal), then apply NULL propagation as a
+        // single tail below. Capturing the temporal branch in this local instead of returning it
+        // directly keeps it on the same validity path as the numeric branch.
+        vector_t output = [&]() -> vector_t {
+            if (types::is_duration(left.type().type()) || types::is_duration(right.type().type())) {
+                return compute_temporal_binary(resource, op, left, right, count);
+            }
+            auto result_logical = types::arithmetic_result_type(left.type().type(), right.type().type(), op);
+            if (result_logical == types::logical_type::FLOAT) {
+                result_logical = types::logical_type::DOUBLE;
+            }
+            auto result_type = types::complex_logical_type(result_logical);
+            vector_t out(resource, result_type, count);
+            if (result_type.type() == types::logical_type::NA) {
+                return out;
+            }
+            switch (op) {
+                case arithmetic_op::add:
+                    dispatch_binary<std::plus>(left, right, out, count);
+                    break;
+                case arithmetic_op::subtract:
+                    dispatch_binary<std::minus>(left, right, out, count);
+                    break;
+                case arithmetic_op::multiply:
+                    dispatch_binary<std::multiplies>(left, right, out, count);
+                    break;
+                case arithmetic_op::divide:
+                    dispatch_binary_div<checked_divides>(left, right, out, count);
+                    break;
+                case arithmetic_op::mod:
+                    dispatch_binary_div<checked_modulus>(left, right, out, count);
+                    break;
+            }
+            return out;
+        }();
+        // SQL three-valued logic: a NULL operand makes the result NULL. combine is a word-wise
+        // AND that is a no-op when the operand mask is all-valid, so NULL-free columns pay nothing.
+        // Applied after the dispatch so it composes with the divide/mod zero-invalidation.
+        output.validity().combine(left.validity(), count);
+        output.validity().combine(right.validity(), count);
         return output;
     }
 
@@ -1173,35 +1183,43 @@ namespace components::vector {
         if (count == 0) {
             return vector_t(resource, types::complex_logical_type(types::logical_type::DOUBLE), 0);
         }
-        if (types::is_duration(vec.type().type()) || types::is_duration(scalar.type().type())) {
-            return compute_temporal_vec_scalar(resource, op, vec, scalar, count);
-        }
-        auto result_logical = types::arithmetic_result_type(vec.type().type(), scalar.type().type(), op);
-        if (result_logical == types::logical_type::FLOAT) {
-            result_logical = types::logical_type::DOUBLE;
-        }
-        auto result_type = types::complex_logical_type(result_logical);
-        vector_t output(resource, result_type, count);
-        if (result_type.type() == types::logical_type::NA) {
-            return output;
-        }
-
-        switch (op) {
-            case arithmetic_op::add:
-                dispatch_vec_scalar<std::plus>(vec, scalar, output, count);
-                break;
-            case arithmetic_op::subtract:
-                dispatch_vec_scalar<std::minus>(vec, scalar, output, count);
-                break;
-            case arithmetic_op::multiply:
-                dispatch_vec_scalar<std::multiplies>(vec, scalar, output, count);
-                break;
-            case arithmetic_op::divide:
-                dispatch_vec_scalar_div<checked_divides>(vec, scalar, output, count);
-                break;
-            case arithmetic_op::mod:
-                dispatch_vec_scalar_div<checked_modulus>(vec, scalar, output, count);
-                break;
+        vector_t output = [&]() -> vector_t {
+            if (types::is_duration(vec.type().type()) || types::is_duration(scalar.type().type())) {
+                return compute_temporal_vec_scalar(resource, op, vec, scalar, count);
+            }
+            auto result_logical = types::arithmetic_result_type(vec.type().type(), scalar.type().type(), op);
+            if (result_logical == types::logical_type::FLOAT) {
+                result_logical = types::logical_type::DOUBLE;
+            }
+            auto result_type = types::complex_logical_type(result_logical);
+            vector_t out(resource, result_type, count);
+            if (result_type.type() == types::logical_type::NA) {
+                return out;
+            }
+            switch (op) {
+                case arithmetic_op::add:
+                    dispatch_vec_scalar<std::plus>(vec, scalar, out, count);
+                    break;
+                case arithmetic_op::subtract:
+                    dispatch_vec_scalar<std::minus>(vec, scalar, out, count);
+                    break;
+                case arithmetic_op::multiply:
+                    dispatch_vec_scalar<std::multiplies>(vec, scalar, out, count);
+                    break;
+                case arithmetic_op::divide:
+                    dispatch_vec_scalar_div<checked_divides>(vec, scalar, out, count);
+                    break;
+                case arithmetic_op::mod:
+                    dispatch_vec_scalar_div<checked_modulus>(vec, scalar, out, count);
+                    break;
+            }
+            return out;
+        }();
+        // A NULL scalar makes every result NULL; otherwise propagate the vector operand's nulls.
+        if (scalar.is_null()) {
+            output.validity().set_all_invalid(count);
+        } else {
+            output.validity().combine(vec.validity(), count);
         }
         return output;
     }
@@ -1217,35 +1235,43 @@ namespace components::vector {
         if (count == 0) {
             return vector_t(resource, types::complex_logical_type(types::logical_type::DOUBLE), 0);
         }
-        if (types::is_duration(scalar.type().type()) || types::is_duration(vec.type().type())) {
-            return compute_temporal_scalar_vec(resource, op, scalar, vec, count);
-        }
-        auto result_logical = types::arithmetic_result_type(scalar.type().type(), vec.type().type(), op);
-        if (result_logical == types::logical_type::FLOAT) {
-            result_logical = types::logical_type::DOUBLE;
-        }
-        auto result_type = types::complex_logical_type(result_logical);
-        vector_t output(resource, result_type, count);
-        if (result_type.type() == types::logical_type::NA) {
-            return output;
-        }
-
-        switch (op) {
-            case arithmetic_op::add:
-                dispatch_scalar_vec<std::plus>(scalar, vec, output, count);
-                break;
-            case arithmetic_op::subtract:
-                dispatch_scalar_vec<std::minus>(scalar, vec, output, count);
-                break;
-            case arithmetic_op::multiply:
-                dispatch_scalar_vec<std::multiplies>(scalar, vec, output, count);
-                break;
-            case arithmetic_op::divide:
-                dispatch_scalar_vec_div<checked_divides>(scalar, vec, output, count);
-                break;
-            case arithmetic_op::mod:
-                dispatch_scalar_vec_div<checked_modulus>(scalar, vec, output, count);
-                break;
+        vector_t output = [&]() -> vector_t {
+            if (types::is_duration(scalar.type().type()) || types::is_duration(vec.type().type())) {
+                return compute_temporal_scalar_vec(resource, op, scalar, vec, count);
+            }
+            auto result_logical = types::arithmetic_result_type(scalar.type().type(), vec.type().type(), op);
+            if (result_logical == types::logical_type::FLOAT) {
+                result_logical = types::logical_type::DOUBLE;
+            }
+            auto result_type = types::complex_logical_type(result_logical);
+            vector_t out(resource, result_type, count);
+            if (result_type.type() == types::logical_type::NA) {
+                return out;
+            }
+            switch (op) {
+                case arithmetic_op::add:
+                    dispatch_scalar_vec<std::plus>(scalar, vec, out, count);
+                    break;
+                case arithmetic_op::subtract:
+                    dispatch_scalar_vec<std::minus>(scalar, vec, out, count);
+                    break;
+                case arithmetic_op::multiply:
+                    dispatch_scalar_vec<std::multiplies>(scalar, vec, out, count);
+                    break;
+                case arithmetic_op::divide:
+                    dispatch_scalar_vec_div<checked_divides>(scalar, vec, out, count);
+                    break;
+                case arithmetic_op::mod:
+                    dispatch_scalar_vec_div<checked_modulus>(scalar, vec, out, count);
+                    break;
+            }
+            return out;
+        }();
+        // A NULL scalar makes every result NULL; otherwise propagate the vector operand's nulls.
+        if (scalar.is_null()) {
+            output.validity().set_all_invalid(count);
+        } else {
+            output.validity().combine(vec.validity(), count);
         }
         return output;
     }
@@ -1262,6 +1288,8 @@ namespace components::vector {
                                                                         vec,
                                                                         output,
                                                                         count);
+        // -NULL is NULL: carry the operand's nulls into the negated result.
+        output.validity().combine(vec.validity(), count);
         return output;
     }
 

--- a/components/vector/data_chunk.cpp
+++ b/components/vector/data_chunk.cpp
@@ -105,6 +105,14 @@ namespace components::vector {
     types::logical_value_t data_chunk_t::value(const std::pmr::vector<size_t>& col_path, uint64_t index) const {
         const vector_t* sub_column = &data[col_path.front()];
         for (auto it = std::next(col_path.begin()); it != col_path.end(); ++it) {
+            // Descending a path stops at the first NULL level: a NULL STRUCT/ARRAY/LIST cell has
+            // no interior to read. Without this, the ARRAY branch would index the flat child by a
+            // stride computed from a NULL row, and the LIST branch would read a garbage
+            // (offset,length) entry and return an arbitrary element of the flat child buffer.
+            if (!sub_column->validity().row_is_valid(index)) {
+                return types::logical_value_t{sub_column->resource(),
+                                              types::complex_logical_type{types::logical_type::NA}};
+            }
             if (std::next(it) == col_path.end()) {
                 if (sub_column->type().type() == types::logical_type::ARRAY) {
                     auto stride =

--- a/components/vector/validation.cpp
+++ b/components/vector/validation.cpp
@@ -263,11 +263,23 @@ namespace components::vector {
             // X & 1 = X
             return;
         }
+        // Two distinct sizes matter here, and conflating them corrupts memory:
+        //  * this mask's buffer must stay sized to entry_count(count_) words -- the invariant every
+        //    other method relies on (copy-ctor/operator= read exactly that many). count_ may be the
+        //    inflated reset() default (DEFAULT_VECTOR_CAPACITY), so we must NOT shrink the buffer to
+        //    the combined row count, or a later copy would over-read THIS buffer.
+        //  * we may only READ entry_count(count) words from `other`: it was built for `count` rows,
+        //    so reading entry_count(count_) words from it would overrun ITS (smaller) buffer.
+        const auto self_entries = validity_data_t::entry_count(count_);
+        const auto other_entries = validity_data_t::entry_count(count);
         if (all_valid()) {
-            // 1 & Y = Y
-            validity_data_ = std::make_shared<validity_data_t>(resource_,
-                                                               other.validity_mask_,
-                                                               validity_data_t::entry_count(count_));
+            // 1 & Y = Y over the first `count` rows; rows in [count, count_) have no operand data
+            // and stay valid (the all-ones fill from the count-only constructor).
+            auto data = std::make_shared<validity_data_t>(resource_, self_entries);
+            for (size_t i = 0; i < other_entries; i++) {
+                data->data()[i] = other.validity_mask_[i];
+            }
+            validity_data_ = std::move(data);
             validity_mask_ = validity_data_->data();
             return;
         }
@@ -276,13 +288,13 @@ namespace components::vector {
             return;
         }
 
-        validity_data_ =
-            std::make_shared<validity_data_t>(resource_, validity_mask_, validity_data_t::entry_count(count_));
+        // Copy-on-write: validity_data_ may be shared, so clone before mutating. Keep the full
+        // entry_count(count_)-word buffer, then AND in only the entry_count(count) words `other`
+        // actually holds.
+        validity_data_ = std::make_shared<validity_data_t>(resource_, validity_mask_, self_entries);
         validity_mask_ = validity_data_->data();
-
-        auto entry_count = validity_data_t::entry_count(count);
-        for (size_t i = 0; i < entry_count; i++) {
-            data()[i] = data()[i] & other.data()[i];
+        for (size_t i = 0; i < other_entries; i++) {
+            validity_mask_[i] &= other.validity_mask_[i];
         }
     }
 

--- a/integration/cpp/test/CMakeLists.txt
+++ b/integration/cpp/test/CMakeLists.txt
@@ -23,6 +23,7 @@ set( ${PROJECT_NAME}_SOURCES
         test_null_three_valued_logic.cpp
         test_null_arithmetic.cpp
         test_null_aggregates.cpp
+        test_null_deep_path.cpp
         test_production_scenarios.cpp
         test_join.cpp
         test_join_raw.cpp

--- a/integration/cpp/test/CMakeLists.txt
+++ b/integration/cpp/test/CMakeLists.txt
@@ -19,6 +19,7 @@ set( ${PROJECT_NAME}_SOURCES
         test_correctness_bugs.cpp
         test_multi_database_isolation.cpp
         test_dispatcher_watchdog_log.cpp
+        test_null_three_valued_logic.cpp
         test_production_scenarios.cpp
         test_join.cpp
         test_join_raw.cpp

--- a/integration/cpp/test/CMakeLists.txt
+++ b/integration/cpp/test/CMakeLists.txt
@@ -22,6 +22,7 @@ set( ${PROJECT_NAME}_SOURCES
         test_dispatcher_watchdog_log.cpp
         test_null_three_valued_logic.cpp
         test_null_arithmetic.cpp
+        test_null_aggregates.cpp
         test_production_scenarios.cpp
         test_join.cpp
         test_join_raw.cpp

--- a/integration/cpp/test/CMakeLists.txt
+++ b/integration/cpp/test/CMakeLists.txt
@@ -21,6 +21,7 @@ set( ${PROJECT_NAME}_SOURCES
         test_index_null_correctness.cpp
         test_dispatcher_watchdog_log.cpp
         test_null_three_valued_logic.cpp
+        test_null_arithmetic.cpp
         test_production_scenarios.cpp
         test_join.cpp
         test_join_raw.cpp

--- a/integration/cpp/test/CMakeLists.txt
+++ b/integration/cpp/test/CMakeLists.txt
@@ -27,6 +27,7 @@ set( ${PROJECT_NAME}_SOURCES
         test_null_array_element.cpp
         test_null_comparison.cpp
         test_null_predicate_3vl.cpp
+        test_null_case_3vl.cpp
         test_null_semantics_matrix.cpp
         test_production_scenarios.cpp
         test_join.cpp

--- a/integration/cpp/test/CMakeLists.txt
+++ b/integration/cpp/test/CMakeLists.txt
@@ -26,6 +26,7 @@ set( ${PROJECT_NAME}_SOURCES
         test_null_deep_path.cpp
         test_null_array_element.cpp
         test_null_comparison.cpp
+        test_null_semantics_matrix.cpp
         test_production_scenarios.cpp
         test_join.cpp
         test_join_raw.cpp

--- a/integration/cpp/test/CMakeLists.txt
+++ b/integration/cpp/test/CMakeLists.txt
@@ -24,6 +24,7 @@ set( ${PROJECT_NAME}_SOURCES
         test_null_arithmetic.cpp
         test_null_aggregates.cpp
         test_null_deep_path.cpp
+        test_null_array_element.cpp
         test_production_scenarios.cpp
         test_join.cpp
         test_join_raw.cpp

--- a/integration/cpp/test/CMakeLists.txt
+++ b/integration/cpp/test/CMakeLists.txt
@@ -19,6 +19,7 @@ set( ${PROJECT_NAME}_SOURCES
         test_correctness_bugs.cpp
         test_multi_database_isolation.cpp
         test_index_null_correctness.cpp
+        test_aggregate_filter.cpp
         test_dispatcher_watchdog_log.cpp
         test_null_three_valued_logic.cpp
         test_null_arithmetic.cpp

--- a/integration/cpp/test/CMakeLists.txt
+++ b/integration/cpp/test/CMakeLists.txt
@@ -26,6 +26,7 @@ set( ${PROJECT_NAME}_SOURCES
         test_null_deep_path.cpp
         test_null_array_element.cpp
         test_null_comparison.cpp
+        test_null_predicate_3vl.cpp
         test_null_semantics_matrix.cpp
         test_production_scenarios.cpp
         test_join.cpp

--- a/integration/cpp/test/CMakeLists.txt
+++ b/integration/cpp/test/CMakeLists.txt
@@ -18,6 +18,7 @@ set( ${PROJECT_NAME}_SOURCES
         test_create_index_backfill_batched.cpp
         test_correctness_bugs.cpp
         test_multi_database_isolation.cpp
+        test_index_null_correctness.cpp
         test_dispatcher_watchdog_log.cpp
         test_null_three_valued_logic.cpp
         test_production_scenarios.cpp

--- a/integration/cpp/test/CMakeLists.txt
+++ b/integration/cpp/test/CMakeLists.txt
@@ -25,6 +25,7 @@ set( ${PROJECT_NAME}_SOURCES
         test_null_aggregates.cpp
         test_null_deep_path.cpp
         test_null_array_element.cpp
+        test_null_comparison.cpp
         test_production_scenarios.cpp
         test_join.cpp
         test_join_raw.cpp

--- a/integration/cpp/test/test_aggregate_filter.cpp
+++ b/integration/cpp/test/test_aggregate_filter.cpp
@@ -1,0 +1,136 @@
+#include "test_config.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <optional>
+#include <string>
+#include <vector>
+
+// Aggregate FILTER clause:  agg(x) FILTER (WHERE p).  The parser captures the predicate into
+// FuncCall.agg_filter, but the transformer dropped it, so the FILTER was silently ignored and the
+// aggregate ran over every row.  It is lowered to  agg(CASE WHEN p THEN x END)  (and COUNT(*) to
+// COUNT(CASE WHEN p THEN 1 END)); every supported aggregate skips NULLs, so rows failing p are
+// excluded.  The predicate reuses the SQL three-valued CASE-WHEN evaluator, so an UNKNOWN (NULL
+// operand) excludes the row.
+
+namespace {
+    using test_helpers::exec;
+    using opt = std::optional<int64_t>;
+    using L = std::vector<opt>;
+
+    template<typename D>
+    bool okq(D* d, const std::string& sql) {
+        auto c = exec(d, sql);
+        return c && c->is_success();
+    }
+
+    // Column 0 of every row as optional<int64> (nullopt == NULL), in result order.
+    template<typename D>
+    std::vector<opt> coli(D* d, const std::string& sql) {
+        auto c = exec(d, sql);
+        REQUIRE(c);
+        INFO(sql);
+        REQUIRE(c->is_success());
+        std::vector<opt> out;
+        for (uint64_t r = 0; r < c->size(); ++r) {
+            auto v = c->value(0, r);
+            out.push_back(v.is_null() ? opt{} : opt{v.template value<int64_t>()});
+        }
+        return out;
+    }
+} // namespace
+
+// -------------------------------------------------------------------------------------------------
+//  Scalar aggregates with FILTER over a whole table.
+// -------------------------------------------------------------------------------------------------
+TEST_CASE("integration::cpp::aggregate_filter::scalar") {
+    auto config = test_helpers::make_test_config("/tmp/aggregate_filter/scalar");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(okq(d, "CREATE DATABASE m;"));
+    REQUIRE(okq(d, "CREATE TABLE m.t (id INT, x BIGINT, g INT);"));
+    // x:                  10    20    30    NULL   40
+    REQUIRE(okq(d, "INSERT INTO m.t (id, x, g) VALUES (1,10,0),(2,20,1),(3,30,0),(4,NULL,1),(5,40,0);"));
+
+    // SUM(x) FILTER (WHERE g = 0): rows 1,3,5 -> 10+30+40 = 80  (unfiltered SUM would be 100).
+    CHECK(coli(d, "SELECT SUM(x) FILTER (WHERE g = 0) FROM m.t;") == L{80});
+    // COUNT(*) FILTER (WHERE g = 0): 3 rows have g=0.
+    CHECK(coli(d, "SELECT COUNT(*) FILTER (WHERE g = 0) FROM m.t;") == L{3});
+    // COUNT(x) FILTER (WHERE g = 1): rows 2 and 4 have g=1, but x is NULL in row 4 -> COUNT(x)=1.
+    CHECK(coli(d, "SELECT COUNT(x) FILTER (WHERE g = 1) FROM m.t;") == L{1});
+    // MIN / MAX FILTER over g=0 -> {10,30,40}.
+    CHECK(coli(d, "SELECT MIN(x) FILTER (WHERE g = 0) FROM m.t;") == L{10});
+    CHECK(coli(d, "SELECT MAX(x) FILTER (WHERE g = 0) FROM m.t;") == L{40});
+    // A predicate on x itself: SUM(x) FILTER (WHERE x > 15) -> 20+30+40 = 90; NULL row excluded.
+    CHECK(coli(d, "SELECT SUM(x) FILTER (WHERE x > 15) FROM m.t;") == L{90});
+    // Compound predicate: SUM(x) FILTER (WHERE g = 0 AND x > 10) -> 30+40 = 70.
+    CHECK(coli(d, "SELECT SUM(x) FILTER (WHERE g = 0 AND x > 10) FROM m.t;") == L{70});
+    // Negated predicate (SQL 3VL: NOT must negate, not behave like OR): rows with g<>1 are 1,3,5 ->
+    // 10+30+40 = 80.  A NOT-as-OR fork instead sums the g=1 rows (20 + NULL) = 20.
+    CHECK(coli(d, "SELECT SUM(x) FILTER (WHERE NOT (g = 1)) FROM m.t;") == L{80});
+    // NOT over a compound predicate: NOT (g = 0 AND x > 10) is TRUE for rows 1,2 (and UNKNOWN for the
+    // NULL-x row 4, which is excluded) -> 10+20 = 30.
+    CHECK(coli(d, "SELECT SUM(x) FILTER (WHERE NOT (g = 0 AND x > 10)) FROM m.t;") == L{30});
+}
+
+// -------------------------------------------------------------------------------------------------
+//  Three-valued logic: a NULL operand makes the filter UNKNOWN, which excludes the row.
+// -------------------------------------------------------------------------------------------------
+TEST_CASE("integration::cpp::aggregate_filter::three_valued") {
+    auto config = test_helpers::make_test_config("/tmp/aggregate_filter/tvl");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(okq(d, "CREATE DATABASE m;"));
+    REQUIRE(okq(d, "CREATE TABLE m.t (id INT, x BIGINT);"));
+    REQUIRE(okq(d, "INSERT INTO m.t (id, x) VALUES (1,10),(2,NULL),(3,30);"));
+
+    // FILTER (WHERE x = 10): row 2 is (NULL = 10) = UNKNOWN -> excluded. Only row 1 qualifies.
+    CHECK(coli(d, "SELECT COUNT(*) FILTER (WHERE x = 10) FROM m.t;") == L{1});
+    // FILTER (WHERE x > 5): rows 1,3 (NULL excluded) -> COUNT 2, SUM 40.
+    CHECK(coli(d, "SELECT COUNT(*) FILTER (WHERE x > 5) FROM m.t;") == L{2});
+    CHECK(coli(d, "SELECT SUM(x) FILTER (WHERE x > 5) FROM m.t;") == L{40});
+    // No row qualifies: COUNT -> 0, SUM -> NULL (empty aggregate).
+    CHECK(coli(d, "SELECT COUNT(*) FILTER (WHERE x = 999) FROM m.t;") == L{0});
+    CHECK(coli(d, "SELECT SUM(x) FILTER (WHERE x = 999) FROM m.t;") == L{opt{}});
+}
+
+// -------------------------------------------------------------------------------------------------
+//  The aggregated column is NULL in the FIRST row.  The CASE-lowered result column must still be
+//  typed from the branch (BIGINT), not from row 0's (NULL) probe value, or the output vector is
+//  built with the unsized NA sentinel type.
+// -------------------------------------------------------------------------------------------------
+TEST_CASE("integration::cpp::aggregate_filter::first_row_null") {
+    auto config = test_helpers::make_test_config("/tmp/aggregate_filter/frn");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(okq(d, "CREATE DATABASE m;"));
+    REQUIRE(okq(d, "CREATE TABLE m.t (id INT, x BIGINT, g INT);"));
+    // Row 0 (id=1) has x = NULL.
+    REQUIRE(okq(d, "INSERT INTO m.t (id, x, g) VALUES (1,NULL,0),(2,20,0),(3,NULL,1),(4,40,0);"));
+
+    // SUM(x) FILTER (WHERE g = 0): rows 1,2,4 pass g=0, but row 1's x is NULL -> 20+40 = 60.
+    CHECK(coli(d, "SELECT SUM(x) FILTER (WHERE g = 0) FROM m.t;") == L{60});
+    // COUNT(x) FILTER (WHERE g = 0): NULL x not counted -> 2.
+    CHECK(coli(d, "SELECT COUNT(x) FILTER (WHERE g = 0) FROM m.t;") == L{2});
+    // A filter no row satisfies -> SUM over an all-NULL column -> NULL (must not fault on typing).
+    CHECK(coli(d, "SELECT SUM(x) FILTER (WHERE g = 999) FROM m.t;") == L{opt{}});
+    // MAX(x) FILTER (WHERE x > 25): only row 4 (x=40); row 1 NULL excluded -> 40.
+    CHECK(coli(d, "SELECT MAX(x) FILTER (WHERE x > 25) FROM m.t;") == L{40});
+}
+
+// -------------------------------------------------------------------------------------------------
+//  FILTER combined with GROUP BY: the filter applies per group, independently of the grouping.
+// -------------------------------------------------------------------------------------------------
+TEST_CASE("integration::cpp::aggregate_filter::group_by") {
+    auto config = test_helpers::make_test_config("/tmp/aggregate_filter/group");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(okq(d, "CREATE DATABASE m;"));
+    REQUIRE(okq(d, "CREATE TABLE m.t (g INT, x BIGINT, flag INT);"));
+    // g=1: x in {10,20} flag {1,0};  g=2: x in {30,40} flag {1,1}
+    REQUIRE(okq(d, "INSERT INTO m.t (g, x, flag) VALUES (1,10,1),(1,20,0),(2,30,1),(2,40,1);"));
+
+    // SUM(x) FILTER (WHERE flag = 1) grouped by g, ordered by g:
+    //   g=1 -> only x=10 (flag=1) -> 10;  g=2 -> 30+40 -> 70
+    CHECK(coli(d, "SELECT SUM(x) FILTER (WHERE flag = 1) FROM m.t GROUP BY g ORDER BY g;") == L{10, 70});
+    // COUNT(*) FILTER per group: g=1 -> 1, g=2 -> 2.
+    CHECK(coli(d, "SELECT COUNT(*) FILTER (WHERE flag = 1) FROM m.t GROUP BY g ORDER BY g;") == L{1, 2});
+}

--- a/integration/cpp/test/test_index_null_correctness.cpp
+++ b/integration/cpp/test/test_index_null_correctness.cpp
@@ -1,0 +1,485 @@
+#include "test_config.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <sstream>
+#include <string>
+
+// Invariant under test: a secondary index contains exactly the non-NULL keys of the live rows.
+//
+// A NULL key must never enter an index. Before the fix it did, with three distinct failure modes,
+// selected by where the NULL sat and what type the column was:
+//
+//   * DROP    — cast_as(NA -> BIGINT) throws (operations_helper.hpp: the NA case is commented out,
+//               falling into `default: throw`). The throw escapes an actor coroutine whose
+//               unhandled_exception() is empty under NDEBUG, so the insert loop dies mid-batch and
+//               the caller is told it succeeded. Every row after the NULL is missing from the index.
+//   * INVENT  — if the NULL is the FIRST key, single_field_index_t latches stored_type_ = NA, the
+//               cast becomes a no-op, and the b-tree fills with mixed NA/typed keys. operator< then
+//               switches on the left operand's type and returns false for NA, so NA compares
+//               "equivalent" to every value while the values are ordered among themselves — not a
+//               strict weak ordering. Lookups return rows that do not match.
+//   * CRASH   — on a TEXT column, comparing a typed value against an NA dereferences a null string.
+//
+// Every query below runs against BOTH an indexed and an unindexed twin holding identical data, and
+// asserts the absolute expected count. Cross-checking alone is not enough: some of these bugs can
+// make both tables wrong, and an equality-only check would pass on two identically wrong answers.
+//
+// Disk and WAL are ON deliberately: the CREATE INDEX backfill branch is skipped entirely when there
+// is no disk address, which would make half of this matrix vacuous.
+
+namespace {
+
+    struct probe_t {
+        bool ok{false};
+        size_t rows{0};
+    };
+
+    template<typename Dispatcher>
+    probe_t run(Dispatcher* d, const std::string& sql) {
+        auto session = otterbrix::session_id_t();
+        auto cur = d->execute_sql(session, sql);
+        if (!cur || !cur->is_success()) {
+            return {false, 0};
+        }
+        return {true, cur->size()};
+    }
+
+    // Run `SELECT id FROM <t> WHERE <pred>` against the indexed and the unindexed table.
+    // Both must return `expected`.
+    template<typename Dispatcher>
+    void both(Dispatcher* d, const std::string& idx_table, const std::string& plain_table,
+              const std::string& pred, size_t expected) {
+        auto with_idx = run(d, "SELECT id FROM " + idx_table + " WHERE " + pred + ";");
+        auto no_idx = run(d, "SELECT id FROM " + plain_table + " WHERE " + pred + ";");
+        INFO("predicate: " << pred << "  indexed=" << idx_table << " rows=" << with_idx.rows
+                           << "  plain=" << plain_table << " rows=" << no_idx.rows
+                           << "  expected=" << expected);
+        CHECK(with_idx.ok);
+        CHECK(no_idx.ok);
+        CHECK(no_idx.rows == expected);   // the scan path (already fixed) is the oracle
+        CHECK(with_idx.rows == expected); // the index must agree with it
+    }
+
+    // The full predicate battery over the standard shape: x=5 / x=NULL / x=0.
+    template<typename Dispatcher>
+    void battery(Dispatcher* d, const std::string& idx_table, const std::string& plain_table) {
+        both(d, idx_table, plain_table, "x = 0", 1);        // only the genuine 0
+        both(d, idx_table, plain_table, "x = 5", 1);
+        both(d, idx_table, plain_table, "x < 1", 1);        // only the 0
+        both(d, idx_table, plain_table, "x <= 5", 2);
+        both(d, idx_table, plain_table, "x > -1", 2);
+        both(d, idx_table, plain_table, "x >= 0", 2);
+        both(d, idx_table, plain_table, "x <> 0", 1);
+        both(d, idx_table, plain_table, "x IS NULL", 1);     // must not use the index
+        both(d, idx_table, plain_table, "x IS NOT NULL", 2);
+    }
+
+    template<typename Dispatcher>
+    void mk(Dispatcher* d, const std::string& t) {
+        REQUIRE(run(d, "CREATE TABLE " + t + " (id INT, x BIGINT);").ok);
+    }
+
+} // namespace
+
+// --- A: index created BEFORE the rows; NULL position and batching vary -------------------
+
+TEST_CASE("integration::cpp::idx_null::index_first_null_middle_separate_inserts") {
+    auto config = test_create_config("/tmp/test_idx_null/a1");
+    test_clear_directory(config);
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE ix;").ok);
+    mk(d, "ix.a1i");
+    mk(d, "ix.a1p");
+    REQUIRE(run(d, "CREATE INDEX ia1 ON ix.a1i (x);").ok);
+    for (auto* t : {"ix.a1i", "ix.a1p"}) {
+        REQUIRE(run(d, std::string("INSERT INTO ") + t + " (id,x) VALUES (1,5);").ok);
+        REQUIRE(run(d, std::string("INSERT INTO ") + t + " (id,x) VALUES (2,NULL);").ok);
+        REQUIRE(run(d, std::string("INSERT INTO ") + t + " (id,x) VALUES (3,0);").ok);
+    }
+    battery(d, "ix.a1i", "ix.a1p");
+}
+
+TEST_CASE("integration::cpp::idx_null::index_first_null_middle_one_batch") {
+    auto config = test_create_config("/tmp/test_idx_null/a2");
+    test_clear_directory(config);
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE ix;").ok);
+    mk(d, "ix.a2i");
+    mk(d, "ix.a2p");
+    REQUIRE(run(d, "CREATE INDEX ia2 ON ix.a2i (x);").ok);
+    for (auto* t : {"ix.a2i", "ix.a2p"}) {
+        REQUIRE(run(d, std::string("INSERT INTO ") + t + " (id,x) VALUES (1,5),(2,NULL),(3,0);").ok);
+    }
+    battery(d, "ix.a2i", "ix.a2p");
+}
+
+TEST_CASE("integration::cpp::idx_null::index_first_null_is_first_key") {
+    // The INVENT mode: a leading NULL latches stored_type_ = NA and poisons the ordering.
+    auto config = test_create_config("/tmp/test_idx_null/a3");
+    test_clear_directory(config);
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE ix;").ok);
+    mk(d, "ix.a3i");
+    mk(d, "ix.a3p");
+    REQUIRE(run(d, "CREATE INDEX ia3 ON ix.a3i (x);").ok);
+    for (auto* t : {"ix.a3i", "ix.a3p"}) {
+        REQUIRE(run(d, std::string("INSERT INTO ") + t + " (id,x) VALUES (2,NULL),(1,5),(3,0);").ok);
+    }
+    battery(d, "ix.a3i", "ix.a3p");
+}
+
+TEST_CASE("integration::cpp::idx_null::index_first_null_last") {
+    auto config = test_create_config("/tmp/test_idx_null/a4");
+    test_clear_directory(config);
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE ix;").ok);
+    mk(d, "ix.a4i");
+    mk(d, "ix.a4p");
+    REQUIRE(run(d, "CREATE INDEX ia4 ON ix.a4i (x);").ok);
+    for (auto* t : {"ix.a4i", "ix.a4p"}) {
+        REQUIRE(run(d, std::string("INSERT INTO ") + t + " (id,x) VALUES (1,5),(3,0),(2,NULL);").ok);
+    }
+    battery(d, "ix.a4i", "ix.a4p");
+}
+
+// --- B: CREATE INDEX backfill over a table that already contains a NULL -----------------
+
+TEST_CASE("integration::cpp::idx_null::backfill_null_middle") {
+    // The originally reported bug.
+    auto config = test_create_config("/tmp/test_idx_null/b2");
+    test_clear_directory(config);
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE ix;").ok);
+    mk(d, "ix.b2i");
+    mk(d, "ix.b2p");
+    for (auto* t : {"ix.b2i", "ix.b2p"}) {
+        REQUIRE(run(d, std::string("INSERT INTO ") + t + " (id,x) VALUES (1,5),(2,NULL),(3,0);").ok);
+    }
+    REQUIRE(run(d, "CREATE INDEX ib2 ON ix.b2i (x);").ok); // backfill sees the NULL
+    battery(d, "ix.b2i", "ix.b2p");
+}
+
+TEST_CASE("integration::cpp::idx_null::backfill_null_first") {
+    auto config = test_create_config("/tmp/test_idx_null/b3");
+    test_clear_directory(config);
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE ix;").ok);
+    mk(d, "ix.b3i");
+    mk(d, "ix.b3p");
+    for (auto* t : {"ix.b3i", "ix.b3p"}) {
+        REQUIRE(run(d, std::string("INSERT INTO ") + t + " (id,x) VALUES (2,NULL),(1,5),(3,0);").ok);
+    }
+    REQUIRE(run(d, "CREATE INDEX ib3 ON ix.b3i (x);").ok);
+    battery(d, "ix.b3i", "ix.b3p");
+}
+
+TEST_CASE("integration::cpp::idx_null::backfill_separate_inserts_null_middle") {
+    auto config = test_create_config("/tmp/test_idx_null/b1");
+    test_clear_directory(config);
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE ix;").ok);
+    mk(d, "ix.b1i");
+    mk(d, "ix.b1p");
+    for (auto* t : {"ix.b1i", "ix.b1p"}) {
+        REQUIRE(run(d, std::string("INSERT INTO ") + t + " (id,x) VALUES (1,5);").ok);
+        REQUIRE(run(d, std::string("INSERT INTO ") + t + " (id,x) VALUES (2,NULL);").ok);
+        REQUIRE(run(d, std::string("INSERT INTO ") + t + " (id,x) VALUES (3,0);").ok);
+    }
+    REQUIRE(run(d, "CREATE INDEX ib1 ON ix.b1i (x);").ok); // backfill re-batches the rows
+    battery(d, "ix.b1i", "ix.b1p");
+}
+
+// --- C: NULL density -------------------------------------------------------------------
+
+TEST_CASE("integration::cpp::idx_null::all_rows_null") {
+    // The sharpest form of INVENT: with every key NULL, `WHERE x = 0` returned every row.
+    auto config = test_create_config("/tmp/test_idx_null/d2");
+    test_clear_directory(config);
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE ix;").ok);
+    mk(d, "ix.d2i");
+    mk(d, "ix.d2p");
+    REQUIRE(run(d, "CREATE INDEX id2 ON ix.d2i (x);").ok);
+    for (auto* t : {"ix.d2i", "ix.d2p"}) {
+        REQUIRE(run(d, std::string("INSERT INTO ") + t + " (id,x) VALUES (1,NULL),(2,NULL),(3,NULL);").ok);
+    }
+    both(d, "ix.d2i", "ix.d2p", "x = 0", 0);
+    both(d, "ix.d2i", "ix.d2p", "x >= 0", 0);
+    both(d, "ix.d2i", "ix.d2p", "x < 1", 0);
+    both(d, "ix.d2i", "ix.d2p", "x IS NULL", 3);
+    both(d, "ix.d2i", "ix.d2p", "x IS NOT NULL", 0);
+}
+
+TEST_CASE("integration::cpp::idx_null::null_only_then_values") {
+    auto config = test_create_config("/tmp/test_idx_null/d3");
+    test_clear_directory(config);
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE ix;").ok);
+    mk(d, "ix.d3i");
+    mk(d, "ix.d3p");
+    for (auto* t : {"ix.d3i", "ix.d3p"}) {
+        REQUIRE(run(d, std::string("INSERT INTO ") + t + " (id,x) VALUES (1,NULL),(2,NULL);").ok);
+    }
+    REQUIRE(run(d, "CREATE INDEX id3 ON ix.d3i (x);").ok); // backfill over an all-NULL column
+    for (auto* t : {"ix.d3i", "ix.d3p"}) {
+        REQUIRE(run(d, std::string("INSERT INTO ") + t + " (id,x) VALUES (3,0),(4,5);").ok);
+    }
+    both(d, "ix.d3i", "ix.d3p", "x = 0", 1);
+    both(d, "ix.d3i", "ix.d3p", "x >= 0", 2);
+    both(d, "ix.d3i", "ix.d3p", "x IS NULL", 2);
+}
+
+TEST_CASE("integration::cpp::idx_null::no_nulls_baseline") {
+    // Sanity: an index over a NULL-free column must keep working exactly as before.
+    auto config = test_create_config("/tmp/test_idx_null/d1");
+    test_clear_directory(config);
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE ix;").ok);
+    mk(d, "ix.d1i");
+    mk(d, "ix.d1p");
+    REQUIRE(run(d, "CREATE INDEX id1 ON ix.d1i (x);").ok);
+    for (auto* t : {"ix.d1i", "ix.d1p"}) {
+        REQUIRE(run(d, std::string("INSERT INTO ") + t + " (id,x) VALUES (1,5),(3,0),(4,7);").ok);
+    }
+    both(d, "ix.d1i", "ix.d1p", "x = 0", 1);
+    both(d, "ix.d1i", "ix.d1p", "x = 7", 1);
+    both(d, "ix.d1i", "ix.d1p", "x >= 0", 3);
+    both(d, "ix.d1i", "ix.d1p", "x > 5", 1);
+    both(d, "ix.d1i", "ix.d1p", "x < 5", 1);
+}
+
+// --- D: index maintenance under UPDATE / DELETE -----------------------------------------
+
+TEST_CASE("integration::cpp::idx_null::update_null_to_value_adds_index_entry") {
+    auto config = test_create_config("/tmp/test_idx_null/e1");
+    test_clear_directory(config);
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE ix;").ok);
+    mk(d, "ix.e1i");
+    mk(d, "ix.e1p");
+    REQUIRE(run(d, "CREATE INDEX ie1 ON ix.e1i (x);").ok);
+    for (auto* t : {"ix.e1i", "ix.e1p"}) {
+        REQUIRE(run(d, std::string("INSERT INTO ") + t + " (id,x) VALUES (1,5);").ok);
+        REQUIRE(run(d, std::string("INSERT INTO ") + t + " (id,x) VALUES (2,NULL);").ok);
+        REQUIRE(run(d, std::string("UPDATE ") + t + " SET x = 42 WHERE id = 2;").ok);
+    }
+    both(d, "ix.e1i", "ix.e1p", "x = 42", 1); // the formerly-NULL row must now be found
+    both(d, "ix.e1i", "ix.e1p", "x = 5", 1);
+    both(d, "ix.e1i", "ix.e1p", "x IS NULL", 0);
+    both(d, "ix.e1i", "ix.e1p", "x >= 0", 2);
+}
+
+TEST_CASE("integration::cpp::idx_null::update_value_to_null_removes_index_entry") {
+    auto config = test_create_config("/tmp/test_idx_null/e2");
+    test_clear_directory(config);
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE ix;").ok);
+    mk(d, "ix.e2i");
+    mk(d, "ix.e2p");
+    REQUIRE(run(d, "CREATE INDEX ie2 ON ix.e2i (x);").ok);
+    for (auto* t : {"ix.e2i", "ix.e2p"}) {
+        REQUIRE(run(d, std::string("INSERT INTO ") + t + " (id,x) VALUES (1,5);").ok);
+        REQUIRE(run(d, std::string("INSERT INTO ") + t + " (id,x) VALUES (2,7);").ok);
+        REQUIRE(run(d, std::string("UPDATE ") + t + " SET x = NULL WHERE id = 2;").ok);
+    }
+    both(d, "ix.e2i", "ix.e2p", "x = 7", 0); // the old key must be gone from the index
+    both(d, "ix.e2i", "ix.e2p", "x = 5", 1);
+    both(d, "ix.e2i", "ix.e2p", "x >= 0", 1);
+}
+
+TEST_CASE("integration::cpp::idx_null::delete_null_and_value_rows") {
+    auto config = test_create_config("/tmp/test_idx_null/e3");
+    test_clear_directory(config);
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE ix;").ok);
+    mk(d, "ix.e3i");
+    mk(d, "ix.e3p");
+    REQUIRE(run(d, "CREATE INDEX ie3 ON ix.e3i (x);").ok);
+    for (auto* t : {"ix.e3i", "ix.e3p"}) {
+        REQUIRE(run(d, std::string("INSERT INTO ") + t + " (id,x) VALUES (1,5);").ok);
+        REQUIRE(run(d, std::string("INSERT INTO ") + t + " (id,x) VALUES (2,NULL);").ok);
+        REQUIRE(run(d, std::string("INSERT INTO ") + t + " (id,x) VALUES (3,0);").ok);
+        REQUIRE(run(d, std::string("DELETE FROM ") + t + " WHERE id = 2;").ok); // delete the NULL row
+    }
+    both(d, "ix.e3i", "ix.e3p", "x = 0", 1);
+    both(d, "ix.e3i", "ix.e3p", "x >= 0", 2);
+    both(d, "ix.e3i", "ix.e3p", "x IS NULL", 0);
+
+    for (auto* t : {"ix.e3i", "ix.e3p"}) {
+        REQUIRE(run(d, std::string("DELETE FROM ") + t + " WHERE id = 3;").ok); // delete the 0 row
+    }
+    both(d, "ix.e3i", "ix.e3p", "x = 0", 0); // its index entry must be gone
+    both(d, "ix.e3i", "ix.e3p", "x = 5", 1);
+}
+
+// --- E: types other than BIGINT ---------------------------------------------------------
+
+TEST_CASE("integration::cpp::idx_null::text_column_with_null") {
+    // The CRASH mode: comparing a typed string against an NA dereferenced a null string pointer.
+    auto config = test_create_config("/tmp/test_idx_null/f1");
+    test_clear_directory(config);
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE ix;").ok);
+    REQUIRE(run(d, "CREATE TABLE ix.f1i (id INT, s TEXT);").ok);
+    REQUIRE(run(d, "CREATE TABLE ix.f1p (id INT, s TEXT);").ok);
+    REQUIRE(run(d, "CREATE INDEX if1 ON ix.f1i (s);").ok);
+    for (auto* t : {"ix.f1i", "ix.f1p"}) {
+        REQUIRE(run(d, std::string("INSERT INTO ") + t + " (id,s) VALUES (1,'ann'),(2,NULL),(3,'bob');").ok);
+    }
+    both(d, "ix.f1i", "ix.f1p", "s = 'ann'", 1);
+    both(d, "ix.f1i", "ix.f1p", "s = 'bob'", 1);
+    both(d, "ix.f1i", "ix.f1p", "s IS NULL", 1);
+    both(d, "ix.f1i", "ix.f1p", "s IS NOT NULL", 2);
+}
+
+// --- F: a NULL constant on the right-hand side ------------------------------------------
+
+TEST_CASE("integration::cpp::idx_null::null_constant_predicates") {
+    // Regression guard for the ordering change: a NULL *constant* makes every comparison UNKNOWN,
+    // so all of these must return 0 rows — with and without an index. If the zonemap or the
+    // per-row compare ever starts treating a NULL constant as an ordinary value, this catches it.
+    auto config = test_create_config("/tmp/test_idx_null/g1");
+    test_clear_directory(config);
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE ix;").ok);
+    mk(d, "ix.g1i");
+    mk(d, "ix.g1p");
+    REQUIRE(run(d, "CREATE INDEX ig1 ON ix.g1i (x);").ok);
+    for (auto* t : {"ix.g1i", "ix.g1p"}) {
+        REQUIRE(run(d, std::string("INSERT INTO ") + t + " (id,x) VALUES (1,5),(2,NULL),(3,0);").ok);
+    }
+    both(d, "ix.g1i", "ix.g1p", "x = NULL", 0);
+    both(d, "ix.g1i", "ix.g1p", "x <> NULL", 0);
+    both(d, "ix.g1i", "ix.g1p", "x > NULL", 0);
+    both(d, "ix.g1i", "ix.g1p", "x >= NULL", 0);
+    both(d, "ix.g1i", "ix.g1p", "x < NULL", 0);
+    both(d, "ix.g1i", "ix.g1p", "x <= NULL", 0);
+}
+
+// --- G: several indexes on one table -----------------------------------------------------
+
+TEST_CASE("integration::cpp::idx_null::sibling_index_survives_null_column") {
+    // insert_row loops over every index of the table in one coroutine, so a throw on the NULL
+    // column's index used to kill the sibling index's entries for the same batch too.
+    auto config = test_create_config("/tmp/test_idx_null/h1");
+    test_clear_directory(config);
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE ix;").ok);
+    REQUIRE(run(d, "CREATE TABLE ix.h1i (id INT, x BIGINT, y BIGINT);").ok);
+    REQUIRE(run(d, "CREATE TABLE ix.h1p (id INT, x BIGINT, y BIGINT);").ok);
+    REQUIRE(run(d, "CREATE INDEX ih1x ON ix.h1i (x);").ok);
+    REQUIRE(run(d, "CREATE INDEX ih1y ON ix.h1i (y);").ok);
+    for (auto* t : {"ix.h1i", "ix.h1p"}) {
+        REQUIRE(run(d, std::string("INSERT INTO ") + t + " (id,x,y) VALUES (1,5,10),(2,NULL,20),(3,0,30);").ok);
+    }
+    // y has no NULLs at all: its index must be complete regardless of what x's index does.
+    both(d, "ix.h1i", "ix.h1p", "y = 20", 1);
+    both(d, "ix.h1i", "ix.h1p", "y = 30", 1);
+    both(d, "ix.h1i", "ix.h1p", "y >= 10", 3);
+    both(d, "ix.h1i", "ix.h1p", "x = 0", 1);
+}
+
+// --- H: a batch larger than one vector (1024 rows) ---------------------------------------
+
+TEST_CASE("integration::cpp::idx_null::large_batch_with_scattered_nulls") {
+    auto config = test_create_config("/tmp/test_idx_null/i1");
+    test_clear_directory(config);
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE ix;").ok);
+    mk(d, "ix.i1i");
+    mk(d, "ix.i1p");
+    REQUIRE(run(d, "CREATE INDEX ii1 ON ix.i1i (x);").ok);
+
+    // 3000 rows: every 7th is NULL, the rest carry x = id.
+    const int N = 3000;
+    size_t nulls = 0;
+    for (auto* t : {"ix.i1i", "ix.i1p"}) {
+        std::ostringstream sql;
+        sql << "INSERT INTO " << t << " (id,x) VALUES ";
+        size_t local_nulls = 0;
+        for (int i = 1; i <= N; ++i) {
+            if (i > 1) {
+                sql << ",";
+            }
+            if (i % 7 == 0) {
+                sql << "(" << i << ",NULL)";
+                ++local_nulls;
+            } else {
+                sql << "(" << i << "," << i << ")";
+            }
+        }
+        sql << ";";
+        REQUIRE(run(d, sql.str()).ok);
+        nulls = local_nulls;
+    }
+    const size_t non_null = static_cast<size_t>(N) - nulls;
+
+    both(d, "ix.i1i", "ix.i1p", "x = 100", 1);
+    both(d, "ix.i1i", "ix.i1p", "x = 2999", 1);
+    both(d, "ix.i1i", "ix.i1p", "x = 7", 0); // that row is NULL
+    both(d, "ix.i1i", "ix.i1p", "x >= 1", non_null);
+    both(d, "ix.i1i", "ix.i1p", "x IS NULL", nulls);
+}
+
+// --- I: persistence — the index must be rebuilt correctly across a restart ---------------
+
+TEST_CASE("integration::cpp::idx_null::survives_restart") {
+    auto config = test_create_config("/tmp/test_idx_null/j1");
+    test_clear_directory(config);
+    {
+        test_spaces space(config);
+        auto* d = space.dispatcher();
+        REQUIRE(run(d, "CREATE DATABASE ix;").ok);
+        mk(d, "ix.j1i");
+        mk(d, "ix.j1p");
+        REQUIRE(run(d, "CREATE INDEX ij1 ON ix.j1i (x);").ok);
+        for (auto* t : {"ix.j1i", "ix.j1p"}) {
+            REQUIRE(run(d, std::string("INSERT INTO ") + t + " (id,x) VALUES (1,5),(2,NULL),(3,0);").ok);
+        }
+        both(d, "ix.j1i", "ix.j1p", "x = 0", 1);
+    }
+    {
+        test_spaces space(config); // reopen: the b-tree is rehydrated from disk
+        auto* d = space.dispatcher();
+        both(d, "ix.j1i", "ix.j1p", "x = 0", 1);
+        both(d, "ix.j1i", "ix.j1p", "x = 5", 1);
+        both(d, "ix.j1i", "ix.j1p", "x >= 0", 2);
+        both(d, "ix.j1i", "ix.j1p", "x IS NULL", 1);
+    }
+}
+
+// --- J: an absent jsonb key on a computing table -----------------------------------------
+
+TEST_CASE("integration::cpp::idx_null::computing_table_absent_key") {
+    auto config = test_create_config("/tmp/test_idx_null/k1");
+    test_clear_directory(config);
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE ix;").ok);
+    REQUIRE(run(d, "CREATE TABLE ix.k1i ();").ok);
+    REQUIRE(run(d, "CREATE TABLE ix.k1p ();").ok);
+    for (auto* t : {"ix.k1i", "ix.k1p"}) {
+        REQUIRE(run(d, std::string("INSERT INTO ") + t + " (id,x) VALUES (1,5);").ok);
+        REQUIRE(run(d, std::string("INSERT INTO ") + t + " (id) VALUES (2);").ok); // absent key -> NULL
+        REQUIRE(run(d, std::string("INSERT INTO ") + t + " (id,x) VALUES (3,0);").ok);
+    }
+    REQUIRE(run(d, "CREATE INDEX ik1 ON ix.k1i (x);").ok);
+    both(d, "ix.k1i", "ix.k1p", "x = 0", 1);
+    both(d, "ix.k1i", "ix.k1p", "x >= 0", 2);
+}

--- a/integration/cpp/test/test_null_aggregates.cpp
+++ b/integration/cpp/test/test_null_aggregates.cpp
@@ -1,0 +1,100 @@
+#include "test_config.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <optional>
+#include <string>
+#include <vector>
+
+// SQL NULL semantics for aggregates.
+//
+// COUNT(x) counts non-NULL values, so over an all-NULL (or empty) group it is 0 — never NULL.
+// Every other aggregate (SUM/MIN/MAX/AVG) skips NULLs and is NULL over an all-NULL group.
+// COUNT(*) counts rows regardless of NULLs. These must agree across the grouped, non-grouped,
+// vectorized (single numeric column) and non-vectorized (DISTINCT) paths.
+//
+// Before the fix, the grouped-aggregate finalizer returned NA for any state that never saw a
+// non-NULL value — taking that branch before the COUNT case — so COUNT over an all-NULL group
+// was reported as NULL, disagreeing with COUNT(DISTINCT x) and COUNT(*), which return 0.
+
+namespace {
+
+    using opt = std::optional<int64_t>;
+
+    template<typename D>
+    bool ok(D* d, const std::string& sql) {
+        auto s = otterbrix::session_id_t();
+        auto c = d->execute_sql(s, sql);
+        return c && c->is_success();
+    }
+
+    template<typename D>
+    std::vector<opt> read_col(D* d, const std::string& sql, uint64_t col = 0) {
+        auto s = otterbrix::session_id_t();
+        auto c = d->execute_sql(s, sql);
+        std::vector<opt> out;
+        REQUIRE(c);
+        REQUIRE(c->is_success());
+        for (uint64_t r = 0; r < c->size(); ++r) {
+            auto v = c->value(col, r);
+            out.push_back(v.is_null() ? opt{} : opt{v.template value<int64_t>()});
+        }
+        return out;
+    }
+
+    template<typename D>
+    opt scalar(D* d, const std::string& sql) {
+        auto v = read_col(d, sql);
+        REQUIRE(v.size() == 1);
+        return v.front();
+    }
+
+} // namespace
+
+TEST_CASE("integration::cpp::null_agg::count_over_all_null_group_is_zero") {
+    auto config = test_create_config("/tmp/test_null_agg/grp");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(ok(d, "CREATE DATABASE ag;"));
+    // group 1: x all NULL ; group 2: x has one value and one NULL.
+    REQUIRE(ok(d, "CREATE TABLE ag.t (k INT, x BIGINT);"));
+    REQUIRE(ok(d, "INSERT INTO ag.t (k, x) VALUES (1, NULL);"));
+    REQUIRE(ok(d, "INSERT INTO ag.t (k, x) VALUES (1, NULL);"));
+    REQUIRE(ok(d, "INSERT INTO ag.t (k, x) VALUES (2, 7);"));
+    REQUIRE(ok(d, "INSERT INTO ag.t (k, x) VALUES (2, NULL);"));
+
+    // COUNT(x): group 1 -> 0 (not NULL) ; group 2 -> 1.
+    CHECK(read_col(d, "SELECT COUNT(x) FROM ag.t GROUP BY k ORDER BY k;") == std::vector<opt>{0, 1});
+    // COUNT(*): counts rows including NULL rows: group 1 -> 2 ; group 2 -> 2.
+    CHECK(read_col(d, "SELECT COUNT(*) FROM ag.t GROUP BY k ORDER BY k;") == std::vector<opt>{2, 2});
+    // COUNT(DISTINCT x): group 1 -> 0 ; group 2 -> 1. Must agree with COUNT(x).
+    CHECK(read_col(d, "SELECT COUNT(DISTINCT x) FROM ag.t GROUP BY k ORDER BY k;") ==
+          std::vector<opt>{0, 1});
+
+    // SUM/MIN/MAX/AVG skip NULLs and are NULL over the all-NULL group, defined over group 2.
+    CHECK(read_col(d, "SELECT SUM(x) FROM ag.t GROUP BY k ORDER BY k;") == std::vector<opt>{{}, 7});
+    CHECK(read_col(d, "SELECT MIN(x) FROM ag.t GROUP BY k ORDER BY k;") == std::vector<opt>{{}, 7});
+    CHECK(read_col(d, "SELECT MAX(x) FROM ag.t GROUP BY k ORDER BY k;") == std::vector<opt>{{}, 7});
+}
+
+TEST_CASE("integration::cpp::null_agg::count_over_all_null_table_is_zero") {
+    auto config = test_create_config("/tmp/test_null_agg/nogrp");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(ok(d, "CREATE DATABASE ag;"));
+    REQUIRE(ok(d, "CREATE TABLE ag.t (id INT, x BIGINT);"));
+    REQUIRE(ok(d, "INSERT INTO ag.t (id, x) VALUES (1, NULL);"));
+    REQUIRE(ok(d, "INSERT INTO ag.t (id, x) VALUES (2, NULL);"));
+
+    // Ungrouped aggregate over an all-NULL column.
+    CHECK(scalar(d, "SELECT COUNT(x) FROM ag.t;") == opt{0});
+    CHECK(scalar(d, "SELECT COUNT(*) FROM ag.t;") == opt{2});
+    CHECK(scalar(d, "SELECT COUNT(DISTINCT x) FROM ag.t;") == opt{0});
+    CHECK(scalar(d, "SELECT SUM(x) FROM ag.t;") == opt{});
+    CHECK(scalar(d, "SELECT MIN(x) FROM ag.t;") == opt{});
+    CHECK(scalar(d, "SELECT MAX(x) FROM ag.t;") == opt{});
+}

--- a/integration/cpp/test/test_null_arithmetic.cpp
+++ b/integration/cpp/test/test_null_arithmetic.cpp
@@ -1,0 +1,174 @@
+#include "test_config.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <optional>
+#include <string>
+#include <vector>
+
+// SQL NULL propagation through arithmetic (three-valued logic, arithmetic half).
+//
+// Any arithmetic operation with a NULL operand yields NULL: `NULL + 1` is NULL, not 1;
+// `5 / NULL` is NULL, not a division-by-zero trap. Two independent engines evaluate
+// arithmetic and both must agree:
+//   - the scalar logical_value_t path (post-aggregates, CASE, constant folding),
+//   - the vectorized components/vector/arithmetic.cpp path (SELECT list, UPDATE SET).
+//
+// Before the fix, the scalar op<> template substituted a zero for the NULL operand — so
+// `NULL + 1` was 1 and `5 / NULL` divided by zero (a SIGFPE on integer types) — and the
+// vector kernels never intersected the operand validity masks into the output, so a NULL
+// row's meaningless payload byte (0) was published as a real, valid result.
+
+namespace {
+
+    using opt = std::optional<int64_t>;
+
+    template<typename D>
+    bool ok(D* d, const std::string& sql) {
+        auto s = otterbrix::session_id_t();
+        auto c = d->execute_sql(s, sql);
+        return c && c->is_success();
+    }
+
+    template<typename D>
+    size_t rows(D* d, const std::string& sql) {
+        auto s = otterbrix::session_id_t();
+        auto c = d->execute_sql(s, sql);
+        REQUIRE(c);
+        REQUIRE(c->is_success());
+        return c->size();
+    }
+
+    // Read column `col` of every row as an optional<int64_t> (nullopt == SQL NULL).
+    template<typename D>
+    std::vector<opt> read_col(D* d, const std::string& sql, uint64_t col = 0) {
+        auto s = otterbrix::session_id_t();
+        auto c = d->execute_sql(s, sql);
+        std::vector<opt> out;
+        REQUIRE(c);
+        REQUIRE(c->is_success());
+        for (uint64_t r = 0; r < c->size(); ++r) {
+            auto v = c->value(col, r);
+            out.push_back(v.is_null() ? opt{} : opt{v.template value<int64_t>()});
+        }
+        return out;
+    }
+
+    // id=1 -> x=5 ; id=2 -> x NULL ; id=3 -> x=0
+    template<typename D>
+    void seed(D* d, const std::string& table) {
+        REQUIRE(ok(d, "CREATE TABLE " + table + " (id INT, x BIGINT);"));
+        REQUIRE(ok(d, "INSERT INTO " + table + " (id, x) VALUES (1, 5);"));
+        REQUIRE(ok(d, "INSERT INTO " + table + " (id, x) VALUES (2, NULL);"));
+        REQUIRE(ok(d, "INSERT INTO " + table + " (id, x) VALUES (3, 0);"));
+    }
+
+} // namespace
+
+TEST_CASE("integration::cpp::null_arith::projection_propagates_null") {
+    auto config = test_create_config("/tmp/test_null_arith/proj");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(ok(d, "CREATE DATABASE na;"));
+    seed(d, "na.t");
+
+    // The NULL row (id=2) must project NULL for every arithmetic result.
+    CHECK(read_col(d, "SELECT x + 1 FROM na.t ORDER BY id;") == std::vector<opt>{6, {}, 1});
+    CHECK(read_col(d, "SELECT x - 1 FROM na.t ORDER BY id;") == std::vector<opt>{4, {}, -1});
+    CHECK(read_col(d, "SELECT x * 2 FROM na.t ORDER BY id;") == std::vector<opt>{10, {}, 0});
+    CHECK(read_col(d, "SELECT -x FROM na.t ORDER BY id;") == std::vector<opt>{-5, {}, 0});
+    CHECK(read_col(d, "SELECT 100 - x FROM na.t ORDER BY id;") == std::vector<opt>{95, {}, 100});
+    CHECK(read_col(d, "SELECT x + x FROM na.t ORDER BY id;") == std::vector<opt>{10, {}, 0});
+}
+
+TEST_CASE("integration::cpp::null_arith::division_by_null_does_not_crash") {
+    auto config = test_create_config("/tmp/test_null_arith/div");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(ok(d, "CREATE DATABASE na;"));
+    seed(d, "na.t");
+
+    // 10 / x : x=5 -> 2 ; x NULL -> NULL ; x=0 -> NULL (division by zero yields NULL here).
+    CHECK(read_col(d, "SELECT 10 / x FROM na.t ORDER BY id;") == std::vector<opt>{2, {}, {}});
+    CHECK(read_col(d, "SELECT 10 % x FROM na.t ORDER BY id;") == std::vector<opt>{0, {}, {}});
+    // x / <non-null> keeps the NULL operand NULL.
+    CHECK(read_col(d, "SELECT x / 2 FROM na.t ORDER BY id;") == std::vector<opt>{2, {}, 0});
+}
+
+TEST_CASE("integration::cpp::null_arith::arithmetic_in_where_excludes_null") {
+    auto config = test_create_config("/tmp/test_null_arith/where");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(ok(d, "CREATE DATABASE na;"));
+    seed(d, "na.t");
+
+    // x=0 -> 0+1=1 TRUE ; x NULL -> NULL+1=NULL, =1 is UNKNOWN (excluded) ; x=5 -> 6=1 FALSE.
+    // A UNKNOWN comparison and a FALSE comparison both exclude the row here, so this positive
+    // form already isolates the arithmetic NULL propagation. The NOT form (where UNKNOWN and
+    // FALSE diverge) is a property of the three-valued predicate evaluator, covered by the
+    // in-memory predicate 3VL tests, not by arithmetic.
+    CHECK(rows(d, "SELECT id FROM na.t WHERE x + 1 = 1;") == 1);  // id=3 only
+    CHECK(rows(d, "SELECT id FROM na.t WHERE x * 2 = 0;") == 1);  // id=3 only
+}
+
+TEST_CASE("integration::cpp::null_arith::update_set_expression_keeps_null") {
+    auto config = test_create_config("/tmp/test_null_arith/upd");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(ok(d, "CREATE DATABASE na;"));
+    seed(d, "na.t");
+
+    // UPDATE t SET x = x + 1 must leave the NULL row NULL (NULL + 1 is NULL), not write a 1.
+    REQUIRE(ok(d, "UPDATE na.t SET x = x + 1;"));
+    CHECK(read_col(d, "SELECT x FROM na.t ORDER BY id;") == std::vector<opt>{6, {}, 1});
+    CHECK(rows(d, "SELECT id FROM na.t WHERE x IS NULL;") == 1); // id=2 still NULL
+}
+
+TEST_CASE("integration::cpp::null_arith::aggregate_arithmetic_propagates_null") {
+    auto config = test_create_config("/tmp/test_null_arith/agg");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(ok(d, "CREATE DATABASE na;"));
+    // group 1: a has values, b all NULL ; group 2: both have values.
+    REQUIRE(ok(d, "CREATE TABLE na.g (k INT, a BIGINT, b BIGINT);"));
+    REQUIRE(ok(d, "INSERT INTO na.g (k, a, b) VALUES (1, 3, NULL);"));
+    REQUIRE(ok(d, "INSERT INTO na.g (k, a, b) VALUES (1, 4, NULL);"));
+    REQUIRE(ok(d, "INSERT INTO na.g (k, a, b) VALUES (2, 5, 10);"));
+    REQUIRE(ok(d, "INSERT INTO na.g (k, a, b) VALUES (2, 5, 20);"));
+
+    // SUM(b) over the all-NULL group is NULL, so SUM(a)+SUM(b) is NULL for group 1, 40 for group 2.
+    CHECK(read_col(d, "SELECT SUM(a) + SUM(b) FROM na.g GROUP BY k ORDER BY k;", 0) ==
+          std::vector<opt>{{}, 40});
+    // SUM(a) / SUM(b): group 1 divides by a NULL SUM -> NULL, not a crash; group 2 -> 10/30 = 0.
+    CHECK(read_col(d, "SELECT SUM(a) / SUM(b) FROM na.g GROUP BY k ORDER BY k;", 0) ==
+          std::vector<opt>{{}, 0});
+}
+
+TEST_CASE("integration::cpp::null_arith::literal_null_folds_to_null") {
+    auto config = test_create_config("/tmp/test_null_arith/fold");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(ok(d, "CREATE DATABASE na;"));
+    seed(d, "na.t");
+
+    // A constant-folded arithmetic with a NULL literal is NULL, so the comparison is UNKNOWN
+    // for every row and nobody is selected.
+    CHECK(rows(d, "SELECT id FROM na.t WHERE 1 + NULL = 1;") == 0);
+    CHECK(rows(d, "SELECT id FROM na.t WHERE x = 1 + NULL;") == 0);
+}

--- a/integration/cpp/test/test_null_array_element.cpp
+++ b/integration/cpp/test/test_null_array_element.cpp
@@ -1,0 +1,94 @@
+#include "test_config.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <string>
+
+// Storage-scan pushdown predicates over an ARRAY/LIST element (v[i]) must handle a NULL element
+// in three-valued logic and must never treat the array column as a struct.
+//
+// A value comparison over a NULL element is UNKNOWN (the row is excluded, and NOT does not
+// resurrect it). IS NULL / IS NOT NULL over the element are always TRUE/FALSE. An element is NULL
+// when the whole array cell is NULL, when the subscript is out of range, or when that element is
+// itself NULL. Before the fix, IS NULL over v[i] cast the array column to a struct and read a
+// bogus sub-column pointer -- a segfault.
+
+namespace {
+    template<typename D>
+    bool ok(D* d, const std::string& sql) {
+        auto s = otterbrix::session_id_t();
+        auto c = d->execute_sql(s, sql);
+        return c && c->is_success();
+    }
+    template<typename D>
+    size_t rows(D* d, const std::string& sql) {
+        auto s = otterbrix::session_id_t();
+        auto c = d->execute_sql(s, sql);
+        REQUIRE(c);
+        REQUIRE(c->is_success());
+        return c->size();
+    }
+} // namespace
+
+TEST_CASE("integration::cpp::null_arr_elem::fixed_array_null_cell") {
+    auto config = test_create_config("/tmp/test_null_arr_elem/fixed");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(ok(d, "CREATE DATABASE ae;"));
+    REQUIRE(ok(d, "CREATE TABLE ae.t (id bigint, v int[3]);"));
+    REQUIRE(ok(d, "INSERT INTO ae.t (id, v) VALUES (1, ARRAY[10, 20, 30]);"));
+    REQUIRE(ok(d, "INSERT INTO ae.t (id, v) VALUES (2, NULL);")); // whole array cell NULL
+    REQUIRE(ok(d, "INSERT INTO ae.t (id, v) VALUES (3, ARRAY[40, 50, 60]);"));
+
+    // Value comparison over the element: the NULL-cell row is UNKNOWN, hence excluded.
+    CHECK(rows(d, "SELECT id FROM ae.t WHERE v[1] = 10;") == 1); // id=1
+    CHECK(rows(d, "SELECT id FROM ae.t WHERE v[1] > 5;") == 2);  // id=1,3 (id=2 excluded)
+    CHECK(rows(d, "SELECT id FROM ae.t WHERE v[2] = 20;") == 1); // id=1
+
+    // IS NULL / IS NOT NULL over the element (previously a segfault).
+    CHECK(rows(d, "SELECT id FROM ae.t WHERE v[1] IS NULL;") == 1);     // id=2
+    CHECK(rows(d, "SELECT id FROM ae.t WHERE v[1] IS NOT NULL;") == 2); // id=1,3
+    CHECK(rows(d, "SELECT id FROM ae.t WHERE v[3] IS NULL;") == 1);     // id=2
+}
+
+TEST_CASE("integration::cpp::null_arr_elem::fixed_array_null_padded_element") {
+    auto config = test_create_config("/tmp/test_null_arr_elem/pad");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(ok(d, "CREATE DATABASE ae;"));
+    REQUIRE(ok(d, "CREATE TABLE ae.t (id bigint, v int[3]);"));
+    REQUIRE(ok(d, "INSERT INTO ae.t (id, v) VALUES (1, ARRAY[10, 20, 30]);"));
+    // A short array pads the missing tail elements with NULL (the column has no default).
+    REQUIRE(ok(d, "INSERT INTO ae.t (id, v) VALUES (2, ARRAY[40]);"));
+
+    // v[3] is a real NULL element in row 2: comparison is UNKNOWN, IS NULL is TRUE.
+    CHECK(rows(d, "SELECT id FROM ae.t WHERE v[3] = 30;") == 1);     // id=1 only
+    CHECK(rows(d, "SELECT id FROM ae.t WHERE v[3] IS NULL;") == 1);  // id=2
+    CHECK(rows(d, "SELECT id FROM ae.t WHERE v[3] IS NOT NULL;") == 1); // id=1
+    // v[1] is present in both rows.
+    CHECK(rows(d, "SELECT id FROM ae.t WHERE v[1] IS NOT NULL;") == 2);
+}
+
+TEST_CASE("integration::cpp::null_arr_elem::variadic_list") {
+    auto config = test_create_config("/tmp/test_null_arr_elem/list");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(ok(d, "CREATE DATABASE ae;"));
+    REQUIRE(ok(d, "CREATE TABLE ae.l (id bigint, v int[]);"));
+    REQUIRE(ok(d, "INSERT INTO ae.l (id, v) VALUES (1, ARRAY[10, 20]);"));
+    REQUIRE(ok(d, "INSERT INTO ae.l (id, v) VALUES (2, NULL);"));    // whole list NULL
+    REQUIRE(ok(d, "INSERT INTO ae.l (id, v) VALUES (3, ARRAY[30]);")); // v[2] out of range
+
+    // v[2]: present in row 1, out of range in row 3, NULL cell in row 2 -> only row 1 has it.
+    CHECK(rows(d, "SELECT id FROM ae.l WHERE v[2] = 20;") == 1);     // id=1
+    CHECK(rows(d, "SELECT id FROM ae.l WHERE v[2] IS NULL;") == 2);  // id=2 (null cell), id=3 (out of range)
+    CHECK(rows(d, "SELECT id FROM ae.l WHERE v[2] IS NOT NULL;") == 1); // id=1
+    CHECK(rows(d, "SELECT id FROM ae.l WHERE v[1] IS NULL;") == 1);  // id=2 only
+}

--- a/integration/cpp/test/test_null_case_3vl.cpp
+++ b/integration/cpp/test/test_null_case_3vl.cpp
@@ -1,0 +1,107 @@
+#include "test_config.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <optional>
+#include <string>
+#include <vector>
+
+// Three-valued logic in the CASE expression evaluator (arithmetic_eval.cpp), used for a CASE in a
+// projection or aggregate. Two independent defects:
+//   1. a NOT inside a WHEN was ignored (union_not was folded like union_or), so `WHEN NOT (p)`
+//      behaved as `WHEN (p)`; and a NULL operand was two-valued (UNKNOWN collapsed to FALSE, then
+//      NOT could resurrect it).
+//   2. a plain projection `SELECT CASE ... FROM t` typed its output vector from the first THEN at
+//      row 0; when that value was NULL the vector took the untyped NA type and the first non-NULL
+//      result bad_alloc'd.
+
+namespace {
+    using test_helpers::exec;
+    using opt = std::optional<int64_t>;
+    using L = std::vector<opt>;
+
+    template<typename D>
+    bool okq(D* d, const std::string& sql) {
+        auto c = exec(d, sql);
+        return c && c->is_success();
+    }
+
+    // Column 0 of every row as optional<int64> (nullopt == NULL), in result order.
+    template<typename D>
+    std::vector<opt> coli(D* d, const std::string& sql) {
+        auto c = exec(d, sql);
+        REQUIRE(c);
+        INFO(sql);
+        REQUIRE(c->is_success());
+        std::vector<opt> out;
+        for (uint64_t r = 0; r < c->size(); ++r) {
+            auto v = c->value(0, r);
+            out.push_back(v.is_null() ? opt{} : opt{v.template value<int64_t>()});
+        }
+        return out;
+    }
+} // namespace
+
+// -------------------------------------------------------------------------------------------------
+//  NOT inside a WHEN condition -- must negate, and a NULL operand makes the WHEN UNKNOWN (-> ELSE).
+// -------------------------------------------------------------------------------------------------
+TEST_CASE("integration::cpp::case3vl::not_in_when") {
+    auto config = test_helpers::make_test_config("/tmp/case3vl/not_in_when");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(okq(d, "CREATE DATABASE m;"));
+    REQUIRE(okq(d, "CREATE TABLE m.t (id INT, x BIGINT);"));
+    REQUIRE(okq(d, "INSERT INTO m.t (id, x) VALUES (1, 5), (2, NULL), (3, 0), (4, 10);"));
+
+    // NOT (x = 5): TRUE for {0,10}; x=5 -> NOT TRUE = FALSE -> ELSE; NULL -> UNKNOWN -> ELSE.
+    CHECK(coli(d, "SELECT CASE WHEN NOT (x = 5) THEN 1 ELSE 0 END FROM m.t ORDER BY id;") == L{0, 0, 1, 1});
+    // NOT (x > 0): only x=0 makes x>0 FALSE -> NOT TRUE.
+    CHECK(coli(d, "SELECT CASE WHEN NOT (x > 0) THEN 1 ELSE 0 END FROM m.t ORDER BY id;") == L{0, 0, 1, 0});
+    // NOT over OR: NOT (x=5 OR x=10) -> TRUE only for x=0; NULL row is (U OR U)=U -> ELSE.
+    CHECK(coli(d, "SELECT CASE WHEN NOT (x = 5 OR x = 10) THEN 1 ELSE 0 END FROM m.t ORDER BY id;") ==
+          L{0, 0, 1, 0});
+    // NOT over AND: NOT (x=0 AND id=3) -> FALSE only for the id=3 row; the NULL row is
+    // (U AND FALSE)=FALSE -> NOT TRUE -> THEN.
+    CHECK(coli(d, "SELECT CASE WHEN NOT (x = 0 AND id = 3) THEN 1 ELSE 0 END FROM m.t ORDER BY id;") ==
+          L{1, 1, 0, 1});
+    // Positive control (no NOT): the plain WHEN still matches only the definitely-TRUE rows.
+    CHECK(coli(d, "SELECT CASE WHEN x = 5 THEN 1 ELSE 0 END FROM m.t ORDER BY id;") == L{1, 0, 0, 0});
+    CHECK(coli(d, "SELECT CASE WHEN x > 0 THEN 1 ELSE 0 END FROM m.t ORDER BY id;") == L{1, 0, 0, 1});
+}
+
+// -------------------------------------------------------------------------------------------------
+//  Projection CASE where the first THEN is NULL at row 0 -- output type must come from a real value.
+// -------------------------------------------------------------------------------------------------
+TEST_CASE("integration::cpp::case3vl::projection_null_row0") {
+    auto config = test_helpers::make_test_config("/tmp/case3vl/proj");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(okq(d, "CREATE DATABASE m;"));
+    REQUIRE(okq(d, "CREATE TABLE m.t (id INT, x BIGINT);"));
+    // Row 0 (id=1) is the NULL row, so the first THEN (x) is NULL at row 0.
+    REQUIRE(okq(d, "INSERT INTO m.t (id, x) VALUES (1, NULL), (2, 5), (3, 0);"));
+
+    // THEN references x: row 0's THEN is NULL, but rows 1..2 must still produce typed values.
+    CHECK(coli(d, "SELECT CASE WHEN x >= 0 THEN x ELSE 99 END FROM m.t ORDER BY id;") == L{99, 5, 0});
+    // THEN yields NULL at row 0 (no match, no ELSE) then a real value later.
+    CHECK(coli(d, "SELECT CASE WHEN x = 5 THEN x END FROM m.t ORDER BY id;") == L{opt{}, 5, opt{}});
+    // ELSE supplies the row-0 value; THEN supplies later ones.
+    CHECK(coli(d, "SELECT CASE WHEN x = 5 THEN x ELSE id END FROM m.t ORDER BY id;") == L{1, 5, 3});
+    // All-NULL result column (never matches, no ELSE): a well-formed all-NULL projection.
+    CHECK(coli(d, "SELECT CASE WHEN x = 777 THEN x END FROM m.t ORDER BY id;") == L{opt{}, opt{}, opt{}});
+}
+
+// -------------------------------------------------------------------------------------------------
+//  CASE inside an aggregate over a NULL row (the SUM(CASE ...) shape) keeps working with NOT.
+// -------------------------------------------------------------------------------------------------
+TEST_CASE("integration::cpp::case3vl::aggregate_case_not") {
+    auto config = test_helpers::make_test_config("/tmp/case3vl/agg");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(okq(d, "CREATE DATABASE m;"));
+    REQUIRE(okq(d, "CREATE TABLE m.t (id INT, x BIGINT);"));
+    REQUIRE(okq(d, "INSERT INTO m.t (id, x) VALUES (1, 5), (2, NULL), (3, 0), (4, 10);"));
+
+    // SUM over NOT(x=5): scores 1 for x in {0,10}; NULL never scores. -> 2
+    CHECK(coli(d, "SELECT SUM(CASE WHEN NOT (x = 5) THEN 1 ELSE 0 END) FROM m.t;") == L{2});
+    // SUM over NOT(x>0): scores 1 for x=0 only. -> 1
+    CHECK(coli(d, "SELECT SUM(CASE WHEN NOT (x > 0) THEN 1 ELSE 0 END) FROM m.t;") == L{1});
+}

--- a/integration/cpp/test/test_null_comparison.cpp
+++ b/integration/cpp/test/test_null_comparison.cpp
@@ -1,0 +1,139 @@
+#include "test_config.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <optional>
+#include <string>
+#include <vector>
+
+// SQL three-valued logic for value comparisons that are NOT part of the WHERE predicate tree:
+// CASE WHEN, GROUP BY CASE, HAVING, and CHECK constraints. A comparison over a NULL operand is
+// UNKNOWN, so a CASE WHEN falls through, a HAVING group is dropped, and a CHECK passes (only a
+// definitely-FALSE check is a violation).
+//
+// Before the fix these sites answered through logical_value_t::compare(), whose total order made
+// NULL == anything TRUE (or, once ordering put NULLs last, some other definite answer) -- so
+// `CASE WHEN x = 1` matched a NULL x, and `CHECK (x > 0)` rejected a NULL x.
+//
+// operator== is also exercised here: it is the structural equality used for DISTINCT, so two NULLs
+// must collapse to one group while a NULL and a value stay distinct.
+
+namespace {
+    using opt = std::optional<int64_t>;
+
+    template<typename D>
+    bool ok(D* d, const std::string& sql) {
+        auto s = otterbrix::session_id_t();
+        auto c = d->execute_sql(s, sql);
+        return c && c->is_success();
+    }
+    template<typename D>
+    size_t rows(D* d, const std::string& sql) {
+        auto s = otterbrix::session_id_t();
+        auto c = d->execute_sql(s, sql);
+        REQUIRE(c);
+        REQUIRE(c->is_success());
+        return c->size();
+    }
+    template<typename D>
+    std::vector<opt> read_col(D* d, const std::string& sql, uint64_t col = 0) {
+        auto s = otterbrix::session_id_t();
+        auto c = d->execute_sql(s, sql);
+        std::vector<opt> out;
+        REQUIRE(c);
+        REQUIRE(c->is_success());
+        for (uint64_t r = 0; r < c->size(); ++r) {
+            auto v = c->value(col, r);
+            out.push_back(v.is_null() ? opt{} : opt{v.template value<int64_t>()});
+        }
+        return out;
+    }
+
+    template<typename D>
+    void seed(D* d, const std::string& table) {
+        REQUIRE(ok(d, "CREATE TABLE " + table + " (id INT, x BIGINT);"));
+        REQUIRE(ok(d, "INSERT INTO " + table + " (id, x) VALUES (1, 5);"));
+        REQUIRE(ok(d, "INSERT INTO " + table + " (id, x) VALUES (2, NULL);"));
+        REQUIRE(ok(d, "INSERT INTO " + table + " (id, x) VALUES (3, 1);"));
+    }
+} // namespace
+
+TEST_CASE("integration::cpp::null_cmp::case_when_falls_through_on_null") {
+    auto config = test_create_config("/tmp/test_null_cmp/case");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(ok(d, "CREATE DATABASE nc;"));
+    seed(d, "nc.t"); // rows: x = 5, NULL, 1
+
+    // SUM over a CASE that scores 1 when the WHEN matches. A NULL operand makes the WHEN UNKNOWN,
+    // which (like FALSE) falls through to the ELSE 0 -- so a NULL row never scores.
+    //   x = 1 : only the x=1 row scores            -> 1
+    //   x <> 1: only the x=5 row scores            -> 1  (NULL does NOT flip in under <>)
+    //   x >= 1: the x=5 and x=1 rows score         -> 2  (NULL excluded)
+    //   x <= 1: only the x=1 row scores            -> 1
+    CHECK(read_col(d, "SELECT SUM(CASE WHEN x = 1 THEN 1 ELSE 0 END) FROM nc.t;") == std::vector<opt>{1});
+    CHECK(read_col(d, "SELECT SUM(CASE WHEN x <> 1 THEN 1 ELSE 0 END) FROM nc.t;") == std::vector<opt>{1});
+    CHECK(read_col(d, "SELECT SUM(CASE WHEN x >= 1 THEN 1 ELSE 0 END) FROM nc.t;") == std::vector<opt>{2});
+    CHECK(read_col(d, "SELECT SUM(CASE WHEN x <= 1 THEN 1 ELSE 0 END) FROM nc.t;") == std::vector<opt>{1});
+}
+
+TEST_CASE("integration::cpp::null_cmp::having_drops_unknown_group") {
+    auto config = test_create_config("/tmp/test_null_cmp/having");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(ok(d, "CREATE DATABASE nc;"));
+    // group 1: all NULL (SUM NULL) ; group 2: sums to 8.
+    REQUIRE(ok(d, "CREATE TABLE nc.g (k INT, x BIGINT);"));
+    REQUIRE(ok(d, "INSERT INTO nc.g (k, x) VALUES (1, NULL);"));
+    REQUIRE(ok(d, "INSERT INTO nc.g (k, x) VALUES (1, NULL);"));
+    REQUIRE(ok(d, "INSERT INTO nc.g (k, x) VALUES (2, 3);"));
+    REQUIRE(ok(d, "INSERT INTO nc.g (k, x) VALUES (2, 5);"));
+
+    // HAVING SUM(x) = 8: group 1's SUM is NULL -> UNKNOWN -> dropped; group 2 kept.
+    CHECK(rows(d, "SELECT k FROM nc.g GROUP BY k HAVING SUM(x) = 8;") == 1);
+    // HAVING SUM(x) <> 8: group 1 UNKNOWN -> still dropped (NOT does not resurrect it); group 2 FALSE.
+    CHECK(rows(d, "SELECT k FROM nc.g GROUP BY k HAVING SUM(x) <> 8;") == 0);
+    // HAVING SUM(x) > 0: group 1 UNKNOWN dropped; group 2 (8>0) kept.
+    CHECK(rows(d, "SELECT k FROM nc.g GROUP BY k HAVING SUM(x) > 0;") == 1);
+}
+
+TEST_CASE("integration::cpp::null_cmp::check_constraint_passes_null") {
+    auto config = test_create_config("/tmp/test_null_cmp/check");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(ok(d, "CREATE DATABASE nc;"));
+    REQUIRE(ok(d, "CREATE TABLE nc.ck (id INT, x BIGINT);"));
+    REQUIRE(ok(d, "ALTER TABLE nc.ck ADD CONSTRAINT ck_pos CHECK (x > 0);"));
+
+    CHECK(ok(d, "INSERT INTO nc.ck (id, x) VALUES (1, 5);"));      // 5 > 0 TRUE  -> accepted
+    CHECK_FALSE(ok(d, "INSERT INTO nc.ck (id, x) VALUES (2, -1);")); // -1 > 0 FALSE -> rejected
+    CHECK(ok(d, "INSERT INTO nc.ck (id, x) VALUES (3, NULL);"));   // NULL > 0 UNKNOWN -> accepted
+    // Only rows 1 and 3 made it in.
+    CHECK(rows(d, "SELECT id FROM nc.ck;") == 2);
+    CHECK(rows(d, "SELECT id FROM nc.ck WHERE x IS NULL;") == 1);
+}
+
+TEST_CASE("integration::cpp::null_cmp::distinct_collapses_nulls") {
+    auto config = test_create_config("/tmp/test_null_cmp/distinct");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(ok(d, "CREATE DATABASE nc;"));
+    REQUIRE(ok(d, "CREATE TABLE nc.t (id INT, x BIGINT);"));
+    REQUIRE(ok(d, "INSERT INTO nc.t (id, x) VALUES (1, 5);"));
+    REQUIRE(ok(d, "INSERT INTO nc.t (id, x) VALUES (2, NULL);"));
+    REQUIRE(ok(d, "INSERT INTO nc.t (id, x) VALUES (3, NULL);"));
+    REQUIRE(ok(d, "INSERT INTO nc.t (id, x) VALUES (4, 5);"));
+
+    // DISTINCT treats all NULLs as one value: {5, NULL} -> 2 distinct rows.
+    CHECK(rows(d, "SELECT DISTINCT x FROM nc.t;") == 2);
+}

--- a/integration/cpp/test/test_null_deep_path.cpp
+++ b/integration/cpp/test/test_null_deep_path.cpp
@@ -1,0 +1,73 @@
+#include "test_config.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <optional>
+#include <string>
+#include <vector>
+
+// A NULL ARRAY / LIST / STRUCT cell has no interior. Reading an element of it -- v[i], a struct
+// field -- must yield NULL, and a predicate over that element must be UNKNOWN (the row excluded),
+// never a value read out of a garbage (offset,length)/stride computed from the NULL row.
+//
+// Before the fix, the deep-path accessor descended into the ARRAY/LIST/STRUCT branch without
+// checking the parent cell's validity, so a NULL array cell's subscript returned an arbitrary
+// element of the flat child buffer.
+
+namespace {
+
+    using opt = std::optional<int64_t>;
+
+    template<typename D>
+    bool ok(D* d, const std::string& sql) {
+        auto s = otterbrix::session_id_t();
+        auto c = d->execute_sql(s, sql);
+        return c && c->is_success();
+    }
+
+    template<typename D>
+    size_t rows(D* d, const std::string& sql) {
+        auto s = otterbrix::session_id_t();
+        auto c = d->execute_sql(s, sql);
+        REQUIRE(c);
+        REQUIRE(c->is_success());
+        return c->size();
+    }
+
+    template<typename D>
+    std::vector<opt> read_col(D* d, const std::string& sql, uint64_t col = 0) {
+        auto s = otterbrix::session_id_t();
+        auto c = d->execute_sql(s, sql);
+        std::vector<opt> out;
+        REQUIRE(c);
+        REQUIRE(c->is_success());
+        for (uint64_t r = 0; r < c->size(); ++r) {
+            auto v = c->value(col, r);
+            out.push_back(v.is_null() ? opt{} : opt{v.template value<int64_t>()});
+        }
+        return out;
+    }
+
+} // namespace
+
+TEST_CASE("integration::cpp::null_deep::array_subscript_of_null_cell") {
+    auto config = test_create_config("/tmp/test_null_deep/arr");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(ok(d, "CREATE DATABASE dp;"));
+    // A declared fixed-size array column. Row 1 and row 3 have arrays; row 2's array cell is
+    // NULL as a whole (an explicit NULL), so v[i] has no interior to read.
+    REQUIRE(ok(d, "CREATE TABLE dp.t (id bigint, v int[3]);"));
+    REQUIRE(ok(d, "INSERT INTO dp.t (id, v) VALUES (1, ARRAY[10, 20, 30]);"));
+    REQUIRE(ok(d, "INSERT INTO dp.t (id, v) VALUES (2, NULL);"));
+    REQUIRE(ok(d, "INSERT INTO dp.t (id, v) VALUES (3, ARRAY[40, 50, 60]);"));
+
+    // Subscript of the NULL cell (row 2) projects NULL, not an element read from a stride
+    // computed off the NULL row. This exercises the in-memory deep-path accessor directly.
+    CHECK(read_col(d, "SELECT v[1] FROM dp.t ORDER BY id;") == std::vector<opt>{10, {}, 40});
+    CHECK(read_col(d, "SELECT v[2] FROM dp.t ORDER BY id;") == std::vector<opt>{20, {}, 50});
+    CHECK(read_col(d, "SELECT v[3] FROM dp.t ORDER BY id;") == std::vector<opt>{30, {}, 60});
+    // (A predicate over v[i] against a NULL array cell takes the storage-scan pushdown path, not
+    //  this accessor; its own three-valued handling is covered by the pushdown array-element test.)
+}

--- a/integration/cpp/test/test_null_predicate_3vl.cpp
+++ b/integration/cpp/test/test_null_predicate_3vl.cpp
@@ -1,0 +1,192 @@
+#include "test_config.hpp"
+#include <algorithm>
+#include <catch2/catch_test_macros.hpp>
+#include <string>
+#include <vector>
+
+// Three-valued logic in the IN-MEMORY predicate evaluator (simple_predicate / function_predicate),
+// the path taken when a WHERE / join / DML condition is NOT pushed down to the storage scan --
+// i.e. it involves arithmetic, a function (LIKE / regex), or a plain-list IN, optionally under NOT.
+//
+// A NULL operand makes a comparison UNKNOWN, not FALSE; the two diverge under NOT. A 2VL evaluator
+// that collapses UNKNOWN to FALSE lets `NOT (...)` resurrect a NULL row. These tests pin the SQL
+// answers for every combinator (=, <>, <, >, arithmetic, LIKE, IN, AND, OR, NOT) over a NULL row,
+// across WHERE, DELETE, UPDATE, join, and CHECK.
+
+namespace {
+    using test_helpers::exec;
+
+    // Sorted list of column-0 (id) values of a successful query.
+    template<typename D>
+    std::vector<int64_t> ids(D* d, const std::string& sql) {
+        auto c = exec(d, sql);
+        REQUIRE(c);
+        INFO(sql);
+        REQUIRE(c->is_success());
+        std::vector<int64_t> out;
+        for (uint64_t r = 0; r < c->size(); ++r) {
+            auto v = c->value(0, r);
+            REQUIRE_FALSE(v.is_null());
+            out.push_back(v.template value<int64_t>());
+        }
+        std::sort(out.begin(), out.end());
+        return out;
+    }
+
+    template<typename D>
+    bool okq(D* d, const std::string& sql) {
+        auto c = exec(d, sql);
+        return c && c->is_success();
+    }
+
+    using L = std::vector<int64_t>;
+
+    // Seed t(id, x, s) with a NULL row (id=2) among numeric + text values.
+    template<typename D>
+    void seed(D* d) {
+        REQUIRE(okq(d, "CREATE DATABASE m;"));
+        REQUIRE(okq(d, "CREATE TABLE m.t (id INT, x BIGINT, s TEXT);"));
+        REQUIRE(okq(d, "INSERT INTO m.t (id, x, s) VALUES (1, 5, 'apple');"));
+        REQUIRE(okq(d, "INSERT INTO m.t (id, x, s) VALUES (2, NULL, NULL);"));
+        REQUIRE(okq(d, "INSERT INTO m.t (id, x, s) VALUES (3, 0, 'banana');"));
+        REQUIRE(okq(d, "INSERT INTO m.t (id, x, s) VALUES (4, 10, 'cherry');"));
+    }
+} // namespace
+
+// -------------------------------------------------------------------------------------------------
+//  Arithmetic operand under NOT -- the in-memory path (arithmetic is not pushed down).
+// -------------------------------------------------------------------------------------------------
+TEST_CASE("integration::cpp::pred3vl::arithmetic_not") {
+    auto config = test_helpers::make_test_config("/tmp/p3vl/arith_not");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    seed(d);
+
+    // positive controls: only the TRUE row(s), NULL never matches.
+    CHECK(ids(d, "SELECT id FROM m.t WHERE x + 1 = 6;") == L{1});
+    CHECK(ids(d, "SELECT id FROM m.t WHERE x * 2 = 20;") == L{4});
+    CHECK(ids(d, "SELECT id FROM m.t WHERE 100 - x = 95;") == L{1});
+
+    // NOT over an arithmetic comparison: NULL stays UNKNOWN -> excluded, not resurrected.
+    CHECK(ids(d, "SELECT id FROM m.t WHERE NOT (x + 1 = 6);") == L{3, 4});
+    CHECK(ids(d, "SELECT id FROM m.t WHERE NOT (x - 1 = 4);") == L{3, 4});
+    CHECK(ids(d, "SELECT id FROM m.t WHERE NOT (x * 2 = 20);") == L{1, 3});
+    CHECK(ids(d, "SELECT id FROM m.t WHERE NOT (100 - x = 95);") == L{3, 4});
+    // <> under NOT collapses to =, NULL still excluded.
+    CHECK(ids(d, "SELECT id FROM m.t WHERE NOT (x + 1 <> 6);") == L{1});
+    // ordering comparisons under NOT.
+    CHECK(ids(d, "SELECT id FROM m.t WHERE NOT (x + 1 > 6);") == L{1, 3}); // x+1<=6 -> x in {5,0}
+    CHECK(ids(d, "SELECT id FROM m.t WHERE NOT (x + 1 <= 6);") == L{4});   // x+1>6 -> x=10
+}
+
+// -------------------------------------------------------------------------------------------------
+//  Function (LIKE) operand under NOT -- function_predicate path.
+// -------------------------------------------------------------------------------------------------
+TEST_CASE("integration::cpp::pred3vl::like_not") {
+    auto config = test_helpers::make_test_config("/tmp/p3vl/like_not");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    seed(d);
+
+    CHECK(ids(d, "SELECT id FROM m.t WHERE s LIKE 'a%';") == L{1});
+    CHECK(ids(d, "SELECT id FROM m.t WHERE s LIKE '%a%';") == L{1, 3}); // apple, banana
+
+    // NOT LIKE / NOT (LIKE): the NULL text row is UNKNOWN, never resurrected.
+    CHECK(ids(d, "SELECT id FROM m.t WHERE NOT (s LIKE 'a%');") == L{3, 4});
+    CHECK(ids(d, "SELECT id FROM m.t WHERE s NOT LIKE 'a%';") == L{3, 4});
+    CHECK(ids(d, "SELECT id FROM m.t WHERE NOT (s LIKE '%a%');") == L{4}); // only cherry lacks 'a'
+}
+
+// -------------------------------------------------------------------------------------------------
+//  IN / NOT IN over a plain list -- union_or(eq) / union_and(ne), and NOT(IN).
+// -------------------------------------------------------------------------------------------------
+TEST_CASE("integration::cpp::pred3vl::in_not") {
+    auto config = test_helpers::make_test_config("/tmp/p3vl/in_not");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    seed(d);
+
+    CHECK(ids(d, "SELECT id FROM m.t WHERE x IN (5, 10);") == L{1, 4});
+    CHECK(ids(d, "SELECT id FROM m.t WHERE x NOT IN (5, 10);") == L{3}); // 0 only; NULL excluded
+    CHECK(ids(d, "SELECT id FROM m.t WHERE NOT (x IN (5, 10));") == L{3});
+    CHECK(ids(d, "SELECT id FROM m.t WHERE NOT (x IN (0));") == L{1, 4});
+    // NULL element in the list makes an otherwise-FALSE membership UNKNOWN (still excluded here).
+    CHECK(ids(d, "SELECT id FROM m.t WHERE x IN (5, 10, NULL);") == L{1, 4});
+}
+
+// -------------------------------------------------------------------------------------------------
+//  NOT distributed over AND / OR (De Morgan) with a NULL operand.
+// -------------------------------------------------------------------------------------------------
+TEST_CASE("integration::cpp::pred3vl::not_over_and_or") {
+    auto config = test_helpers::make_test_config("/tmp/p3vl/demorgan");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    seed(d);
+
+    // NOT (P OR Q): id2 is (U OR U)=U -> NOT U -> excluded (2VL wrongly includes it).
+    CHECK(ids(d, "SELECT id FROM m.t WHERE NOT (x + 1 = 6 OR s LIKE 'b%');") == L{4});
+    // NOT (P AND Q): id2 is (U AND FALSE)=FALSE -> NOT TRUE -> included.
+    CHECK(ids(d, "SELECT id FROM m.t WHERE NOT (x + 1 = 6 AND id = 1);") == L{2, 3, 4});
+    // positive control (no NOT): OR of the TRUE rows.
+    CHECK(ids(d, "SELECT id FROM m.t WHERE x + 1 = 6 OR s LIKE 'b%';") == L{1, 3});
+    // AND mixing arithmetic with a plain column.
+    CHECK(ids(d, "SELECT id FROM m.t WHERE x + 1 = 6 AND id = 1;") == L{1});
+    CHECK(ids(d, "SELECT id FROM m.t WHERE x + 1 = 6 AND id = 2;") == L{});
+}
+
+// -------------------------------------------------------------------------------------------------
+//  DELETE / UPDATE consumers: only definitely-TRUE rows are affected.
+// -------------------------------------------------------------------------------------------------
+TEST_CASE("integration::cpp::pred3vl::delete_update") {
+    auto config = test_helpers::make_test_config("/tmp/p3vl/dml", true, true);
+    {
+        test_spaces space(config);
+        auto* d = space.dispatcher();
+        seed(d);
+
+        // DELETE WHERE NOT(arith): removes the definitely-TRUE rows {3,4}; NULL row survives.
+        REQUIRE(okq(d, "DELETE FROM m.t WHERE NOT (x + 1 = 6);"));
+        CHECK(ids(d, "SELECT id FROM m.t;") == L{1, 2});
+        CHECK(ids(d, "SELECT id FROM m.t WHERE x IS NULL;") == L{2});
+    }
+    {
+        test_spaces space(config); // restart: recovery keeps the same rows.
+        auto* d = space.dispatcher();
+        CHECK(ids(d, "SELECT id FROM m.t;") == L{1, 2});
+    }
+
+    auto cfg2 = test_helpers::make_test_config("/tmp/p3vl/dml_upd");
+    test_spaces space(cfg2);
+    auto* d = space.dispatcher();
+    seed(d);
+    // UPDATE WHERE NOT(LIKE): updates only {3,4}; NULL row untouched.
+    REQUIRE(okq(d, "UPDATE m.t SET x = 999 WHERE NOT (s LIKE 'a%');"));
+    CHECK(ids(d, "SELECT id FROM m.t WHERE x = 999;") == L{3, 4});
+    CHECK(ids(d, "SELECT id FROM m.t WHERE x IS NULL;") == L{2}); // id=2 still NULL, not updated
+}
+
+// -------------------------------------------------------------------------------------------------
+//  CHECK constraint consumer: a NULL operand is UNKNOWN, which PASSES a CHECK (permits), even
+//  under NOT. Only a definitely-FALSE row is rejected.
+// -------------------------------------------------------------------------------------------------
+TEST_CASE("integration::cpp::pred3vl::check_not") {
+    auto config = test_helpers::make_test_config("/tmp/p3vl/check");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(okq(d, "CREATE DATABASE m;"));
+
+    REQUIRE(okq(d, "CREATE TABLE m.t (id INT, x BIGINT);"));
+    REQUIRE(okq(d, "ALTER TABLE m.t ADD CONSTRAINT cc CHECK (NOT (x = 5));"));
+    CHECK(okq(d, "INSERT INTO m.t (id, x) VALUES (1, 0);"));         // NOT(FALSE)=TRUE -> ok
+    CHECK_FALSE(okq(d, "INSERT INTO m.t (id, x) VALUES (2, 5);"));   // NOT(TRUE)=FALSE -> rejected
+    CHECK(okq(d, "INSERT INTO m.t (id, x) VALUES (3, NULL);"));      // NOT(UNKNOWN)=UNKNOWN -> ok
+    CHECK(ids(d, "SELECT id FROM m.t;") == L{1, 3});
+
+    // Plain comparison CHECK: NULL passes, FALSE rejected.
+    REQUIRE(okq(d, "CREATE TABLE m.u (id INT, x BIGINT);"));
+    REQUIRE(okq(d, "ALTER TABLE m.u ADD CONSTRAINT cc CHECK (x <> 5);"));
+    CHECK(okq(d, "INSERT INTO m.u (id, x) VALUES (1, 0);"));
+    CHECK_FALSE(okq(d, "INSERT INTO m.u (id, x) VALUES (2, 5);"));
+    CHECK(okq(d, "INSERT INTO m.u (id, x) VALUES (3, NULL);"));
+    CHECK(ids(d, "SELECT id FROM m.u;") == L{1, 3});
+}

--- a/integration/cpp/test/test_null_semantics_matrix.cpp
+++ b/integration/cpp/test/test_null_semantics_matrix.cpp
@@ -1,0 +1,553 @@
+#include "test_config.hpp"
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <optional>
+#include <string>
+#include <vector>
+
+// Massive coverage of the NULL / SQL three-valued-logic behaviour that this branch fixes.
+//
+// The tests are written as SQL: a small harness runs a statement and asserts on its result
+// (row count, a scalar, a whole projected column, or success/failure), and the batteries below
+// feed it hundreds of SQL cases. Each battery is re-run across the axes that must not change the
+// answer -- column type (BIGINT / INTEGER / DOUBLE / TEXT), table shape (declared vs schemaless
+// "computing" table), storage (in-memory vs disk+WAL, and across a restart), and an indexed vs
+// unindexed twin -- so a regression on any axis is caught.
+//
+// Scope note: only behaviour that is actually fixed on this branch is asserted here. The in-memory
+// predicate evaluator is still two-valued (NOT over an arithmetic/function/LIKE operand, or a
+// plain-list NOT IN, resurrects a NULL row), so those forms are deliberately NOT asserted -- they
+// belong to the predicate-3VL unit. Every NOT asserted below is over a plain column comparison,
+// which the storage-scan filter evaluates in full three-valued logic.
+
+namespace {
+
+    using opt = std::optional<int64_t>;
+    using test_helpers::exec;
+
+    template<typename D>
+    bool okq(D* d, const std::string& sql) {
+        auto c = exec(d, sql);
+        return c && c->is_success();
+    }
+
+    // Row count of a successful query.
+    template<typename D>
+    long nrows(D* d, const std::string& sql) {
+        auto c = exec(d, sql);
+        REQUIRE(c);
+        INFO(sql);
+        REQUIRE(c->is_success());
+        return static_cast<long>(c->size());
+    }
+
+    // Column 0 of every row as optional<int64> (nullopt == SQL NULL), in result order.
+    template<typename D>
+    std::vector<opt> coli(D* d, const std::string& sql) {
+        auto c = exec(d, sql);
+        REQUIRE(c);
+        INFO(sql);
+        REQUIRE(c->is_success());
+        std::vector<opt> out;
+        for (uint64_t r = 0; r < c->size(); ++r) {
+            auto v = c->value(0, r);
+            out.push_back(v.is_null() ? opt{} : opt{v.template value<int64_t>()});
+        }
+        return out;
+    }
+
+    // Single integer scalar (exactly one row).
+    template<typename D>
+    opt scal(D* d, const std::string& sql) {
+        auto v = coli(d, sql);
+        INFO(sql);
+        REQUIRE(v.size() == 1);
+        return v.front();
+    }
+
+    // Single double scalar (exactly one row, non-null).
+    template<typename D>
+    double scald(D* d, const std::string& sql) {
+        auto c = exec(d, sql);
+        REQUIRE(c);
+        INFO(sql);
+        REQUIRE(c->is_success());
+        REQUIRE(c->size() == 1);
+        auto v = c->value(0, 0);
+        REQUIRE_FALSE(v.is_null());
+        return v.template value<double>();
+    }
+
+    // ---- batteries ----------------------------------------------------------------------------
+
+    // A NULLABLE numeric column `x` seeded with {5, NULL, 0, 10, NULL} at ids {1..5}. Only value
+    // comparisons, IS NULL, boolean combinations of plain columns, and aggregates -- all fixed.
+    template<typename D>
+    void comparison_battery(D* d, const std::string& t) {
+        // equality / inequality
+        CHECK(nrows(d, "SELECT id FROM " + t + " WHERE x = 0;") == 1);
+        CHECK(nrows(d, "SELECT id FROM " + t + " WHERE x = 5;") == 1);
+        CHECK(nrows(d, "SELECT id FROM " + t + " WHERE x = 10;") == 1);
+        CHECK(nrows(d, "SELECT id FROM " + t + " WHERE x = 7;") == 0);
+        CHECK(nrows(d, "SELECT id FROM " + t + " WHERE x <> 0;") == 2);  // 5,10
+        CHECK(nrows(d, "SELECT id FROM " + t + " WHERE x <> 5;") == 2);  // 0,10
+        // ordering
+        CHECK(nrows(d, "SELECT id FROM " + t + " WHERE x > 0;") == 2);   // 5,10
+        CHECK(nrows(d, "SELECT id FROM " + t + " WHERE x >= 0;") == 3);  // 0,5,10
+        CHECK(nrows(d, "SELECT id FROM " + t + " WHERE x < 10;") == 2);  // 0,5
+        CHECK(nrows(d, "SELECT id FROM " + t + " WHERE x <= 10;") == 3); // 0,5,10
+        CHECK(nrows(d, "SELECT id FROM " + t + " WHERE x < 0;") == 0);
+        CHECK(nrows(d, "SELECT id FROM " + t + " WHERE x > 10;") == 0);
+        // NOT over a plain column comparison (storage-scan 3VL): NULL stays excluded.
+        CHECK(nrows(d, "SELECT id FROM " + t + " WHERE NOT (x = 0);") == 2);   // 5,10
+        CHECK(nrows(d, "SELECT id FROM " + t + " WHERE NOT (x = 5);") == 2);   // 0,10
+        CHECK(nrows(d, "SELECT id FROM " + t + " WHERE NOT (x <> 0);") == 1);  // 0
+        CHECK(nrows(d, "SELECT id FROM " + t + " WHERE NOT (x >= 0);") == 0);
+        CHECK(nrows(d, "SELECT id FROM " + t + " WHERE NOT (x < 10);") == 1);  // 10
+        CHECK(nrows(d, "SELECT id FROM " + t + " WHERE NOT (x > 0);") == 1);   // 0
+        // IS NULL / IS NOT NULL
+        CHECK(nrows(d, "SELECT id FROM " + t + " WHERE x IS NULL;") == 2);
+        CHECK(nrows(d, "SELECT id FROM " + t + " WHERE x IS NOT NULL;") == 3);
+        // AND
+        CHECK(nrows(d, "SELECT id FROM " + t + " WHERE x >= 0 AND x <= 5;") == 2);  // 0,5
+        CHECK(nrows(d, "SELECT id FROM " + t + " WHERE x > 0 AND x < 10;") == 1);   // 5
+        CHECK(nrows(d, "SELECT id FROM " + t + " WHERE x >= 0 AND id = 3;") == 1);  // 3
+        CHECK(nrows(d, "SELECT id FROM " + t + " WHERE x >= 0 AND id = 2;") == 0);  // NULL row
+        CHECK(nrows(d, "SELECT id FROM " + t + " WHERE x IS NULL AND id = 2;") == 1);
+        // OR
+        CHECK(nrows(d, "SELECT id FROM " + t + " WHERE x = 0 OR x = 10;") == 2);
+        CHECK(nrows(d, "SELECT id FROM " + t + " WHERE x = 7 OR x = 5;") == 1);
+        CHECK(nrows(d, "SELECT id FROM " + t + " WHERE x = 0 OR id = 2;") == 2);    // 2,3
+        CHECK(nrows(d, "SELECT id FROM " + t + " WHERE x IS NULL OR x = 0;") == 3); // 2,3,5
+        CHECK(nrows(d, "SELECT id FROM " + t + " WHERE x = 0 OR x IS NULL;") == 3);
+        // aggregates (NULLs skipped; COUNT(*) counts rows)
+        CHECK(scal(d, "SELECT COUNT(x) FROM " + t + ";") == opt{3});
+        CHECK(scal(d, "SELECT COUNT(*) FROM " + t + ";") == opt{5});
+        CHECK(scal(d, "SELECT COUNT(DISTINCT x) FROM " + t + ";") == opt{3});
+        CHECK(scal(d, "SELECT SUM(x) FROM " + t + ";") == opt{15});
+        CHECK(scal(d, "SELECT MIN(x) FROM " + t + ";") == opt{0});
+        CHECK(scal(d, "SELECT MAX(x) FROM " + t + ";") == opt{10});
+        // AVG skips NULLs: mean of {5,0,10} = 5 (integer-typed AVG on an integer column, read as int64).
+        CHECK(scal(d, "SELECT AVG(x) FROM " + t + ";") == opt{5});
+    }
+
+    // Seed the {5,NULL,0,10,NULL} numeric shape into an existing declared table (id, x).
+    template<typename D>
+    void seed_numeric(D* d, const std::string& t) {
+        REQUIRE(okq(d, "INSERT INTO " + t + " (id, x) VALUES (1, 5);"));
+        REQUIRE(okq(d, "INSERT INTO " + t + " (id, x) VALUES (2, NULL);"));
+        REQUIRE(okq(d, "INSERT INTO " + t + " (id, x) VALUES (3, 0);"));
+        REQUIRE(okq(d, "INSERT INTO " + t + " (id, x) VALUES (4, 10);"));
+        REQUIRE(okq(d, "INSERT INTO " + t + " (id, x) VALUES (5, NULL);"));
+    }
+
+} // namespace
+
+// ===========================================================================================
+//  Comparison battery across column types and table shapes
+// ===========================================================================================
+
+TEST_CASE("integration::cpp::null_matrix::comparisons_bigint") {
+    auto config = test_helpers::make_test_config("/tmp/nmx/cmp_bigint");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(okq(d, "CREATE DATABASE m;"));
+    REQUIRE(okq(d, "CREATE TABLE m.t (id INT, x BIGINT);"));
+    seed_numeric(d, "m.t");
+    comparison_battery(d, "m.t");
+}
+
+TEST_CASE("integration::cpp::null_matrix::comparisons_integer") {
+    auto config = test_helpers::make_test_config("/tmp/nmx/cmp_int");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(okq(d, "CREATE DATABASE m;"));
+    REQUIRE(okq(d, "CREATE TABLE m.t (id INT, x INTEGER);"));
+    seed_numeric(d, "m.t");
+    comparison_battery(d, "m.t");
+}
+
+TEST_CASE("integration::cpp::null_matrix::comparisons_double") {
+    auto config = test_helpers::make_test_config("/tmp/nmx/cmp_double");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(okq(d, "CREATE DATABASE m;"));
+    REQUIRE(okq(d, "CREATE TABLE m.t (id INT, x DOUBLE PRECISION);"));
+    seed_numeric(d, "m.t");
+    // Row-count / count-aggregate half of the battery (values are whole numbers, but reading a
+    // DOUBLE projection back as an int is avoided -- counts and comparisons are type-agnostic).
+    CHECK(nrows(d, "SELECT id FROM m.t WHERE x = 0;") == 1);
+    CHECK(nrows(d, "SELECT id FROM m.t WHERE x <> 0;") == 2);
+    CHECK(nrows(d, "SELECT id FROM m.t WHERE x >= 0;") == 3);
+    CHECK(nrows(d, "SELECT id FROM m.t WHERE NOT (x = 0);") == 2);
+    CHECK(nrows(d, "SELECT id FROM m.t WHERE NOT (x >= 0);") == 0);
+    CHECK(nrows(d, "SELECT id FROM m.t WHERE x IS NULL;") == 2);
+    CHECK(nrows(d, "SELECT id FROM m.t WHERE x IS NOT NULL;") == 3);
+    CHECK(scal(d, "SELECT COUNT(x) FROM m.t;") == opt{3});
+    CHECK(scal(d, "SELECT COUNT(*) FROM m.t;") == opt{5});
+    CHECK(scald(d, "SELECT SUM(x) FROM m.t;") == Catch::Approx(15.0));
+    CHECK(scald(d, "SELECT MIN(x) FROM m.t;") == Catch::Approx(0.0));
+    CHECK(scald(d, "SELECT MAX(x) FROM m.t;") == Catch::Approx(10.0));
+    CHECK(scald(d, "SELECT AVG(x) FROM m.t;") == Catch::Approx(5.0)); // NULLs skipped: mean of 5,0,10
+}
+
+TEST_CASE("integration::cpp::null_matrix::comparisons_text") {
+    auto config = test_helpers::make_test_config("/tmp/nmx/cmp_text");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(okq(d, "CREATE DATABASE m;"));
+    REQUIRE(okq(d, "CREATE TABLE m.t (id INT, s TEXT);"));
+    REQUIRE(okq(d, "INSERT INTO m.t (id, s) VALUES (1, 'ann');"));
+    REQUIRE(okq(d, "INSERT INTO m.t (id, s) VALUES (2, NULL);"));
+    REQUIRE(okq(d, "INSERT INTO m.t (id, s) VALUES (3, 'bob');"));
+    REQUIRE(okq(d, "INSERT INTO m.t (id, s) VALUES (4, 'cat');"));
+    REQUIRE(okq(d, "INSERT INTO m.t (id, s) VALUES (5, NULL);"));
+
+    CHECK(nrows(d, "SELECT id FROM m.t WHERE s = 'ann';") == 1);
+    CHECK(nrows(d, "SELECT id FROM m.t WHERE s <> 'ann';") == 2);   // bob,cat
+    CHECK(nrows(d, "SELECT id FROM m.t WHERE s > 'bob';") == 1);    // cat
+    CHECK(nrows(d, "SELECT id FROM m.t WHERE s >= 'bob';") == 2);   // bob,cat
+    CHECK(nrows(d, "SELECT id FROM m.t WHERE s < 'bob';") == 1);    // ann
+    CHECK(nrows(d, "SELECT id FROM m.t WHERE NOT (s = 'ann');") == 2);
+    CHECK(nrows(d, "SELECT id FROM m.t WHERE NOT (s <> 'ann');") == 1);
+    CHECK(nrows(d, "SELECT id FROM m.t WHERE s IS NULL;") == 2);
+    CHECK(nrows(d, "SELECT id FROM m.t WHERE s IS NOT NULL;") == 3);
+    CHECK(nrows(d, "SELECT id FROM m.t WHERE s = 'ann' OR id = 2;") == 2);
+    CHECK(scal(d, "SELECT COUNT(s) FROM m.t;") == opt{3});
+    CHECK(scal(d, "SELECT COUNT(*) FROM m.t;") == opt{5});
+}
+
+TEST_CASE("integration::cpp::null_matrix::comparisons_computing_table") {
+    // Schemaless table: id=2 and id=5 simply omit `x`, so its cell is absent == NULL.
+    auto config = test_helpers::make_test_config("/tmp/nmx/cmp_comp");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(okq(d, "CREATE DATABASE m;"));
+    REQUIRE(okq(d, "CREATE TABLE m.c ();"));
+    REQUIRE(okq(d, "INSERT INTO m.c (id, x) VALUES (1, 5);"));
+    REQUIRE(okq(d, "INSERT INTO m.c (id) VALUES (2);"));
+    REQUIRE(okq(d, "INSERT INTO m.c (id, x) VALUES (3, 0);"));
+    REQUIRE(okq(d, "INSERT INTO m.c (id, x) VALUES (4, 10);"));
+    REQUIRE(okq(d, "INSERT INTO m.c (id) VALUES (5);"));
+    comparison_battery(d, "m.c");
+}
+
+TEST_CASE("integration::cpp::null_matrix::comparisons_disk_and_restart") {
+    auto config = test_helpers::make_test_config("/tmp/nmx/cmp_disk", /*disk*/ true, /*wal*/ true);
+    {
+        test_spaces space(config);
+        auto* d = space.dispatcher();
+        REQUIRE(okq(d, "CREATE DATABASE m;"));
+        REQUIRE(okq(d, "CREATE TABLE m.t (id INT, x BIGINT);"));
+        seed_numeric(d, "m.t");
+        comparison_battery(d, "m.t"); // with disk + WAL on
+    }
+    {
+        test_spaces space(config); // restart: state recovered from disk/WAL
+        auto* d = space.dispatcher();
+        comparison_battery(d, "m.t"); // identical answers after recovery
+    }
+}
+
+// ===========================================================================================
+//  Arithmetic NULL propagation -- every operator, every context
+// ===========================================================================================
+
+TEST_CASE("integration::cpp::null_matrix::arithmetic_projection") {
+    auto config = test_helpers::make_test_config("/tmp/nmx/arith_proj");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(okq(d, "CREATE DATABASE m;"));
+    REQUIRE(okq(d, "CREATE TABLE m.t (id INT, x BIGINT);"));
+    REQUIRE(okq(d, "INSERT INTO m.t (id, x) VALUES (1, 5);"));
+    REQUIRE(okq(d, "INSERT INTO m.t (id, x) VALUES (2, NULL);"));
+    REQUIRE(okq(d, "INSERT INTO m.t (id, x) VALUES (3, 0);"));
+
+    // Every arithmetic operator, NULL row (id=2) must project NULL.
+    CHECK(coli(d, "SELECT x + 1 FROM m.t ORDER BY id;") == std::vector<opt>{6, {}, 1});
+    CHECK(coli(d, "SELECT x - 1 FROM m.t ORDER BY id;") == std::vector<opt>{4, {}, -1});
+    CHECK(coli(d, "SELECT x * 2 FROM m.t ORDER BY id;") == std::vector<opt>{10, {}, 0});
+    CHECK(coli(d, "SELECT x / 2 FROM m.t ORDER BY id;") == std::vector<opt>{2, {}, 0});
+    CHECK(coli(d, "SELECT x % 3 FROM m.t ORDER BY id;") == std::vector<opt>{2, {}, 0});
+    CHECK(coli(d, "SELECT -x FROM m.t ORDER BY id;") == std::vector<opt>{-5, {}, 0});
+    CHECK(coli(d, "SELECT 100 - x FROM m.t ORDER BY id;") == std::vector<opt>{95, {}, 100});
+    CHECK(coli(d, "SELECT 1 + x FROM m.t ORDER BY id;") == std::vector<opt>{6, {}, 1});
+    // NULL as a divisor and division by zero both yield NULL (no SIGFPE).
+    CHECK(coli(d, "SELECT 10 / x FROM m.t ORDER BY id;") == std::vector<opt>{2, {}, {}});
+    CHECK(coli(d, "SELECT 10 % x FROM m.t ORDER BY id;") == std::vector<opt>{0, {}, {}});
+    // Chained arithmetic keeps propagating NULL.
+    CHECK(coli(d, "SELECT (x + 1) * 2 FROM m.t ORDER BY id;") == std::vector<opt>{12, {}, 2});
+    CHECK(coli(d, "SELECT x + x FROM m.t ORDER BY id;") == std::vector<opt>{10, {}, 0});
+    CHECK(coli(d, "SELECT x * x - 1 FROM m.t ORDER BY id;") == std::vector<opt>{24, {}, -1});
+}
+
+TEST_CASE("integration::cpp::null_matrix::arithmetic_where_and_update") {
+    auto config = test_helpers::make_test_config("/tmp/nmx/arith_wu", true, true);
+    {
+        test_spaces space(config);
+        auto* d = space.dispatcher();
+        REQUIRE(okq(d, "CREATE DATABASE m;"));
+        REQUIRE(okq(d, "CREATE TABLE m.t (id INT, x BIGINT);"));
+        REQUIRE(okq(d, "INSERT INTO m.t (id, x) VALUES (1, 5);"));
+        REQUIRE(okq(d, "INSERT INTO m.t (id, x) VALUES (2, NULL);"));
+        REQUIRE(okq(d, "INSERT INTO m.t (id, x) VALUES (3, 0);"));
+
+        // Positive arithmetic comparison in WHERE excludes the NULL row.
+        CHECK(nrows(d, "SELECT id FROM m.t WHERE x + 1 = 1;") == 1);  // id=3
+        CHECK(nrows(d, "SELECT id FROM m.t WHERE x * 2 = 0;") == 1);  // id=3
+        CHECK(nrows(d, "SELECT id FROM m.t WHERE x - 5 = 0;") == 1);  // id=1
+        // Constant folding of a NULL literal makes the comparison UNKNOWN for all rows.
+        CHECK(nrows(d, "SELECT id FROM m.t WHERE 1 + NULL = 1;") == 0);
+        CHECK(nrows(d, "SELECT id FROM m.t WHERE x = 1 + NULL;") == 0);
+
+        // UPDATE SET x = x + 1 must keep the NULL row NULL, not write a 1.
+        REQUIRE(okq(d, "UPDATE m.t SET x = x + 1;"));
+        CHECK(coli(d, "SELECT x FROM m.t ORDER BY id;") == std::vector<opt>{6, {}, 1});
+        CHECK(nrows(d, "SELECT id FROM m.t WHERE x IS NULL;") == 1); // id=2 still NULL
+        CHECK(scal(d, "SELECT COUNT(x) FROM m.t;") == opt{2});
+    }
+    {
+        test_spaces space(config); // restart
+        auto* d = space.dispatcher();
+        CHECK(coli(d, "SELECT x FROM m.t ORDER BY id;") == std::vector<opt>{6, {}, 1});
+        CHECK(nrows(d, "SELECT id FROM m.t WHERE x IS NULL;") == 1);
+    }
+}
+
+TEST_CASE("integration::cpp::null_matrix::arithmetic_aggregate") {
+    auto config = test_helpers::make_test_config("/tmp/nmx/arith_agg");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(okq(d, "CREATE DATABASE m;"));
+    REQUIRE(okq(d, "CREATE TABLE m.g (k INT, a BIGINT, b BIGINT);"));
+    // group 1: a has values, b all NULL ; group 2: both present.
+    REQUIRE(okq(d, "INSERT INTO m.g (k, a, b) VALUES (1, 3, NULL);"));
+    REQUIRE(okq(d, "INSERT INTO m.g (k, a, b) VALUES (1, 4, NULL);"));
+    REQUIRE(okq(d, "INSERT INTO m.g (k, a, b) VALUES (2, 5, 10);"));
+    REQUIRE(okq(d, "INSERT INTO m.g (k, a, b) VALUES (2, 5, 20);"));
+
+    // SUM over an all-NULL column is NULL; SUM(a)+SUM(b) is NULL for group 1, defined for group 2.
+    CHECK(coli(d, "SELECT SUM(a) + SUM(b) FROM m.g GROUP BY k ORDER BY k;") == std::vector<opt>{{}, 40});
+    CHECK(coli(d, "SELECT SUM(a) - SUM(b) FROM m.g GROUP BY k ORDER BY k;") == std::vector<opt>{{}, -20});
+    CHECK(coli(d, "SELECT SUM(a) / SUM(b) FROM m.g GROUP BY k ORDER BY k;") == std::vector<opt>{{}, 0});
+    // SUM over a per-row arithmetic that itself may be NULL.
+    CHECK(scal(d, "SELECT SUM(a + b) FROM m.g;") == opt{40}); // group1 rows are NULL (a+NULL), skipped
+}
+
+// ===========================================================================================
+//  Aggregates over NULL -- COUNT is 0, the rest are NULL, grouped and ungrouped
+// ===========================================================================================
+
+TEST_CASE("integration::cpp::null_matrix::aggregates_grouped") {
+    auto config = test_helpers::make_test_config("/tmp/nmx/agg_grp");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(okq(d, "CREATE DATABASE m;"));
+    REQUIRE(okq(d, "CREATE TABLE m.t (k INT, x BIGINT);"));
+    // group 1: all NULL ; group 2: one value + one NULL ; group 3: two values.
+    REQUIRE(okq(d, "INSERT INTO m.t (k, x) VALUES (1, NULL);"));
+    REQUIRE(okq(d, "INSERT INTO m.t (k, x) VALUES (1, NULL);"));
+    REQUIRE(okq(d, "INSERT INTO m.t (k, x) VALUES (2, 7);"));
+    REQUIRE(okq(d, "INSERT INTO m.t (k, x) VALUES (2, NULL);"));
+    REQUIRE(okq(d, "INSERT INTO m.t (k, x) VALUES (3, 3);"));
+    REQUIRE(okq(d, "INSERT INTO m.t (k, x) VALUES (3, 5);"));
+
+    CHECK(coli(d, "SELECT COUNT(x) FROM m.t GROUP BY k ORDER BY k;") == std::vector<opt>{0, 1, 2});
+    CHECK(coli(d, "SELECT COUNT(*) FROM m.t GROUP BY k ORDER BY k;") == std::vector<opt>{2, 2, 2});
+    CHECK(coli(d, "SELECT COUNT(DISTINCT x) FROM m.t GROUP BY k ORDER BY k;") == std::vector<opt>{0, 1, 2});
+    CHECK(coli(d, "SELECT SUM(x) FROM m.t GROUP BY k ORDER BY k;") == std::vector<opt>{{}, 7, 8});
+    CHECK(coli(d, "SELECT MIN(x) FROM m.t GROUP BY k ORDER BY k;") == std::vector<opt>{{}, 7, 3});
+    CHECK(coli(d, "SELECT MAX(x) FROM m.t GROUP BY k ORDER BY k;") == std::vector<opt>{{}, 7, 5});
+    // AVG per group: all-NULL group -> NULL, {7} -> 7, {3,5} -> 4 (NULLs skipped).
+    CHECK(coli(d, "SELECT AVG(x) FROM m.t GROUP BY k ORDER BY k;") == std::vector<opt>{{}, 7, 4});
+
+    // Ungrouped over an all-NULL table.
+    REQUIRE(okq(d, "CREATE TABLE m.allnull (id INT, x BIGINT);"));
+    REQUIRE(okq(d, "INSERT INTO m.allnull (id, x) VALUES (1, NULL);"));
+    REQUIRE(okq(d, "INSERT INTO m.allnull (id, x) VALUES (2, NULL);"));
+    CHECK(scal(d, "SELECT COUNT(x) FROM m.allnull;") == opt{0});
+    CHECK(scal(d, "SELECT COUNT(*) FROM m.allnull;") == opt{2});
+    CHECK(scal(d, "SELECT COUNT(DISTINCT x) FROM m.allnull;") == opt{0});
+    CHECK(scal(d, "SELECT SUM(x) FROM m.allnull;") == opt{});
+    CHECK(scal(d, "SELECT MIN(x) FROM m.allnull;") == opt{});
+    CHECK(scal(d, "SELECT MAX(x) FROM m.allnull;") == opt{});
+    CHECK(scal(d, "SELECT AVG(x) FROM m.allnull;") == opt{}); // AVG over all-NULL is NULL, not 0
+}
+
+// ===========================================================================================
+//  CASE / HAVING / CHECK / DISTINCT
+// ===========================================================================================
+
+TEST_CASE("integration::cpp::null_matrix::case_when") {
+    auto config = test_helpers::make_test_config("/tmp/nmx/case");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(okq(d, "CREATE DATABASE m;"));
+    REQUIRE(okq(d, "CREATE TABLE m.t (id INT, x BIGINT);"));
+    REQUIRE(okq(d, "INSERT INTO m.t (id, x) VALUES (1, 5);"));
+    REQUIRE(okq(d, "INSERT INTO m.t (id, x) VALUES (2, NULL);"));
+    REQUIRE(okq(d, "INSERT INTO m.t (id, x) VALUES (3, 1);"));
+
+    // A NULL operand makes the WHEN condition UNKNOWN -> falls through to ELSE, for every operator.
+    CHECK(scal(d, "SELECT SUM(CASE WHEN x = 1 THEN 1 ELSE 0 END) FROM m.t;") == opt{1});   // x=1
+    CHECK(scal(d, "SELECT SUM(CASE WHEN x <> 1 THEN 1 ELSE 0 END) FROM m.t;") == opt{1});  // x=5
+    CHECK(scal(d, "SELECT SUM(CASE WHEN x > 1 THEN 1 ELSE 0 END) FROM m.t;") == opt{1});   // x=5
+    CHECK(scal(d, "SELECT SUM(CASE WHEN x >= 1 THEN 1 ELSE 0 END) FROM m.t;") == opt{2});  // x=5,1
+    CHECK(scal(d, "SELECT SUM(CASE WHEN x < 5 THEN 1 ELSE 0 END) FROM m.t;") == opt{1});   // x=1
+    CHECK(scal(d, "SELECT SUM(CASE WHEN x <= 1 THEN 1 ELSE 0 END) FROM m.t;") == opt{1});  // x=1
+    // The NULL row never scores under any WHEN.
+    CHECK(scal(d, "SELECT SUM(CASE WHEN x = 999 THEN 1 ELSE 0 END) FROM m.t;") == opt{0});
+}
+
+TEST_CASE("integration::cpp::null_matrix::having") {
+    auto config = test_helpers::make_test_config("/tmp/nmx/having");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(okq(d, "CREATE DATABASE m;"));
+    REQUIRE(okq(d, "CREATE TABLE m.g (k INT, x BIGINT);"));
+    REQUIRE(okq(d, "INSERT INTO m.g (k, x) VALUES (1, NULL);"));  // group 1 SUM -> NULL
+    REQUIRE(okq(d, "INSERT INTO m.g (k, x) VALUES (1, NULL);"));
+    REQUIRE(okq(d, "INSERT INTO m.g (k, x) VALUES (2, 3);"));     // group 2 SUM -> 8
+    REQUIRE(okq(d, "INSERT INTO m.g (k, x) VALUES (2, 5);"));
+    REQUIRE(okq(d, "INSERT INTO m.g (k, x) VALUES (3, 1);"));     // group 3 SUM -> 1
+    REQUIRE(okq(d, "INSERT INTO m.g (k, x) VALUES (3, 0);"));
+
+    // The all-NULL group's SUM is NULL -> UNKNOWN for every HAVING comparison -> always dropped.
+    CHECK(nrows(d, "SELECT k FROM m.g GROUP BY k HAVING SUM(x) = 8;") == 1);   // group 2
+    CHECK(nrows(d, "SELECT k FROM m.g GROUP BY k HAVING SUM(x) <> 8;") == 1);  // group 3 (1<>8)
+    CHECK(nrows(d, "SELECT k FROM m.g GROUP BY k HAVING SUM(x) > 0;") == 2);   // groups 2,3
+    CHECK(nrows(d, "SELECT k FROM m.g GROUP BY k HAVING SUM(x) >= 1;") == 2);
+    CHECK(nrows(d, "SELECT k FROM m.g GROUP BY k HAVING SUM(x) < 2;") == 1);   // group 3
+    CHECK(nrows(d, "SELECT k FROM m.g GROUP BY k HAVING SUM(x) <= 8;") == 2);
+    // The all-NULL group is never in the result regardless of operator.
+    CHECK(nrows(d, "SELECT k FROM m.g GROUP BY k HAVING SUM(x) = 0;") == 0);
+}
+
+TEST_CASE("integration::cpp::null_matrix::check_constraints") {
+    auto config = test_helpers::make_test_config("/tmp/nmx/check");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(okq(d, "CREATE DATABASE m;"));
+
+    // Each comparison operator in a CHECK: a NULL is UNKNOWN -> accepted; a definitely-false row
+    // is rejected; a true row is accepted.
+    struct ck {
+        std::string op;
+        std::string good; // satisfies
+        std::string bad;  // violates
+    };
+    const std::vector<ck> cks = {
+        {"x > 0", "5", "-1"},
+        {"x >= 0", "0", "-1"},
+        {"x < 10", "5", "10"},
+        {"x <= 10", "10", "11"},
+        {"x <> 0", "5", "0"},
+    };
+    int n = 0;
+    for (const auto& c : cks) {
+        const std::string t = "m.ck" + std::to_string(n++);
+        REQUIRE(okq(d, "CREATE TABLE " + t + " (id INT, x BIGINT);"));
+        REQUIRE(okq(d, "ALTER TABLE " + t + " ADD CONSTRAINT cc CHECK (" + c.op + ");"));
+        CHECK(okq(d, "INSERT INTO " + t + " (id, x) VALUES (1, " + c.good + ");")); // accepted
+        CHECK_FALSE(okq(d, "INSERT INTO " + t + " (id, x) VALUES (2, " + c.bad + ");")); // rejected
+        CHECK(okq(d, "INSERT INTO " + t + " (id, x) VALUES (3, NULL);"));            // UNKNOWN -> accepted
+        CHECK(nrows(d, "SELECT id FROM " + t + ";") == 2);                           // rows 1 and 3
+        CHECK(nrows(d, "SELECT id FROM " + t + " WHERE x IS NULL;") == 1);
+    }
+}
+
+TEST_CASE("integration::cpp::null_matrix::distinct") {
+    auto config = test_helpers::make_test_config("/tmp/nmx/distinct");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(okq(d, "CREATE DATABASE m;"));
+    REQUIRE(okq(d, "CREATE TABLE m.t (id INT, x BIGINT, y BIGINT);"));
+    REQUIRE(okq(d, "INSERT INTO m.t (id, x, y) VALUES (1, 5, 1);"));
+    REQUIRE(okq(d, "INSERT INTO m.t (id, x, y) VALUES (2, NULL, 1);"));
+    REQUIRE(okq(d, "INSERT INTO m.t (id, x, y) VALUES (3, NULL, 2);"));
+    REQUIRE(okq(d, "INSERT INTO m.t (id, x, y) VALUES (4, 5, 1);"));
+    REQUIRE(okq(d, "INSERT INTO m.t (id, x, y) VALUES (5, NULL, 2);"));
+
+    // DISTINCT treats all NULLs as one value: {5, NULL} -> 2 distinct.
+    CHECK(nrows(d, "SELECT DISTINCT x FROM m.t;") == 2);
+    // Multi-column DISTINCT: (5,1),(NULL,1),(NULL,2) -> 3 distinct rows.
+    CHECK(nrows(d, "SELECT DISTINCT x, y FROM m.t;") == 3);
+    // COUNT(DISTINCT) excludes NULL entirely.
+    CHECK(scal(d, "SELECT COUNT(DISTINCT x) FROM m.t;") == opt{1});
+}
+
+// ===========================================================================================
+//  ARRAY / LIST element nullness
+// ===========================================================================================
+
+TEST_CASE("integration::cpp::null_matrix::array_element") {
+    auto config = test_helpers::make_test_config("/tmp/nmx/arr");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(okq(d, "CREATE DATABASE m;"));
+    REQUIRE(okq(d, "CREATE TABLE m.a (id BIGINT, v INT[3]);"));
+    REQUIRE(okq(d, "INSERT INTO m.a (id, v) VALUES (1, ARRAY[10, 20, 30]);"));
+    REQUIRE(okq(d, "INSERT INTO m.a (id, v) VALUES (2, NULL);"));       // whole cell NULL
+    REQUIRE(okq(d, "INSERT INTO m.a (id, v) VALUES (3, ARRAY[40]);"));  // v[2],v[3] NULL-padded
+    REQUIRE(okq(d, "INSERT INTO m.a (id, v) VALUES (4, ARRAY[50, 60, 70]);"));
+
+    // Subscript of the NULL cell projects NULL (deep-path accessor).
+    CHECK(coli(d, "SELECT v[1] FROM m.a ORDER BY id;") == std::vector<opt>{10, {}, 40, 50});
+    CHECK(coli(d, "SELECT v[2] FROM m.a ORDER BY id;") == std::vector<opt>{20, {}, {}, 60});
+    CHECK(coli(d, "SELECT v[3] FROM m.a ORDER BY id;") == std::vector<opt>{30, {}, {}, 70});
+
+    // Value comparison over the element excludes NULL cells / NULL elements.
+    CHECK(nrows(d, "SELECT id FROM m.a WHERE v[1] = 10;") == 1);  // id=1
+    CHECK(nrows(d, "SELECT id FROM m.a WHERE v[1] > 5;") == 3);   // id 1,3,4 (id=2 NULL cell out)
+    CHECK(nrows(d, "SELECT id FROM m.a WHERE v[3] = 30;") == 1);  // id=1 only
+    // IS NULL / IS NOT NULL over the element (previously a segfault).
+    CHECK(nrows(d, "SELECT id FROM m.a WHERE v[1] IS NULL;") == 1);      // id=2
+    CHECK(nrows(d, "SELECT id FROM m.a WHERE v[1] IS NOT NULL;") == 3);  // id 1,3,4
+    CHECK(nrows(d, "SELECT id FROM m.a WHERE v[3] IS NULL;") == 2);      // id 2 (cell), 3 (padded)
+    CHECK(nrows(d, "SELECT id FROM m.a WHERE v[3] IS NOT NULL;") == 2);  // id 1,4
+}
+
+// ===========================================================================================
+//  Index parity -- an indexed column answers exactly like an unindexed twin
+// ===========================================================================================
+
+TEST_CASE("integration::cpp::null_matrix::index_parity") {
+    auto config = test_helpers::make_test_config("/tmp/nmx/idx", true, true);
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(okq(d, "CREATE DATABASE m;"));
+    REQUIRE(okq(d, "CREATE TABLE m.t (id INT, x BIGINT);"));
+    seed_numeric(d, "m.t");
+    REQUIRE(okq(d, "CREATE INDEX ix ON m.t (x);"));
+
+    // The same battery, now with a secondary index on x -- NULL keys are not indexed, so the
+    // index-driven answers match the earlier unindexed runs.
+    comparison_battery(d, "m.t");
+    // Point lookups that use the index.
+    CHECK(nrows(d, "SELECT id FROM m.t WHERE x = 10;") == 1);
+    CHECK(nrows(d, "SELECT id FROM m.t WHERE x = 5;") == 1);
+    CHECK(nrows(d, "SELECT id FROM m.t WHERE x = 7;") == 0);
+    CHECK(nrows(d, "SELECT id FROM m.t WHERE x IS NULL;") == 2);
+}
+
+// ===========================================================================================
+//  jsonb navigation to an absent key == NULL (same physical NULL as a plain column)
+// ===========================================================================================
+
+TEST_CASE("integration::cpp::null_matrix::jsonb_absent_key") {
+    auto config = test_helpers::make_test_config("/tmp/nmx/jsonb");
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(okq(d, "CREATE DATABASE m;"));
+    REQUIRE(okq(d, "CREATE TABLE m.j ();"));
+    REQUIRE(okq(d, "INSERT INTO m.j (id, doc) VALUES (1, 5);"));
+    REQUIRE(okq(d, "INSERT INTO m.j (id) VALUES (2);"));         // doc absent -> NULL
+    REQUIRE(okq(d, "INSERT INTO m.j (id, doc) VALUES (3, 0);"));
+
+    // A comparison through a navigation to an absent key is UNKNOWN, exactly like a plain NULL.
+    CHECK(nrows(d, "SELECT id FROM m.j WHERE doc = 0;") == 1);      // id=3
+    CHECK(nrows(d, "SELECT id FROM m.j WHERE doc >= 0;") == 2);     // id 1,3
+    CHECK(nrows(d, "SELECT id FROM m.j WHERE NOT (doc = 0);") == 1);// id=1
+    CHECK(nrows(d, "SELECT id FROM m.j WHERE doc IS NULL;") == 1);  // id=2
+    CHECK(scal(d, "SELECT COUNT(doc) FROM m.j;") == opt{2});
+}

--- a/integration/cpp/test/test_null_three_valued_logic.cpp
+++ b/integration/cpp/test/test_null_three_valued_logic.cpp
@@ -1,0 +1,273 @@
+#include "test_config.hpp"
+#include <catch2/catch_test_macros.hpp>
+
+// SQL three-valued logic over NULL operands.
+//
+// A NULL operand makes a value comparison UNKNOWN, not FALSE, and UNKNOWN rows are excluded
+// from WHERE / DELETE / UPDATE. The distinction matters under NOT: `NOT UNKNOWN` is UNKNOWN
+// (the row stays excluded), whereas `NOT FALSE` is TRUE (the row would be wrongly included).
+//
+// Before the fix, a pure comparison was pushed down into the storage scan, whose fast path
+// compared the raw data buffer without consulting the validity mask. Validity lives in a
+// separate sibling column, so a NULL row's payload bytes are a meaningless 0 — every NULL row
+// therefore matched `= 0` / `>= 0` / `< 1` ..., and DELETE/UPDATE mutated those rows.
+//
+// Both surfaces are covered here because they are the same bug: a jsonb nav (`t ->> 'x'`) is
+// resolved at transform time into a plain column reference, and an absent key is stored as a
+// NULL. A plain NULL and an absent jsonb key reach the identical scan path.
+
+namespace {
+
+    struct probe_t {
+        bool ok{false};
+        size_t rows{0};
+    };
+
+    template<typename Dispatcher>
+    probe_t run(Dispatcher* dispatcher, const std::string& sql) {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, sql);
+        if (!cur || !cur->is_success()) {
+            return {false, 0};
+        }
+        return {true, cur->size()};
+    }
+
+    // id=1 -> x=5 ; id=2 -> x NULL ; id=3 -> x=0
+    template<typename Dispatcher>
+    void seed_plain(Dispatcher* d, const std::string& table) {
+        REQUIRE(run(d, "CREATE TABLE " + table + " (id INT, x BIGINT);").ok);
+        REQUIRE(run(d, "INSERT INTO " + table + " (id, x) VALUES (1, 5);").ok);
+        REQUIRE(run(d, "INSERT INTO " + table + " (id, x) VALUES (2, NULL);").ok);
+        REQUIRE(run(d, "INSERT INTO " + table + " (id, x) VALUES (3, 0);").ok);
+    }
+
+    // The same three rows on a computing table, where id=2 simply has no 'x' key at all.
+    template<typename Dispatcher>
+    void seed_computed(Dispatcher* d, const std::string& table) {
+        REQUIRE(run(d, "CREATE TABLE " + table + " ();").ok);
+        REQUIRE(run(d, "INSERT INTO " + table + " (id, x) VALUES (1, 5);").ok);
+        REQUIRE(run(d, "INSERT INTO " + table + " (id) VALUES (2);").ok);
+        REQUIRE(run(d, "INSERT INTO " + table + " (id, x) VALUES (3, 0);").ok);
+    }
+
+} // namespace
+
+TEST_CASE("integration::cpp::null_3vl::comparisons_exclude_null") {
+    auto config = test_create_config("/tmp/test_null_3vl/cmp");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE n3;").ok);
+    seed_plain(d, "n3.t");
+
+    // The NULL row (id=2) must satisfy NO value comparison.
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x = 0;").rows == 1);   // id=3
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x <> 0;").rows == 1);  // id=1
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x >= 0;").rows == 2);  // id=1,3
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x > -1;").rows == 2);  // id=1,3
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x < 1;").rows == 1);   // id=3
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x <= 5;").rows == 2);  // id=1,3
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x = 5;").rows == 1);   // id=1
+
+    // IS NULL / IS NOT NULL keep working — they are TRUE/FALSE, never UNKNOWN.
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x IS NULL;").rows == 1);     // id=2
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x IS NOT NULL;").rows == 2); // id=1,3
+}
+
+TEST_CASE("integration::cpp::null_3vl::not_does_not_resurrect_null") {
+    // The guard against a naive fix. Merely excluding NULL from a comparison is not enough:
+    // if the filter tree is two-valued, NOT flips that exclusion into an inclusion.
+    // NOT UNKNOWN must stay UNKNOWN.
+    auto config = test_create_config("/tmp/test_null_3vl/not");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE n3;").ok);
+    seed_plain(d, "n3.t");
+
+    CHECK(run(d, "SELECT id FROM n3.t WHERE NOT (x = 0);").rows == 1);  // id=1 only
+    CHECK(run(d, "SELECT id FROM n3.t WHERE NOT (x >= 0);").rows == 0); // nobody
+    CHECK(run(d, "SELECT id FROM n3.t WHERE NOT (x = 5);").rows == 1);  // id=3 only
+    CHECK(run(d, "SELECT id FROM n3.t WHERE NOT (x <> 0);").rows == 1); // id=3 only
+}
+
+TEST_CASE("integration::cpp::null_3vl::and_or_propagate_unknown") {
+    auto config = test_create_config("/tmp/test_null_3vl/andor");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE n3;").ok);
+    seed_plain(d, "n3.t");
+
+    // OR: UNKNOWN or TRUE = TRUE; UNKNOWN or FALSE = UNKNOWN (excluded).
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x = 0 OR x = 5;").rows == 2);       // id=1,3
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x = 999 OR x = 5;").rows == 1);     // id=1
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x = 0 OR id = 2;").rows == 2);      // id=2,3 — TRUE rescues it
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x IS NULL OR x = 0;").rows == 2);   // id=2,3
+
+    // AND: UNKNOWN and TRUE = UNKNOWN (excluded); UNKNOWN and FALSE = FALSE.
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x >= 0 AND x <= 9;").rows == 2);    // id=1,3
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x >= 0 AND id = 2;").rows == 0);    // nobody
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x IS NULL AND id = 2;").rows == 1); // id=2
+}
+
+TEST_CASE("integration::cpp::null_3vl::dml_does_not_touch_null_rows") {
+    auto config = test_create_config("/tmp/test_null_3vl/dml");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE n3;").ok);
+
+    // DELETE must not remove the NULL row.
+    seed_plain(d, "n3.del");
+    CHECK(run(d, "DELETE FROM n3.del WHERE x = 0;").ok);
+    CHECK(run(d, "SELECT id FROM n3.del;").rows == 2);                 // id=1,2 survive
+    CHECK(run(d, "SELECT id FROM n3.del WHERE x IS NULL;").rows == 1); // id=2 still there
+
+    // UPDATE must not clobber the NULL row.
+    seed_plain(d, "n3.upd");
+    CHECK(run(d, "UPDATE n3.upd SET id = 99 WHERE x > -1;").ok);
+    CHECK(run(d, "SELECT id FROM n3.upd WHERE id = 99;").rows == 2); // only id=1,3 -> 99
+    CHECK(run(d, "SELECT id FROM n3.upd WHERE id = 2;").rows == 1);  // the NULL row is untouched
+}
+
+TEST_CASE("integration::cpp::null_3vl::update_overlay_keeps_null_excluded") {
+    // The update-overlay branch of column_data_t::check_predicate: once a vector carries
+    // updates, matching is answered from the overlay. The NULL row must stay excluded there
+    // too — the validity gate runs before the overlay is consulted.
+    auto config = test_create_config("/tmp/test_null_3vl/overlay");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE n3;").ok);
+    seed_plain(d, "n3.t");
+
+    CHECK(run(d, "UPDATE n3.t SET x = 7 WHERE id = 1;").ok); // put this vector into the overlay
+
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x = 7;").rows == 1);     // id=1, read from the overlay
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x = 5;").rows == 0);     // old value is gone
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x = 0;").rows == 1);     // id=3 only — NOT the NULL row
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x >= 0;").rows == 2);    // id=1(7),3(0) — NOT the NULL row
+    CHECK(run(d, "SELECT id FROM n3.t WHERE x IS NULL;").rows == 1); // id=2 still NULL
+}
+
+TEST_CASE("integration::cpp::null_3vl::string_column_null") {
+    // The string fast path (string_check_row) has the same raw-buffer shape as the fixed-size
+    // one: an empty string must not be conflated with a NULL.
+    auto config = test_create_config("/tmp/test_null_3vl/str");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE n3;").ok);
+    REQUIRE(run(d, "CREATE TABLE n3.s (id INT, name TEXT);").ok);
+    REQUIRE(run(d, "INSERT INTO n3.s (id, name) VALUES (1, 'ann');").ok);
+    REQUIRE(run(d, "INSERT INTO n3.s (id, name) VALUES (2, NULL);").ok);
+    REQUIRE(run(d, "INSERT INTO n3.s (id, name) VALUES (3, '');").ok);
+
+    CHECK(run(d, "SELECT id FROM n3.s WHERE name = '';").rows == 1);     // id=3, NOT the NULL
+    CHECK(run(d, "SELECT id FROM n3.s WHERE name <> 'ann';").rows == 1); // id=3
+    CHECK(run(d, "SELECT id FROM n3.s WHERE name IS NULL;").rows == 1);  // id=2
+}
+
+// NOTE — two adjacent gaps are deliberately NOT covered here. They are separate pre-existing
+// bugs that this change neither causes nor fixes (verified: identical results with and without
+// it), and pinning them would misattribute them to this fix:
+//
+//   * INDEX SCAN route. `CREATE INDEX idx_x ON t (x)` then `WHERE x = 0` returns 0 rows — it
+//     loses id=3, whose value genuinely IS 0. A pure compare on an indexed column is planned
+//     as an index_scan (create_plan_match.cpp:112-127), bypassing the scan filter entirely,
+//     and the index mishandles a column containing NULLs.
+//   * `UPDATE t SET x = NULL` does not mark the row NULL: afterwards, `x IS NULL` still does
+//     not see it.
+//
+// Both are silent-wrong-result bugs and deserve their own fix and tests.
+
+// ---------------------------------------------------------------------------
+// JSONB surface: the same bug, reached through a nav operator over an absent key.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("integration::cpp::null_3vl::jsonb_absent_key_comparisons") {
+    auto config = test_create_config("/tmp/test_null_3vl/jsonb_cmp");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE n3;").ok);
+    seed_computed(d, "n3.co");
+
+    // An absent key projects as NULL (this was already correct before the fix).
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = d->execute_sql(session, "SELECT co ->> 'x' AS v FROM n3.co WHERE id = 2;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        CHECK(cur->value(0, 0).is_null());
+    }
+
+    // ...and it must now be excluded from every value comparison through the nav operand.
+    CHECK(run(d, "SELECT id FROM n3.co WHERE co ->> 'x' = 0;").rows == 1);  // id=3
+    CHECK(run(d, "SELECT id FROM n3.co WHERE co ->> 'x' > -1;").rows == 2); // id=1,3
+    CHECK(run(d, "SELECT id FROM n3.co WHERE co ->> 'x' < 1;").rows == 1);  // id=3
+    CHECK(run(d, "SELECT id FROM n3.co WHERE co ->> 'x' >= 0;").rows == 2); // id=1,3
+    CHECK(run(d, "SELECT id FROM n3.co WHERE co ->> 'x' <> 0;").rows == 1); // id=1
+
+    // The same rows, addressed as a plain column on the same computing table.
+    CHECK(run(d, "SELECT id FROM n3.co WHERE x = 0;").rows == 1);
+    CHECK(run(d, "SELECT id FROM n3.co WHERE x >= 0;").rows == 2);
+}
+
+TEST_CASE("integration::cpp::null_3vl::jsonb_not_and_dml") {
+    auto config = test_create_config("/tmp/test_null_3vl/jsonb_dml");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE n3;").ok);
+
+    seed_computed(d, "n3.co");
+    CHECK(run(d, "SELECT id FROM n3.co WHERE NOT (co ->> 'x' = 0);").rows == 1); // id=1 only
+
+    // DELETE through a nav operand must not remove the keyless row.
+    seed_computed(d, "n3.cod");
+    CHECK(run(d, "DELETE FROM n3.cod WHERE cod ->> 'x' = 0;").ok);
+    CHECK(run(d, "SELECT id FROM n3.cod;").rows == 2); // id=1,2 survive
+
+    // UPDATE through a nav operand must not clobber it.
+    seed_computed(d, "n3.cou");
+    CHECK(run(d, "UPDATE n3.cou SET id = 99 WHERE cou ->> 'x' > -1;").ok);
+    CHECK(run(d, "SELECT id FROM n3.cou WHERE id = 99;").rows == 2); // id=1,3 only
+    CHECK(run(d, "SELECT id FROM n3.cou WHERE id = 2;").rows == 1);  // keyless row untouched
+}
+
+TEST_CASE("integration::cpp::null_3vl::jsonb_nested_absent_key") {
+    // A dotted/nested key flattens to the column "a/b"; an absent nested key is a NULL there.
+    auto config = test_create_config("/tmp/test_null_3vl/jsonb_nested");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* d = space.dispatcher();
+    REQUIRE(run(d, "CREATE DATABASE n3;").ok);
+    REQUIRE(run(d, "CREATE TABLE n3.nd ();").ok);
+    REQUIRE(run(d, "INSERT INTO n3.nd (id, a.b) VALUES (1, 5);").ok);
+    REQUIRE(run(d, "INSERT INTO n3.nd (id) VALUES (2);").ok); // no a.b
+    REQUIRE(run(d, "INSERT INTO n3.nd (id, a.b) VALUES (3, 0);").ok);
+
+    CHECK(run(d, "SELECT id FROM n3.nd WHERE nd #>> '{a,b}' = 0;").rows == 1);  // id=3
+    CHECK(run(d, "SELECT id FROM n3.nd WHERE nd #>> '{a,b}' >= 0;").rows == 2); // id=1,3
+}

--- a/services/dispatcher/validate_logical_plan.cpp
+++ b/services/dispatcher/validate_logical_plan.cpp
@@ -707,6 +707,12 @@ namespace services::dispatcher {
                 return find_types(resource, key, schema);
             } else if (std::holds_alternative<expression_ptr>(param)) {
                 auto& sub = std::get<expression_ptr>(param);
+                if (!sub) {
+                    // A null operand slot -- e.g. the unused right() of a unary IS NULL, or the
+                    // left()/right() sentinels of a union node whose operands live in children_.
+                    // Nothing to resolve, and dereferencing sub->group() below would crash.
+                    return type_paths{resource};
+                }
                 if (sub->group() == expression_group::scalar) {
                     auto* scalar = static_cast<scalar_expression_t*>(sub.get());
                     auto res = resolve_key_paths_in_group(resource, scalar->params(), schema);
@@ -715,25 +721,26 @@ namespace services::dispatcher {
                     }
                 } else if (sub->group() == expression_group::compare) {
                     auto* cmp = static_cast<compare_expression_t*>(sub.get());
-                    auto res = resolve_key_path(resource, cmp->left(), schema);
-                    if (res.has_error()) {
-                        return res;
-                    }
-                    res = resolve_key_path(resource, cmp->right(), schema);
-                    if (res.has_error()) {
-                        return res;
-                    }
-                    for (auto& child : cmp->children()) {
-                        if (child->group() == expression_group::compare) {
-                            auto* child_cmp = static_cast<compare_expression_t*>(child.get());
-                            res = resolve_key_path(resource, child_cmp->left(), schema);
+                    if (cmp->is_union()) {
+                        // union_and / union_or / union_not: the operands are the children_; the
+                        // left()/right() slots are null sentinels and must not be dereferenced.
+                        // Recurse so keys nested arbitrarily deep (NOT (a AND b), ...) resolve.
+                        for (auto& child : cmp->children()) {
+                            param_storage child_param{child};
+                            auto res = resolve_key_path(resource, child_param, schema);
                             if (res.has_error()) {
                                 return res;
                             }
-                            res = resolve_key_path(resource, child_cmp->right(), schema);
-                            if (res.has_error()) {
-                                return res;
-                            }
+                        }
+                    } else {
+                        // Leaf comparison: the operands live in left()/right().
+                        auto res = resolve_key_path(resource, cmp->left(), schema);
+                        if (res.has_error()) {
+                            return res;
+                        }
+                        res = resolve_key_path(resource, cmp->right(), schema);
+                        if (res.has_error()) {
+                            return res;
                         }
                     }
                 }

--- a/services/index/manager_index.cpp
+++ b/services/index/manager_index.cpp
@@ -24,6 +24,46 @@ namespace {
     using value_t = components::types::logical_value_t;
     using namespace components::types;
 
+    // Index maintenance must never fail SILENTLY.
+    //
+    // These loops run inside actor coroutines whose promise discards exceptions: its
+    // unhandled_exception() is empty under NDEBUG (actor-zeta detail/future.hpp), so a throw from
+    // one row abandoned the rest of the batch while the caller still observed success. The index
+    // was left partially maintained, with no diagnostic anywhere — which is how a NULL key could
+    // silently drop every row after it from the index.
+    //
+    // Running each row's maintenance under its own guard restores two properties: one bad key can
+    // no longer truncate the batch (the remaining rows are still indexed), and a failure is
+    // reported instead of being invisible. It does not make the operation atomic — a genuinely
+    // failing key still leaves that one entry missing — but a corrupt index becomes observable
+    // rather than silent. Failing the statement outright would mean threading an error out through
+    // these void coroutines and their callers, which is a larger change.
+    template<typename Fn>
+    void guarded_index_row(log_t& log,
+                           const char* op,
+                           components::catalog::oid_t table_oid,
+                           int64_t row_id,
+                           Fn&& fn) {
+        try {
+            fn();
+        } catch (const std::exception& e) {
+            error(log,
+                  "manager_index_t::{}: index maintenance FAILED for table oid {} row {} : {} — this "
+                  "row is missing from the index",
+                  op,
+                  table_oid,
+                  row_id,
+                  e.what());
+        } catch (...) {
+            error(log,
+                  "manager_index_t::{}: index maintenance FAILED for table oid {} row {} : unknown "
+                  "exception — this row is missing from the index",
+                  op,
+                  table_oid,
+                  row_id);
+        }
+    }
+
     value_t reverse_convert(std::pmr::memory_resource* r, const physical_value& pv) {
         switch (pv.type()) {
             case physical_type::BOOL:
@@ -809,7 +849,10 @@ namespace services::index {
         uint64_t global_row = 0;
         for (const auto& chunk : chunks) {
             for (uint64_t i = 0; i < chunk.size() && global_row < row_count; ++i, ++global_row) {
-                engine->insert_row(chunk, i, static_cast<int64_t>(global_row), /*txn_id=*/0, bootstrap_tz);
+                const auto row_id = static_cast<int64_t>(global_row);
+                guarded_index_row(log_, "bootstrap_repopulate", table_oid, row_id, [&] {
+                    engine->insert_row(chunk, i, row_id, /*txn_id=*/0, bootstrap_tz);
+                });
             }
         }
         trace(log_,
@@ -838,7 +881,12 @@ namespace services::index {
         uint64_t inserted = 0;
         for (const auto& chunk : data) {
             for (uint64_t i = 0; i < chunk.size() && inserted < count; i++) {
-                engine->insert_row(chunk, i, static_cast<int64_t>(start_row_id + inserted), txn_id, ctx.session_tz);
+                const auto row_id = static_cast<int64_t>(start_row_id + inserted);
+                // NB: `inserted` advances for every row, failure or not — the row-id is positional,
+                // so skipping the increment would silently re-point every later entry at the wrong row.
+                guarded_index_row(log_, "insert_rows", table_oid, row_id, [&] {
+                    engine->insert_row(chunk, i, row_id, txn_id, ctx.session_tz);
+                });
                 ++inserted;
             }
         }
@@ -866,7 +914,10 @@ namespace services::index {
         size_t deleted = 0;
         for (const auto& chunk : data) {
             for (uint64_t i = 0; i < chunk.size() && deleted < row_ids.size(); i++) {
-                engine->mark_delete_row(chunk, i, row_ids[deleted], txn_id, ctx.session_tz);
+                const auto row_id = row_ids[deleted];
+                guarded_index_row(log_, "delete_rows", table_oid, row_id, [&] {
+                    engine->mark_delete_row(chunk, i, row_id, txn_id, ctx.session_tz);
+                });
                 ++deleted;
             }
         }
@@ -893,10 +944,14 @@ namespace services::index {
         auto& engine = it->second;
 
         // Mark old entries as deleted — walk the old chunks in lockstep with row_ids.
+        // A throw here used to skip the insert half entirely, leaving the new keys unindexed.
         size_t deleted = 0;
         for (const auto& chunk : old_data) {
             for (uint64_t i = 0; i < chunk.size() && deleted < row_ids.size(); i++) {
-                engine->mark_delete_row(chunk, i, row_ids[deleted], txn_id, ctx.session_tz);
+                const auto row_id = row_ids[deleted];
+                guarded_index_row(log_, "update_rows(old)", table_oid, row_id, [&] {
+                    engine->mark_delete_row(chunk, i, row_id, txn_id, ctx.session_tz);
+                });
                 ++deleted;
             }
         }
@@ -906,7 +961,10 @@ namespace services::index {
         size_t inserted = 0;
         for (const auto& chunk : new_data) {
             for (uint64_t i = 0; i < chunk.size() && inserted < row_ids.size(); i++) {
-                engine->insert_row(chunk, i, new_start_row_id + static_cast<int64_t>(inserted), txn_id, ctx.session_tz);
+                const auto row_id = new_start_row_id + static_cast<int64_t>(inserted);
+                guarded_index_row(log_, "update_rows(new)", table_oid, row_id, [&] {
+                    engine->insert_row(chunk, i, row_id, txn_id, ctx.session_tz);
+                });
                 ++inserted;
             }
         }
@@ -1230,7 +1288,10 @@ namespace services::index {
             uint64_t global = 0;
             for (const auto& chunk : chunks) {
                 for (uint64_t i = 0; i < chunk.size() && global < row_count; ++i) {
-                    engine_after->insert_row(chunk, i, static_cast<int64_t>(global), /*txn_id=*/0, session_tz);
+                    const auto row_id = static_cast<int64_t>(global);
+                    guarded_index_row(log_, "repopulate_table", table_oid, row_id, [&] {
+                        engine_after->insert_row(chunk, i, row_id, /*txn_id=*/0, session_tz);
+                    });
                     ++global;
                 }
             }
@@ -1506,11 +1567,10 @@ namespace services::index {
             uint64_t global = 0;
             for (const auto& chunk : physical_data) {
                 for (uint64_t i = 0; i < chunk.size(); ++i) {
-                    engine->insert_row(chunk,
-                                       static_cast<size_t>(i),
-                                       static_cast<int64_t>(physical_row_start + global),
-                                       txn_id,
-                                       session_tz);
+                    const auto row_id = static_cast<int64_t>(physical_row_start + global);
+                    guarded_index_row(log_, "wal_replay(insert)", table_oid, row_id, [&] {
+                        engine->insert_row(chunk, static_cast<size_t>(i), row_id, txn_id, session_tz);
+                    });
                     ++global;
                 }
             }
@@ -1538,7 +1598,10 @@ namespace services::index {
                 size_t global = 0;
                 for (const auto& chunk : physical_data) {
                     for (uint64_t i = 0; i < chunk.size() && global < row_ids.size(); ++i) {
-                        engine->mark_delete_row(chunk, static_cast<size_t>(i), row_ids[global], txn_id, session_tz);
+                        const auto row_id = row_ids[global];
+                        guarded_index_row(log_, "wal_replay(delete)", table_oid, row_id, [&] {
+                            engine->mark_delete_row(chunk, static_cast<size_t>(i), row_id, txn_id, session_tz);
+                        });
                         ++global;
                     }
                 }
@@ -1564,11 +1627,10 @@ namespace services::index {
                 uint64_t global = 0;
                 for (const auto& chunk : physical_data) {
                     for (uint64_t i = 0; i < chunk.size(); ++i) {
-                        engine->insert_row(chunk,
-                                           static_cast<size_t>(i),
-                                           static_cast<int64_t>(physical_row_start + global),
-                                           txn_id,
-                                           session_tz);
+                        const auto row_id = static_cast<int64_t>(physical_row_start + global);
+                        guarded_index_row(log_, "wal_replay(update-new)", table_oid, row_id, [&] {
+                            engine->insert_row(chunk, static_cast<size_t>(i), row_id, txn_id, session_tz);
+                        });
                         ++global;
                     }
                 }


### PR DESCRIPTION
## SQL three-valued logic for NULL

A comparison with a NULL operand is **UNKNOWN**, not FALSE — and they diverge under `NOT`
(`NOT UNKNOWN` = UNKNOWN, `NOT FALSE` = TRUE). otterbrix collapsed UNKNOWN to FALSE, so a NULL row
leaked through `NOT`, got mis-aggregated, or crashed. This makes NULL three-valued end to end
(storage-scan pushdown, arithmetic, aggregates, and the in-memory predicate evaluator for
`WHERE` / join / DML / `CHECK` / `HAVING`).

### Fixed scenarios

```sql
CREATE TABLE t (id INT, x BIGINT, s TEXT);
INSERT INTO t VALUES (1, 5, 'apple'), (2, NULL, NULL), (3, 0, 'banana'), (4, 10, 'cherry');
-- row 2 is all-NULL; it used to leak through NOT.
```

**`NOT` no longer resurrects a NULL row**

| Query | Before | Now |
|---|---|---|
| `SELECT id FROM t WHERE NOT (x + 1 = 6);` | `{2,3,4}` | `{3,4}` |
| `SELECT id FROM t WHERE NOT (x * 2 = 20);` | `{1,2,3}` | `{1,3}` |
| `SELECT id FROM t WHERE s NOT LIKE 'a%';` | `{2,3,4}` | `{3,4}` |
| `SELECT id FROM t WHERE NOT (x IN (5, 10));` | `{2,3}` | `{3}` |
| `SELECT id FROM t WHERE NOT (x + 1 = 6 OR s LIKE 'b%');` | `{2,4}` | `{4}` |

**DML: the same bug was deleting / overwriting rows the `WHERE` excludes**

```sql
DELETE FROM t WHERE NOT (x + 1 = 6);           -- before: also deleted NULL row 2; now: kept
UPDATE t SET x = 999 WHERE NOT (s LIKE 'a%');  -- before: also overwrote row 2; now: left NULL
```

**`CHECK`: UNKNOWN passes, even under `NOT`**

```sql
ALTER TABLE u ADD CONSTRAINT cc CHECK (NOT (x = 5));  -- before: rejected at DDL; now: accepted
INSERT INTO u VALUES (1, 0);      -- NOT(FALSE)=TRUE      -> accepted
INSERT INTO u VALUES (2, 5);      -- NOT(TRUE)=FALSE      -> rejected
INSERT INTO u VALUES (3, NULL);   -- NOT(UNKNOWN)=UNKNOWN -> accepted (was wrongly rejected)
```

**Arithmetic & aggregates over NULL** — `x = {5, NULL, 0, 10}`

```sql
SELECT x + 1  FROM t;   -- NULL row stays NULL (was 1); 5/NULL no longer SIGFPEs
SELECT COUNT(x) FROM t; -- 3   (COUNT(*) = 4)
SELECT AVG(x)  FROM t;  -- 5   (skips NULLs; all-NULL group -> NULL, not 0)
```

**Crash fix:** `WHERE v[i] IS NULL` over an `ARRAY`/`LIST` element (was a segfault).



### Aggregate `FILTER (WHERE p)`

`agg(x) FILTER (WHERE p)` is lowered to `agg(CASE WHEN p THEN x END)` (and `COUNT(*)` to
`COUNT(CASE WHEN p THEN 1 END)`), reusing the three-valued CASE-WHEN evaluator above — so an
UNKNOWN predicate excludes the row and `NOT` negates correctly.

```sql
CREATE TABLE t (x BIGINT, g INT);
INSERT INTO t VALUES (10, 0), (20, 1), (30, 0), (NULL, 1), (40, 0);

SELECT SUM(x)   FILTER (WHERE g = 0)            FROM t;  -- 80
SELECT COUNT(*) FILTER (WHERE g = 1)            FROM t;  -- 2
SELECT SUM(x)   FILTER (WHERE NOT (g = 1))      FROM t;  -- 80  (NOT negates)
SELECT SUM(x)   FILTER (WHERE g = 0 AND x > 10) FROM t;  -- 70
```

Works with `GROUP BY` and `HAVING`.


### Hardening the 3VL type itself

Three follow-up commits harden `types::tri_bool_t` (no behavior change):

- **`tri_of(value, is_null)`** — a single named seam for lifting the engine's native
  (value, validity) pairs into three-valued logic, replacing hand-written
  `is_null ? unknown : tri_of(v)` at the `function_predicate` boundaries. Its truth table is
  pinned by `static_assert` next to the combinator tables.
- **The no-implicit-bool guarantee is now a compile-time contract.** `tri_bool_t` deliberately
  has no `operator bool` and no `&&`/`||` — `if (v)` and `a && b` have no single right meaning
  in 3VL — and the header now `static_assert`s non-convertibility in both directions, so a
  convenience operator can never quietly reintroduce the classic tribool pitfalls.
- **One algebra implementation.** The pushed-down filter tree
  (`row_group_t::check_predicate` `union_or`/`union_and`/`union_not`) now folds with the
  canonical `tri_or`/`tri_and`/`tri_not` combinators instead of a hand-rolled `saw_unknown`
  re-derivation, so the storage path and the in-memory evaluator share one definition of the
  Kleene truth tables.
