### PR TITLE
fix(catalog): identity primitive hygiene

### DIFF
--- a/components/base/collection_full_name.hpp
+++ b/components/base/collection_full_name.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <compare>
 #include <sstream>
 #include <string>
 
@@ -54,22 +55,11 @@ struct qualified_name_t {
     bool empty() const noexcept {
         return unique_identifier.empty() && database.empty() && schema.empty() && collection.empty();
     }
-};
 
-inline bool operator==(const qualified_name_t& c1, const qualified_name_t& c2) {
-    return c1.unique_identifier == c2.unique_identifier && c1.database == c2.database && c1.schema == c2.schema &&
-           c1.collection == c2.collection;
-}
-
-inline bool operator<(const qualified_name_t& c1, const qualified_name_t& c2) {
-    return c1.unique_identifier < c2.unique_identifier || c1.database < c2.database ||
-           (c1.database == c2.database && c1.schema < c2.schema) ||
-           (c1.database == c2.database && c1.schema == c2.schema && c1.collection < c2.collection);
-}
-
-struct collection_name_hash {
-    inline std::size_t operator()(const qualified_name_t& key) const {
-        return std::hash<std::string>()(key.unique_identifier) ^ std::hash<std::string>()(key.database) ^
-               std::hash<std::string>()(key.schema) ^ std::hash<std::string>()(key.collection);
-    }
+    // Lexicographic over declaration order (unique_identifier, database,
+    // schema, collection) — the 4-part uid.db.schema.rel syntax order, uid
+    // outermost. Note this SORT order differs from table_id's namespace
+    // STORAGE order, which is database-first (resolution order).
+    bool operator==(const qualified_name_t&) const = default;
+    auto operator<=>(const qualified_name_t&) const = default;
 };

--- a/components/catalog/table_id.cpp
+++ b/components/catalog/table_id.cpp
@@ -1,54 +1,27 @@
 #include "table_id.hpp"
 
 #include <cassert>
-#include <sstream>
-#include <stdexcept>
 
 namespace components::catalog {
-    table_id::table_id(std::pmr::memory_resource* resource, std::pmr::vector<std::pmr::string> full_name)
-        : namespace_parts_(std::move(full_name), resource)
-        , name_(namespace_parts_.back())
-        , resource_(resource) {
-        namespace_parts_.erase(namespace_parts_.cend() - 1);
-    }
-
-    table_id::table_id(std::pmr::memory_resource* resource, table_namespace_t ns, std::pmr::string name)
-        : namespace_parts_(std::move(ns), resource)
-        , name_(std::move(name), resource)
-        , resource_(resource) {}
-
     table_id::table_id(std::pmr::memory_resource* resource, const qualified_name_t& full_name)
         : namespace_parts_(resource)
         , name_(full_name.collection)
         , resource_(resource) {
-        bool has_schema = !full_name.schema.empty();
-        bool has_uid = !full_name.unique_identifier.empty();
-
-        if (has_uid) {
-            namespace_parts_.emplace_back(full_name.unique_identifier.c_str());
+        // Storage order is database-first (see header); empty parts omitted.
+        if (!full_name.database.empty()) {
+            namespace_parts_.emplace_back(full_name.database.c_str());
         }
-
-        if (has_schema || has_uid) {
+        if (!full_name.schema.empty()) {
             namespace_parts_.emplace_back(full_name.schema.c_str());
         }
-
-        namespace_parts_.emplace_back(full_name.database.c_str());
+        if (!full_name.unique_identifier.empty()) {
+            namespace_parts_.emplace_back(full_name.unique_identifier.c_str());
+        }
     }
 
     const table_namespace_t& table_id::get_namespace() const { return namespace_parts_; }
 
     const std::pmr::string& table_id::table_name() const { return name_; }
-
-    std::pmr::string table_id::to_pmr_string() const {
-        std::ostringstream oss;
-        for (size_t i = 0; i < namespace_parts_.size(); ++i) {
-            if (i > 0)
-                oss << ".";
-            oss << namespace_parts_[i];
-        }
-        oss << "." << name_;
-        return std::pmr::string(oss.str(), resource_);
-    }
 
     void table_id::set_oid(oid_t oid) {
         // OID is immutable after first assignment — programmer-error precondition.

--- a/components/catalog/table_id.hpp
+++ b/components/catalog/table_id.hpp
@@ -13,13 +13,17 @@ namespace components::catalog {
 
     class table_id {
     public:
-        table_id(std::pmr::memory_resource* resource, std::pmr::vector<std::pmr::string> full_name);
-        table_id(std::pmr::memory_resource* resource, table_namespace_t ns, std::pmr::string name);
         table_id(std::pmr::memory_resource* resource, const qualified_name_t& full_name);
 
+        // Namespace STORAGE order is database-first: [database, schema?, uid?],
+        // empty parts omitted — so database() is front() whenever a database
+        // was given. Consumers (check_namespace_exists / check_collection_exists
+        // / the type-search-path builder) read the database through database().
         [[nodiscard]] const table_namespace_t& get_namespace() const;
+        [[nodiscard]] std::string_view database() const noexcept {
+            return namespace_parts_.empty() ? std::string_view{} : std::string_view(namespace_parts_.front());
+        }
         [[nodiscard]] const std::pmr::string& table_name() const;
-        [[nodiscard]] std::pmr::string to_pmr_string() const;
 
         // pg_class.oid for this table. INVALID_OID until assigned by the CREATE TABLE
         // pipeline (build_create_table_writes / operator_create_collection) —
@@ -38,12 +42,3 @@ namespace components::catalog {
         oid_t oid_{INVALID_OID};
     };
 } // namespace components::catalog
-
-namespace std {
-    template<>
-    struct hash<components::catalog::table_id> {
-        std::size_t operator()(const components::catalog::table_id& id) const noexcept {
-            return std::hash<std::pmr::string>{}(id.to_pmr_string());
-        }
-    };
-} // namespace std

--- a/components/catalog/tests/CMakeLists.txt
+++ b/components/catalog/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ set(${PROJECT_NAME}_SOURCES
         # Read-side coverage lives in services/disk/tests (resolve / DDL) and
         # services/dispatcher/tests (catalog_view_t / validate). Per-component tests here
         # cover only the structural primitives.
+        test_identity_primitives.cpp
         test_oids.cpp
         test_set_membership_filter.cpp
         test_system_schemas.cpp

--- a/components/catalog/tests/test_identity_primitives.cpp
+++ b/components/catalog/tests/test_identity_primitives.cpp
@@ -1,0 +1,45 @@
+#include <catch2/catch_test_macros.hpp>
+#include <components/base/collection_full_name.hpp>
+#include <components/catalog/table_id.hpp>
+#include <core/pmr.hpp>
+
+#include <string_view>
+
+using namespace components::catalog;
+
+// qualified_name_t ordering must be a strict weak ordering: asymmetric,
+// transitive, with a consistent equivalence. The comparison is lexicographic
+// over (unique_identifier, database, schema, collection) — the 4-part
+// uid.db.schema.rel syntax order, uid outermost.
+TEST_CASE("catalog::identity::qualified_name_ordering_is_asymmetric") {
+    const qualified_name_t a("1", "z", "s", "t");
+    const qualified_name_t b("2", "a", "s", "t");
+    REQUIRE_FALSE(((a < b) && (b < a)));
+}
+
+TEST_CASE("catalog::identity::qualified_name_ordering_trichotomy") {
+    const qualified_name_t names[] = {
+        qualified_name_t("1", "b", "", "t"),
+        qualified_name_t("2", "a", "", "t"),
+        qualified_name_t("2", "c", "", "t"),
+    };
+    for (const auto& p : names) {
+        for (const auto& q : names) {
+            const bool lt = p < q;
+            const bool gt = q < p;
+            const bool equiv = !lt && !gt;
+            const int holds = static_cast<int>(lt) + static_cast<int>(gt) + static_cast<int>(equiv);
+            REQUIRE(holds == 1);
+        }
+    }
+}
+
+TEST_CASE("catalog::identity::qualified_name_equality_matches_ordering") {
+    const qualified_name_t a("u", "db", "s", "t");
+    const qualified_name_t b("u", "db", "s", "t");
+    const qualified_name_t c("u", "db", "s", "other");
+    REQUIRE(a == b);
+    REQUIRE_FALSE(a < b);
+    REQUIRE_FALSE(b < a);
+    REQUIRE_FALSE(a == c);
+}

--- a/components/catalog/tests/test_identity_primitives.cpp
+++ b/components/catalog/tests/test_identity_primitives.cpp
@@ -43,3 +43,46 @@ TEST_CASE("catalog::identity::qualified_name_equality_matches_ordering") {
     REQUIRE_FALSE(b < a);
     REQUIRE_FALSE(a == c);
 }
+
+// table_id namespace layout: the database is the FIRST namespace part
+// whenever one exists — consumers (check_namespace_exists,
+// check_collection_exists, the executor's type-search-path builder) read
+// the database through database().
+TEST_CASE("catalog::identity::table_id_two_part_database_first") {
+    core::pmr::otterbrix_resource resource;
+    const table_id tid(&resource, qualified_name_t("db", "tbl"));
+    REQUIRE(tid.get_namespace().size() == 1);
+    REQUIRE(tid.database() == "db");
+    REQUIRE(std::string_view(tid.table_name()) == "tbl");
+}
+
+TEST_CASE("catalog::identity::table_id_three_part_database_first") {
+    core::pmr::otterbrix_resource resource;
+    const table_id tid(&resource, qualified_name_t("db", "sch", "tbl"));
+    REQUIRE(tid.database() == "db");
+    REQUIRE(std::string_view(tid.table_name()) == "tbl");
+}
+
+TEST_CASE("catalog::identity::table_id_four_part_database_first") {
+    core::pmr::otterbrix_resource resource;
+    const table_id tid(&resource, qualified_name_t("9f8e-uid", "db", "sch", "tbl"));
+    REQUIRE(tid.database() == "db");
+    REQUIRE(std::string_view(tid.table_name()) == "tbl");
+}
+
+TEST_CASE("catalog::identity::table_id_no_empty_namespace_parts") {
+    core::pmr::otterbrix_resource resource;
+    // uid present, schema absent: no empty placeholder part may appear.
+    const table_id tid(&resource, qualified_name_t("9f8e-uid", "db", "", "tbl"));
+    for (const auto& part : tid.get_namespace()) {
+        REQUIRE_FALSE(part.empty());
+    }
+    REQUIRE(tid.database() == "db");
+}
+
+TEST_CASE("catalog::identity::table_id_unqualified_has_no_database") {
+    core::pmr::otterbrix_resource resource;
+    const table_id tid(&resource, qualified_name_t("", "tbl"));
+    REQUIRE(tid.get_namespace().empty());
+    REQUIRE(tid.database().empty());
+}

--- a/services/collection/executor.cpp
+++ b/services/collection/executor.cpp
@@ -1015,8 +1015,7 @@ namespace services::collection::executor {
                                                           std::pmr::string{"collection already exists", resource()}});
                     }
                 } else {
-                    const std::string target_db =
-                        id.get_namespace().empty() ? std::string{} : std::string(id.get_namespace().front());
+                    const std::string target_db{id.database()};
                     const auto str_path = services::catalog_resolve::build_type_search_path_str(target_db);
                     auto* n = static_cast<node_create_collection_t*>(
                         services::catalog_resolve::effective_root_node(plan.sub_queries.back().get()));
@@ -1210,13 +1209,13 @@ namespace services::collection::executor {
                     err.contains_error()) {
                     error = make_cursor(resource(), err);
                 }
-                if (!error && !id.get_namespace().empty()) {
+                if (!error && !id.database().empty()) {
                     auto* cstr = static_cast<node_create_constraint_t*>(
                         services::catalog_resolve::effective_root_node(plan.sub_queries.back().get()));
                     if (cstr->kind() == constraint_kind::foreign_key || cstr->kind() == constraint_kind::check) {
                         const auto* tbl_local =
                             services::catalog_resolve::tbl_md_for(&dispatcher_idx,
-                                                                  std::string_view(id.get_namespace().front()),
+                                                                  id.database(),
                                                                   std::string_view(id.table_name()));
                         const bool local_is_g = tbl_local && tbl_local->relkind == 'g';
                         bool ref_is_g = false;

--- a/services/dispatcher/validate_logical_plan.cpp
+++ b/services/dispatcher/validate_logical_plan.cpp
@@ -1264,12 +1264,11 @@ namespace services::dispatcher {
     core::error_t check_namespace_exists(std::pmr::memory_resource* resource,
                                          const impl::plan_resolve_index_t* idx,
                                          const components::catalog::table_id& id) {
-        const auto& ns = id.get_namespace();
-        if (ns.empty()) {
+        if (id.database().empty()) {
             return core::error_t(core::error_code_t::database_not_exists,
                                  std::pmr::string{"database does not exist", resource});
         }
-        if (impl::ns_oid_for_dbname(idx, std::string_view(ns.front())) == components::catalog::INVALID_OID) {
+        if (impl::ns_oid_for_dbname(idx, id.database()) == components::catalog::INVALID_OID) {
             return core::error_t(core::error_code_t::database_not_exists,
                                  std::pmr::string{"database does not exist", resource});
         }
@@ -1282,8 +1281,7 @@ namespace services::dispatcher {
         if (auto err = check_namespace_exists(resource, idx, id); err.contains_error()) {
             return err;
         }
-        const auto* tbl =
-            impl::tbl_md_for(idx, std::string_view(id.get_namespace().front()), std::string_view(id.table_name()));
+        const auto* tbl = impl::tbl_md_for(idx, id.database(), std::string_view(id.table_name()));
         if (!tbl) {
             return core::error_t(core::error_code_t::table_not_exists,
                                  std::pmr::string{"collection does not exist", resource});


### PR DESCRIPTION
Two latent defects in the catalog identity primitives. Neither is reachable through SQL today (the transformer discards the schema part of qualified names before the logical plan — recorded separately), but both are landmines for their first future caller.

### 1. `qualified_name_t::operator<` violated strict weak ordering

The first disjunct compared `database` without tying off `unique_identifier`, so for `a = {uid:"1", db:"z"}`, `b = {uid:"2", db:"a"}` both `a < b` and `b < a` were true — undefined behavior in any ordered container. Replaced the free `operator<`/`operator==` with defaulted member `==`/`<=>` (lexicographic over declaration order, matching the 4-part `uid.db.schema.rel` syntax). The dead `collection_name_hash` (commutative XOR: hashed `("a","b")` and `("b","a")` equal) is deleted. Pinned by comparator-law unit tests (asymmetry, trichotomy, equality consistency).

### 2. `table_id` stored its namespace parts in the wrong order

The `qualified_name_t` constructor emitted `[uid, schema, database]` — database **last** — while every consumer (`check_namespace_exists`, `check_collection_exists`, the executor's type-search-path builder) reads the **first** namespace part as the database. Correct by accident for 2-part `db.rel` names, wrong for 3/4-part ones. Now stores `[database, schema?, uid?]` with empty parts omitted, exposes a named `database()` accessor, and migrates the four `front()` readers to it. Deleted dead API: the two unused constructors (the vector form dereferenced `back()` of a possibly-empty vector), `to_pmr_string`, and the `std::hash<table_id>` specialization that consumed it.

Tests: `components/catalog/tests/test_identity_primitives.cpp` — 5 of 7 cases fail on main, all green after the fix. Full suite: ctest 181/181, all 21 component binaries pass.
