### PR TITLE
fix(catalog): resolve qualified table names within their database

### DIFF
--- a/components/logical_plan/node_catalog_resolve.hpp
+++ b/components/logical_plan/node_catalog_resolve.hpp
@@ -94,7 +94,10 @@ namespace components::logical_plan {
     //
     // Field usage by kind:
     //   table       — dbname_ / relname_ / namespace_oid_ / table_oid() (base) /
-    //                 resolved_metadata_
+    //                 resolved_metadata_ / target_ (optional back-pointer to the
+    //                 sibling namespace resolve; execution-time namespace fast
+    //                 path — operator_resolve_table_t reads its stamp before
+    //                 falling back to its own pg_namespace scan)
     //   namespace_  — dbname_ / namespace_oid_
     //   database    — dbname_ / database_oid_
     //   type        — dbname_ / type_name_ / type_oid_ / resolved_type_metadata_
@@ -147,6 +150,10 @@ namespace components::logical_plan {
 
         // constraint — back-pointer to a sibling resolve node (must be
         // kind()==table); its Pass 1 stamp provides the target's table_oid.
+        // table — optional back-pointer to the sibling namespace resolve node
+        // (must be kind()==namespace_, same dbname); its Pass 1 stamp lets
+        // operator_resolve_table_t skip its own pg_namespace scan. Pure fast
+        // path: absent or unstamped, the operator self-resolves the dbname.
         node_catalog_resolve_t* target() const noexcept { return target_; }
         void set_target(node_catalog_resolve_t* target) noexcept { target_ = target; }
         resolve_direction direction() const noexcept { return direction_; }

--- a/components/physical_plan/operators/operator_resolve_table.cpp
+++ b/components/physical_plan/operators/operator_resolve_table.cpp
@@ -42,33 +42,13 @@ namespace components::operators {
 
     operator_resolve_table_t::operator_resolve_table_t(std::pmr::memory_resource* resource,
                                                        log_t log,
-                                                       catalog::oid_t table_oid)
-        : read_write_operator_t(resource, std::move(log), operator_type::resolve_table)
-        , table_oid_(table_oid)
-        , output_schema_(resource) {
-        build_output_schema(output_schema_);
-    }
-
-    operator_resolve_table_t::operator_resolve_table_t(std::pmr::memory_resource* resource,
-                                                       log_t log,
                                                        catalog::oid_t namespace_oid,
-                                                       std::string relname)
-        : read_write_operator_t(resource, std::move(log), operator_type::resolve_table)
-        , table_oid_(catalog::INVALID_OID)
-        , input_namespace_oid_(namespace_oid)
-        , relname_(std::move(relname))
-        , output_schema_(resource) {
-        build_output_schema(output_schema_);
-    }
-
-    operator_resolve_table_t::operator_resolve_table_t(std::pmr::memory_resource* resource,
-                                                       log_t log,
-                                                       catalog::oid_t namespace_oid,
+                                                       std::string dbname,
                                                        std::string relname,
                                                        components::logical_plan::node_catalog_resolve_t* target_node)
         : read_write_operator_t(resource, std::move(log), operator_type::resolve_table)
-        , table_oid_(catalog::INVALID_OID)
         , input_namespace_oid_(namespace_oid)
+        , dbname_(std::move(dbname))
         , relname_(std::move(relname))
         , target_node_(target_node)
         , output_schema_(resource) {
@@ -76,6 +56,7 @@ namespace components::operators {
     }
 
     actor_zeta::unique_future<void> operator_resolve_table_t::await_async_and_resume(pipeline::context_t* ctx) {
+        constexpr catalog::oid_t kPgNamespace = catalog::well_known_oid::pg_namespace_table;
         constexpr catalog::oid_t kPgClass = catalog::well_known_oid::pg_class_table;
         constexpr catalog::oid_t kPgAttribute = catalog::well_known_oid::pg_attribute_table;
         constexpr catalog::oid_t kPgComputedColumn = catalog::well_known_oid::pg_computed_column_table;
@@ -95,9 +76,8 @@ namespace components::operators {
             co_return;
         }
 
-        // (name-form only): when only (namespace_oid, relname) is known,
-        // first resolve table_oid via pg_class scan by (relname, relnamespace).
-        // If relname_ is empty we cannot resolve — emit empty output.
+        // (name-form): resolve table_oid via pg_class scan. If relname_ is
+        // empty we cannot resolve — emit empty output.
         if (table_oid_ == catalog::INVALID_OID) {
             if (relname_.empty()) {
                 output_ = make_operator_data(resource_, output_schema_, 0);
@@ -105,6 +85,60 @@ namespace components::operators {
                 mark_executed();
                 co_return;
             }
+            // Database-qualified name: translate dbname -> namespace_oid at
+            // EXECUTION time via a pg_namespace read (mirrors
+            // operator_resolve_type_t). This cannot be a plan-generation-time
+            // constructor argument: the sibling resolve_namespace operator only
+            // stamps its own node after the whole resolve sub-plan is already
+            // built, so a ctor-frozen oid is always INVALID — which used to
+            // degrade the pg_class scan to relname-only and leak the first
+            // same-named table from ANY database (issue #557). A namespace
+            // miss is a hard not-found: validate then reports
+            // database_not_exists. Deliberately NO ""->public defaulting
+            // (unlike resolve_type): unqualified CREATE TABLE writes
+            // relnamespace=INVALID, so mapping ""->public would break every
+            // unqualified table.
+            // Fast path: the transformer links the table-resolve node to its
+            // sibling namespace-resolve node (same dbname), and the sibling's
+            // operator executes earlier in the Pass-1 chain — read its stamp
+            // instead of re-scanning pg_namespace. Never a correctness
+            // dependency: absent link or unstamped sibling falls through to
+            // the self-resolve read below.
+            if (input_namespace_oid_ == catalog::INVALID_OID && !dbname_.empty() && target_node_) {
+                if (auto* ns = target_node_->target();
+                    ns && ns->kind() == components::logical_plan::resolve_kind::namespace_ &&
+                    ns->dbname() == dbname_ && ns->namespace_oid() != catalog::INVALID_OID) {
+                    input_namespace_oid_ = ns->namespace_oid();
+                }
+            }
+            if (input_namespace_oid_ == catalog::INVALID_OID && !dbname_.empty()) {
+                std::pmr::vector<std::string> ns_keys(resource_);
+                ns_keys.emplace_back("nspname");
+                auto [_ns, nsf] =
+                    actor_zeta::send(ctx->disk_address,
+                                     &services::disk::manager_disk_t::read_chunks_by_key,
+                                     exec_ctx,
+                                     kPgNamespace,
+                                     std::move(ns_keys),
+                                     components::operators::make_key_chunk(resource_, std::string_view{dbname_}));
+                auto ns_batches = co_await std::move(nsf);
+                if (!ns_batches.empty() && ns_batches[0].size() != 0 && ns_batches[0].column_count() >= 1 &&
+                    !ns_batches[0].is_null(0, 0)) {
+                    input_namespace_oid_ = static_cast<catalog::oid_t>(ns_batches[0].get_value<std::uint32_t>(0, 0));
+                } else {
+                    // Database does not exist — emit empty output, leave
+                    // found_=false. Never fall through to a relname-only scan.
+                    output_ = make_operator_data(resource_, output_schema_, 0);
+                    output_->chunks().front().set_cardinality(0);
+                    mark_executed();
+                    co_return;
+                }
+            }
+            // Two-key (relname, relnamespace) scan whenever a namespace is
+            // known — i.e. always for qualified names. The relname-only scan
+            // remains ONLY for unqualified names (dbname_ empty): no session
+            // default-database substitution exists, so it is what makes
+            // unqualified access work.
             std::pmr::vector<std::string> key_cols(resource_);
             key_cols.emplace_back("relname");
             auto keys_chunk = [&] {

--- a/components/physical_plan/operators/operator_resolve_table.hpp
+++ b/components/physical_plan/operators/operator_resolve_table.hpp
@@ -17,12 +17,22 @@ namespace components::operators {
     // manager_disk_t::resolve_table actor message. Self-resolves a table's
     // column schema via standard disk-actor primitives (read_rows_by_key).
     //
-    // Inputs: either table_oid (oid in pg_class) OR (namespace_oid, relname).
-    // In the name-resolution form the operator first scans pg_class by
-    // (relname, relnamespace) to recover the oid, then proceeds identically.
+    // Inputs: (namespace_oid, dbname, relname). Table identity is resolved
+    // at EXECUTION time with the following precedence:
+    //   1. namespace_oid != INVALID_OID -> pg_class scan by
+    //      (relname, relnamespace).
+    //   2. dbname non-empty -> pg_namespace scan by nspname first (an
+    //      execution-time disk read, mirroring operator_resolve_type_t),
+    //      then the MANDATORY two-key pg_class scan. A namespace miss is a
+    //      hard not-found: a qualified name never degrades to a
+    //      relname-only scan (that degradation was the #557 cross-database
+    //      leak — the first same-named table from ANY database won).
+    //   3. dbname empty (unqualified name) -> pg_class scan by relname
+    //      alone. No session default-database substitution exists, so this
+    //      is what makes unqualified access work.
     //
     // Steps:
-    //   0. (name form only) read pg_class by (relname,relnamespace) -> oid.
+    //   0. resolve table_oid as described above.
     //   1. read pg_class by oid -> capture relkind, relnamespace.
     //   2. relkind='r': read pg_attribute by attrelid -> rows. Drop tombstones
     //      (attisdropped=true), sort by attnum.
@@ -40,24 +50,16 @@ namespace components::operators {
     // another resolve.
     class operator_resolve_table_t final : public read_write_operator_t {
     public:
-        // oid-form: caller already knows pg_class.oid.
-        operator_resolve_table_t(std::pmr::memory_resource* resource, log_t log, components::catalog::oid_t table_oid);
-
-        // name-form: operator scans pg_class by (relname, relnamespace) to
-        // recover the oid before resolving columns. namespace_oid may be
-        // INVALID_OID, in which case the operator scans by relname alone
-        // (matches "no namespace enrichment yet" — typically yields not-found).
+        // After resolving, the operator stamps namespace_oid + table_oid
+        // onto target_node so the dispatcher (validate / enrich) can read
+        // them via plan_resolve_index_t. namespace_oid is a pre-resolved
+        // relnamespace when the caller already has one; INVALID_OID
+        // otherwise (the common case — dbname is then resolved at
+        // execution time, see the class comment).
         operator_resolve_table_t(std::pmr::memory_resource* resource,
                                  log_t log,
                                  components::catalog::oid_t namespace_oid,
-                                 std::string relname);
-
-        // back-pointer form. After resolving, the operator stamps
-        // namespace_oid + table_oid onto target_node so the dispatcher's
-        // (validate / enrich) can read it via plan_resolve_index_t.
-        operator_resolve_table_t(std::pmr::memory_resource* resource,
-                                 log_t log,
-                                 components::catalog::oid_t namespace_oid,
+                                 std::string dbname,
                                  std::string relname,
                                  components::logical_plan::node_catalog_resolve_t* target_node);
 
@@ -70,25 +72,29 @@ namespace components::operators {
         components::catalog::oid_t resolved_table_oid() const noexcept { return table_oid_; }
 
         // Sourceless SINK leaf (catalog read, no data pipeline, no children).
-        // The executor admits the resolve front-pass as an all-sink chain and drives
-        // await_async_and_resume via the bottom-up needs_async_finalize pass —
-        // deepest-first, so a preceding resolve_namespace (its left in the chain)
-        // commits and stamps its node BEFORE this resolve_table reads it. The async
-        // pg_class / pg_attribute / pg_computed_column scan emits the column-schema
-        // chunk into output_ and stamps namespace_oid_/table_oid_ onto target_node_;
-        // push()/finalize() inherit the no-op defaults (the metadata handoff is the
-        // node stamp, read later via plan_resolve_index).
+        // The executor admits the resolve front-pass as an all-sink chain and
+        // drives await_async_and_resume via the bottom-up needs_async_finalize
+        // pass. The operator is self-contained: every input it needs (dbname,
+        // relname) is a plan-time constant, and all catalog lookups — including
+        // the dbname -> namespace_oid translation — happen inside
+        // await_async_and_resume, so it does not depend on any sibling
+        // operator's execution-time stamps. The async pg_namespace / pg_class /
+        // pg_attribute / pg_computed_column scans emit the column-schema chunk
+        // into output_ and stamp namespace_oid_/table_oid_ onto target_node_;
+        // push()/finalize() inherit the no-op defaults (the metadata handoff is
+        // the node stamp, read later via plan_resolve_index).
         [[nodiscard]] bool needs_async_finalize() const noexcept override { return true; }
 
     private:
         actor_zeta::unique_future<void> await_async_and_resume(pipeline::context_t* ctx) override;
 
-        // When table_oid_ == INVALID_OID we use (input_namespace_oid_,
-        // relname_) and resolve table_oid_ inside await_async_and_resume.
-        // namespace_oid_ (below) is the *resolved* relnamespace, populated by
-        // the oid-keyed pg_class scan.
-        components::catalog::oid_t table_oid_;
+        // table_oid_ is resolved inside await_async_and_resume from
+        // (input_namespace_oid_ | dbname_, relname_). namespace_oid_ (below)
+        // is the *resolved* relnamespace, populated by the oid-keyed
+        // pg_class scan.
+        components::catalog::oid_t table_oid_{components::catalog::INVALID_OID};
         components::catalog::oid_t input_namespace_oid_{components::catalog::INVALID_OID};
+        std::string dbname_;
         std::string relname_;
         bool found_{false};
         char relkind_{0};

--- a/components/physical_plan_generator/impl/create_plan_resolve_table.cpp
+++ b/components/physical_plan_generator/impl/create_plan_resolve_table.cpp
@@ -11,9 +11,16 @@ namespace services::planner::impl {
         // Pass the back-pointer so the operator stamps namespace_oid +
         // table_oid onto the logical node after a successful pg_class scan.
         // plan_resolve_index_t reads them in Pass 2.
+        //
+        // dbname is passed as a STRING: at plan-generation time the node's
+        // namespace_oid() is still INVALID_OID (the sibling resolve_namespace
+        // operator stamps its own node only at execution time), so the
+        // operator translates dbname -> namespace_oid itself at execution
+        // time. Dropping the dbname here was the #557 cross-database leak.
         return boost::intrusive_ptr(new components::operators::operator_resolve_table_t(context.resource,
                                                                                         context.log.clone(),
                                                                                         n->namespace_oid(),
+                                                                                        n->dbname(),
                                                                                         n->relname(),
                                                                                         n));
     }

--- a/components/sql/transformer/impl/transform_matview.cpp
+++ b/components/sql/transformer/impl/transform_matview.cpp
@@ -80,19 +80,28 @@ namespace components::sql::transform {
         // of an outer sequence_t. Pass 1 walks the sequence's leading
         // catalog_resolve_*_t children and stamps oids + metadata.
         auto outer = boost::intrusive_ptr(new logical_plan::node_sequence_t(resource_));
+        logical_plan::node_catalog_resolve_t* mv_ns_ptr = nullptr;
         if (!mv_db.empty()) {
-            outer->append_child(logical_plan::make_node_catalog_resolve_namespace(resource_, core::dbname_t{mv_db}));
+            auto mv_ns = logical_plan::make_node_catalog_resolve_namespace(resource_, core::dbname_t{mv_db});
+            mv_ns_ptr = mv_ns.get();
+            outer->append_child(std::move(mv_ns));
         }
         // Source's namespace + table resolve so Pass 1 stamps source's
         // resolved_metadata.columns for the planner's derive_output_schema.
+        logical_plan::node_catalog_resolve_t* source_ns_ptr = (source_db == mv_db) ? mv_ns_ptr : nullptr;
         if (!source_db.empty() && source_db != mv_db) {
-            outer->append_child(
-                logical_plan::make_node_catalog_resolve_namespace(resource_, core::dbname_t{source_db}));
+            auto source_ns = logical_plan::make_node_catalog_resolve_namespace(resource_, core::dbname_t{source_db});
+            source_ns_ptr = source_ns.get();
+            outer->append_child(std::move(source_ns));
         }
         if (!source_rel.empty()) {
-            outer->append_child(logical_plan::make_node_catalog_resolve_table(resource_,
+            auto source_table = logical_plan::make_node_catalog_resolve_table(resource_,
                                                                               core::dbname_t{source_db},
-                                                                              core::relname_t{source_rel}));
+                                                                              core::relname_t{source_rel});
+            // Namespace fast path: link the source table resolve to its
+            // matching-dbname ns sibling (see maybe_wrap_with_catalog_resolve_table).
+            source_table->set_target(source_ns_ptr);
+            outer->append_child(std::move(source_table));
         }
         outer->append_child(matview_node);
         return outer;

--- a/components/sql/transformer/utils.cpp
+++ b/components/sql/transformer/utils.cpp
@@ -811,8 +811,11 @@ namespace components::sql::transform {
         // (e.g. parameter-only statements, schemaless DDL) — skip the resolve
         // node so the wrapped plan still carries useful structure.
         auto seq = boost::intrusive_ptr(new logical_plan::node_sequence_t(resource));
+        logical_plan::node_catalog_resolve_t* ns_node_ptr = nullptr;
         if (!dbname.empty()) {
-            seq->append_child(logical_plan::make_node_catalog_resolve_namespace(resource, core::dbname_t{dbname}));
+            auto ns_node = logical_plan::make_node_catalog_resolve_namespace(resource, core::dbname_t{dbname});
+            ns_node_ptr = ns_node.get();
+            seq->append_child(std::move(ns_node));
         }
         logical_plan::node_catalog_resolve_t* table_node_ptr = nullptr;
         if (!relname.empty()) {
@@ -820,6 +823,11 @@ namespace components::sql::transform {
                                                                             core::dbname_t{dbname},
                                                                             core::relname_t{relname});
             table_node_ptr = table_node.get();
+            // Namespace fast path: the ns sibling executes first in Pass 1, so
+            // operator_resolve_table_t can read its stamp instead of doing its
+            // own pg_namespace scan (it still self-resolves when the link is
+            // absent or unstamped — the link is never a correctness dependency).
+            table_node_ptr->set_target(ns_node_ptr);
             seq->append_child(std::move(table_node));
         }
         if (with_constraints != constraint_resolve_kind::none && table_node_ptr) {
@@ -856,27 +864,37 @@ namespace components::sql::transform {
         }
         auto seq = boost::intrusive_ptr(new logical_plan::node_sequence_t(resource));
         // Dedupe dbname for namespace resolves; preserve table order.
-        std::vector<std::string> seen_dbs;
+        std::vector<std::pair<std::string, logical_plan::node_catalog_resolve_t*>> seen_dbs;
         for (const auto& [db, rel] : targets) {
             if (db.empty())
                 continue;
             bool already = false;
             for (const auto& s : seen_dbs) {
-                if (s == db) {
+                if (s.first == db) {
                     already = true;
                     break;
                 }
             }
             if (already)
                 continue;
-            seen_dbs.push_back(db);
-            seq->append_child(logical_plan::make_node_catalog_resolve_namespace(resource, core::dbname_t{db}));
+            auto ns_node = logical_plan::make_node_catalog_resolve_namespace(resource, core::dbname_t{db});
+            seen_dbs.emplace_back(db, ns_node.get());
+            seq->append_child(std::move(ns_node));
         }
         for (auto& [db, rel] : targets) {
             if (rel.empty())
                 continue;
-            seq->append_child(
-                logical_plan::make_node_catalog_resolve_table(resource, core::dbname_t{db}, core::relname_t{rel}));
+            auto table_node =
+                logical_plan::make_node_catalog_resolve_table(resource, core::dbname_t{db}, core::relname_t{rel});
+            // Namespace fast path (see maybe_wrap_with_catalog_resolve_table):
+            // link each table node to the deduped ns sibling of its dbname.
+            for (const auto& s : seen_dbs) {
+                if (s.first == db) {
+                    table_node->set_target(s.second);
+                    break;
+                }
+            }
+            seq->append_child(std::move(table_node));
         }
         seq->append_child(std::move(main_node));
         return seq;

--- a/integration/cpp/test/CMakeLists.txt
+++ b/integration/cpp/test/CMakeLists.txt
@@ -17,6 +17,7 @@ set( ${PROJECT_NAME}_SOURCES
         test_unique_constraint_operator.cpp
         test_create_index_backfill_batched.cpp
         test_correctness_bugs.cpp
+        test_multi_database_isolation.cpp
         test_dispatcher_watchdog_log.cpp
         test_production_scenarios.cpp
         test_join.cpp

--- a/integration/cpp/test/test_multi_database_isolation.cpp
+++ b/integration/cpp/test/test_multi_database_isolation.cpp
@@ -477,33 +477,16 @@ TEST_CASE("integration::cpp::multi_database_isolation::unqualified_names_preserv
     test_spaces space(config);
     auto* dispatcher = space.dispatcher();
 
-    // Unqualified handling must be UNCHANGED by the isolation fix (the
-    // relname-only scan is preserved for empty dbnames; no session
-    // default-database substitution exists). What "unchanged" means today:
-    // unqualified CREATE TABLE succeeds (pg_class row with
-    // relnamespace=INVALID), but unqualified DML against it fails validation
-    // ("collection does not exist") because gather_plan_resolve_index drops
-    // metadata whose namespace is INVALID — a pre-existing gap on main
-    // (verified on unpatched b3eb02ba), tracked separately as part of the
-    // default-database/search-path design task.
+    // Unqualified CREATE TABLE keeps working (the relname-only scan is
+    // preserved for empty dbnames). Unqualified DML behavior is a known gap
+    // tracked in issue #574 and deliberately NOT asserted here.
     {
         auto session = otterbrix::session_id_t();
         REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE t1 (id BIGINT);")->is_success());
     }
-    {
-        auto session = otterbrix::session_id_t();
-        auto c = dispatcher->execute_sql(session, "INSERT INTO t1 (id) VALUES (7);");
-        REQUIRE(c->is_error()); // pre-existing: identical failure on unpatched main
-    }
-    {
-        auto session = otterbrix::session_id_t();
-        auto c = dispatcher->execute_sql(session, "SELECT * FROM t1;");
-        REQUIRE(c->is_error()); // pre-existing: same tbl_md gate as INSERT
-    }
 
-    // Intended behavior change pinned: a table created UNQUALIFIED
-    // (relnamespace = INVALID) is NOT reachable through a database-qualified
-    // name — previously the relname-only scan leak-matched it.
+    // A table created UNQUALIFIED (relnamespace = INVALID) is not reachable
+    // through a database-qualified name.
     {
         auto session = otterbrix::session_id_t();
         REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE db1;")->is_success());

--- a/integration/cpp/test/test_multi_database_isolation.cpp
+++ b/integration/cpp/test/test_multi_database_isolation.cpp
@@ -1,0 +1,558 @@
+#include "test_config.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+// Regression tests for issue #557: two tables with the same name in different
+// databases must be fully independent. Before the fix, name→OID resolution
+// scanned pg_class by relname alone (the relnamespace filter never fired
+// because the namespace OID was read at plan-generation time, before the
+// sibling resolve_namespace operator stamped it), so `db2.t1` resolved to
+// whichever same-named table was created first — a cross-database data leak.
+//
+// The fix: operator_resolve_table_t translates the user-typed dbname to a
+// namespace oid itself at execution time (mirroring operator_resolve_type_t)
+// and then always scans pg_class by (relname, relnamespace) for qualified
+// names. The relname-only scan survives ONLY for unqualified names.
+
+TEST_CASE("integration::cpp::multi_database_isolation::same_name_select") {
+    auto config = test_create_config("/tmp/test_multi_db_isolation/same_name_select");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE db1;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE db2;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE db1.t1 (id BIGINT);")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE db2.t1 (id BIGINT);")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "INSERT INTO db1.t1 (id) VALUES (1);")->is_success());
+    }
+
+    // The core of issue #557: db2.t1 is empty and must stay empty.
+    {
+        auto session = otterbrix::session_id_t();
+        auto c = dispatcher->execute_sql(session, "SELECT * FROM db2.t1;");
+        REQUIRE(c->is_success());
+        REQUIRE(c->size() == 0);
+    }
+    // db1.t1 still owns its row.
+    {
+        auto session = otterbrix::session_id_t();
+        auto c = dispatcher->execute_sql(session, "SELECT * FROM db1.t1;");
+        REQUIRE(c->is_success());
+        REQUIRE(c->size() == 1);
+        REQUIRE(c->value(0, 0).value<int64_t>() == 1);
+    }
+}
+
+TEST_CASE("integration::cpp::multi_database_isolation::same_name_dml_routing") {
+    auto config = test_create_config("/tmp/test_multi_db_isolation/same_name_dml_routing");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    for (const auto* sql : {"CREATE DATABASE db1;",
+                            "CREATE DATABASE db2;",
+                            "CREATE TABLE db1.t1 (id BIGINT);",
+                            "CREATE TABLE db2.t1 (id BIGINT);",
+                            "INSERT INTO db1.t1 (id) VALUES (10);",
+                            "INSERT INTO db2.t1 (id) VALUES (20);"}) {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, sql)->is_success());
+    }
+
+    // Each table sees exactly its own row.
+    {
+        auto session = otterbrix::session_id_t();
+        auto c = dispatcher->execute_sql(session, "SELECT * FROM db1.t1;");
+        REQUIRE(c->is_success());
+        REQUIRE(c->size() == 1);
+        REQUIRE(c->value(0, 0).value<int64_t>() == 10);
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto c = dispatcher->execute_sql(session, "SELECT * FROM db2.t1;");
+        REQUIRE(c->is_success());
+        REQUIRE(c->size() == 1);
+        REQUIRE(c->value(0, 0).value<int64_t>() == 20);
+    }
+
+    // UPDATE routed to db2.t1 must not touch db1.t1.
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "UPDATE db2.t1 SET id = 21;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto c = dispatcher->execute_sql(session, "SELECT * FROM db1.t1;");
+        REQUIRE(c->is_success());
+        REQUIRE(c->size() == 1);
+        REQUIRE(c->value(0, 0).value<int64_t>() == 10);
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto c = dispatcher->execute_sql(session, "SELECT * FROM db2.t1;");
+        REQUIRE(c->is_success());
+        REQUIRE(c->size() == 1);
+        REQUIRE(c->value(0, 0).value<int64_t>() == 21);
+    }
+
+    // DELETE routed to db1.t1 must not touch db2.t1.
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "DELETE FROM db1.t1;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto c = dispatcher->execute_sql(session, "SELECT * FROM db1.t1;");
+        REQUIRE(c->is_success());
+        REQUIRE(c->size() == 0);
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto c = dispatcher->execute_sql(session, "SELECT * FROM db2.t1;");
+        REQUIRE(c->is_success());
+        REQUIRE(c->size() == 1);
+        REQUIRE(c->value(0, 0).value<int64_t>() == 21);
+    }
+}
+
+TEST_CASE("integration::cpp::multi_database_isolation::same_name_drop") {
+    auto config = test_create_config("/tmp/test_multi_db_isolation/same_name_drop");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    for (const auto* sql : {"CREATE DATABASE db1;",
+                            "CREATE DATABASE db2;",
+                            "CREATE TABLE db1.t1 (id BIGINT);",
+                            "CREATE TABLE db2.t1 (id BIGINT);",
+                            "INSERT INTO db1.t1 (id) VALUES (1);"}) {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, sql)->is_success());
+    }
+
+    // Dropping db2.t1 must not take db1.t1 (or its rows) with it.
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "DROP TABLE db2.t1;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto c = dispatcher->execute_sql(session, "SELECT * FROM db1.t1;");
+        REQUIRE(c->is_success());
+        REQUIRE(c->size() == 1);
+        REQUIRE(c->value(0, 0).value<int64_t>() == 1);
+    }
+    // db2.t1 is gone: selecting it must NOT silently read db1.t1.
+    {
+        auto session = otterbrix::session_id_t();
+        auto c = dispatcher->execute_sql(session, "SELECT * FROM db2.t1;");
+        REQUIRE(c->is_error());
+        REQUIRE(c->get_error().type == core::error_code_t::table_not_exists);
+    }
+}
+
+TEST_CASE("integration::cpp::multi_database_isolation::missing_table_not_aliased") {
+    auto config = test_create_config("/tmp/test_multi_db_isolation/missing_table_not_aliased");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    for (const auto* sql : {"CREATE DATABASE db1;",
+                            "CREATE DATABASE db2;",
+                            "CREATE TABLE db1.t1 (id BIGINT);",
+                            "INSERT INTO db1.t1 (id) VALUES (1);"}) {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, sql)->is_success());
+    }
+
+    // db2 exists but has no t1: the select must fail, not read db1.t1.
+    {
+        auto session = otterbrix::session_id_t();
+        auto c = dispatcher->execute_sql(session, "SELECT * FROM db2.t1;");
+        REQUIRE(c->is_error());
+        REQUIRE(c->get_error().type == core::error_code_t::table_not_exists);
+    }
+    // INSERT must not create-or-route into db1's table either.
+    {
+        auto session = otterbrix::session_id_t();
+        auto c = dispatcher->execute_sql(session, "INSERT INTO db2.t1 (id) VALUES (99);");
+        REQUIRE(c->is_error());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto c = dispatcher->execute_sql(session, "SELECT * FROM db1.t1;");
+        REQUIRE(c->is_success());
+        REQUIRE(c->size() == 1);
+        REQUIRE(c->value(0, 0).value<int64_t>() == 1);
+    }
+}
+
+TEST_CASE("integration::cpp::multi_database_isolation::nonexistent_database_errors") {
+    auto config = test_create_config("/tmp/test_multi_db_isolation/nonexistent_database_errors");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    for (const auto* sql : {"CREATE DATABASE db1;",
+                            "CREATE TABLE db1.t1 (id BIGINT);",
+                            "INSERT INTO db1.t1 (id) VALUES (1);"}) {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, sql)->is_success());
+    }
+
+    // A table named t1 exists (in db1), but nosuchdb does not. Before the
+    // fix the mis-resolved table node poisoned ns_by_dbname["nosuchdb"] and
+    // this returned db1's rows instead of an error.
+    {
+        auto session = otterbrix::session_id_t();
+        auto c = dispatcher->execute_sql(session, "SELECT * FROM nosuchdb.t1;");
+        REQUIRE(c->is_error());
+        REQUIRE(c->get_error().type == core::error_code_t::database_not_exists);
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto c = dispatcher->execute_sql(session, "INSERT INTO nosuchdb.t1 (id) VALUES (2);");
+        REQUIRE(c->is_error());
+    }
+    // db1.t1 is untouched.
+    {
+        auto session = otterbrix::session_id_t();
+        auto c = dispatcher->execute_sql(session, "SELECT * FROM db1.t1;");
+        REQUIRE(c->is_success());
+        REQUIRE(c->size() == 1);
+    }
+}
+
+TEST_CASE("integration::cpp::multi_database_isolation::view_resolves_in_own_database") {
+    auto config = test_create_config("/tmp/test_multi_db_isolation/view_resolves_in_own_database");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    for (const auto* sql : {"CREATE DATABASE db1;",
+                            "CREATE DATABASE db2;",
+                            "CREATE TABLE db1.t1 (id BIGINT);",
+                            "CREATE TABLE db2.t1 (id BIGINT);",
+                            "INSERT INTO db1.t1 (id) VALUES (10);",
+                            "INSERT INTO db2.t1 (id) VALUES (20);",
+                            "CREATE VIEW db2.v AS SELECT id FROM db2.t1;"}) {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, sql)->is_success());
+    }
+
+    // The view body must resolve t1 against db2, not db1 — this covers the
+    // view-expansion fresh-resolve path, where the namespace sibling is
+    // filtered out of the re-resolve sub-plan and the table operator must
+    // resolve the dbname on its own.
+    {
+        auto session = otterbrix::session_id_t();
+        auto c = dispatcher->execute_sql(session, "SELECT * FROM db2.v;");
+        REQUIRE(c->is_success());
+        REQUIRE(c->size() == 1);
+        REQUIRE(c->value(0, 0).value<int64_t>() == 20);
+    }
+}
+
+TEST_CASE("integration::cpp::multi_database_isolation::unique_constraint_binds_to_own_table") {
+    auto config = test_create_config("/tmp/test_multi_db_isolation/unique_constraint_binds_to_own_table");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    for (const auto* sql : {"CREATE DATABASE db1;",
+                            "CREATE DATABASE db2;",
+                            "CREATE TABLE db1.t1 (id BIGINT);",
+                            "CREATE TABLE db2.t1 (id BIGINT);",
+                            "ALTER TABLE db2.t1 ADD CONSTRAINT uq_t1_id UNIQUE (id);",
+                            "INSERT INTO db2.t1 (id) VALUES (1);"}) {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, sql)->is_success());
+    }
+
+    // db1.t1 has NO unique constraint: duplicate values are fine — and the
+    // constraint attached to db2.t1 must not bleed over.
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "INSERT INTO db1.t1 (id) VALUES (1);")->is_success());
+        auto session2 = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session2, "INSERT INTO db1.t1 (id) VALUES (1);")->is_success());
+    }
+    // db2.t1's own constraint still enforces.
+    {
+        auto session = otterbrix::session_id_t();
+        auto c = dispatcher->execute_sql(session, "INSERT INTO db2.t1 (id) VALUES (1);");
+        REQUIRE(c->is_error());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto c = dispatcher->execute_sql(session, "SELECT * FROM db1.t1;");
+        REQUIRE(c->is_success());
+        REQUIRE(c->size() == 2);
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto c = dispatcher->execute_sql(session, "SELECT * FROM db2.t1;");
+        REQUIRE(c->is_success());
+        REQUIRE(c->size() == 1);
+    }
+}
+
+TEST_CASE("integration::cpp::multi_database_isolation::index_isolation") {
+    auto config = test_create_config("/tmp/test_multi_db_isolation/index_isolation");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    for (const auto* sql : {"CREATE DATABASE db1;",
+                            "CREATE DATABASE db2;",
+                            "CREATE TABLE db1.t1 (id BIGINT);",
+                            "CREATE TABLE db2.t1 (id BIGINT);",
+                            "CREATE INDEX idx_id ON db1.t1 (id);",
+                            "CREATE INDEX idx_id ON db2.t1 (id);",
+                            "INSERT INTO db1.t1 (id) VALUES (10);",
+                            "INSERT INTO db2.t1 (id) VALUES (20);"}) {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, sql)->is_success());
+    }
+
+    // Keyed lookups hit each table's own index and own rows.
+    {
+        auto session = otterbrix::session_id_t();
+        auto c = dispatcher->execute_sql(session, "SELECT * FROM db1.t1 WHERE id = 10;");
+        REQUIRE(c->is_success());
+        REQUIRE(c->size() == 1);
+        REQUIRE(c->value(0, 0).value<int64_t>() == 10);
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto c = dispatcher->execute_sql(session, "SELECT * FROM db2.t1 WHERE id = 10;");
+        REQUIRE(c->is_success());
+        REQUIRE(c->size() == 0);
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto c = dispatcher->execute_sql(session, "SELECT * FROM db2.t1 WHERE id = 20;");
+        REQUIRE(c->is_success());
+        REQUIRE(c->size() == 1);
+        REQUIRE(c->value(0, 0).value<int64_t>() == 20);
+    }
+
+    // Dropping db2's same-named index must not break db1's.
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "DROP INDEX db2.t1.idx_id;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto c = dispatcher->execute_sql(session, "SELECT * FROM db1.t1 WHERE id = 10;");
+        REQUIRE(c->is_success());
+        REQUIRE(c->size() == 1);
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto c = dispatcher->execute_sql(session, "SELECT * FROM db2.t1 WHERE id = 20;");
+        REQUIRE(c->is_success());
+        REQUIRE(c->size() == 1);
+    }
+}
+
+TEST_CASE("integration::cpp::multi_database_isolation::cross_database_join") {
+    auto config = test_create_config("/tmp/test_multi_db_isolation/cross_database_join");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    for (const auto* sql : {"CREATE DATABASE db1;",
+                            "CREATE DATABASE db2;",
+                            "CREATE TABLE db1.t1 (id BIGINT, a BIGINT);",
+                            "CREATE TABLE db2.t1 (id BIGINT, b BIGINT);",
+                            "INSERT INTO db1.t1 (id, a) VALUES (1, 100);",
+                            "INSERT INTO db2.t1 (id, b) VALUES (1, 200);"}) {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, sql)->is_success());
+    }
+
+    // One statement touching BOTH same-named tables: each side must bind to
+    // its own database's store (covers the executor's per-key resolve dedup).
+    {
+        auto session = otterbrix::session_id_t();
+        auto c = dispatcher->execute_sql(session,
+                                         "SELECT * FROM db1.t1 INNER JOIN db2.t1 "
+                                         "ON db1.t1.id >= db2.t1.id AND db1.t1.id <= db2.t1.id;");
+        REQUIRE(c->is_success());
+        REQUIRE(c->size() == 1);
+        // 4 columns: db1.t1(id, a) + db2.t1(id, b); values 1, 100, 1, 200.
+        REQUIRE(c->column_count() == 4);
+    }
+}
+
+TEST_CASE("integration::cpp::multi_database_isolation::alter_column_isolated") {
+    auto config = test_create_config("/tmp/test_multi_db_isolation/alter_column_isolated");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    for (const auto* sql : {"CREATE DATABASE db1;",
+                            "CREATE DATABASE db2;",
+                            "CREATE TABLE db1.t1 (id BIGINT);",
+                            "CREATE TABLE db2.t1 (id BIGINT);",
+                            "INSERT INTO db1.t1 (id) VALUES (10);",
+                            "INSERT INTO db2.t1 (id) VALUES (20);"}) {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, sql)->is_success());
+    }
+
+    // ALTER on db2.t1 must not touch db1.t1 (ALTER rides the AnyName grammar
+    // path where the qualifier arrives via the schema position).
+    //
+    // NOTE: this case asserts ISOLATION only — that the ALTER binds to db2's
+    // table and db1 stays untouched. It deliberately does NOT assert that the
+    // rename itself took effect: node_alter_column_t::set_attoid has no
+    // callers anywhere in the pipeline, so operator_alter_column_rename_t
+    // no-ops with attoid_==INVALID_OID and reports success — a pre-existing
+    // defect independent of cross-database isolation, tracked separately.
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "ALTER TABLE db2.t1 RENAME COLUMN id TO id2;")->is_success());
+    }
+    // db1.t1 keeps its original column and its single row (before the fix,
+    // the INSERT mis-route alone already gave db1.t1 two rows here).
+    {
+        auto session = otterbrix::session_id_t();
+        auto c = dispatcher->execute_sql(session, "SELECT id FROM db1.t1;");
+        REQUIRE(c->is_success());
+        REQUIRE(c->size() == 1);
+        REQUIRE(c->value(0, 0).value<int64_t>() == 10);
+    }
+    // db2.t1's data is intact and its own.
+    {
+        auto session = otterbrix::session_id_t();
+        auto c = dispatcher->execute_sql(session, "SELECT * FROM db2.t1;");
+        REQUIRE(c->is_success());
+        REQUIRE(c->size() == 1);
+        REQUIRE(c->value(0, 0).value<int64_t>() == 20);
+    }
+}
+
+TEST_CASE("integration::cpp::multi_database_isolation::unqualified_names_preserved") {
+    auto config = test_create_config("/tmp/test_multi_db_isolation/unqualified_names_preserved");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    // Unqualified handling must be UNCHANGED by the isolation fix (the
+    // relname-only scan is preserved for empty dbnames; no session
+    // default-database substitution exists). What "unchanged" means today:
+    // unqualified CREATE TABLE succeeds (pg_class row with
+    // relnamespace=INVALID), but unqualified DML against it fails validation
+    // ("collection does not exist") because gather_plan_resolve_index drops
+    // metadata whose namespace is INVALID — a pre-existing gap on main
+    // (verified on unpatched b3eb02ba), tracked separately as part of the
+    // default-database/search-path design task.
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE t1 (id BIGINT);")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto c = dispatcher->execute_sql(session, "INSERT INTO t1 (id) VALUES (7);");
+        REQUIRE(c->is_error()); // pre-existing: identical failure on unpatched main
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto c = dispatcher->execute_sql(session, "SELECT * FROM t1;");
+        REQUIRE(c->is_error()); // pre-existing: same tbl_md gate as INSERT
+    }
+
+    // Intended behavior change pinned: a table created UNQUALIFIED
+    // (relnamespace = INVALID) is NOT reachable through a database-qualified
+    // name — previously the relname-only scan leak-matched it.
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE db1;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto c = dispatcher->execute_sql(session, "SELECT * FROM db1.t1;");
+        REQUIRE(c->is_error());
+        REQUIRE(c->get_error().type == core::error_code_t::table_not_exists);
+    }
+}
+
+TEST_CASE("integration::cpp::multi_database_isolation::restart_persistence_isolation") {
+    auto config = test_create_config("/tmp/test_multi_db_isolation/restart_persistence_isolation");
+    test_clear_directory(config);
+    // disk + WAL ON: isolation must survive checkpoint/recovery.
+
+    INFO("phase 1: create same-named tables in two databases, insert distinct rows");
+    {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+        for (const auto* sql : {"CREATE DATABASE db1;",
+                                "CREATE DATABASE db2;",
+                                "CREATE TABLE db1.t1 (id BIGINT);",
+                                "CREATE TABLE db2.t1 (id BIGINT);",
+                                "INSERT INTO db1.t1 (id) VALUES (10);",
+                                "INSERT INTO db2.t1 (id) VALUES (20);"}) {
+            auto session = otterbrix::session_id_t();
+            REQUIRE(dispatcher->execute_sql(session, sql)->is_success());
+        }
+    }
+
+    INFO("phase 2: restart — both tables keep exactly their own rows");
+    {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+        {
+            auto session = otterbrix::session_id_t();
+            auto c = dispatcher->execute_sql(session, "SELECT * FROM db1.t1;");
+            REQUIRE(c->is_success());
+            REQUIRE(c->size() == 1);
+            REQUIRE(c->value(0, 0).value<int64_t>() == 10);
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            auto c = dispatcher->execute_sql(session, "SELECT * FROM db2.t1;");
+            REQUIRE(c->is_success());
+            REQUIRE(c->size() == 1);
+            REQUIRE(c->value(0, 0).value<int64_t>() == 20);
+        }
+    }
+}

--- a/services/dispatcher/plan_resolve_index.hpp
+++ b/services/dispatcher/plan_resolve_index.hpp
@@ -108,7 +108,13 @@ namespace services::catalog_resolve {
                     case resolve_kind::table: {
                         auto* rt = rn;
                         if (rt->namespace_oid() != components::catalog::INVALID_OID) {
-                            out->ns_by_dbname[rt->dbname()] = rt->namespace_oid();
+                            // ns_by_dbname is populated ONLY from namespace-kind
+                            // nodes (above): a table node's stamped namespace is
+                            // derived from the pg_class row it resolved to, and
+                            // letting it write the map under the user-typed
+                            // dbname allowed a mis-resolve to overwrite the
+                            // namespace node's correct entry and defeat
+                            // check_namespace_exists (issue #557 amplifier).
                             std::string key;
                             key.reserve(rt->dbname().size() + 1 + rt->relname().size());
                             key.append(rt->dbname()).push_back('|');


### PR DESCRIPTION
## Summary

Fixes #557 — two tables with the same name in different databases shared one store: `SELECT`/`INSERT`/`UPDATE`/`DELETE`/`DROP` on `db2.t1` silently operated on `db1.t1` (cross-database reads, writes, and `DROP` data loss).

## Root cause

Name→OID resolution ignored the database qualifier:

- `operator_resolve_table_t` scanned `pg_class` by `relname` alone whenever `input_namespace_oid_ == INVALID_OID` and took the first matching row — the first-created table of that name from **any** database (`operator_resolve_table.cpp`).
- It was *always* `INVALID_OID`: `create_plan_resolve_table` read the node's `namespace_oid()` at plan-generation time, but the sibling `resolve_namespace` operator only stamps its own node at execution time, after the whole resolve sub-plan is already built. The node's `dbname()` (carrying `"db2"`) was silently dropped, so the `(relname, relnamespace)` two-key branch was dead code.
- Amplifier: `plan_resolve_index` let the mis-stamped table node overwrite the correct `ns_by_dbname` entry under the user-typed dbname, defeating the database-existence check — `SELECT * FROM nosuchdb.t1` returned `db1`'s rows.

Everything downstream (storage, indexes, WAL, DROP cascade) is honestly OID-keyed and faithfully executed the wrong OID. The regression dates to the OID migration (#486): pre-#486 storage was keyed by the full `(database, collection)` name; #486 re-keyed by `table_oid`, which is only safe if name→OID resolution is namespace-aware.

## Fix

Mirrors the pattern `operator_resolve_type_t` already uses:

- `operator_resolve_table_t` now receives the user-typed **dbname** and translates it to a namespace OID at **execution time** (keyed `pg_namespace` read); the `(relname, relnamespace)` two-key scan is then mandatory for qualified names. A namespace miss is a hard not-found (`database_not_exists`) — never a relname-only downgrade. The relname-only scan survives **only** for unqualified names (no session default database exists).
- **Namespace fast path**: the transformer links each table-resolve node to its namespace-resolve sibling (`node_catalog_resolve_t::target_`); the operator reads the sibling's execution-time stamp before doing its own `pg_namespace` read. Pure optimization — an absent/unstamped link self-resolves.
- `plan_resolve_index`: `ns_by_dbname` is now populated only from namespace-kind resolve nodes.
- Dead `operator_resolve_table_t` constructors removed; stale header comment describing the never-implemented sibling-stamp design rewritten.

## Intended behavior changes

- Wrong-database references now **error** (`table_not_exists` / `database_not_exists`) instead of silently returning another database's rows.
- A table created *unqualified* (`relnamespace = INVALID`) is no longer reachable through a database-qualified name (that reachability was the leak).

## Tests

New `integration/cpp/test/test_multi_database_isolation.cpp` — 12 cases / 148 assertions, all failing before the fix: select/DML/DROP isolation (before the fix, `INSERT INTO db2.t1` landed in `db1.t1` and `DROP TABLE db2.t1` destroyed `db1.t1`), wrong-db and nonexistent-db errors, view expansion, unique constraints, same-named indexes, cross-db JOIN, qualified ALTER, unqualified-name status quo, disk+WAL restart.

## Validation

- Full integration ctest suite: 186/186 pass (Release).
- All 21 component/service test binaries: pass.
- ASAN (`ENABLE_ASAN=ON`, CI options): full integration case set + `test_sql` / `test_translator` / `test_dispatcher` / `test_disk` — clean.
- Benchmarks (`scripts/benchmark_select_key_lookup.py`, 100k rows, 7 runs, median ms):

| scenario | main | fix (no fast path) | fix (final) |
|---|---|---|---|
| no_index | 4.611 | 4.782 | 4.625 |
| single_field_index | 3.989 | 4.145–4.284 | 3.980 |
| hash_single_field_index | 3.984 | 4.136 | 3.984 |

The interim +0.15–0.3 ms/statement from the extra `pg_namespace` read is what motivated the fast path; final numbers match main.
