### PR TITLE
fix(storage): restart consistency — repeat-history replay, fenced compaction epochs, checkpoint fences

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,11 @@ if (ENABLE_TSAN)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -g -fno-omit-frame-pointer -fsanitize=thread")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=thread")
     add_compile_definitions(OTTERBRIX_TSAN_ENABLED)
+    # gcc's -Wmaybe-uninitialized false-positives on coroutine frame teardown
+    # under -fsanitize=thread (actor-zeta future awaiters); keep it a warning
+    # here so -Werror doesn't block the TSAN build. Same for -Wtsan: actor-zeta
+    # headers use atomic_thread_fence, which TSAN cannot model.
+    add_compile_options(-Wno-error=maybe-uninitialized -Wno-error=tsan)
 endif()
 
 if (ENABLE_UBSAN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,8 +108,11 @@ if (ENABLE_TSAN)
     # gcc's -Wmaybe-uninitialized false-positives on coroutine frame teardown
     # under -fsanitize=thread (actor-zeta future awaiters); keep it a warning
     # here so -Werror doesn't block the TSAN build. Same for -Wtsan: actor-zeta
-    # headers use atomic_thread_fence, which TSAN cannot model.
-    add_compile_options(-Wno-error=maybe-uninitialized -Wno-error=tsan)
+    # headers use atomic_thread_fence, which TSAN cannot model. gcc-only: clang
+    # has neither option and -Werror turns the unknown-option warning fatal.
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+        add_compile_options(-Wno-error=maybe-uninitialized -Wno-error=tsan)
+    endif()
 endif()
 
 if (ENABLE_UBSAN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,14 +105,6 @@ if (ENABLE_TSAN)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -g -fno-omit-frame-pointer -fsanitize=thread")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=thread")
     add_compile_definitions(OTTERBRIX_TSAN_ENABLED)
-    # gcc's -Wmaybe-uninitialized false-positives on coroutine frame teardown
-    # under -fsanitize=thread (actor-zeta future awaiters); keep it a warning
-    # here so -Werror doesn't block the TSAN build. Same for -Wtsan: actor-zeta
-    # headers use atomic_thread_fence, which TSAN cannot model. gcc-only: clang
-    # has neither option and -Werror turns the unknown-option warning fatal.
-    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-        add_compile_options(-Wno-error=maybe-uninitialized -Wno-error=tsan)
-    endif()
 endif()
 
 if (ENABLE_UBSAN)

--- a/components/physical_plan/operators/operator_abort_transaction.cpp
+++ b/components/physical_plan/operators/operator_abort_transaction.cpp
@@ -259,7 +259,7 @@ namespace components::operators {
             }
         }
 
-        // (4) I-2 scan-cursor sweep. A DELETE/UPDATE whose scan drained and captured physical
+        // (4) Mutating-scan cursor sweep. A DELETE/UPDATE whose scan drained and captured physical
         //     ids but whose apply never landed (this txn is aborting) leaves a mutating cursor
         //     RETAINED on the owning agent (awaiting_apply); it would keep deferring compaction of
         //     that oid until the session's next mutating open. Erase all of this session's cursors

--- a/components/physical_plan/operators/operator_abort_transaction.cpp
+++ b/components/physical_plan/operators/operator_abort_transaction.cpp
@@ -236,6 +236,21 @@ namespace components::operators {
             }
         }
 
+        // (4) I-2 scan-cursor sweep. A DELETE/UPDATE whose scan drained and captured physical
+        //     ids but whose apply never landed (this txn is aborting) leaves a mutating cursor
+        //     RETAINED on the owning agent (awaiting_apply); it would keep deferring compaction of
+        //     that oid until the session's next mutating open. Erase all of this session's cursors
+        //     now so reclaim deferral ends deterministically at abort ("cleared at apply OR txn
+        //     abort"). Session-keyed, one broadcast — unconditional (any statement in the txn may
+        //     have opened one), cheap on the rare abort path. The captured ids are discarded with
+        //     the txn, so nothing depends on the cursor surviving.
+        if (ctx->disk_address != actor_zeta::address_t::empty_address()) {
+            auto [_rs, rsf] = actor_zeta::send(ctx->disk_address,
+                                               &services::disk::manager_disk_t::release_scans_for_session,
+                                               ctx->session);
+            co_await std::move(rsf);
+        }
+
         output_ = nullptr;
         mark_executed();
         co_return;

--- a/components/physical_plan/operators/operator_abort_transaction.cpp
+++ b/components/physical_plan/operators/operator_abort_transaction.cpp
@@ -38,6 +38,7 @@ namespace components::operators {
         // physically removed (they were created mid-txn and never committed).
         std::vector<components::catalog::oid_t> dropped_storage_oids;
         std::vector<components::catalog::oid_t> created_storage_oids;
+        std::vector<components::table::dml_append_range_t> base_appends;
         std::vector<components::table::created_index_t> created_indexes;
         // Null-sender guard: with no dispatcher to talk to there is no txn to
         // drain or abort — leave the locals empty.
@@ -48,6 +49,7 @@ namespace components::operators {
             services::dispatcher::txn_abort_drain_t drain = co_await std::move(drf);
             txn_data = drain.txn;
             swap_appends = std::move(drain.swap_appends);
+            base_appends = std::move(drain.base_appends);
             base_append_tables = std::move(drain.base_append_tables);
             base_delete_tables = std::move(drain.base_delete_tables);
             pg_catalog_delete_tables = std::move(drain.pg_catalog_delete_tables);
@@ -65,6 +67,27 @@ namespace components::operators {
                                              swap_ctx,
                                              std::move(swap_appends));
             co_await std::move(rf);
+        }
+
+        // Retire the txn's base-table appends committed-dead IN PLACE. Abort
+        // reverts marks, never placement: the rows keep their physical ids (so
+        // positional WAL records written after this abort replay against the same
+        // numbering the live run used), but their pending insert stamps must not
+        // survive — a pending stamp trips has_version_above at every compaction
+        // site (commit-time, VACUUM, checkpoint) forever.
+        if (txn_data.transaction_id != 0 && !base_appends.empty() &&
+            ctx->disk_address != actor_zeta::address_t::empty_address()) {
+            std::vector<components::pg_catalog_append_range_t> abort_ranges;
+            abort_ranges.reserve(base_appends.size());
+            for (const auto& r : base_appends) {
+                abort_ranges.push_back(components::pg_catalog_append_range_t{r.table_oid, r.row_start, r.row_count});
+            }
+            components::execution_context_t abort_ctx{ctx->session, txn_data, {}};
+            auto [_aa, aaf] = actor_zeta::send(ctx->disk_address,
+                                               &services::disk::manager_disk_t::storage_abort_appends,
+                                               abort_ctx,
+                                               std::move(abort_ranges));
+            co_await std::move(aaf);
         }
 
         // Index revert: drop this txn's PENDING in-memory index entries for every

--- a/components/physical_plan/operators/operator_create_index_backfill.cpp
+++ b/components/physical_plan/operators/operator_create_index_backfill.cpp
@@ -137,7 +137,8 @@ namespace components::operators {
                                      std::unique_ptr<components::table::table_filter_t>(nullptr),
                                      int64_t{-1}, // unbounded — index every row
                                      std::vector<size_t>{}, // empty == read all columns
-                                     ctx->txn);
+                                     ctx->txn,
+                                     /*mutating=*/false); // read-only backfill (builds the index)
                 auto fetch_result = co_await std::move(fbf);
                 if (fetch_result.has_error()) {
                     set_error(fetch_result.error());

--- a/components/physical_plan/operators/operator_delete.cpp
+++ b/components/physical_plan/operators/operator_delete.cpp
@@ -343,13 +343,17 @@ namespace components::operators {
             co_return;
         }
 
-        // Flush the buffered matched-id slice, if any. The divergent DELETE storage op
-        // (WAL-first physical_delete, then storage_delete_rows, then the index mirror)
-        // lives in the NAMED coroutine lambda `op`, which yields a flush_outcome_t;
-        // record_flush() then does the COMMON post-storage bookkeeping (constraint
-        // accumulation when a parent constraint sits above the DML). DELETE writes its
-        // OWN WAL (unlike INSERT, where the disk agent owns it) and appends
-        // nothing, so the outcome carries no append range.
+        // Flush the buffered matched-id slice, if any. The DELETE storage op
+        // (storage_delete_rows, then the index mirror) lives in the NAMED coroutine
+        // lambda `op`, which yields a flush_outcome_t; record_flush() then does the
+        // COMMON post-storage bookkeeping (constraint accumulation when a parent
+        // constraint sits above the DML). The disk agent owns the WAL record now (I-1),
+        // exactly as it does for INSERT and UPDATE: storage_delete_rows_inner writes the
+        // PHYSICAL_DELETE after the mutation, inside its mailbox turn, so the wal_id is
+        // minted in apply order and no same-oid compaction can slip between the mark and
+        // the record. DELETE appends nothing, so the outcome carries no append range.
+        // Durability is the commit's FULL-sync COMMIT record (which flushes all preceding
+        // WAL), so no per-op flush is added here.
         if (modified_ && modified_->size() > 0) {
             const bool mirror_index =
                 ctx->index_address != actor_zeta::address_t::empty_address() && !index_old_chunks_.empty();
@@ -360,39 +364,8 @@ namespace components::operators {
                 auto& ids = modified_->ids();
                 const size_t modified_size = modified_->size();
 
-                // 1. WAL-FIRST: physical_delete BEFORE the storage mark, so a crash
-                //    between the two replays the delete (uncommitted deletes are
-                //    filtered by replay). The row_ids come from the upstream scan, so
-                //    they are fully known before any storage mutation — unlike INSERT
-                //    (whose final count depends on dedup), DELETE has no post-op
-                //    dependency, so it adopts the same WAL-first ordering the catalog
-                //    delete uses (delete_pg_catalog_rows_inner).
-                if (ctx->wal_address != actor_zeta::address_t::empty_address()) {
-                    std::pmr::vector<int64_t> wal_row_ids(res);
-                    wal_row_ids.reserve(modified_size);
-                    for (size_t i = 0; i < modified_size; i++) {
-                        wal_row_ids.push_back(static_cast<int64_t>(ids[i]));
-                    }
-                    auto count = static_cast<uint64_t>(wal_row_ids.size());
-                    // See operator_insert comment on db_oid temporary hardcode.
-                    constexpr auto db_oid = components::catalog::well_known_oid::main_database;
-                    auto [_w, wf] = actor_zeta::send(ctx->wal_address,
-                                                     &services::wal::manager_wal_replicate_t::write_physical_delete,
-                                                     ctx->session,
-                                                     table_oid_,
-                                                     std::move(wal_row_ids),
-                                                     count,
-                                                     ctx->txn.transaction_id,
-                                                     db_oid);
-                    auto wal_id = co_await std::move(wf);
-                    auto [_df2, dff] = actor_zeta::send(ctx->disk_address,
-                                                        &services::disk::manager_disk_t::flush,
-                                                        ctx->session,
-                                                        wal_id);
-                    ctx->add_pending_disk_future(std::move(dff));
-                }
-
-                // 2. storage_delete_rows — mark the rows deleted under this txn (MVCC).
+                // storage_delete_rows — mark the rows deleted under this txn (MVCC) AND
+                // write the PHYSICAL_DELETE record (agent-owned, I-1).
                 vector_t row_ids(res, types::logical_type::BIGINT, modified_size);
                 for (size_t i = 0; i < modified_size; i++) {
                     row_ids.data<int64_t>()[i] = static_cast<int64_t>(ids[i]);

--- a/components/physical_plan/operators/operator_delete.cpp
+++ b/components/physical_plan/operators/operator_delete.cpp
@@ -462,9 +462,11 @@ namespace components::operators {
         // apply that releases the retained mutating scan pin (release_mutating_scans
         // at storage_delete_rows_inner's top) cannot fire now, and the mid-pump
         // applies could not release it (the cursor was still open when they landed).
-        // No later statement can sweep the pin either — sessions are minted per
-        // statement — so release explicitly with the same broadcast the abort path
-        // uses, or compaction of the target table defers forever.
+        // No later statement is guaranteed to sweep the pin either — an autocommit
+        // statement's session dies with the statement, and only statements inside one
+        // explicit transaction share a session — so release explicitly with the same
+        // broadcast the abort path uses, or compaction of the target table defers
+        // forever.
         if (!flushing_now && ctx->disk_address != actor_zeta::address_t::empty_address()) {
             auto [_rs, rsf] = actor_zeta::send(ctx->disk_address,
                                                &services::disk::manager_disk_t::release_scans_for_session,

--- a/components/physical_plan/operators/operator_delete.cpp
+++ b/components/physical_plan/operators/operator_delete.cpp
@@ -354,7 +354,8 @@ namespace components::operators {
         // the record. DELETE appends nothing, so the outcome carries no append range.
         // Durability is the commit's FULL-sync COMMIT record (which flushes all preceding
         // WAL), so no per-op flush is added here.
-        if (modified_ && modified_->size() > 0) {
+        const bool flushing_now = modified_ && modified_->size() > 0;
+        if (flushing_now) {
             const bool mirror_index =
                 ctx->index_address != actor_zeta::address_t::empty_address() && !index_old_chunks_.empty();
 
@@ -453,6 +454,22 @@ namespace components::operators {
         // Mid-pump flush: emit nothing, keep accumulating for the next call.
         if (!is_final) {
             co_return;
+        }
+
+        // I-2 zero-apply release. This FINAL drive flushed nothing — either the DML
+        // matched zero rows, or the matched count was an exact multiple of the flush
+        // threshold so the last mid-pump flush drained the buffer. Either way the
+        // apply that releases the retained mutating scan pin (release_mutating_scans
+        // at storage_delete_rows_inner's top) cannot fire now, and the mid-pump
+        // applies could not release it (the cursor was still open when they landed).
+        // No later statement can sweep the pin either — sessions are minted per
+        // statement — so release explicitly with the same broadcast the abort path
+        // uses, or compaction of the target table defers forever.
+        if (!flushing_now && ctx->disk_address != actor_zeta::address_t::empty_address()) {
+            auto [_rs, rsf] = actor_zeta::send(ctx->disk_address,
+                                               &services::disk::manager_disk_t::release_scans_for_session,
+                                               ctx->session);
+            co_await std::move(rsf);
         }
 
         // FINAL: with RETURNING, drain the staged RETURNING accumulator. Without

--- a/components/physical_plan/operators/operator_delete.cpp
+++ b/components/physical_plan/operators/operator_delete.cpp
@@ -347,7 +347,7 @@ namespace components::operators {
         // (storage_delete_rows, then the index mirror) lives in the NAMED coroutine
         // lambda `op`, which yields a flush_outcome_t; record_flush() then does the
         // COMMON post-storage bookkeeping (constraint accumulation when a parent
-        // constraint sits above the DML). The disk agent owns the WAL record now (I-1),
+        // constraint sits above the DML). The disk agent owns the WAL record now,
         // exactly as it does for INSERT and UPDATE: storage_delete_rows_inner writes the
         // PHYSICAL_DELETE after the mutation, inside its mailbox turn, so the wal_id is
         // minted in apply order and no same-oid compaction can slip between the mark and
@@ -366,7 +366,7 @@ namespace components::operators {
                 const size_t modified_size = modified_->size();
 
                 // storage_delete_rows — mark the rows deleted under this txn (MVCC) AND
-                // write the PHYSICAL_DELETE record (agent-owned, I-1).
+                // write the PHYSICAL_DELETE record (agent-owned).
                 vector_t row_ids(res, types::logical_type::BIGINT, modified_size);
                 for (size_t i = 0; i < modified_size; i++) {
                     row_ids.data<int64_t>()[i] = static_cast<int64_t>(ids[i]);
@@ -456,7 +456,7 @@ namespace components::operators {
             co_return;
         }
 
-        // I-2 zero-apply release. This FINAL drive flushed nothing — either the DML
+        // Zero-apply release. This FINAL drive flushed nothing — either the DML
         // matched zero rows, or the matched count was an exact multiple of the flush
         // threshold so the last mid-pump flush drained the buffer. Either way the
         // apply that releases the retained mutating scan pin (release_mutating_scans

--- a/components/physical_plan/operators/operator_update.cpp
+++ b/components/physical_plan/operators/operator_update.cpp
@@ -308,7 +308,8 @@ namespace components::operators {
         // single flush.
         const bool is_final = ctx->dml_flush_is_final;
 
-        if (output_ && output_->size() > 0) {
+        const bool flushing_now = output_ && output_->size() > 0;
+        if (flushing_now) {
             // See operator_insert comment on db_oid temporary hardcode. The agent writes
             // this UPDATE's WAL record, so the database oid travels with the context.
             constexpr auto db_oid = components::catalog::well_known_oid::main_database;
@@ -494,6 +495,22 @@ namespace components::operators {
         // mark executed. Only the final drive finalizes.
         if (!is_final) {
             co_return;
+        }
+
+        // I-2 zero-apply release. This FINAL drive flushed nothing — either the UPDATE
+        // matched zero rows, or the matched count was an exact multiple of the flush
+        // threshold so the last mid-pump flush drained the buffer. Either way the apply
+        // that releases the retained mutating scan pin (release_mutating_scans at
+        // storage_update_inner's top) cannot fire now, and the mid-pump applies could
+        // not release it (the cursor was still open when they landed). No later
+        // statement can sweep the pin either — sessions are minted per statement — so
+        // release explicitly with the same broadcast the abort path uses, or compaction
+        // of the target table defers forever.
+        if (!flushing_now && ctx->disk_address != actor_zeta::address_t::empty_address()) {
+            auto [_rs, rsf] = actor_zeta::send(ctx->disk_address,
+                                               &services::disk::manager_disk_t::release_scans_for_session,
+                                               ctx->session);
+            co_await std::move(rsf);
         }
 
         // FINAL. output_ was cleared per flush, so it cannot double as the

--- a/components/physical_plan/operators/operator_update.cpp
+++ b/components/physical_plan/operators/operator_update.cpp
@@ -309,9 +309,14 @@ namespace components::operators {
         const bool is_final = ctx->dml_flush_is_final;
 
         if (output_ && output_->size() > 0) {
-            components::execution_context_t exec_ctx{ctx->session, ctx->txn, ctx->session_tz, table_oid_};
-            // See operator_insert comment on db_oid temporary hardcode.
+            // See operator_insert comment on db_oid temporary hardcode. The agent writes
+            // this UPDATE's WAL record, so the database oid travels with the context.
             constexpr auto db_oid = components::catalog::well_known_oid::main_database;
+            components::execution_context_t exec_ctx{ctx->session,
+                                                     ctx->txn,
+                                                     ctx->session_tz,
+                                                     table_oid_,
+                                                     db_oid};
             const bool mirror_index = ctx->index_address != actor_zeta::address_t::empty_address();
 
             // STREAMING invariant: consume_batch_/consume_join_batch_ stage exactly one
@@ -337,8 +342,6 @@ namespace components::operators {
 
                 chunks_vector_t update_data(resource_);               // storage_update payload (mutated)
                 std::pmr::vector<vector_t> update_row_ids(resource_); // storage_update row_ids, one per chunk
-                chunks_vector_t wal_chunks(resource_);                // WAL payload (submitted new rows)
-                std::pmr::vector<int64_t> wal_row_ids(resource_);     // WAL row_ids, flat
                 chunks_vector_t idx_old(resource_);                   // index: old row versions, one per chunk
                 chunks_vector_t idx_new(resource_);                   // index: new rows, one per chunk
                 std::pmr::vector<int64_t> idx_row_ids(resource_);     // index row_ids, flat
@@ -357,12 +360,6 @@ namespace components::operators {
                     }
                     update_row_ids.emplace_back(std::move(row_ids));
                     update_data.emplace_back(copy_of(out_chunk));
-
-                    // WAL needs the submitted new rows + their flat row_ids.
-                    wal_chunks.emplace_back(copy_of(out_chunk));
-                    for (uint64_t i = 0; i < n; i++) {
-                        wal_row_ids.push_back(out_chunk.row_ids.data<int64_t>()[i]);
-                    }
 
                     // Index needs the n old row versions + the new rows and their ids.
                     // index_old_chunks_[out_chunk_idx] is this updated chunk's OLD
@@ -422,31 +419,16 @@ namespace components::operators {
                 }
                 auto [range_start, total_count] = update_result.value();
 
-                // 3. WAL physical_update: one record for THIS flushed range. UPDATE
-                //    owns its WAL write (unlike INSERT's WAL-first storage_append).
-                //    row_start is `range_start` -- where the MVCC update's new rows were
-                //    actually appended. The record's row_ids are the OLD locations, which
-                //    replay tombstones; a consumer that needs the NEW ones (the CREATE
-                //    INDEX WAL catch-up) reads them off row_start.
-                if (ctx->wal_address != actor_zeta::address_t::empty_address()) {
-                    const uint64_t wal_count = wal_row_ids.size();
-                    auto [_w, wf] = actor_zeta::send(ctx->wal_address,
-                                                     &services::wal::manager_wal_replicate_t::write_physical_update,
-                                                     ctx->session,
-                                                     table_oid_,
-                                                     std::move(wal_row_ids),
-                                                     std::move(wal_chunks),
-                                                     static_cast<uint64_t>(range_start),
-                                                     wal_count,
-                                                     ctx->txn.transaction_id,
-                                                     db_oid);
-                    auto wal_id = co_await std::move(wf);
-                    auto [_df, dff] = actor_zeta::send(ctx->disk_address,
-                                                       &services::disk::manager_disk_t::flush,
-                                                       ctx->session,
-                                                       wal_id);
-                    ctx->add_pending_disk_future(std::move(dff));
-                }
+                // 3. The WAL record is written by the disk AGENT, inside the same handler
+                //    that performed the mutation (storage_update_inner), exactly as
+                //    PHYSICAL_INSERT is. It cannot be written from here: an MVCC update
+                //    APPENDS its new rows, so it consumes row-ids, and between this
+                //    operator's storage_update returning and its WAL send another
+                //    session's append can land -- minting a LOWER wal_id for a HIGHER
+                //    row-id. Replay, which rebuilds the row-id space by walking the WAL
+                //    in id order, would then place the two rows swapped. Owning the WAL
+                //    write inside the agent's mailbox-atomic handler is what makes the
+                //    replayed row-id space equal the live one.
 
                 // 4. Mirror to index (old + new data) — one batched send. idx_old came
                 //    from the streaming staging (index_old_chunks_), aligned row-for-row

--- a/components/physical_plan/operators/operator_update.cpp
+++ b/components/physical_plan/operators/operator_update.cpp
@@ -509,7 +509,7 @@ namespace components::operators {
             co_return;
         }
 
-        // I-2 zero-apply release. This FINAL drive flushed nothing — either the UPDATE
+        // Zero-apply release. This FINAL drive flushed nothing — either the UPDATE
         // matched zero rows, or the matched count was an exact multiple of the flush
         // threshold so the last mid-pump flush drained the buffer. Either way the apply
         // that releases the retained mutating scan pin (release_mutating_scans at

--- a/components/physical_plan/operators/operator_update.cpp
+++ b/components/physical_plan/operators/operator_update.cpp
@@ -424,6 +424,10 @@ namespace components::operators {
 
                 // 3. WAL physical_update: one record for THIS flushed range. UPDATE
                 //    owns its WAL write (unlike INSERT's WAL-first storage_append).
+                //    row_start is `range_start` -- where the MVCC update's new rows were
+                //    actually appended. The record's row_ids are the OLD locations, which
+                //    replay tombstones; a consumer that needs the NEW ones (the CREATE
+                //    INDEX WAL catch-up) reads them off row_start.
                 if (ctx->wal_address != actor_zeta::address_t::empty_address()) {
                     const uint64_t wal_count = wal_row_ids.size();
                     auto [_w, wf] = actor_zeta::send(ctx->wal_address,
@@ -432,6 +436,7 @@ namespace components::operators {
                                                      table_oid_,
                                                      std::move(wal_row_ids),
                                                      std::move(wal_chunks),
+                                                     static_cast<uint64_t>(range_start),
                                                      wal_count,
                                                      ctx->txn.transaction_id,
                                                      db_oid);

--- a/components/physical_plan/operators/operator_update.cpp
+++ b/components/physical_plan/operators/operator_update.cpp
@@ -310,8 +310,10 @@ namespace components::operators {
 
         const bool flushing_now = output_ && output_->size() > 0;
         if (flushing_now) {
-            // See operator_insert comment on db_oid temporary hardcode. The agent writes
-            // this UPDATE's WAL record, so the database oid travels with the context.
+            // The executor does not propagate the catalog database onto the DML context
+            // (ctx->database_oid stays INVALID), so user-table DML resolves to
+            // main_database. The agent writes this UPDATE's WAL record, so the database
+            // oid travels with the context.
             constexpr auto db_oid = components::catalog::well_known_oid::main_database;
             components::execution_context_t exec_ctx{ctx->session,
                                                      ctx->txn,
@@ -503,9 +505,10 @@ namespace components::operators {
         // that releases the retained mutating scan pin (release_mutating_scans at
         // storage_update_inner's top) cannot fire now, and the mid-pump applies could
         // not release it (the cursor was still open when they landed). No later
-        // statement can sweep the pin either — sessions are minted per statement — so
-        // release explicitly with the same broadcast the abort path uses, or compaction
-        // of the target table defers forever.
+        // statement is guaranteed to sweep the pin either — an autocommit statement's
+        // session dies with the statement, and only statements inside one explicit
+        // transaction share a session — so release explicitly with the same broadcast
+        // the abort path uses, or compaction of the target table defers forever.
         if (!flushing_now && ctx->disk_address != actor_zeta::address_t::empty_address()) {
             auto [_rs, rsf] = actor_zeta::send(ctx->disk_address,
                                                &services::disk::manager_disk_t::release_scans_for_session,

--- a/components/physical_plan/operators/operator_update.cpp
+++ b/components/physical_plan/operators/operator_update.cpp
@@ -16,10 +16,15 @@ namespace components::operators {
 #ifdef DEV_MODE
     namespace {
         std::atomic<uint64_t> g_update_storage_update_sends{0};
+        // One-shot fault injection: fail the statement in the drain->apply window —
+        // after the mutating scan retired awaiting-apply, before storage_update is
+        // sent — the same window a RETURNING projection error fails in.
+        std::atomic<bool> g_update_fail_before_apply{false};
     } // namespace
     uint64_t update_storage_update_sends() noexcept {
         return g_update_storage_update_sends.load(std::memory_order_relaxed);
     }
+    void arm_update_fail_before_apply() noexcept { g_update_fail_before_apply.store(true, std::memory_order_relaxed); }
 #endif
 
     operator_update::operator_update(std::pmr::memory_resource* resource,
@@ -408,6 +413,11 @@ namespace components::operators {
                 //    table-layer MVCC update as a value; surface it as a clean error so
                 //    the txn aborts gracefully.
 #ifdef DEV_MODE
+                if (g_update_fail_before_apply.exchange(false, std::memory_order_relaxed)) {
+                    co_return dml_detail::flush_outcome_t{
+                        core::error_t(core::error_code_t::arithmetics_failure,
+                                      std::pmr::string{"injected pre-apply failure", res})};
+                }
                 g_update_storage_update_sends.fetch_add(1, std::memory_order_relaxed);
 #endif
                 auto [_u, uf] = actor_zeta::send(ctx->disk_address,

--- a/components/physical_plan/operators/operator_update.hpp
+++ b/components/physical_plan/operators/operator_update.hpp
@@ -16,6 +16,7 @@ namespace components::operators {
     // RETURNING projection error) must leave this counter untouched. Process-global
     // + relaxed: coarse instrumentation, mirroring create_index_backfill_batches().
     uint64_t update_storage_update_sends() noexcept;
+    void arm_update_fail_before_apply() noexcept;
 #endif
 
     class operator_update final : public read_write_operator_t {

--- a/components/physical_plan/operators/scan/full_scan.cpp
+++ b/components/physical_plan/operators/scan/full_scan.cpp
@@ -316,7 +316,8 @@ namespace components::operators {
                                              std::move(filter),
                                              scan_limit,
                                              projected_cols_,
-                                             ctx->txn);
+                                             ctx->txn,
+                                             mutating_);
             auto fetch_result = co_await std::move(sf);
             if (fetch_result.has_error()) {
                 set_error(fetch_result.error());
@@ -329,6 +330,8 @@ namespace components::operators {
         }
 
         // ADVANCE: read one more batch from the open cursor (filter dropped — the agent owns it).
+        // mutating_ is an OPEN-time attribute (the agent reads it only when minting the cursor); it
+        // is forwarded here purely for call-site uniformity.
         auto [_s, sf] = actor_zeta::send(ctx->disk_address,
                                          &services::disk::manager_disk_t::storage_fetch_next_batch,
                                          ctx->session,
@@ -337,7 +340,8 @@ namespace components::operators {
                                          std::unique_ptr<table::table_filter_t>(nullptr),
                                          int64_t{-1},
                                          projected_cols_,
-                                         ctx->txn);
+                                         ctx->txn,
+                                         mutating_);
         auto fetch_result = co_await std::move(sf);
         if (fetch_result.has_error()) {
             set_error(fetch_result.error());

--- a/components/physical_plan/operators/scan/full_scan.hpp
+++ b/components/physical_plan/operators/scan/full_scan.hpp
@@ -34,6 +34,15 @@ namespace components::operators {
         const expressions::compare_expression_ptr& expression() const { return expression_; }
         const logical_plan::limit_t& limit() const { return limit_; }
         const std::vector<size_t>& projected_cols() const noexcept { return projected_cols_; }
+        components::catalog::oid_t table_oid() const noexcept { return table_oid_; }
+
+        // I-2: mark this scan as the id-source of a DELETE/UPDATE. The DML planner calls this so
+        // the OPEN fetch tells the owning agent to RETAIN the cursor past drain (awaiting_apply) —
+        // has_active_scan_for_oid then keeps deferring compaction of table_oid across the whole
+        // capture->apply window, so a commit-time / VACUUM compaction can never renumber the rows
+        // out from under the physical ids this scan hands to the mutation operator. Plain SELECT
+        // scans leave it false (cursor GC'd on drain, as before).
+        void mark_mutating() noexcept { mutating_ = true; }
 
         // --- Push-based streaming pipeline source (PER-BATCH FETCH-NEXT, bounded) ---
         // role()==source drives the streaming push/finalize pipeline. The FIRST source_next call
@@ -95,6 +104,7 @@ namespace components::operators {
         bool opened_{false};
         bool drained_{false};
         bool emitted_any_{false};
+        bool mutating_{false}; // I-2: DELETE/UPDATE id-source ⇒ agent retains the cursor past drain
         uint64_t cursor_id_{0};
         std::pmr::vector<types::complex_logical_type> guard_types_{resource_};
     };

--- a/components/physical_plan/operators/scan/full_scan.hpp
+++ b/components/physical_plan/operators/scan/full_scan.hpp
@@ -36,7 +36,7 @@ namespace components::operators {
         const std::vector<size_t>& projected_cols() const noexcept { return projected_cols_; }
         components::catalog::oid_t table_oid() const noexcept { return table_oid_; }
 
-        // I-2: mark this scan as the id-source of a DELETE/UPDATE. The DML planner calls this so
+        // Mark this scan as the id-source of a DELETE/UPDATE. The DML planner calls this so
         // the OPEN fetch tells the owning agent to RETAIN the cursor past drain (awaiting_apply) —
         // has_active_scan_for_oid then keeps deferring compaction of table_oid across the whole
         // capture->apply window, so a commit-time / VACUUM compaction can never renumber the rows
@@ -104,7 +104,7 @@ namespace components::operators {
         bool opened_{false};
         bool drained_{false};
         bool emitted_any_{false};
-        bool mutating_{false}; // I-2: DELETE/UPDATE id-source ⇒ agent retains the cursor past drain
+        bool mutating_{false}; // DELETE/UPDATE id-source ⇒ agent retains the cursor past drain
         uint64_t cursor_id_{0};
         std::pmr::vector<types::complex_logical_type> guard_types_{resource_};
     };

--- a/components/physical_plan/operators/scan/full_scan.hpp
+++ b/components/physical_plan/operators/scan/full_scan.hpp
@@ -41,7 +41,7 @@ namespace components::operators {
         // has_active_scan_for_oid then keeps deferring compaction of table_oid across the whole
         // capture->apply window, so a commit-time / VACUUM compaction can never renumber the rows
         // out from under the physical ids this scan hands to the mutation operator. Plain SELECT
-        // scans leave it false (cursor GC'd on drain, as before).
+        // scans leave it false (cursor GC'd on drain).
         void mark_mutating() noexcept { mutating_ = true; }
 
         // --- Push-based streaming pipeline source (PER-BATCH FETCH-NEXT, bounded) ---

--- a/components/physical_plan/operators/scan/transfer_scan.cpp
+++ b/components/physical_plan/operators/scan/transfer_scan.cpp
@@ -69,7 +69,8 @@ namespace components::operators {
                                              std::unique_ptr<table::table_filter_t>(nullptr),
                                              scan_limit,
                                              projected_cols_,
-                                             ctx->txn);
+                                             ctx->txn,
+                                             mutating_);
             auto fetch_result = co_await std::move(sf);
             if (fetch_result.has_error()) {
                 set_error(fetch_result.error());
@@ -90,7 +91,8 @@ namespace components::operators {
                                          std::unique_ptr<table::table_filter_t>(nullptr),
                                          int64_t{-1},
                                          projected_cols_,
-                                         ctx->txn);
+                                         ctx->txn,
+                                         mutating_);
         auto fetch_result = co_await std::move(sf);
         if (fetch_result.has_error()) {
             set_error(fetch_result.error());

--- a/components/physical_plan/operators/scan/transfer_scan.hpp
+++ b/components/physical_plan/operators/scan/transfer_scan.hpp
@@ -29,7 +29,7 @@ namespace components::operators {
         const std::vector<size_t>& projected_cols() const noexcept { return projected_cols_; }
         components::catalog::oid_t table_oid() const noexcept { return table_oid_; }
 
-        // I-2: mark this scan as the id-source of a whole-table DELETE/UPDATE (no WHERE ⇒
+        // Mark this scan as the id-source of a whole-table DELETE/UPDATE (no WHERE ⇒
         // create_plan_match lowers the target to a transfer_scan). Same contract as
         // full_scan::mark_mutating — the OPEN fetch asks the owning agent to retain the cursor
         // past drain so compaction of table_oid defers across the capture->apply window. A
@@ -89,7 +89,7 @@ namespace components::operators {
         bool drained_{false};
         bool emitted_any_{false};
         bool guard_types_loaded_{false};
-        bool mutating_{false}; // I-2: whole-table DELETE/UPDATE id-source ⇒ agent retains the cursor
+        bool mutating_{false}; // whole-table DELETE/UPDATE id-source ⇒ agent retains the cursor
         uint64_t cursor_id_{0};
         std::pmr::vector<types::complex_logical_type> guard_types_{resource_};
     };

--- a/components/physical_plan/operators/scan/transfer_scan.hpp
+++ b/components/physical_plan/operators/scan/transfer_scan.hpp
@@ -27,6 +27,15 @@ namespace components::operators {
         // Storage-chunk column indices the scan projects (empty ⇒ all columns), so a downstream
         // group/select sees the SAME projected column layout it expects.
         const std::vector<size_t>& projected_cols() const noexcept { return projected_cols_; }
+        components::catalog::oid_t table_oid() const noexcept { return table_oid_; }
+
+        // I-2: mark this scan as the id-source of a whole-table DELETE/UPDATE (no WHERE ⇒
+        // create_plan_match lowers the target to a transfer_scan). Same contract as
+        // full_scan::mark_mutating — the OPEN fetch asks the owning agent to retain the cursor
+        // past drain so compaction of table_oid defers across the capture->apply window. A
+        // transfer_scan reading an INSERT..SELECT / CTAS source (not a mutation target) leaves it
+        // false.
+        void mark_mutating() noexcept { mutating_ = true; }
 
         // --- Push-based streaming pipeline source (PER-BATCH FETCH-NEXT, bounded) ---
         // role()==source drives the streaming push/finalize pipeline. The FIRST source_next OPENs a
@@ -80,6 +89,7 @@ namespace components::operators {
         bool drained_{false};
         bool emitted_any_{false};
         bool guard_types_loaded_{false};
+        bool mutating_{false}; // I-2: whole-table DELETE/UPDATE id-source ⇒ agent retains the cursor
         uint64_t cursor_id_{0};
         std::pmr::vector<types::complex_logical_type> guard_types_{resource_};
     };

--- a/components/physical_plan_generator/impl/create_plan_delete.cpp
+++ b/components/physical_plan_generator/impl/create_plan_delete.cpp
@@ -68,7 +68,11 @@ namespace services::planner::impl {
                                                                                         context.log.clone(),
                                                                                         table_oid,
                                                                                         std::move(returning)));
-            plan->set_children(create_plan_match(context, node_match, limit));
+            // I-2: the predicate scan is this DELETE's physical-id source — mark it mutating so the
+            // owning agent defers compaction of table_oid across its capture->apply window.
+            auto match_scan = create_plan_match(context, node_match, limit);
+            mark_mutation_target_scan(match_scan, table_oid);
+            plan->set_children(std::move(match_scan));
 
             return plan;
         }
@@ -84,12 +88,18 @@ namespace services::planner::impl {
                                                                                     std::move(returning),
                                                                                     *expr,
                                                                                     limit.limit()));
+        // I-2: the target-table scan (LEFT child) sources the row_ids this DELETE applies; mark ONLY
+        // it mutating. The USING source (RIGHT child) is a read even when it scans the same oid, so
+        // it stays non-mutating — one mutating cursor per (oid, session) (HOLE B invariant).
+        auto target_scan = boost::intrusive_ptr(
+            new components::operators::full_scan(context.resource,
+                                                 context.log.clone(),
+                                                 table_oid,
+                                                 nullptr,
+                                                 components::logical_plan::limit_t::unlimit()));
+        target_scan->mark_mutating();
         plan->set_children(
-            boost::intrusive_ptr(new components::operators::full_scan(context.resource,
-                                                                      context.log.clone(),
-                                                                      table_oid,
-                                                                      nullptr,
-                                                                      components::logical_plan::limit_t::unlimit())),
+            std::move(target_scan),
             create_plan(context, function_registry, node_source, components::logical_plan::limit_t::unlimit(), params));
         return plan;
     }

--- a/components/physical_plan_generator/impl/create_plan_delete.cpp
+++ b/components/physical_plan_generator/impl/create_plan_delete.cpp
@@ -68,7 +68,7 @@ namespace services::planner::impl {
                                                                                         context.log.clone(),
                                                                                         table_oid,
                                                                                         std::move(returning)));
-            // I-2: the predicate scan is this DELETE's physical-id source — mark it mutating so the
+            // The predicate scan is this DELETE's physical-id source — mark it mutating so the
             // owning agent defers compaction of table_oid across its capture->apply window.
             auto match_scan = create_plan_match(context, node_match, limit);
             mark_mutation_target_scan(match_scan, table_oid);
@@ -88,9 +88,9 @@ namespace services::planner::impl {
                                                                                     std::move(returning),
                                                                                     *expr,
                                                                                     limit.limit()));
-        // I-2: the target-table scan (LEFT child) sources the row_ids this DELETE applies; mark ONLY
+        // The target-table scan (LEFT child) sources the row_ids this DELETE applies; mark ONLY
         // it mutating. The USING source (RIGHT child) is a read even when it scans the same oid, so
-        // it stays non-mutating — one mutating cursor per (oid, session) (HOLE B invariant).
+        // it stays non-mutating — one mutating cursor per (oid, session).
         auto target_scan = boost::intrusive_ptr(
             new components::operators::full_scan(context.resource,
                                                  context.log.clone(),

--- a/components/physical_plan_generator/impl/create_plan_match.cpp
+++ b/components/physical_plan_generator/impl/create_plan_match.cpp
@@ -243,4 +243,38 @@ namespace services::planner::impl {
                                                                                  node->expressions()[0]));
     }
 
+    void mark_mutation_target_scan(const components::operators::operator_ptr& root,
+                                   components::catalog::oid_t target_oid) {
+        using components::operators::operator_type;
+        // Descend the LEFT spine: create_plan_match lowers a DML target to either a bare
+        // full_scan / index_scan / transfer_scan, or that scan under a single-child wrapper
+        // (operator_match_t for a non-pure-compare predicate), which is always the left child.
+        // The USING/FROM source (when present) is the operator_delete/update's RIGHT child, so it
+        // is never on this spine — that is what keeps the single-mutating-scan invariant (HOLE B).
+        for (auto op = root; op != nullptr; op = op->left()) {
+            switch (op->type()) {
+                case operator_type::full_scan: {
+                    auto* fs = static_cast<components::operators::full_scan*>(op.get());
+                    if (fs->table_oid() == target_oid) {
+                        fs->mark_mutating();
+                    }
+                    return;
+                }
+                case operator_type::transfer_scan: {
+                    auto* ts = static_cast<components::operators::transfer_scan*>(op.get());
+                    if (ts->table_oid() == target_oid) {
+                        ts->mark_mutating();
+                    }
+                    return;
+                }
+                case operator_type::index_scan:
+                    // One-shot fetch, no cursor; index_scan only runs on INDEXED tables, which are
+                    // excluded from every compaction site — nothing renumbers under its captured ids.
+                    return;
+                default:
+                    break;
+            }
+        }
+    }
+
 } // namespace services::planner::impl

--- a/components/physical_plan_generator/impl/create_plan_match.cpp
+++ b/components/physical_plan_generator/impl/create_plan_match.cpp
@@ -254,7 +254,7 @@ namespace services::planner::impl {
         // full_scan / index_scan / transfer_scan, or that scan under a single-child wrapper
         // (operator_match_t for a non-pure-compare predicate), which is always the left child.
         // The USING/FROM source (when present) is the operator_delete/update's RIGHT child, so it
-        // is never on this spine — that is what keeps the single-mutating-scan invariant (HOLE B).
+        // is never on this spine — that is what keeps the single-mutating-scan invariant.
         for (auto op = root; op != nullptr; op = op->left()) {
             switch (op->type()) {
                 case operator_type::full_scan: {

--- a/components/physical_plan_generator/impl/create_plan_match.cpp
+++ b/components/physical_plan_generator/impl/create_plan_match.cpp
@@ -171,7 +171,11 @@ namespace services::planner::impl {
                     return match_operator;
                 }
             } else {
-                return boost::intrusive_ptr(new components::operators::operator_match_t(nullptr, log_t{}, expr, limit));
+                // The sourceless no-table match still owns pmr members (stream_types_ is
+                // constructed from resource_), so it needs a real resource: a null one
+                // violates polymorphic_allocator's nonnull contract at construction.
+                return boost::intrusive_ptr(
+                    new components::operators::operator_match_t(context.resource, context.log.clone(), expr, limit));
             }
         }
     } // namespace

--- a/components/physical_plan_generator/impl/create_plan_match.hpp
+++ b/components/physical_plan_generator/impl/create_plan_match.hpp
@@ -20,7 +20,7 @@ namespace services::planner::impl {
     components::operators::operator_ptr create_plan_having(const context_storage_t& context,
                                                            const components::logical_plan::node_ptr& node);
 
-    // I-2: descend `root`'s left spine to the physical scan that SOURCES the target table's
+    // Descend `root`'s left spine to the physical scan that SOURCES the target table's
     // physical row_ids for an enclosing DELETE/UPDATE and mark exactly that ONE scan mutating,
     // so the owning disk agent retains its streaming cursor past drain (has_active_scan_for_oid
     // then keeps deferring compaction across the capture->apply window). Marking a SINGLE scan

--- a/components/physical_plan_generator/impl/create_plan_match.hpp
+++ b/components/physical_plan_generator/impl/create_plan_match.hpp
@@ -20,4 +20,17 @@ namespace services::planner::impl {
     components::operators::operator_ptr create_plan_having(const context_storage_t& context,
                                                            const components::logical_plan::node_ptr& node);
 
+    // I-2: descend `root`'s left spine to the physical scan that SOURCES the target table's
+    // physical row_ids for an enclosing DELETE/UPDATE and mark exactly that ONE scan mutating,
+    // so the owning disk agent retains its streaming cursor past drain (has_active_scan_for_oid
+    // then keeps deferring compaction across the capture->apply window). Marking a SINGLE scan
+    // per statement is load-bearing: release_mutating_scans clears by (oid, session), so two
+    // retained mutating cursors on one (oid, session) would clear each other prematurely — hence
+    // USING/FROM/subquery source scans (even on the same oid) are left non-mutating. A matched
+    // index_scan needs no mark: it is a one-shot fetch with no cursor, and it only runs on INDEXED
+    // tables, which are excluded from every compaction site (tables_without_indexes), so nothing
+    // can renumber under its captured ids.
+    void mark_mutation_target_scan(const components::operators::operator_ptr& root,
+                                   components::catalog::oid_t target_oid);
+
 } // namespace services::planner::impl

--- a/components/physical_plan_generator/impl/create_plan_update.cpp
+++ b/components/physical_plan_generator/impl/create_plan_update.cpp
@@ -59,7 +59,7 @@ namespace services::planner::impl {
                                                                                         node_update->updates(),
                                                                                         node_update->upsert(),
                                                                                         std::move(returning)));
-            // I-2: mark the predicate scan (this UPDATE's physical-id source) mutating so the owning
+            // Mark the predicate scan (this UPDATE's physical-id source) mutating so the owning
             // agent defers compaction of table_oid across its capture->apply window.
             auto match_scan = create_plan_match(context, node_match, limit);
             mark_mutation_target_scan(match_scan, table_oid);
@@ -78,8 +78,8 @@ namespace services::planner::impl {
                                                                                     std::move(returning),
                                                                                     node_match->expressions()[0],
                                                                                     limit.limit()));
-        // I-2: mark ONLY the target-table scan (LEFT child); the FROM source (RIGHT child) stays a
-        // read even on the same oid — one mutating cursor per (oid, session) (HOLE B invariant).
+        // Mark ONLY the target-table scan (LEFT child); the FROM source (RIGHT child) stays a
+        // read even on the same oid — one mutating cursor per (oid, session).
         auto target_scan = boost::intrusive_ptr(
             new components::operators::full_scan(context.resource,
                                                  context.log.clone(),

--- a/components/physical_plan_generator/impl/create_plan_update.cpp
+++ b/components/physical_plan_generator/impl/create_plan_update.cpp
@@ -59,7 +59,11 @@ namespace services::planner::impl {
                                                                                         node_update->updates(),
                                                                                         node_update->upsert(),
                                                                                         std::move(returning)));
-            plan->set_children(create_plan_match(context, node_match, limit));
+            // I-2: mark the predicate scan (this UPDATE's physical-id source) mutating so the owning
+            // agent defers compaction of table_oid across its capture->apply window.
+            auto match_scan = create_plan_match(context, node_match, limit);
+            mark_mutation_target_scan(match_scan, table_oid);
+            plan->set_children(std::move(match_scan));
 
             return plan;
         }
@@ -74,12 +78,17 @@ namespace services::planner::impl {
                                                                                     std::move(returning),
                                                                                     node_match->expressions()[0],
                                                                                     limit.limit()));
+        // I-2: mark ONLY the target-table scan (LEFT child); the FROM source (RIGHT child) stays a
+        // read even on the same oid — one mutating cursor per (oid, session) (HOLE B invariant).
+        auto target_scan = boost::intrusive_ptr(
+            new components::operators::full_scan(context.resource,
+                                                 context.log.clone(),
+                                                 table_oid,
+                                                 nullptr,
+                                                 components::logical_plan::limit_t::unlimit()));
+        target_scan->mark_mutating();
         plan->set_children(
-            boost::intrusive_ptr(new components::operators::full_scan(context.resource,
-                                                                      context.log.clone(),
-                                                                      table_oid,
-                                                                      nullptr,
-                                                                      components::logical_plan::limit_t::unlimit())),
+            std::move(target_scan),
             create_plan(context, function_registry, node_source, components::logical_plan::limit_t::unlimit(), params));
         return plan;
     }

--- a/components/storage/storage.hpp
+++ b/components/storage/storage.hpp
@@ -151,6 +151,9 @@ namespace components::storage {
             return delete_rows(row_ids, count);
         }
         virtual void commit_append(uint64_t /*commit_id*/, int64_t /*row_start*/, uint64_t /*count*/) {}
+        // Abort-side counterpart of commit_append: re-stamp the range committed-dead.
+        // Abort reverts marks, never placement (see data_table_t::abort_append).
+        virtual void abort_append(int64_t /*row_start*/, uint64_t /*count*/) {}
         virtual void revert_append(int64_t /*row_start*/, uint64_t /*count*/) {}
         virtual void commit_all_deletes(uint64_t /*txn_id*/, uint64_t /*commit_id*/) {}
         virtual void revert_all_deletes(uint64_t /*txn_id*/) {}

--- a/components/storage/table_storage_adapter.hpp
+++ b/components/storage/table_storage_adapter.hpp
@@ -306,6 +306,8 @@ namespace components::storage {
             table_.commit_append(commit_id, row_start, count);
         }
 
+        void abort_append(int64_t row_start, uint64_t count) override { table_.abort_append(row_start, count); }
+
         void revert_append(int64_t row_start, uint64_t count) override { table_.revert_append(row_start, count); }
 
         void commit_all_deletes(uint64_t txn_id, uint64_t commit_id) override {

--- a/components/table/collection.cpp
+++ b/components/table/collection.cpp
@@ -267,6 +267,21 @@ namespace components::table {
         }
     }
 
+    void collection_t::abort_append(int64_t row_start, uint64_t count) {
+        for (auto& rg : row_groups_->segments()) {
+            auto rg_end = rg.start + static_cast<int64_t>(rg.count.load());
+            if (rg.start >= row_start + static_cast<int64_t>(count))
+                break;
+            if (rg_end <= row_start)
+                continue;
+            auto local_start = static_cast<uint64_t>(std::max(int64_t{0}, row_start - rg.start));
+            auto local_end =
+                std::min(rg.count.load(), static_cast<uint64_t>(row_start + static_cast<int64_t>(count) - rg.start));
+            auto local_count = local_end - local_start;
+            rg.abort_append(local_start, local_count);
+        }
+    }
+
     void collection_t::commit_all_deletes(uint64_t txn_id, uint64_t commit_id) {
         for (auto& rg : row_groups_->segments()) {
             rg.commit_all_deletes(txn_id, commit_id);

--- a/components/table/collection.hpp
+++ b/components/table/collection.hpp
@@ -75,6 +75,7 @@ namespace components::table {
         [[nodiscard]] core::result_wrapper_t<bool> append(vector::data_chunk_t& chunk, table_append_state& state);
         void finalize_append(table_append_state& state, transaction_data txn);
         void commit_append(uint64_t commit_id, int64_t row_start, uint64_t count);
+        void abort_append(int64_t row_start, uint64_t count);
         void revert_append(int64_t row_start, uint64_t count);
         void commit_all_deletes(uint64_t txn_id, uint64_t commit_id);
         void revert_all_deletes(uint64_t txn_id);

--- a/components/table/column_segment.cpp
+++ b/components/table/column_segment.cpp
@@ -211,7 +211,11 @@ namespace components::table {
             auto ptr = handle.ptr() + state.head->offset;
             store<uint32_t>(static_cast<uint32_t>(string.size()), ptr);
             ptr += sizeof(uint32_t);
-            memcpy(ptr, string.data(), string.size());
+            // An empty string_view has a null data(); memcpy's pointer args are
+            // declared nonnull even for zero bytes.
+            if (!string.empty()) {
+                memcpy(ptr, string.data(), string.size());
+            }
             state.head->offset += total_length;
             return true;
         }
@@ -520,7 +524,11 @@ namespace components::table {
                     *dictionary_size += static_cast<uint32_t>(required_space);
                     remaining -= required_space;
                     auto dict_pos = end - *dictionary_size;
-                    memcpy(dict_pos, source_data[source_idx].data(), string_length);
+                    // An empty string has a null data(); memcpy's pointer args are
+                    // declared nonnull even for zero bytes.
+                    if (string_length != 0) {
+                        memcpy(dict_pos, source_data[source_idx].data(), string_length);
+                    }
 
                     assert(static_cast<uint64_t>(*dictionary_size) <= segment.block_manager().block_size());
                     result_data[target_idx] = static_cast<int32_t>(*dictionary_size);
@@ -839,8 +847,9 @@ namespace components::table {
 
             static_assert(sizeof(uint64_t) == sizeof(uint64_t), "uint64_t should be 64-bit");
             auto& result_mask = result.validity();
+            // block_offset() is not a multiple of 8, so the validity payload must be
+            // read bytewise: a u64 load through a cast pointer is a misaligned access.
             auto buffer_ptr = state.scan_state->ptr() + segment.block_offset();
-            auto input_data = reinterpret_cast<uint64_t*>(buffer_ptr);
 
             auto result_data = result_mask.data();
 
@@ -853,7 +862,8 @@ namespace components::table {
             while (pos < scan_count) {
                 uint64_t current_result_idx = result_entry;
                 uint64_t offset;
-                uint64_t input_mask = input_data[input_entry];
+                uint64_t input_mask;
+                std::memcpy(&input_mask, buffer_ptr + input_entry * sizeof(uint64_t), sizeof(input_mask));
 
                 if (result_idx < input_idx) {
                     auto shift_amount = input_idx - result_idx;
@@ -908,14 +918,18 @@ namespace components::table {
             auto start = segment.relative_index(state.row_index);
             if (static_cast<uint64_t>(start) % vector::validity_mask_t::BITS_PER_VALUE == 0) {
                 auto& result_mask = result.validity();
+                // Bytewise reads for the same reason as validity_scan_partial: the
+                // payload behind block_offset() is not 8-aligned.
                 auto buffer_ptr = state.scan_state->ptr() + segment.block_offset();
-                auto input_data = reinterpret_cast<uint64_t*>(buffer_ptr);
                 auto result_data = result_mask.data();
                 uint64_t start_offset = static_cast<uint64_t>(start) / vector::validity_mask_t::BITS_PER_VALUE;
                 uint64_t entry_scan_count = (scan_count + vector::validity_mask_t::BITS_PER_VALUE - 1) /
                                             vector::validity_mask_t::BITS_PER_VALUE;
                 for (uint64_t i = 0; i < entry_scan_count; i++) {
-                    auto input_entry = input_data[start_offset + i];
+                    uint64_t input_entry;
+                    std::memcpy(&input_entry,
+                                buffer_ptr + (start_offset + i) * sizeof(uint64_t),
+                                sizeof(input_entry));
                     if (!result_data && input_entry == vector::validity_data_t::MAX_ENTRY) {
                         continue;
                     }

--- a/components/table/data_table.cpp
+++ b/components/table/data_table.cpp
@@ -385,6 +385,10 @@ namespace components::table {
         row_groups_->commit_append(commit_id, row_start, count);
     }
 
+    void data_table_t::abort_append(int64_t row_start, uint64_t count) {
+        row_groups_->abort_append(row_start, count);
+    }
+
     void data_table_t::revert_append(int64_t row_start, uint64_t count) {
         row_groups_->revert_append(row_start, count);
     }

--- a/components/table/data_table.hpp
+++ b/components/table/data_table.hpp
@@ -91,6 +91,11 @@ namespace components::table {
         [[nodiscard]] core::result_wrapper_t<bool> append(vector::data_chunk_t& chunk, table_append_state& state);
         void finalize_append(table_append_state& state, transaction_data txn);
         void commit_append(uint64_t commit_id, int64_t row_start, uint64_t count);
+        // Abort-side counterpart of commit_append: re-stamp the range committed-dead
+        // ({insert 0, delete 0}). Abort reverts marks, never placement — a placed row
+        // keeps its physical id until a compact, so positional WAL records written
+        // after the abort resolve identically live and on replay.
+        void abort_append(int64_t row_start, uint64_t count);
         void revert_append(int64_t row_start, uint64_t count);
         void commit_all_deletes(uint64_t txn_id, uint64_t commit_id);
         void revert_all_deletes(uint64_t txn_id);

--- a/components/table/row_group.cpp
+++ b/components/table/row_group.cpp
@@ -810,7 +810,10 @@ namespace components::table {
         // in_flight set is a see-all snapshot covering every committed row.
         transaction_data td(0, 0);
         td.snapshot_horizon = std::numeric_limits<uint64_t>::max();
-        return indexing_vector(td, index, temp_indexing, count);
+        return indexing_vector(td,
+                               static_cast<uint64_t>(start) / vector::DEFAULT_VECTOR_CAPACITY,
+                               temp_indexing,
+                               count);
     }
 
     uint64_t row_group_t::indexing_vector(transaction_data txn,
@@ -821,7 +824,15 @@ namespace components::table {
         if (!vinfo) {
             return max_count;
         }
-        return vinfo->indexing_vector(txn, vector_idx, indexing_vector, max_count);
+        // Callers address vectors collection-absolute (scan state.vector_index is
+        // cumulative across row groups), but version slots are row-group-local:
+        // the append/commit/abort walks and the chunk start math all anchor at
+        // slot 0. Row groups start vector-aligned, so the offset is exact.
+        assert(static_cast<uint64_t>(start) % vector::DEFAULT_VECTOR_CAPACITY == 0);
+        return vinfo->indexing_vector(txn,
+                                      vector_idx - static_cast<uint64_t>(start) / vector::DEFAULT_VECTOR_CAPACITY,
+                                      indexing_vector,
+                                      max_count);
     }
 
     std::shared_ptr<row_version_manager_t> row_group_t::get_or_create_version_info_internal() {
@@ -852,14 +863,17 @@ namespace components::table {
     }
 
     void version_delete_state::delete_row(int64_t row_id) {
-        assert(row_id >= 0);
-        uint64_t vector_idx = static_cast<uint64_t>(row_id) / vector::DEFAULT_VECTOR_CAPACITY;
-        uint64_t idx_in_vector = static_cast<uint64_t>(row_id) - vector_idx * vector::DEFAULT_VECTOR_CAPACITY;
+        assert(row_id >= base_row);
+        // Version slots are row-group-local (see row_group_t::indexing_vector);
+        // row ids arrive collection-absolute.
+        uint64_t local_row = static_cast<uint64_t>(row_id - base_row);
+        uint64_t vector_idx = local_row / vector::DEFAULT_VECTOR_CAPACITY;
+        uint64_t idx_in_vector = local_row - vector_idx * vector::DEFAULT_VECTOR_CAPACITY;
         if (current_chunk != vector_idx) {
             flush();
 
             current_chunk = vector_idx;
-            chunk_row = vector_idx * vector::DEFAULT_VECTOR_CAPACITY;
+            chunk_row = static_cast<uint64_t>(base_row) + vector_idx * vector::DEFAULT_VECTOR_CAPACITY;
         }
         rows[count++] = static_cast<int64_t>(idx_in_vector);
     }

--- a/components/table/row_group.cpp
+++ b/components/table/row_group.cpp
@@ -580,6 +580,15 @@ namespace components::table {
         }
     }
 
+    void row_group_t::abort_append(uint64_t row_group_start, uint64_t count) {
+        // get_or_create, not version_info(): the rows being retired may already be
+        // committed with their version info cleaned away (inline-published flushes
+        // of a statement that failed later), and a missing info reads as
+        // "all rows live" — silently skipping would leak the rows.
+        get_or_create_version_info().abort_append(row_group_start, count);
+        // No current_version_ bump: nothing became visible.
+    }
+
     void row_group_t::revert_append(uint64_t row_group_start) {
         auto vinfo = version_info();
         if (vinfo) {

--- a/components/table/row_group.hpp
+++ b/components/table/row_group.hpp
@@ -69,6 +69,7 @@ namespace components::table {
         void append_version_info(transaction_data txn, uint64_t count);
 
         void commit_append(uint64_t commit_id, uint64_t row_group_start, uint64_t count);
+        void abort_append(uint64_t row_group_start, uint64_t count);
         void revert_append(uint64_t row_group_start);
 
         uint64_t delete_rows(uint64_t vector_idx, int64_t rows[], uint64_t count);

--- a/components/table/row_version_manager.cpp
+++ b/components/table/row_version_manager.cpp
@@ -283,10 +283,20 @@ namespace components::table {
                 constant->insert_id = same_inserted_id ? insert_id : inserted[0];
                 constant->delete_id = min_delete_id;
                 result = std::move(constant);
+                return true;
             }
-            // else: partial deletes — still allow cleanup (version info no longer needed
-            //       because all versions are visible to all active transactions)
+            // Partial deletes: some rows live, some deleted. This chunk_vector_info's per-row
+            // delete marks are the ONLY record of which rows are tombstoned — a null vector_info
+            // reads as "all rows live", so signalling cleanup here (the caller replaces the slot
+            // with the unset `result`, i.e. nullptr) resurrects every deleted row in the vector
+            // (issue #567). KEEP the info: compact() physically reclaims the dead rows and rebuilds
+            // fresh, delete-free version metadata, so the version-history GC this pass would have
+            // done is merely deferred to the compaction — never a correctness requirement. Only a
+            // FULL vector reaches here (the caller skips sub-capacity ones).
+            return false;
         }
+        // No deletes: an all-live, all-committed vector needs no version metadata at all, so
+        // dropping it (null result) is correct — a null vector_info already means "all rows live".
         return true;
     }
 

--- a/components/table/row_version_manager.cpp
+++ b/components/table/row_version_manager.cpp
@@ -78,6 +78,15 @@ namespace components::table {
         insert_id = commit_id;
     }
 
+    void chunk_constant_info::abort_append(uint64_t /*start*/, uint64_t /*end*/) {
+        // A constant chunk carries ONE insert stamp — every row belongs to the
+        // aborting transaction — so a sub-range abort retires the whole vector.
+        // Rows outside the range are the same txn's other append ranges: retiring
+        // them a call early only moves them from pending-invisible to dead-invisible.
+        insert_id = 0;
+        delete_id = 0;
+    }
+
     bool chunk_constant_info::has_deletes() const {
         bool is_deleted = insert_id >= TRANSACTION_ID_START || delete_id < TRANSACTION_ID_START;
         return is_deleted;
@@ -240,6 +249,26 @@ namespace components::table {
         for (uint64_t i = start; i < end; i++) {
             inserted[i] = commit_id;
         }
+    }
+
+    void chunk_vector_info::abort_append(uint64_t start, uint64_t end) {
+        if (same_inserted_id) {
+            // Materialize per-row stamps first: only [start, end) aborts NOW. Other
+            // rows of this vector may belong to a different range of the same txn
+            // (aborted by a separate call) — flipping the shared insert_id to 0
+            // would make them insert-visible with no delete mark in the interim.
+            same_inserted_id = false;
+            for (uint64_t i = 0; i < vector::DEFAULT_VECTOR_CAPACITY; i++) {
+                inserted[i] = insert_id;
+            }
+        }
+        // {insert 0, delete 0}: deleted before every snapshot's start time, counted
+        // as committed-dead, and below every compaction watermark.
+        for (uint64_t i = start; i < end; i++) {
+            inserted[i] = 0;
+            deleted[i] = 0;
+        }
+        any_deleted = true;
     }
 
     bool chunk_vector_info::cleanup(uint64_t lowest_transaction, std::unique_ptr<chunk_info>& result) const {
@@ -487,6 +516,39 @@ namespace components::table {
                                 : vector::DEFAULT_VECTOR_CAPACITY;
             auto& info = *vector_info_[vector_idx];
             info.commit_append(commit_id, vstart, vend);
+        }
+    }
+
+    void row_version_manager_t::abort_append(uint64_t row_group_start, uint64_t count) {
+        if (count == 0) {
+            return;
+        }
+        uint64_t row_group_end = row_group_start + count;
+
+        std::lock_guard lock(version_lock_);
+        has_changes_ = true;
+        uint64_t start_vector_idx = row_group_start / vector::DEFAULT_VECTOR_CAPACITY;
+        uint64_t end_vector_idx = (row_group_end - 1) / vector::DEFAULT_VECTOR_CAPACITY;
+        fill_vector_info(end_vector_idx);
+        for (uint64_t vector_idx = start_vector_idx; vector_idx <= end_vector_idx; vector_idx++) {
+            uint64_t vstart = vector_idx == start_vector_idx
+                                  ? row_group_start - start_vector_idx * vector::DEFAULT_VECTOR_CAPACITY
+                                  : 0;
+            uint64_t vend = vector_idx == end_vector_idx
+                                ? row_group_end - end_vector_idx * vector::DEFAULT_VECTOR_CAPACITY
+                                : vector::DEFAULT_VECTOR_CAPACITY;
+            if (!vector_info_[vector_idx]) {
+                // An absent slot reads as "every row committed-live" (see
+                // indexing_vector). Inline-published autocommit flushes reach that
+                // state before their statement can still fail: publish commits the
+                // rows and cleanup_append may then drop the fully-committed info.
+                // Materialize the committed-live baseline the absent slot stood
+                // for (fresh chunk_vector_info: inserted 0 / no deletes), so the
+                // dead stamps have somewhere to land.
+                vector_info_[vector_idx] = std::make_unique<chunk_vector_info>(
+                    start_ + static_cast<int64_t>(vector_idx * vector::DEFAULT_VECTOR_CAPACITY));
+            }
+            vector_info_[vector_idx]->abort_append(vstart, vend);
         }
     }
 

--- a/components/table/row_version_manager.hpp
+++ b/components/table/row_version_manager.hpp
@@ -83,6 +83,13 @@ namespace components::table {
                                          uint64_t max_count) = 0;
         virtual bool fetch(const transaction_data& transaction, int64_t row) = 0;
         virtual void commit_append(uint64_t commit_id, uint64_t start, uint64_t end) = 0;
+        // Abort-side counterpart of commit_append: re-stamp [start, end) as
+        // committed-dead ({insert 0, delete 0}) — visible to no snapshot, counted
+        // as committed-dead, and below every compaction watermark. Abort reverts
+        // marks, never placement (a placed row must keep its physical id until a
+        // compact, or later positional WAL records and their replay diverge), so
+        // this is how an aborted txn's appended rows are retired.
+        virtual void abort_append(uint64_t start, uint64_t end) = 0;
         virtual uint64_t committed_deleted_count(uint64_t max_count) = 0;
         // True when ANY stamp in [0, max_count) is not yet visible-to-all under
         // `watermark`: a pending txn id (>= TRANSACTION_ID_START) or a committed
@@ -118,6 +125,7 @@ namespace components::table {
                                  uint64_t max_count) override;
         bool fetch(const transaction_data& transaction, int64_t row) override;
         void commit_append(uint64_t commit_id, uint64_t start, uint64_t end) override;
+        void abort_append(uint64_t start, uint64_t end) override;
         uint64_t committed_deleted_count(uint64_t max_count) override;
         bool has_version_above(uint64_t watermark, uint64_t max_count) const override;
         bool cleanup(uint64_t lowest_transaction, std::unique_ptr<chunk_info>& result) const override;
@@ -148,6 +156,7 @@ namespace components::table {
                                  uint64_t max_count) override;
         bool fetch(const transaction_data& transaction, int64_t row) override;
         void commit_append(uint64_t commit_id, uint64_t start, uint64_t end) override;
+        void abort_append(uint64_t start, uint64_t end) override;
         bool cleanup(uint64_t lowest_transaction, std::unique_ptr<chunk_info>& result) const override;
         uint64_t committed_deleted_count(uint64_t max_count) override;
         bool has_version_above(uint64_t watermark, uint64_t max_count) const override;
@@ -217,6 +226,7 @@ namespace components::table {
                                  uint64_t row_group_start,
                                  uint64_t row_group_end);
         void commit_append(uint64_t commit_id, uint64_t row_group_start, uint64_t count);
+        void abort_append(uint64_t row_group_start, uint64_t count);
         void revert_append(uint64_t start_row);
         void cleanup_append(uint64_t lowest_active_transaction, uint64_t row_group_start, uint64_t count);
 

--- a/components/table/storage/single_file_block_manager.cpp
+++ b/components/table/storage/single_file_block_manager.cpp
@@ -145,6 +145,7 @@ namespace components::table::storage {
             block_id = max_block_++;
         }
         used_blocks_.insert(block_id);
+        allocated_since_swap_.insert(block_id);
         return block_id;
     }
 
@@ -164,12 +165,20 @@ namespace components::table::storage {
         std::lock_guard lock(allocation_lock_);
         used_blocks_.erase(block_id);
         modified_blocks_.erase(block_id);
-        free_list_.insert(block_id);
+        // A block allocated after the last header swap is referenced by no durable root
+        // and is reusable immediately. Anything else may still be referenced by the
+        // current root: quarantine it until the next swap (see quarantined_blocks_).
+        if (allocated_since_swap_.count(block_id) != 0) {
+            free_list_.insert(block_id);
+        } else {
+            quarantined_blocks_.insert(block_id);
+        }
     }
 
     void single_file_block_manager_t::mark_as_used(uint64_t block_id) {
         std::lock_guard lock(allocation_lock_);
         free_list_.erase(block_id);
+        quarantined_blocks_.erase(block_id);
         used_blocks_.insert(block_id);
     }
 
@@ -260,6 +269,15 @@ namespace components::table::storage {
         uint64_t other_slot = (slot == SECTOR_SIZE) ? (2 * SECTOR_SIZE) : SECTOR_SIZE;
         handle_->write(&write_header, sizeof(write_header), other_slot);
         handle_->sync();
+
+        // The swap is durable: no durable root references the blocks freed since the
+        // previous swap, so they become allocatable.
+        {
+            std::lock_guard lock(allocation_lock_);
+            free_list_.insert(quarantined_blocks_.begin(), quarantined_blocks_.end());
+            quarantined_blocks_.clear();
+            allocated_since_swap_.clear();
+        }
     }
 
     void single_file_block_manager_t::file_sync() {
@@ -278,16 +296,43 @@ namespace components::table::storage {
     // --- Free List Persistence ---
 
     meta_block_pointer_t single_file_block_manager_t::serialize_free_list() {
-        if (free_list_.empty()) {
+        // Serialize the post-swap allocatable set: free_list_ PLUS the quarantined
+        // blocks — the header this list is written for is the new durable root, which
+        // no longer references any quarantined block, so a reload from it may reuse
+        // them.
+        //
+        // Pull BOTH sets out of circulation for the duration of the write: the
+        // metadata_writer allocates its chain blocks via free_block_id, and a chain
+        // block must never appear in the list it stores — after a reload it would be
+        // handed out as free while the durable header still points its free_list
+        // chain at it, so a crash after that reuse would boot from a clobbered
+        // chain. With the sets emptied the writer can only mint fresh ids.
+        std::vector<uint64_t> free_ids, quarantined_ids;
+        {
+            std::lock_guard lock(allocation_lock_);
+            free_ids.assign(free_list_.begin(), free_list_.end());
+            quarantined_ids.assign(quarantined_blocks_.begin(), quarantined_blocks_.end());
+            free_list_.clear();
+            quarantined_blocks_.clear();
+        }
+        if (free_ids.empty() && quarantined_ids.empty()) {
             return meta_block_pointer_t{}; // INVALID_INDEX
         }
         metadata_manager_t meta_mgr(*this);
         metadata_writer_t writer(meta_mgr);
-        writer.write<uint64_t>(free_list_.size());
-        for (auto block_id : free_list_) {
+        writer.write<uint64_t>(free_ids.size() + quarantined_ids.size());
+        for (auto block_id : free_ids) {
+            writer.write<uint64_t>(block_id);
+        }
+        for (auto block_id : quarantined_ids) {
             writer.write<uint64_t>(block_id);
         }
         writer.flush();
+        {
+            std::lock_guard lock(allocation_lock_);
+            free_list_.insert(free_ids.begin(), free_ids.end());
+            quarantined_blocks_.insert(quarantined_ids.begin(), quarantined_ids.end());
+        }
         return writer.get_block_pointer();
     }
 

--- a/components/table/storage/single_file_block_manager.hpp
+++ b/components/table/storage/single_file_block_manager.hpp
@@ -113,6 +113,18 @@ namespace components::table::storage {
 
         std::mutex allocation_lock_;
         std::set<uint64_t> free_list_;
+        // Blocks freed since the last header swap that the CURRENT durable root may still
+        // reference. Not allocatable: handing one out would let an append write-through
+        // overwrite root-referenced bytes in place, and a crash before the next swap (live,
+        // or during WAL replay — which compacts the just-loaded root's own collection)
+        // would leave the root pointing at clobbered blocks with no .prev to fall back to.
+        // write_header() (the swap's durability point) drains them into free_list_; the
+        // serialized free list includes them, because the header being written no longer
+        // references them.
+        std::set<uint64_t> quarantined_blocks_;
+        // Blocks handed out since the last header swap: no durable root references these,
+        // so on free they may return straight to free_list_ instead of quarantine.
+        std::set<uint64_t> allocated_since_swap_;
         std::set<uint64_t> used_blocks_;
         std::set<uint64_t> modified_blocks_;
         uint64_t max_block_{0};

--- a/components/table/test/test_checkpoint_load.cpp
+++ b/components/table/test/test_checkpoint_load.cpp
@@ -1008,3 +1008,81 @@ TEST_CASE("checkpoint_load: shared partial block survives reopen after table gro
 
     cleanup_test_file();
 }
+
+// A compact frees the disk blocks of the collection it replaces. When that
+// collection was LOADED from the durable root — exactly what WAL replay does:
+// load the .otbx, replay a PHYSICAL_COMPACT, replay the post-compact appends —
+// the freed ids are the root's own blocks. They must NOT be handed out again
+// before the next header swap: the append write-through would overwrite
+// root-referenced blocks in place, and a crash before the next checkpoint
+// leaves the root pointing at clobbered blocks with no .prev to fall back to.
+TEST_CASE("checkpoint_load: compact on a loaded table must not recycle root-referenced blocks") {
+    using namespace components::table;
+    using namespace components::table::storage;
+    using namespace components::types;
+    using namespace components::vector;
+    cleanup_test_file();
+
+    test_env_t env;
+    // Enough rows that both the compact's rebuild and the post-compact append
+    // fill whole 256 KiB segments, forcing real block write-throughs.
+    constexpr uint64_t NUM_ROWS = 40000;
+
+    meta_block_pointer_t table_pointer;
+
+    // Phase 1: build + checkpoint the durable root.
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+        REQUIRE(!bm.create_new_database().has_error());
+
+        std::vector<column_definition_t> columns;
+        columns.emplace_back("value", logical_type::BIGINT);
+        auto table = std::make_unique<data_table_t>(&env.resource, bm, std::move(columns), "test_table");
+
+        append_int64_data(*table, &env.resource, NUM_ROWS);
+        table_pointer = full_checkpoint(*table, bm);
+    }
+
+    // Phase 2: the replay window. Load from the root, compact (frees the root's
+    // blocks), append (write-through fills segments and allocates blocks), then
+    // "crash" — no checkpoint, the root never advances.
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+        REQUIRE(!bm.load_existing_database().has_error());
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded_result = data_table_t::load_from_disk(&env.resource, bm, reader);
+        REQUIRE(!loaded_result.has_error());
+        auto& loaded = loaded_result.value();
+
+        REQUIRE(loaded->compact(std::numeric_limits<uint64_t>::max()));
+        append_int64_data_with_fn(*loaded, &env.resource, NUM_ROWS, [](uint64_t i) {
+            return -1 - static_cast<int64_t>(i);
+        });
+    }
+
+    // Phase 3: reopen from the same root: the checkpointed rows must read back
+    // intact.
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+        REQUIRE(!bm.load_existing_database().has_error());
+
+        metadata_manager_t meta_mgr(bm);
+        metadata_reader_t reader(meta_mgr, table_pointer);
+        auto loaded_result = data_table_t::load_from_disk(&env.resource, bm, reader);
+        REQUIRE(!loaded_result.has_error());
+        auto& loaded = loaded_result.value();
+
+        uint64_t scanned = 0;
+        loaded->scan_table_segment(0, NUM_ROWS, [&](data_chunk_t& chunk) {
+            for (uint64_t i = 0; i < chunk.size(); i++) {
+                auto val = chunk.data[0].value(i);
+                REQUIRE(val.value<int64_t>() == static_cast<int64_t>(scanned + i));
+            }
+            scanned += chunk.size();
+        });
+        REQUIRE(scanned == NUM_ROWS);
+    }
+
+    cleanup_test_file();
+}

--- a/components/table/test/test_mvcc_operations.cpp
+++ b/components/table/test/test_mvcc_operations.cpp
@@ -161,6 +161,49 @@ TEST_CASE("components::table::mvcc::cleanup_versions") {
     REQUIRE(count == 10);
 }
 
+// Issue #567. cleanup_versions over a FULL (DEFAULT_VECTOR_CAPACITY) vector holding COMMITTED
+// PARTIAL deletes must not drop that vector's version info: its per-row delete marks are the only
+// record of which rows are tombstoned, and a null vector_info reads as "all rows live", so dropping
+// it resurrects the deleted rows. The caller only cleans FULL vectors, so the pre-existing 10-row
+// cleanup test (a sub-capacity vector) never reached this branch.
+TEST_CASE("components::table::mvcc::cleanup_versions_keeps_partial_deletes_in_full_vector") {
+    test_env env;
+    auto table = make_int_table(env);
+
+    // Vector 0 (rows 0..DEFAULT_VECTOR_CAPACITY-1) must be exactly full; a few rows spill into
+    // vector 1 so the delete+cleanup below acts on a genuinely full vector.
+    constexpr uint64_t full = DEFAULT_VECTOR_CAPACITY;
+    constexpr uint64_t spill = 476;
+    append_rows(*table, env, 0, full);
+    append_rows(*table, env, static_cast<int64_t>(full), spill);
+    REQUIRE(scan_count(*table, env) == full + spill);
+
+    // Commit a partial delete of the full vector (its first 200 rows).
+    transaction_manager_t mgr(&env.resource);
+    auto session = components::session::session_id_t::generate_uid();
+    auto& txn = mgr.begin_transaction(session);
+    constexpr uint64_t ndel = 200;
+    std::pmr::vector<complex_logical_type> id_type(&env.resource);
+    id_type.emplace_back(logical_type::BIGINT);
+    auto row_ids_chunk = data_chunk_t(&env.resource, id_type, ndel);
+    for (uint64_t i = 0; i < ndel; i++) {
+        row_ids_chunk.data[0].set_value(i, static_cast<int64_t>(i));
+    }
+    row_ids_chunk.set_cardinality(ndel);
+    auto txn_id = txn.data().transaction_id;
+    table_delete_state del_state(&env.resource);
+    table->delete_rows(del_state, row_ids_chunk.data[0], ndel, txn_id);
+    auto commit_id = mgr.commit(session);
+    mgr.publish(commit_id);
+    table->commit_all_deletes(txn_id, commit_id);
+    REQUIRE(scan_count(*table, env) == full + spill - ndel);
+
+    // With no active txns the deletes are visible-to-all and old enough, so cleanup_versions
+    // processes vector 0. It must keep the tombstones: the count stays the same, not resurrect.
+    table->cleanup_versions(mgr.lowest_active_start_time());
+    REQUIRE(scan_count(*table, env) == full + spill - ndel);
+}
+
 TEST_CASE("components::table::mvcc::multiple_txn_appends") {
     test_env env;
     auto table = make_int_table(env);

--- a/components/table/test/test_mvcc_operations.cpp
+++ b/components/table/test/test_mvcc_operations.cpp
@@ -844,13 +844,13 @@ TEST_CASE("components::table::mvcc::abort_append_dead_in_place") {
     REQUIRE(scan_count(*table, env) == 10);
 }
 
-// Version slots are row-group-LOCAL. The scan's cumulative vector_index and the
-// delete path's collection-absolute row ids used to be forwarded into the slot
-// array unconverted, so for every row group after the first the lookups read —
-// and the delete stamps wrote — the wrong slot: pending appends beyond the first
-// row group scanned as committed-live for every snapshot, and delete stamps were
-// invisible to the dead-count/compaction walks. All probes act on row groups
-// past the first (row group size == DEFAULT_VECTOR_CAPACITY here).
+// Version slots are row-group-LOCAL. If the scan's cumulative vector_index or
+// the delete path's collection-absolute row ids were forwarded into the slot
+// array unconverted, every row group after the first would read — and the
+// delete stamps would write — the wrong slot: pending appends beyond the first
+// row group would scan as committed-live for every snapshot, and delete stamps
+// would be invisible to the dead-count/compaction walks. All probes act on row
+// groups past the first (row group size == DEFAULT_VECTOR_CAPACITY here).
 TEST_CASE("components::table::mvcc::version_slots_are_row_group_local") {
     test_env env;
     auto table = make_int_table(env);

--- a/components/table/test/test_mvcc_operations.cpp
+++ b/components/table/test/test_mvcc_operations.cpp
@@ -815,6 +815,35 @@ TEST_CASE("components::table::mvcc::revert_append_truncates_columns_direct") {
 // Abort retires appended rows IN PLACE: {insert 0, delete 0} — invisible to every
 // snapshot, counted committed-dead, reclaimable — while the rows keep their
 // physical ids (positional WAL records and their replay depend on placement).
+TEST_CASE("components::table::mvcc::abort_append_dead_in_place") {
+    test_env env;
+    auto table = make_int_table(env);
+
+    // A committed base so the aborted rows sit between live neighbours.
+    append_rows(*table, env, 0, 5);
+
+    transaction_manager_t mgr(&env.resource);
+    auto session = components::session::session_id_t::generate_uid();
+    auto& txn = mgr.begin_transaction(session);
+    append_rows_txn(*table, env, 100, 10, txn.data());
+
+    // More committed rows after: the aborted range must not swallow them.
+    append_rows(*table, env, 200, 5);
+
+    mgr.abort(session);
+    table->abort_append(5, 10);
+
+    // Placement intact, contents dead.
+    REQUIRE(table->row_group()->total_rows() == 20);
+    REQUIRE(scan_count(*table, env) == 10);
+
+    // The dead stamps are below every watermark: compaction proceeds and
+    // reclaims exactly the aborted rows.
+    REQUIRE(table->compact(std::numeric_limits<uint64_t>::max()));
+    REQUIRE(table->row_group()->total_rows() == 10);
+    REQUIRE(scan_count(*table, env) == 10);
+}
+
 // Version slots are row-group-LOCAL. The scan's cumulative vector_index and the
 // delete path's collection-absolute row ids used to be forwarded into the slot
 // array unconverted, so for every row group after the first the lookups read —

--- a/components/table/test/test_mvcc_operations.cpp
+++ b/components/table/test/test_mvcc_operations.cpp
@@ -811,3 +811,67 @@ TEST_CASE("components::table::mvcc::revert_append_truncates_columns_direct") {
         }
     }
 }
+
+// Abort retires appended rows IN PLACE: {insert 0, delete 0} — invisible to every
+// snapshot, counted committed-dead, reclaimable — while the rows keep their
+// physical ids (positional WAL records and their replay depend on placement).
+// Version slots are row-group-LOCAL. The scan's cumulative vector_index and the
+// delete path's collection-absolute row ids used to be forwarded into the slot
+// array unconverted, so for every row group after the first the lookups read —
+// and the delete stamps wrote — the wrong slot: pending appends beyond the first
+// row group scanned as committed-live for every snapshot, and delete stamps were
+// invisible to the dead-count/compaction walks. All probes act on row groups
+// past the first (row group size == DEFAULT_VECTOR_CAPACITY here).
+TEST_CASE("components::table::mvcc::version_slots_are_row_group_local") {
+    test_env env;
+    auto table = make_int_table(env);
+
+    constexpr uint64_t cap = DEFAULT_VECTOR_CAPACITY;
+    for (int64_t i = 0; i < 3; i++) {
+        append_rows(*table, env, i * static_cast<int64_t>(cap), cap);
+    }
+    REQUIRE(scan_count(*table, env) == 3 * cap);
+
+    transaction_manager_t mgr(&env.resource);
+
+    // Pending appends land in the fourth row group; a fresh snapshot must not
+    // see them until commit.
+    auto writer_session = components::session::session_id_t::generate_uid();
+    auto& writer = mgr.begin_transaction(writer_session);
+    append_rows_txn(*table, env, 5000, 10, writer.data());
+
+    auto reader_session = components::session::session_id_t::generate_uid();
+    auto& reader = mgr.begin_transaction(reader_session);
+    REQUIRE(scan_count_txn(*table, env, reader.data()) == 3 * cap);
+    mgr.abort(reader_session);
+
+    auto write_cid = mgr.commit(writer_session);
+    mgr.publish(write_cid);
+    table->commit_append(write_cid, 3 * cap, 10);
+    REQUIRE(scan_count(*table, env) == 3 * cap + 10);
+
+    // Committed deletes in the second row group tombstone in place...
+    constexpr uint64_t ndel = 200;
+    auto del_session = components::session::session_id_t::generate_uid();
+    auto& del_txn = mgr.begin_transaction(del_session);
+    std::pmr::vector<complex_logical_type> id_type(&env.resource);
+    id_type.emplace_back(logical_type::BIGINT);
+    auto row_ids_chunk = data_chunk_t(&env.resource, id_type, ndel);
+    for (uint64_t i = 0; i < ndel; i++) {
+        row_ids_chunk.data[0].set_value(i, static_cast<int64_t>(cap + 100 + i));
+    }
+    row_ids_chunk.set_cardinality(ndel);
+    auto del_txn_id = del_txn.data().transaction_id;
+    table_delete_state del_state(&env.resource);
+    table->delete_rows(del_state, row_ids_chunk.data[0], ndel, del_txn_id);
+    auto del_cid = mgr.commit(del_session);
+    mgr.publish(del_cid);
+    table->commit_all_deletes(del_txn_id, del_cid);
+    REQUIRE(scan_count(*table, env) == 3 * cap + 10 - ndel);
+
+    // ...and the dead-count/compaction walks see those stamps: compaction
+    // reclaims exactly the deleted rows.
+    REQUIRE(table->compact(std::numeric_limits<uint64_t>::max()));
+    REQUIRE(table->row_group()->total_rows() == 3 * cap + 10 - ndel);
+    REQUIRE(scan_count(*table, env) == 3 * cap + 10 - ndel);
+}

--- a/components/vector/data_chunk_binary.cpp
+++ b/components/vector/data_chunk_binary.cpp
@@ -317,12 +317,18 @@ namespace components::vector {
                 write_le32(output, running_offset);
                 output += 4;
                 for (uint32_t row_index = 0; row_index < num_rows; ++row_index) {
-                    std::memcpy(output, views[row_index].data(), views[row_index].size());
-                    output += views[row_index].size();
+                    // An empty view's data() may be null, and memcpy's pointer
+                    // args are declared nonnull even for 0 bytes.
+                    if (views[row_index].size() != 0) {
+                        std::memcpy(output, views[row_index].data(), views[row_index].size());
+                        output += views[row_index].size();
+                    }
                 }
             } else {
-                std::memcpy(output, column.data(), column_data_sizes[column_index]);
-                output += column_data_sizes[column_index];
+                if (column_data_sizes[column_index] != 0) {
+                    std::memcpy(output, column.data(), column_data_sizes[column_index]);
+                    output += column_data_sizes[column_index];
+                }
             }
         }
 
@@ -433,7 +439,11 @@ namespace components::vector {
 
                 column.set_auxiliary(std::move(string_buffer));
             } else {
-                std::memcpy(column.data(), pointer, data_size);
+                // A zero-row column deserializes as 0 bytes and data() may be
+                // null; memcpy's pointer args are declared nonnull even then.
+                if (data_size != 0) {
+                    std::memcpy(column.data(), pointer, data_size);
+                }
             }
             pointer += data_size;
 

--- a/components/vector/tests/test_validity_mask.cpp
+++ b/components/vector/tests/test_validity_mask.cpp
@@ -192,3 +192,22 @@ TEST_CASE("validity_mask_t: slice() at non-zero offset on a pointer-constructed 
     REQUIRE(ptr_mask.data() != buffer); // sliced into a private allocation
     REQUIRE(buffer[0] == components::vector::validity_data_t::MAX_ENTRY);
 }
+
+TEST_CASE("validity_mask_t: set_valid flips one row bit, not a whole entry", "[validity-mask]") {
+    // set_valid takes a ROW index; writing validity_mask_[row_idx] would treat
+    // it as an entry index — stomping 64 unrelated rows (and, for row_idx past
+    // the entry count, memory beyond the mask: revert_append passes raw bit
+    // positions within a segment).
+    auto resource = core::pmr::otterbrix_resource();
+    validity_mask_t mask(&resource, uint64_t{256});
+    mask.set_invalid(uint64_t{1});
+    mask.set_invalid(uint64_t{2});
+
+    mask.set_valid(uint64_t{2});
+
+    REQUIRE(mask.row_is_valid(2));
+    REQUIRE_FALSE(mask.row_is_valid(1));
+    for (uint64_t row = 3; row < 256; row++) {
+        REQUIRE(mask.row_is_valid(row));
+    }
+}

--- a/components/vector/validation.cpp
+++ b/components/vector/validation.cpp
@@ -16,9 +16,9 @@ namespace components::vector {
         : data_(new (resource->allocate(sizeof(uint64_t) * size, alignof(uint64_t))) uint64_t[size],
                 core::pmr::array_deleter_t(resource, size, alignof(uint64_t))) {
         if (mask) {
-            for (uint64_t i = 0; i < size; i++) {
-                data_[i] = mask[i];
-            }
+            // mask may view a column-segment block whose validity payload is
+            // not 8-aligned; copy bytewise instead of loading u64s through it.
+            std::memcpy(data_.get(), mask, sizeof(uint64_t) * size);
         }
     }
 
@@ -312,7 +312,11 @@ namespace components::vector {
         if (!validity_mask_) {
             return validity_data_t::MAX_ENTRY;
         }
-        return validity_mask_[entry_idx];
+        // The mask may be a read-only view into a column-segment block, where the
+        // validity payload is not 8-aligned; a direct u64 load is UB there.
+        uint64_t entry;
+        std::memcpy(&entry, validity_mask_ + entry_idx, sizeof(entry));
+        return entry;
     }
 
     void validity_mask_t::copy_indexing(const validity_mask_t& other,

--- a/components/vector/validation.cpp
+++ b/components/vector/validation.cpp
@@ -94,7 +94,9 @@ namespace components::vector {
         if (!validity_mask_) {
             resize(resource_, count_);
         }
-        validity_mask_[row_idx] = true;
+        uint64_t entry_idx, idx_in_entry;
+        entry_index(row_idx, entry_idx, idx_in_entry);
+        validity_mask_[entry_idx] |= (uint64_t(1) << uint64_t(idx_in_entry));
     }
 
     void validity_mask_t::set_all_invalid(uint64_t count) {

--- a/core/result_wrapper.hpp
+++ b/core/result_wrapper.hpp
@@ -156,10 +156,16 @@ namespace core {
             : value_(std::forward<Args>(args)...)
             , error_(error_t::no_error()) {}
 
+        // value_{} and not default-init: with trivial_store the store is a bare T,
+        // and a default-initialized primitive is indeterminate — the (defaulted)
+        // copy/move members then read it, which is UB even though callers never
+        // consume value() on the error path.
         result_wrapper_t(const error_t& error)
-            : error_(error) {}
+            : value_{}
+            , error_(error) {}
         result_wrapper_t(error_t&& error)
-            : error_(std::move(error)) {}
+            : value_{}
+            , error_(std::move(error)) {}
 
 #if not defined(NDEBUG)
         result_wrapper_t(const result_wrapper_t& other) requires(std::is_copy_constructible_v<T>)

--- a/core/string_buffer/object_buffer.hpp
+++ b/core/string_buffer/object_buffer.hpp
@@ -26,7 +26,11 @@ namespace core {
         // Copy `count` objects into the arena and return the stored run.
         T* insert(const T* data, size_t count) {
             T* ptr = allocate(count);
-            std::memcpy(ptr, data, count * sizeof(T));
+            // memcpy's pointer args are declared nonnull even for 0 bytes, and an
+            // empty run legitimately arrives as (nullptr, 0).
+            if (count != 0) {
+                std::memcpy(ptr, data, count * sizeof(T));
+            }
             return ptr;
         }
 

--- a/integration/cpp/base_spaces.cpp
+++ b/integration/cpp/base_spaces.cpp
@@ -249,8 +249,25 @@ namespace otterbrix {
                                     }
                                 }
                                 // TODO: load timezone from settings?
+                                // Repeat history: an uncommitted txn's INSERT still
+                                // occupied these row-ids live, so place the rows at the
+                                // same slots, then retire them committed-dead — the txn
+                                // never became visible. The dead range is the record's
+                                // own base: replay placement equals live placement by
+                                // induction over the per-oid record sequence.
+                                int64_t dead_base = static_cast<int64_t>(r->physical_row_start);
                                 for (auto& chunk : r->physical_data) {
+                                    const uint64_t placed = chunk.size(); // direct_append_sync returns the START row
                                     disk_ptr->direct_append_sync(table_oid, chunk, {});
+                                    if (!r->txn_committed && placed > 0) {
+                                        std::pmr::vector<int64_t> dead_ids(r->physical_row_ids.get_allocator().resource());
+                                        dead_ids.reserve(placed);
+                                        for (uint64_t i = 0; i < placed; ++i) {
+                                            dead_ids.push_back(dead_base + static_cast<int64_t>(i));
+                                        }
+                                        disk_ptr->direct_delete_sync(table_oid, dead_ids, placed);
+                                    }
+                                    dead_base += static_cast<int64_t>(placed);
                                 }
                             }
                             break;
@@ -311,6 +328,29 @@ namespace otterbrix {
                             const bool in_place =
                                 r->record_type == services::wal::wal_record_type::PHYSICAL_UPDATE_INPLACE ||
                                 table_oid < components::catalog::FIRST_USER_OID;
+                            if (!r->txn_committed) {
+                                // Repeat history for an uncommitted UPDATE: its new-row
+                                // appends occupied row-ids live (the tombstones were
+                                // reverted at abort, the placement was not). Place the
+                                // new rows at the record's append base and retire them
+                                // dead; do NOT tombstone the old rows. In-place records
+                                // never reach here (system-oid only, always committed).
+                                int64_t dead_base = static_cast<int64_t>(r->physical_row_start);
+                                for (auto& chunk : r->physical_data) {
+                                    const uint64_t placed = chunk.size(); // direct_append_sync returns the START row
+                                    disk_ptr->direct_append_sync(table_oid, chunk, {});
+                                    if (placed > 0) {
+                                        std::pmr::vector<int64_t> dead_ids(r->physical_row_ids.get_allocator().resource());
+                                        dead_ids.reserve(placed);
+                                        for (uint64_t i = 0; i < placed; ++i) {
+                                            dead_ids.push_back(dead_base + static_cast<int64_t>(i));
+                                        }
+                                        disk_ptr->direct_delete_sync(table_oid, dead_ids, placed);
+                                    }
+                                    dead_base += static_cast<int64_t>(placed);
+                                }
+                                break;
+                            }
                             if (!r->physical_data.empty()) {
                                 // physical_row_ids is flat across the batch; slice it per
                                 // chunk in vector order to match each chunk's rows.

--- a/integration/cpp/base_spaces.cpp
+++ b/integration/cpp/base_spaces.cpp
@@ -285,6 +285,22 @@ namespace otterbrix {
                             break;
                         }
                         case services::wal::wal_record_type::PHYSICAL_UPDATE:
+                        case services::wal::wal_record_type::PHYSICAL_UPDATE_INPLACE: {
+                            // An MVCC update tombstones the old rows and APPENDS the new
+                            // ones, so replay must do the same -- otherwise the row-id
+                            // space it rebuilds is not the one the live run produced, and
+                            // every later record keyed by a physical row_id lands on the
+                            // wrong slot or off the end of the segment tree.
+                            //
+                            // PHYSICAL_UPDATE_INPLACE is the one exception: the
+                            // pg_attribute commit-id backfill rewrites a catalog row that
+                            // must keep its identity. A WAL written before that record
+                            // type existed spelled it PHYSICAL_UPDATE, and only a system
+                            // table ever carried in-place semantics, so an old record on a
+                            // system oid still replays the way it was written.
+                            const bool in_place =
+                                r->record_type == services::wal::wal_record_type::PHYSICAL_UPDATE_INPLACE ||
+                                table_oid < components::catalog::FIRST_USER_OID;
                             if (!r->physical_data.empty()) {
                                 // physical_row_ids is flat across the batch; slice it per
                                 // chunk in vector order to match each chunk's rows.
@@ -297,10 +313,15 @@ namespace otterbrix {
                                         ids.push_back(r->physical_row_ids[id_base + i]);
                                     }
                                     id_base += n;
-                                    disk_ptr->direct_update_sync(table_oid, ids, chunk);
+                                    if (in_place) {
+                                        disk_ptr->direct_update_sync(table_oid, ids, chunk);
+                                    } else {
+                                        disk_ptr->direct_update_mvcc_sync(table_oid, ids, chunk);
+                                    }
                                 }
                             }
                             break;
+                        }
                         default:
                             break;
                     }

--- a/integration/cpp/base_spaces.cpp
+++ b/integration/cpp/base_spaces.cpp
@@ -284,6 +284,16 @@ namespace otterbrix {
                             disk_ptr->direct_delete_sync(table_oid, r->physical_row_ids, r->physical_row_count);
                             break;
                         }
+                        case services::wal::wal_record_type::PHYSICAL_COMPACT: {
+                            // Row-id numbering-epoch boundary: re-run the dense renumber the live
+                            // path ran here (maybe_cleanup / VACUUM), so every DML record BEFORE
+                            // this resolved against the pre-compaction numbering and every record
+                            // AFTER resolves against the post-compaction numbering. Explicit case
+                            // (NOT a generic physical-record path): a COMPACT carries empty
+                            // physical_data AND empty physical_row_ids — {table_oid} is all it needs.
+                            disk_ptr->direct_compact_sync(table_oid);
+                            break;
+                        }
                         case services::wal::wal_record_type::PHYSICAL_UPDATE:
                         case services::wal::wal_record_type::PHYSICAL_UPDATE_INPLACE: {
                             // An MVCC update tombstones the old rows and APPENDS the new

--- a/integration/cpp/test/CMakeLists.txt
+++ b/integration/cpp/test/CMakeLists.txt
@@ -122,3 +122,26 @@ target_link_libraries(profile_arithmetic PRIVATE
         ZLIB::ZLIB
         BZip2::BZip2
 )
+
+# Focused DML + restart micro-benchmark (UPDATE storm + reopen/replay). Standalone
+# so it can be A/B'd against a baseline commit; not registered with ctest.
+add_executable(bench_dml_restart bench_dml_restart.cpp)
+target_link_libraries(bench_dml_restart PRIVATE
+        cpp_otterbrix
+        otterbrix::test_generaty
+        otterbrix::log
+        otterbrix::cursor
+        otterbrix::session
+        otterbrix::services
+        otterbrix::locks
+        spdlog::spdlog
+        Catch2::Catch2
+        absl::crc32c
+        absl::int128
+        benchmark::benchmark
+        actor-zeta::actor-zeta
+        Boost::boost
+        fmt::fmt
+        ZLIB::ZLIB
+        BZip2::BZip2
+)

--- a/integration/cpp/test/CMakeLists.txt
+++ b/integration/cpp/test/CMakeLists.txt
@@ -13,6 +13,7 @@ set( ${PROJECT_NAME}_SOURCES
         test_update.cpp
         test_wal_pool.cpp
         test_persistence.cpp
+        test_restart_consistency.cpp
         test_sql_features.cpp
         test_unique_constraint_operator.cpp
         test_create_index_backfill_batched.cpp

--- a/integration/cpp/test/bench_dml_restart.cpp
+++ b/integration/cpp/test/bench_dml_restart.cpp
@@ -1,0 +1,117 @@
+// ===========================================================================
+// Focused DML + restart micro-benchmark.
+//
+// The restart-consistency fixes touch exactly two hot paths:
+//   * UPDATE  -- the disk agent now writes the WAL record inside its mailbox
+//               handler, and the update carries an extra deep-copy of the chunk.
+//   * REPLAY  -- an UPDATE record now replays as an MVCC delete+append instead
+//               of an in-place rewrite.
+// The stock analytical benchmarks (SSB/TPC-H) are read-only and exercise
+// neither. This measures the two paths directly, in wall-clock milliseconds, so
+// the branch can be compared against its own baseline commit.
+//
+// Deterministic and self-contained: no external data, a fixed workload, and a
+// data directory taken from RC_DATA_ROOT (kept off tmpfs). Prints one
+// "BENCH|<name>|<ms>" line per phase so an A/B script can diff them.
+// ===========================================================================
+
+#include "test_config.hpp"
+
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+using clock_type = std::chrono::steady_clock;
+
+namespace {
+
+    double ms_since(clock_type::time_point start) {
+        return std::chrono::duration<double, std::milli>(clock_type::now() - start).count();
+    }
+
+    void emit(const std::string& name, double ms) {
+        std::cout << "BENCH|" << name << "|" << ms << '\n' << std::flush;
+    }
+
+    configuration::config bench_config(const std::string& sub) {
+        std::string root = "/var/tmp/otterbrix/bench";
+        if (const char* env = std::getenv("RC_DATA_ROOT")) {
+            root = env;
+        }
+        auto config = test_create_config(std::filesystem::path(root) / sub);
+        test_clear_directory(config);
+        return config;
+    }
+
+    otterbrix::wrapper_dispatcher_t* run(otterbrix::wrapper_dispatcher_t* d, const std::string& sql) {
+        auto cur = d->execute_sql(otterbrix::session_id_t(), sql);
+        if (!cur || cur->is_error()) {
+            std::cerr << "bench statement failed: " << sql.substr(0, 80) << " -> "
+                      << (cur ? std::string(cur->get_error().what.c_str()) : "null") << '\n';
+            std::abort();
+        }
+        return d;
+    }
+
+    // Number of rows / iterations. Small enough to finish in seconds under
+    // contention, large enough that the timed loop dominates fixed startup cost.
+    constexpr int kRows = 2000;
+    constexpr int kUpdatePasses = 20;
+
+    // Time kUpdatePasses full-table UPDATEs on a disk+WAL table, then the reopen
+    // that must replay all of them.
+    void bench_update_and_replay(const char* label, bool disk) {
+        const std::string storage = disk ? " WITH (storage = 'disk')" : "";
+        auto config = bench_config(std::string("update_") + label);
+        config.disk.on = disk;
+        config.wal.on = true;
+
+        // --- phase 1: build, then time the UPDATE storm ---
+        {
+            test_spaces space(config);
+            auto* d = space.dispatcher();
+            run(d, "CREATE DATABASE b;");
+            run(d, "CREATE TABLE b.t (k bigint, v bigint)" + storage + ";");
+            {
+                std::stringstream q;
+                q << "INSERT INTO b.t (k, v) VALUES ";
+                for (int i = 0; i < kRows; ++i) {
+                    q << '(' << i << ", " << i << ')' << (i + 1 == kRows ? ";" : ", ");
+                }
+                run(d, q.str());
+            }
+
+            const auto start = clock_type::now();
+            for (int pass = 0; pass < kUpdatePasses; ++pass) {
+                run(d, "UPDATE b.t SET v = v + 1 WHERE k >= 0;");
+            }
+            emit(std::string("update.") + label, ms_since(start));
+            // Leave the scope WITHOUT an explicit checkpoint on the in-memory run,
+            // so the whole UPDATE storm sits in the WAL and the reopen must replay
+            // it. On the disk run the destructor checkpoints (that is the realistic
+            // clean-shutdown path).
+        }
+
+        // --- phase 2: time the reopen (replay of the update storm) ---
+        {
+            const auto start = clock_type::now();
+            test_spaces space(config);
+            auto* d = space.dispatcher();
+            const double reopen_ms = ms_since(start);
+            // Touch the table so a broken reopen would fault here rather than pass
+            // silently.
+            run(d, "SELECT COUNT(*) FROM b.t;");
+            emit(std::string("reopen.") + label, reopen_ms);
+        }
+    }
+
+} // namespace
+
+int main() {
+    components::compute::function_registry_t::reset_default();
+    bench_update_and_replay("mem", /*disk=*/false);
+    bench_update_and_replay("disk", /*disk=*/true);
+    return 0;
+}

--- a/integration/cpp/test/bench_dml_restart.cpp
+++ b/integration/cpp/test/bench_dml_restart.cpp
@@ -1,14 +1,13 @@
 // ===========================================================================
 // Focused DML + restart micro-benchmark.
 //
-// The restart-consistency fixes touch exactly two hot paths:
-//   * UPDATE  -- the disk agent now writes the WAL record inside its mailbox
-//               handler, and the update carries an extra deep-copy of the chunk.
-//   * REPLAY  -- an UPDATE record now replays as an MVCC delete+append instead
-//               of an in-place rewrite.
+// Two DML hot paths dominate the restart-consistency cost model:
+//   * UPDATE  -- the disk agent writes the WAL record inside its mailbox
+//               handler, and the update carries a deep-copy of the chunk.
+//   * REPLAY  -- an UPDATE record replays as an MVCC delete+append (the same
+//               contract the live path uses).
 // The stock analytical benchmarks (SSB/TPC-H) are read-only and exercise
-// neither. This measures the two paths directly, in wall-clock milliseconds, so
-// the branch can be compared against its own baseline commit.
+// neither. This measures the two paths directly, in wall-clock milliseconds.
 //
 // Deterministic and self-contained: no external data, a fixed workload, and a
 // data directory taken from RC_DATA_ROOT (kept off tmpfs). Prints one

--- a/integration/cpp/test/restart_probe.hpp
+++ b/integration/cpp/test/restart_probe.hpp
@@ -29,8 +29,7 @@
 // defect of the probe, and is reported as INCONCLUSIVE rather than as a
 // violation of the invariant.
 //
-// Five further properties are load-bearing; each was learned by getting it
-// wrong first:
+// Five further properties are load-bearing:
 //
 //   1. PROBES MUST WRITE, not only read. A row inserted before the restart
 //      carries its DEFAULT in the WAL/checkpoint payload, so it reads back

--- a/integration/cpp/test/restart_probe.hpp
+++ b/integration/cpp/test/restart_probe.hpp
@@ -352,17 +352,20 @@ namespace restart_rc {
             case lt::BLOB:
                 os << '"' << v.value<std::string_view>() << '"';
                 break;
+            // .count(): the raw tick count. gcc 11 (CI) has no ostream inserter for
+            // std::chrono::duration, and the C++20 one would append a unit suffix,
+            // so the count is also the render that is identical across toolchains.
             case lt::DATE:
-                os << v.value<core::date::date_t>().value;
+                os << v.value<core::date::date_t>().value.count();
                 break;
             case lt::TIMESTAMP:
-                os << v.value<core::date::timestamp_t>().value;
+                os << v.value<core::date::timestamp_t>().value.count();
                 break;
             case lt::TIMESTAMP_TZ:
-                os << v.value<core::date::timestamptz_t>().value;
+                os << v.value<core::date::timestamptz_t>().value.count();
                 break;
             case lt::TIME:
-                os << v.value<core::date::time_t>().value;
+                os << v.value<core::date::time_t>().value.count();
                 break;
             case lt::ARRAY:
             case lt::LIST:

--- a/integration/cpp/test/restart_probe.hpp
+++ b/integration/cpp/test/restart_probe.hpp
@@ -1,0 +1,613 @@
+#pragma once
+
+// ===========================================================================
+// RESTART-CONSISTENCY DIFFERENTIAL HARNESS
+//
+// The invariant under test (RC):
+//
+//   For any statement sequence S = S1 . S2, any restart flavor f, and any
+//   storage mode m, the observable trace of
+//
+//       run(S1) ; terminate(f) ; reopen ; run(S2)
+//
+//   restricted to S2 must equal the observable trace of run(S1 . S2) with no
+//   restart at all, over the committed prefix of S1.
+//
+// The harness realizes that by running an identical PROBE list twice against
+// the same data directory -- once before the restart and once after -- and
+// diffing the two observation vectors probe by probe.
+//
+// Four properties of this design are load-bearing; each of them was learned by
+// getting it wrong first:
+//
+//   1. PROBES MUST WRITE, not only read.
+//      A row inserted before the restart carries its DEFAULT in the WAL/
+//      checkpoint payload, so it reads back correctly no matter how badly the
+//      schema was restored. The loss is only observable on a write issued
+//      AFTER the restart. Read-only persistence tests are structurally blind
+//      to it. Every probe may therefore carry `writes`, which run in both
+//      phases, keyed by a phase-unique $K so the two phases cannot collide.
+//
+//   2. EVERY GROUP RUNS IN ITS OWN PROCESS, ON ITS OWN DATA DIRECTORY.
+//      Several restart bugs make the database permanently unopenable. In a
+//      shared process one poisoned group takes the whole battery down with it
+//      and every other result is lost.
+//
+//   3. "THE DATABASE DID NOT REOPEN" IS AN OBSERVATION, NOT A CRASH.
+//      The reopen happens in a forked child. If it dies of SIGSEGV/SIGBUS, or
+//      throws out of the constructor, the parent records RESTART_FAIL(...) and
+//      diffs it like any other observation.
+//
+//   4. A CRASH RESTART MUST BE A REAL CRASH.
+//      ~base_otterbrix_t runs a full CHECKPOINT on every clean shutdown, so a
+//      "disk, no explicit CHECKPOINT" run is NOT a no-checkpoint control. The
+//      crash flavor calls _exit() from inside the live scope, so no destructor
+//      -- and therefore no checkpoint -- ever runs.
+//
+// An observation is canonicalized to a single line, so a divergence in row
+// count, row content, NULL-ness, reported column type, or error text all show
+// up as the same kind of string inequality.
+// ===========================================================================
+
+#include "test_config.hpp"
+
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+#include <exception>
+#include <fstream>
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace restart_rc {
+
+    // ---------------------------------------------------------------------
+    // Storage mode and restart flavor
+    // ---------------------------------------------------------------------
+
+    enum class storage_mode
+    {
+        in_memory,      // default table storage; durability via WAL replay only
+        disk,           // WITH (storage = 'disk'); checkpoint only on clean shutdown
+        disk_checkpoint // WITH (storage = 'disk') + an explicit CHECKPOINT after setup
+    };
+
+    enum class restart_flavor
+    {
+        clean, // scopes unwind: ~base_otterbrix_t runs a full checkpoint
+        crash  // _exit() from inside the live scope: no destructor, no checkpoint
+    };
+
+    inline const char* to_string(storage_mode m) {
+        switch (m) {
+            case storage_mode::in_memory:
+                return "mem";
+            case storage_mode::disk:
+                return "disk";
+            case storage_mode::disk_checkpoint:
+                return "diskck";
+        }
+        return "?";
+    }
+
+    inline const char* to_string(restart_flavor f) {
+        return f == restart_flavor::clean ? "clean" : "crash";
+    }
+
+    // The CREATE TABLE suffix that selects the storage mode.
+    inline std::string storage_clause(storage_mode m) {
+        return m == storage_mode::in_memory ? std::string{} : std::string{" WITH (storage = 'disk')"};
+    }
+
+    // ---------------------------------------------------------------------
+    // Probes and groups
+    // ---------------------------------------------------------------------
+
+    // One observation. `writes` (optional) run first and are themselves observed
+    // -- an INSERT that silently reports success with 0 rows is a divergence we
+    // must see. `read` is the query whose canonicalized result is compared.
+    //
+    // Any occurrence of $K in either is replaced by a phase-unique key, so the
+    // post-restart phase writes different rows than the pre-restart phase did
+    // and the two can never collide on the same data directory.
+    using named_sql = std::pair<std::string, std::string>; // observation name -> SQL
+
+    struct probe_t {
+        std::string name;                // prefixes every observation this probe makes
+        std::vector<std::string> writes; // run first; each one is itself observed
+        std::vector<named_sql> reads;    // the observations that are compared
+        // Statements that undo `writes`, so the table is back in its setup state
+        // when the next probe runs. Without this, a probe's pre-restart row is
+        // still there in the post-restart phase and every later unkeyed read (a
+        // COUNT, a full scan) sees one extra row -- a divergence the harness
+        // itself manufactured. A probe that writes MUST clean up after itself.
+        std::vector<std::string> cleanup;
+    };
+
+    // One table (or small set of tables) plus the probes over it. A group owns
+    // its own data directory and its own process, so a group that bricks the
+    // database cannot hide a divergence in any other group.
+    struct group_t {
+        std::string name;
+        std::vector<std::string> setup; // runs once, pre-restart, on a fresh database
+        std::vector<probe_t> probes;    // run identically in both phases
+    };
+
+    // ---------------------------------------------------------------------
+    // Canonicalization
+    //
+    // A row renders as its values AND their reported types, so losing a column
+    // type across the restart (BLOB -> UNKNOWN) diverges exactly like losing a
+    // value does. NULL renders distinctly from any value, so a validity bitmap
+    // that comes back all-valid diverges too.
+    // ---------------------------------------------------------------------
+
+    inline std::string type_tag(components::types::logical_type t) {
+        using lt = components::types::logical_type;
+        switch (t) {
+            case lt::NA:
+                return "NA";
+            case lt::BOOLEAN:
+                return "BOOL";
+            case lt::TINYINT:
+                return "I8";
+            case lt::SMALLINT:
+                return "I16";
+            case lt::INTEGER:
+                return "I32";
+            case lt::BIGINT:
+                return "I64";
+            case lt::HUGEINT:
+                return "I128";
+            case lt::UTINYINT:
+                return "U8";
+            case lt::USMALLINT:
+                return "U16";
+            case lt::UINTEGER:
+                return "U32";
+            case lt::UBIGINT:
+                return "U64";
+            case lt::UHUGEINT:
+                return "U128";
+            case lt::FLOAT:
+                return "F32";
+            case lt::DOUBLE:
+                return "F64";
+            case lt::DECIMAL:
+                return "DEC";
+            case lt::DATE:
+                return "DATE";
+            case lt::TIME:
+                return "TIME";
+            case lt::TIME_TZ:
+                return "TIMETZ";
+            case lt::TIMESTAMP:
+                return "TS";
+            case lt::TIMESTAMP_TZ:
+                return "TSTZ";
+            case lt::INTERVAL:
+                return "IVL";
+            case lt::BLOB:
+                return "BLOB";
+            case lt::BIT:
+                return "BIT";
+            case lt::UUID:
+                return "UUID";
+            case lt::STRING_LITERAL:
+                return "STR";
+            case lt::INTEGER_LITERAL:
+                return "ILIT";
+            case lt::STRUCT:
+                return "STRUCT";
+            case lt::LIST:
+                return "LIST";
+            case lt::MAP:
+                return "MAP";
+            case lt::ARRAY:
+                return "ARRAY";
+            case lt::ENUM:
+                return "ENUM";
+            case lt::UNKNOWN:
+                return "UNKNOWN";
+            case lt::INVALID:
+                return "INVALID";
+            default:
+                break;
+        }
+        return "T" + std::to_string(static_cast<int>(t));
+    }
+
+    // Render one cell as <TYPE>:<value>, or <TYPE>:NULL. Dispatches only on the
+    // bare logical_type enum -- never on the type's extension, which is exactly
+    // the thing a restart can leave in a type-confused state.
+    inline std::string render_value(const components::types::logical_value_t& v) {
+        using lt = components::types::logical_type;
+        const auto t = v.type().type();
+        const std::string tag = type_tag(t);
+        if (v.is_null()) {
+            return tag + ":NULL";
+        }
+        std::ostringstream os;
+        os << tag << ':';
+        switch (t) {
+            case lt::BOOLEAN:
+                os << (v.value<bool>() ? "true" : "false");
+                break;
+            case lt::TINYINT:
+                os << static_cast<int64_t>(v.value<int8_t>());
+                break;
+            case lt::SMALLINT:
+                os << static_cast<int64_t>(v.value<int16_t>());
+                break;
+            case lt::INTEGER:
+                os << static_cast<int64_t>(v.value<int32_t>());
+                break;
+            case lt::BIGINT:
+            // A DECIMAL renders as its raw scaled integer payload: reading its
+            // scale would mean touching the type extension, which is precisely
+            // what a v1 .otbx reload corrupts. The raw payload is enough to see
+            // a divergence, and the value probes (WHERE price = 12.34) cover the
+            // scale itself.
+            case lt::DECIMAL:
+            case lt::INTEGER_LITERAL:
+                os << v.value<int64_t>();
+                break;
+            case lt::UTINYINT:
+                os << static_cast<uint64_t>(v.value<uint8_t>());
+                break;
+            case lt::USMALLINT:
+                os << static_cast<uint64_t>(v.value<uint16_t>());
+                break;
+            case lt::UINTEGER:
+                os << static_cast<uint64_t>(v.value<uint32_t>());
+                break;
+            case lt::UBIGINT:
+                os << v.value<uint64_t>();
+                break;
+            case lt::FLOAT:
+                os << std::to_string(v.value<float>());
+                break;
+            case lt::DOUBLE:
+                os << std::to_string(v.value<double>());
+                break;
+            case lt::STRING_LITERAL:
+            case lt::BLOB:
+                os << '"' << v.value<std::string_view>() << '"';
+                break;
+            case lt::DATE:
+                os << v.value<core::date::date_t>().value;
+                break;
+            case lt::TIMESTAMP:
+                os << v.value<core::date::timestamp_t>().value;
+                break;
+            case lt::TIMESTAMP_TZ:
+                os << v.value<core::date::timestamptz_t>().value;
+                break;
+            case lt::TIME:
+                os << v.value<core::date::time_t>().value;
+                break;
+            default:
+                os << '?';
+                break;
+        }
+        return os.str();
+    }
+
+    inline std::string sanitize(std::string s) {
+        for (auto& c : s) {
+            if (c == '\n' || c == '\r' || c == '\t') {
+                c = ' ';
+            }
+        }
+        if (s.size() > 400) {
+            s.resize(400);
+            s += "...";
+        }
+        return s;
+    }
+
+    // Run one statement and canonicalize its outcome.
+    //
+    //   ERR|<message>                         a failing statement (text compared verbatim)
+    //   OK|rows=N|cols=M|<row>|<row>|...      a succeeding one, rows sorted so that
+    //                                         physical order -- which legitimately
+    //                                         differs between a WAL-replayed and an
+    //                                         .otbx-loaded table -- is not compared
+    inline std::string observe_raw(otterbrix::wrapper_dispatcher_t* dispatcher, const std::string& sql) {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, sql);
+        if (!cur) {
+            return "ERR|<null cursor>";
+        }
+        if (cur->is_error()) {
+            return "ERR|" + sanitize(std::string(cur->get_error().what.c_str()));
+        }
+        const std::size_t rows = cur->size();
+        const std::size_t cols = cur->column_count();
+        std::vector<std::string> rendered;
+        rendered.reserve(rows);
+        for (std::size_t r = 0; r < rows; ++r) {
+            std::string line;
+            for (std::size_t c = 0; c < cols; ++c) {
+                if (c) {
+                    line += ',';
+                }
+                line += render_value(cur->value(c, r));
+            }
+            rendered.push_back(std::move(line));
+        }
+        std::sort(rendered.begin(), rendered.end());
+        std::ostringstream os;
+        os << "OK|rows=" << rows << "|cols=" << cols;
+        for (const auto& row : rendered) {
+            os << "|[" << row << ']';
+        }
+        return sanitize(os.str());
+    }
+
+    inline std::string replace_all(std::string s, std::string_view token, const std::string& with) {
+        for (std::size_t pos = s.find(token); pos != std::string::npos; pos = s.find(token, pos + with.size())) {
+            s.replace(pos, token.size(), with);
+        }
+        return s;
+    }
+
+    // $K -> the phase-unique key; $S -> the storage clause for this mode. A group
+    // is therefore written once and runs unchanged in every storage mode.
+    inline std::string expand(const std::string& sql, int key, storage_mode mode) {
+        return replace_all(replace_all(sql, "$S", storage_clause(mode)), "$K", std::to_string(key));
+    }
+
+    // The phase key is different in the two phases BY CONSTRUCTION -- that is how a
+    // post-restart write is kept from colliding with the row its pre-restart twin
+    // left behind. So a probe that selects the key column would "diverge" on every
+    // run. Fold the key back out of the observation before comparing: a row keyed
+    // $K+3 renders identically in both phases.
+    inline std::string normalize_key(std::string observation, int key) {
+        for (int offset = 0; offset < 100; ++offset) {
+            observation =
+                replace_all(std::move(observation), std::to_string(key + offset), "$K+" + std::to_string(offset));
+        }
+        return observation;
+    }
+
+    inline std::string
+    observe(otterbrix::wrapper_dispatcher_t* dispatcher, const std::string& sql, int key, storage_mode mode) {
+        return normalize_key(observe_raw(dispatcher, expand(sql, key, mode)), key);
+    }
+
+    // ---------------------------------------------------------------------
+    // The phase runner (child process)
+    // ---------------------------------------------------------------------
+
+    // Keys are phase-unique so a probe's post-restart write cannot collide with
+    // the row its pre-restart write left behind.
+    constexpr int key_pre = 700100;
+    constexpr int key_post = 700200;
+
+    struct phase_result {
+        bool opened{false};
+        std::string failure; // set when `opened` is false
+        std::vector<std::pair<std::string, std::string>> observations;
+    };
+
+    namespace detail {
+
+        inline void write_results(const std::string& path,
+                                  const std::vector<std::pair<std::string, std::string>>& obs) {
+            std::ofstream out(path, std::ios::trunc);
+            for (const auto& [name, value] : obs) {
+                out << name << '\t' << value << '\n';
+            }
+            out.flush();
+        }
+
+        inline void write_failure(const std::string& path, const std::string& what) {
+            std::ofstream out(path, std::ios::trunc);
+            out << "\t__OPEN_FAILED__\t" << sanitize(what) << '\n';
+            out.flush();
+        }
+
+        // Runs inside the forked child. Never returns.
+        [[noreturn]] inline void run_phase_child(const group_t& group,
+                                                 const configuration::config& config,
+                                                 storage_mode mode,
+                                                 restart_flavor flavor,
+                                                 bool is_setup_phase,
+                                                 const std::string& out_path) {
+            std::vector<std::pair<std::string, std::string>> obs;
+            try {
+                // Everything that talks to the database lives in this scope. On a
+                // clean restart the scope exits normally and ~base_otterbrix_t runs
+                // its checkpoint; on a crash restart we _exit() while still inside
+                // it, so no destructor runs at all.
+                {
+                    test_spaces space(config);
+                    auto* dispatcher = space.dispatcher();
+
+                    const int key = is_setup_phase ? key_pre : key_post;
+
+                    if (is_setup_phase) {
+                        for (const auto& sql : group.setup) {
+                            obs.emplace_back("setup: " + sanitize(expand(sql, key, mode)),
+                                             observe(dispatcher, sql, key, mode));
+                        }
+                        if (mode == storage_mode::disk_checkpoint) {
+                            obs.emplace_back("setup: CHECKPOINT", observe(dispatcher, "CHECKPOINT;", key, mode));
+                        }
+                    }
+
+                    for (const auto& p : group.probes) {
+                        for (std::size_t i = 0; i < p.writes.size(); ++i) {
+                            obs.emplace_back(p.name + ".write" + std::to_string(i),
+                                             observe(dispatcher, p.writes[i], key, mode));
+                        }
+                        for (const auto& [read_name, sql] : p.reads) {
+                            obs.emplace_back(p.name + '.' + read_name, observe(dispatcher, sql, key, mode));
+                        }
+                        for (std::size_t i = 0; i < p.cleanup.size(); ++i) {
+                            obs.emplace_back(p.name + ".cleanup" + std::to_string(i),
+                                             observe(dispatcher, p.cleanup[i], key, mode));
+                        }
+                    }
+
+                    write_results(out_path, obs);
+
+                    if (is_setup_phase && flavor == restart_flavor::crash) {
+                        // No unwinding: no checkpoint, no clean WAL seal. This is the
+                        // state a `kill -9` or a power loss leaves behind.
+                        _exit(0);
+                    }
+                }
+            } catch (const std::exception& e) {
+                write_failure(out_path, std::string("exception: ") + e.what());
+                _exit(0);
+            } catch (...) {
+                write_failure(out_path, "exception: <unknown>");
+                _exit(0);
+            }
+            _exit(0);
+        }
+
+        inline phase_result read_results(const std::string& path, int wait_status) {
+            phase_result result;
+            if (WIFSIGNALED(wait_status)) {
+                result.failure = std::string("signal: ") + strsignal(WTERMSIG(wait_status));
+                return result;
+            }
+            std::ifstream in(path);
+            if (!in) {
+                result.failure = "no results file (child produced nothing)";
+                return result;
+            }
+            std::string line;
+            while (std::getline(in, line)) {
+                const auto tab = line.find('\t');
+                if (tab == std::string::npos) {
+                    continue;
+                }
+                const std::string name = line.substr(0, tab);
+                const std::string value = line.substr(tab + 1);
+                if (name.empty() && value.rfind("__OPEN_FAILED__\t", 0) == 0) {
+                    result.failure = value.substr(std::strlen("__OPEN_FAILED__\t"));
+                    return result;
+                }
+                result.observations.emplace_back(name, value);
+            }
+            result.opened = true;
+            return result;
+        }
+
+        // Fork, run one phase in the child, collect its observations.
+        inline phase_result run_phase(const group_t& group,
+                                      const configuration::config& config,
+                                      storage_mode mode,
+                                      restart_flavor flavor,
+                                      bool is_setup_phase,
+                                      const std::string& out_path) {
+            std::remove(out_path.c_str());
+            const pid_t pid = ::fork();
+            if (pid == 0) {
+                run_phase_child(group, config, mode, flavor, is_setup_phase, out_path);
+            }
+            int status = 0;
+            ::waitpid(pid, &status, 0);
+            return read_results(out_path, status);
+        }
+
+    } // namespace detail
+
+    // ---------------------------------------------------------------------
+    // The diff
+    // ---------------------------------------------------------------------
+
+    struct divergence_t {
+        std::string probe;
+        std::string before;
+        std::string after;
+    };
+
+    struct rc_report {
+        bool reopened{false};
+        std::string reopen_failure;
+        std::vector<divergence_t> divergences;
+        std::size_t compared{0};
+
+        bool consistent() const { return reopened && divergences.empty(); }
+
+        std::string describe() const {
+            std::ostringstream os;
+            if (!reopened) {
+                os << "DATABASE DID NOT REOPEN: " << reopen_failure;
+                return os.str();
+            }
+            os << divergences.size() << " of " << compared << " probes diverged across the restart:\n";
+            for (const auto& d : divergences) {
+                os << "  " << d.probe << "\n    before: " << d.before << "\n    after : " << d.after << '\n';
+            }
+            return os.str();
+        }
+    };
+
+    // Where a group's data directory lives. Deliberately NOT under /tmp: on this
+    // machine /tmp is a small tmpfs shared with other work, and a restart battery
+    // that fills it would take unrelated processes down with it.
+    inline std::filesystem::path data_root() {
+        if (const char* env = std::getenv("RC_DATA_ROOT")) {
+            return std::filesystem::path(env);
+        }
+        return std::filesystem::path("/tmp/otterbrix/restart_consistency");
+    }
+
+    // Run one group under one (mode, flavor) and report every divergence.
+    inline rc_report check_group(const group_t& group, storage_mode mode, restart_flavor flavor) {
+        const auto dir = data_root() / group.name / to_string(mode) / to_string(flavor);
+        auto config = test_create_config(dir);
+        test_clear_directory(config);
+        const std::string out_pre = (dir / "rc_pre.tsv").string();
+        const std::string out_post = (dir / "rc_post.tsv").string();
+
+        const auto before = detail::run_phase(group, config, mode, flavor, /*is_setup_phase=*/true, out_pre);
+        rc_report report;
+        if (!before.opened) {
+            // The pre-restart phase itself failed. That is a bug, but not a RESTART
+            // bug -- report it as such rather than blaming the restart.
+            report.reopened = false;
+            report.reopen_failure = "pre-restart phase failed: " + before.failure;
+            return report;
+        }
+
+        const auto after = detail::run_phase(group, config, mode, flavor, /*is_setup_phase=*/false, out_post);
+        if (!after.opened) {
+            report.reopened = false;
+            report.reopen_failure = after.failure;
+            return report;
+        }
+        report.reopened = true;
+
+        std::map<std::string, std::string> after_by_name;
+        for (const auto& [name, value] : after.observations) {
+            after_by_name.emplace(name, value);
+        }
+        for (const auto& [name, value] : before.observations) {
+            if (name.rfind("setup: ", 0) == 0) {
+                continue; // setup runs pre-restart only; it has no post-restart twin
+            }
+            ++report.compared;
+            const auto it = after_by_name.find(name);
+            if (it == after_by_name.end()) {
+                report.divergences.push_back({name, value, "<probe missing after restart>"});
+            } else if (it->second != value) {
+                report.divergences.push_back({name, value, it->second});
+            }
+        }
+        return report;
+    }
+
+} // namespace restart_rc

--- a/integration/cpp/test/restart_probe.hpp
+++ b/integration/cpp/test/restart_probe.hpp
@@ -13,56 +13,81 @@
 //   restricted to S2 must equal the observable trace of run(S1 . S2) with no
 //   restart at all, over the committed prefix of S1.
 //
-// The harness realizes that by running an identical PROBE list twice against
-// the same data directory -- once before the restart and once after -- and
-// diffing the two observation vectors probe by probe.
+// The harness realizes that with THREE runs of an identical probe list:
 //
-// Four properties of this design are load-bearing; each of them was learned by
-// getting it wrong first:
+//   before   -- fresh database, run setup, run probes at key_pre
+//   after    -- reopen that same data directory, run probes at key_post
+//   control  -- a SEPARATE database, ONE process, NO restart: setup, probes at
+//               key_pre, then probes at key_post again
 //
-//   1. PROBES MUST WRITE, not only read.
-//      A row inserted before the restart carries its DEFAULT in the WAL/
-//      checkpoint payload, so it reads back correctly no matter how badly the
-//      schema was restored. The loss is only observable on a write issued
-//      AFTER the restart. Read-only persistence tests are structurally blind
-//      to it. Every probe may therefore carry `writes`, which run in both
-//      phases, keyed by a phase-unique $K so the two phases cannot collide.
+// The control is what makes the other two mean anything. `before` and `after`
+// are not symmetric -- `after` starts from `before`'s end state -- so a probe
+// can differ across the restart for reasons that have nothing to do with the
+// restart (residue a cleanup failed to remove, an ordering effect, a value that
+// is simply not deterministic). The control run reproduces exactly that
+// asymmetry with the restart REMOVED. Anything that moves in the control is a
+// defect of the probe, and is reported as INCONCLUSIVE rather than as a
+// violation of the invariant.
 //
-//   2. EVERY GROUP RUNS IN ITS OWN PROCESS, ON ITS OWN DATA DIRECTORY.
-//      Several restart bugs make the database permanently unopenable. In a
-//      shared process one poisoned group takes the whole battery down with it
-//      and every other result is lost.
+// Five further properties are load-bearing; each was learned by getting it
+// wrong first:
 //
-//   3. "THE DATABASE DID NOT REOPEN" IS AN OBSERVATION, NOT A CRASH.
-//      The reopen happens in a forked child. If it dies of SIGSEGV/SIGBUS, or
-//      throws out of the constructor, the parent records RESTART_FAIL(...) and
-//      diffs it like any other observation.
+//   1. PROBES MUST WRITE, not only read. A row inserted before the restart
+//      carries its DEFAULT in the WAL/checkpoint payload, so it reads back
+//      correctly no matter how badly the schema was restored. The loss is only
+//      observable on a write issued AFTER the restart. Read-only persistence
+//      tests are structurally blind to it. A probe that writes must also CLEAN
+//      UP, or its row inflates every later unkeyed read in the next phase.
 //
-//   4. A CRASH RESTART MUST BE A REAL CRASH.
-//      ~base_otterbrix_t runs a full CHECKPOINT on every clean shutdown, so a
-//      "disk, no explicit CHECKPOINT" run is NOT a no-checkpoint control. The
-//      crash flavor calls _exit() from inside the live scope, so no destructor
-//      -- and therefore no checkpoint -- ever runs.
+//   2. `after == before` IS NOT ENOUGH. It is satisfied by being equally broken
+//      on both sides. A read may therefore carry an `expect`: an absolute oracle
+//      checked against the PRE-restart observation. A mismatch is BASELINE_WRONG
+//      -- the value was already wrong before any restart, so its survival proves
+//      nothing.
 //
-// An observation is canonicalized to a single line, so a divergence in row
-// count, row content, NULL-ness, reported column type, or error text all show
-// up as the same kind of string inequality.
+//   3. A GROUP WHOSE SETUP FAILED TESTED NOTHING. Setup runs pre-restart only,
+//      so a CREATE/INSERT that silently ERRs leaves both phases agreeing on the
+//      same empty table -- and the group passes. Any setup statement that
+//      returns an error fails the group, unless it is listed in
+//      known_broken_setup (which keeps the engine gap reviewed instead of
+//      silent).
+//
+//   4. "THE DATABASE DID NOT REOPEN" IS AN OBSERVATION, NOT A CRASH. Each phase
+//      runs in a forked child. A fatal signal, an exception out of the
+//      constructor, or a HANG (the child arms an alarm) is recorded and diffed
+//      like any other result.
+//
+//   5. A CRASH RESTART MUST BE A REAL CRASH. ~base_otterbrix_t runs a full
+//      CHECKPOINT on every clean shutdown, so a "disk, no explicit CHECKPOINT"
+//      run is NOT a no-checkpoint control. The crash flavor _exit()s from inside
+//      the live scope, so no destructor -- and therefore no checkpoint -- runs.
 // ===========================================================================
 
 #include "test_config.hpp"
 
+#include <spdlog/spdlog.h>
+
+#include <signal.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
 #include <algorithm>
+#include <cctype>
+#include <cerrno>
+#include <chrono>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <exception>
 #include <fstream>
+#include <iostream>
 #include <map>
+#include <set>
 #include <sstream>
 #include <string>
+#include <system_error>
+#include <utility>
 #include <vector>
 
 namespace restart_rc {
@@ -96,9 +121,7 @@ namespace restart_rc {
         return "?";
     }
 
-    inline const char* to_string(restart_flavor f) {
-        return f == restart_flavor::clean ? "clean" : "crash";
-    }
+    inline const char* to_string(restart_flavor f) { return f == restart_flavor::clean ? "clean" : "crash"; }
 
     // The CREATE TABLE suffix that selects the storage mode.
     inline std::string storage_clause(storage_mode m) {
@@ -109,34 +132,44 @@ namespace restart_rc {
     // Probes and groups
     // ---------------------------------------------------------------------
 
-    // One observation. `writes` (optional) run first and are themselves observed
-    // -- an INSERT that silently reports success with 0 rows is a divergence we
-    // must see. `read` is the query whose canonicalized result is compared.
-    //
-    // Any occurrence of $K in either is replaced by a phase-unique key, so the
-    // post-restart phase writes different rows than the pre-restart phase did
-    // and the two can never collide on the same data directory.
-    using named_sql = std::pair<std::string, std::string>; // observation name -> SQL
+    struct read_t {
+        std::string name;
+        std::string sql;
+        // Optional ABSOLUTE oracle for the PRE-restart observation, written in
+        // normalized form ("$K+0", never the literal key). Empty means the read is
+        // differential only. Without an oracle, `after == before` certifies a value
+        // that was already wrong before the restart.
+        std::string expect;
+
+        read_t(std::string read_name, std::string read_sql, std::string expected = {})
+            : name(std::move(read_name))
+            , sql(std::move(read_sql))
+            , expect(std::move(expected)) {}
+    };
 
     struct probe_t {
         std::string name;                // prefixes every observation this probe makes
         std::vector<std::string> writes; // run first; each one is itself observed
-        std::vector<named_sql> reads;    // the observations that are compared
-        // Statements that undo `writes`, so the table is back in its setup state
-        // when the next probe runs. Without this, a probe's pre-restart row is
-        // still there in the post-restart phase and every later unkeyed read (a
-        // COUNT, a full scan) sees one extra row -- a divergence the harness
-        // itself manufactured. A probe that writes MUST clean up after itself.
+        std::vector<read_t> reads;       // the observations that are compared
+        // Statements that undo `writes`, so the table is back in its setup state when
+        // the next probe runs. A probe that writes MUST clean up after itself, or its
+        // row is still there in the next phase and every later unkeyed read (a COUNT,
+        // a full scan) sees one extra row -- a divergence the harness manufactured.
         std::vector<std::string> cleanup;
     };
 
-    // One table (or small set of tables) plus the probes over it. A group owns
-    // its own data directory and its own process, so a group that bricks the
-    // database cannot hide a divergence in any other group.
     struct group_t {
         std::string name;
-        std::vector<std::string> setup; // runs once, pre-restart, on a fresh database
-        std::vector<probe_t> probes;    // run identically in both phases
+        // Session-scoped statements (SET TIMEZONE, ...). Re-issued at the top of EVERY
+        // phase, because a session does not survive a restart -- only what the setting
+        // persisted into the catalog does. Putting these in `setup` would test nothing:
+        // the control run would keep them in-process while a real reopen loses them.
+        std::vector<std::string> session_setup;
+        std::vector<std::string> setup; // DDL+DML, run once, pre-restart, on a fresh db
+        std::vector<probe_t> probes;    // run identically in every phase
+        // Setup SQL this engine cannot execute today. Listed here, a failure is a known
+        // gap rather than a silent pass; not listed, it fails the group.
+        std::vector<std::string> known_broken_setup;
     };
 
     // ---------------------------------------------------------------------
@@ -223,13 +256,38 @@ namespace restart_rc {
         return "T" + std::to_string(static_cast<int>(t));
     }
 
+    inline std::string to_string_i128(components::types::int128_t v) {
+        if (v == 0) {
+            return "0";
+        }
+        const bool negative = v < 0;
+        auto magnitude = static_cast<components::types::uint128_t>(negative ? -v : v);
+        std::string digits;
+        while (magnitude != 0) {
+            digits += static_cast<char>('0' + static_cast<int>(magnitude % 10));
+            magnitude /= 10;
+        }
+        if (negative) {
+            digits += '-';
+        }
+        std::reverse(digits.begin(), digits.end());
+        return digits;
+    }
+
     // Render one cell as <TYPE>:<value>, or <TYPE>:NULL. Dispatches only on the
-    // bare logical_type enum -- never on the type's extension, which is exactly
-    // the thing a restart can leave in a type-confused state.
-    inline std::string render_value(const components::types::logical_value_t& v) {
+    // bare logical_type enum, never on the type's extension -- a restart can leave
+    // the extension type-confused (set_alias on a null extension allocates a
+    // GENERIC one), so a blind downcast here would fault inside the test harness.
+    //
+    // `declared` is the column's type as the cursor reports it. It is what tags a
+    // NULL cell: the value of a NULL row carries no type of its own (it comes back
+    // as NA), so without the declared type a column that decayed to UNKNOWN across
+    // the restart would render identically to one that did not.
+    inline std::string render_value(const components::types::logical_value_t& v,
+                                    const components::types::logical_type* declared = nullptr) {
         using lt = components::types::logical_type;
         const auto t = v.type().type();
-        const std::string tag = type_tag(t);
+        const std::string tag = type_tag(declared != nullptr && t == lt::NA ? *declared : t);
         if (v.is_null()) {
             return tag + ":NULL";
         }
@@ -249,15 +307,26 @@ namespace restart_rc {
                 os << static_cast<int64_t>(v.value<int32_t>());
                 break;
             case lt::BIGINT:
-            // A DECIMAL renders as its raw scaled integer payload: reading its
-            // scale would mean touching the type extension, which is precisely
-            // what a v1 .otbx reload corrupts. The raw payload is enough to see
-            // a divergence, and the value probes (WHERE price = 12.34) cover the
-            // scale itself.
-            case lt::DECIMAL:
             case lt::INTEGER_LITERAL:
                 os << v.value<int64_t>();
                 break;
+            case lt::HUGEINT:
+                os << to_string_i128(v.value<components::types::int128_t>());
+                break;
+            case lt::DECIMAL: {
+                // The scale lives in the type extension, which a v1 .otbx reload
+                // corrupts -- so read it only if it is there, and never downcast blind.
+                // The raw scaled payload alone would make a lost scale invisible.
+                os << v.value<int64_t>() << '@';
+                const auto* extension = v.type().extension();
+                if (extension != nullptr) {
+                    os << static_cast<int>(
+                        static_cast<const components::types::decimal_logical_type_extension*>(extension)->scale());
+                } else {
+                    os << '?';
+                }
+                break;
+            }
             case lt::UTINYINT:
                 os << static_cast<uint64_t>(v.value<uint8_t>());
                 break;
@@ -292,6 +361,25 @@ namespace restart_rc {
             case lt::TIME:
                 os << v.value<core::date::time_t>().value;
                 break;
+            case lt::ARRAY:
+            case lt::LIST:
+            case lt::STRUCT:
+            case lt::MAP: {
+                // The element COUNT is part of the render, so a lost ARRAY fixed size
+                // diverges; the recursion renders each element's type, so a lost child
+                // type diverges too. ENUM is deliberately NOT routed here: it stores a
+                // scalar, and children() is null-guarded but not type-guarded.
+                const auto& children = v.children();
+                os << '{' << children.size() << ':';
+                for (std::size_t i = 0; i < children.size(); ++i) {
+                    if (i != 0) {
+                        os << ',';
+                    }
+                    os << render_value(children[i]);
+                }
+                os << '}';
+                break;
+            }
             default:
                 os << '?';
                 break;
@@ -305,8 +393,8 @@ namespace restart_rc {
                 c = ' ';
             }
         }
-        if (s.size() > 400) {
-            s.resize(400);
+        if (s.size() > 800) {
+            s.resize(800);
             s += "...";
         }
         return s;
@@ -316,12 +404,18 @@ namespace restart_rc {
     //
     //   ERR|<message>                         a failing statement (text compared verbatim)
     //   OK|rows=N|cols=M|<row>|<row>|...      a succeeding one, rows sorted so that
-    //                                         physical order -- which legitimately
-    //                                         differs between a WAL-replayed and an
-    //                                         .otbx-loaded table -- is not compared
-    inline std::string observe_raw(otterbrix::wrapper_dispatcher_t* dispatcher, const std::string& sql) {
-        auto session = otterbrix::session_id_t();
-        auto cur = dispatcher->execute_sql(session, sql);
+    //                                         physical order -- which legitimately differs
+    //                                         between a WAL-replayed and an .otbx-loaded
+    //                                         table -- is not compared
+    //
+    // `session` lets several statements share one session, which is how a transaction
+    // is expressed (transactions are keyed by session id). Passing nullptr mints a
+    // fresh session, i.e. autocommit.
+    inline std::string observe_raw(otterbrix::wrapper_dispatcher_t* dispatcher,
+                                   const std::string& sql,
+                                   const otterbrix::session_id_t* session = nullptr) {
+        otterbrix::session_id_t own_session;
+        auto cur = dispatcher->execute_sql(session != nullptr ? *session : own_session, sql);
         if (!cur) {
             return "ERR|<null cursor>";
         }
@@ -330,15 +424,18 @@ namespace restart_rc {
         }
         const std::size_t rows = cur->size();
         const std::size_t cols = cur->column_count();
+        const auto& column_types = cur->type_data();
         std::vector<std::string> rendered;
         rendered.reserve(rows);
         for (std::size_t r = 0; r < rows; ++r) {
             std::string line;
             for (std::size_t c = 0; c < cols; ++c) {
-                if (c) {
+                if (c != 0) {
                     line += ',';
                 }
-                line += render_value(cur->value(c, r));
+                const components::types::logical_type declared =
+                    c < column_types.size() ? column_types[c].type() : components::types::logical_type::NA;
+                line += render_value(cur->value(c, r), &declared);
             }
             rendered.push_back(std::move(line));
         }
@@ -351,6 +448,21 @@ namespace restart_rc {
         return sanitize(os.str());
     }
 
+    // ---------------------------------------------------------------------
+    // Phase keys
+    //
+    // The two phases write different rows on purpose, so a post-restart write
+    // cannot collide with the row its pre-restart twin left behind. The key is
+    // then folded back out of the observation, so a probe may freely SELECT it.
+    // ---------------------------------------------------------------------
+
+    constexpr int key_window = 100; // a probe may use $K .. $K+99
+    constexpr int key_pre = 700100;
+    constexpr int key_post = 800100; // NOT key_pre + key_window: adjacent windows would
+                                     // make a probe's `$K + 99` collide with the other
+                                     // phase's own key on the shared data directory.
+    static_assert(key_post - key_pre >= key_window, "the two key windows must not overlap");
+
     inline std::string replace_all(std::string s, std::string_view token, const std::string& with) {
         for (std::size_t pos = s.find(token); pos != std::string::npos; pos = s.find(token, pos + with.size())) {
             s.replace(pos, token.size(), with);
@@ -358,118 +470,263 @@ namespace restart_rc {
         return s;
     }
 
-    // $K -> the phase-unique key; $S -> the storage clause for this mode. A group
-    // is therefore written once and runs unchanged in every storage mode.
+    // $K -> the phase-unique key; $S -> the storage clause for this mode. A group is
+    // therefore written once and runs unchanged in every storage mode.
     inline std::string expand(const std::string& sql, int key, storage_mode mode) {
         return replace_all(replace_all(sql, "$S", storage_clause(mode)), "$K", std::to_string(key));
     }
 
-    // The phase key is different in the two phases BY CONSTRUCTION -- that is how a
-    // post-restart write is kept from colliding with the row its pre-restart twin
-    // left behind. So a probe that selects the key column would "diverge" on every
-    // run. Fold the key back out of the observation before comparing: a row keyed
-    // $K+3 renders identically in both phases.
-    inline std::string normalize_key(std::string observation, int key) {
-        for (int offset = 0; offset < 100; ++offset) {
-            observation =
-                replace_all(std::move(observation), std::to_string(key + offset), "$K+" + std::to_string(offset));
+    // Fold BOTH phases' key windows, in BOTH phases, matching only WHOLE digit runs.
+    //
+    //   both windows: a data value that coincidentally lands in a key window (a
+    //     timestamp's raw epoch, a bigint literal) is then folded IDENTICALLY on both
+    //     sides and cancels out, instead of being folded in one phase only -- which
+    //     would manufacture a divergence.
+    //   whole runs:   1700100 must not become 1$K+0. Substring replacement would.
+    inline std::string normalize_keys(const std::string& s) {
+        std::string out;
+        out.reserve(s.size());
+        std::size_t i = 0;
+        while (i < s.size()) {
+            if (std::isdigit(static_cast<unsigned char>(s[i])) == 0) {
+                out += s[i++];
+                continue;
+            }
+            std::size_t j = i;
+            while (j < s.size() && std::isdigit(static_cast<unsigned char>(s[j])) != 0) {
+                ++j;
+            }
+            const std::string run = s.substr(i, j - i);
+            bool folded = false;
+            if (run.size() <= 18) {
+                const long long value = std::stoll(run);
+                for (const int base : {key_pre, key_post}) {
+                    if (value >= base && value < base + key_window) {
+                        out += "$K+" + std::to_string(value - base);
+                        folded = true;
+                        break;
+                    }
+                }
+            }
+            if (!folded) {
+                out += run;
+            }
+            i = j;
         }
-        return observation;
+        return out;
     }
 
-    inline std::string
-    observe(otterbrix::wrapper_dispatcher_t* dispatcher, const std::string& sql, int key, storage_mode mode) {
-        return normalize_key(observe_raw(dispatcher, expand(sql, key, mode)), key);
+    inline std::string observe(otterbrix::wrapper_dispatcher_t* dispatcher,
+                               const std::string& sql,
+                               int key,
+                               storage_mode mode,
+                               const otterbrix::session_id_t* session = nullptr) {
+        return normalize_keys(observe_raw(dispatcher, expand(sql, key, mode), session));
+    }
+
+    // Where a group's data directory lives. Deliberately NOT under /tmp: on many
+    // machines that is a small tmpfs shared with other work, and a battery that fills
+    // it produces phantom "database did not reopen" results -- and takes unrelated
+    // processes down with it.
+    inline std::filesystem::path data_root() {
+        if (const char* env = std::getenv("RC_DATA_ROOT")) {
+            return std::filesystem::path(env);
+        }
+        return std::filesystem::path("/var/tmp/otterbrix/restart_consistency");
+    }
+
+    // A hung reopen is one of the four ways this database fails to come back, and
+    // without a deadline it wedges the whole suite instead of reporting. Generous by
+    // design: a timeout firing on an honest-but-slow phase would be reported as a
+    // database that did not reopen, i.e. a fabricated bug.
+    inline unsigned phase_timeout_seconds() {
+        if (const char* env = std::getenv("RC_PHASE_TIMEOUT")) {
+            const long v = std::strtol(env, nullptr, 10);
+            if (v > 0) {
+                return static_cast<unsigned>(v);
+            }
+        }
+        return 180;
     }
 
     // ---------------------------------------------------------------------
-    // The phase runner (child process)
+    // Running a phase in a child process
     // ---------------------------------------------------------------------
-
-    // Keys are phase-unique so a probe's post-restart write cannot collide with
-    // the row its pre-restart write left behind.
-    constexpr int key_pre = 700100;
-    constexpr int key_post = 700200;
 
     struct phase_result {
         bool opened{false};
-        std::string failure; // set when `opened` is false
+        std::string failure;         // set when `opened` is false
+        std::string shutdown_signal; // opened and answered, then died on the way out
         std::vector<std::pair<std::string, std::string>> observations;
     };
 
     namespace detail {
 
-        inline void write_results(const std::string& path,
-                                  const std::vector<std::pair<std::string, std::string>>& obs) {
-            std::ofstream out(path, std::ios::trunc);
-            for (const auto& [name, value] : obs) {
-                out << name << '\t' << value << '\n';
+        // fork() preserves signal dispositions. Catch2 keeps SIGSEGV/SIGBUS/SIGABRT
+        // engaged for the whole test body, so without this a child that crashes -- the
+        // DESIGNED outcome for a group whose database will not reopen -- runs Catch2's
+        // fatal-signal handler and writes a spurious failure report for the PARENT's
+        // test case onto the shared output stream.
+        inline void detach_from_catch2_signal_handlers() {
+            for (const int sig : {SIGINT, SIGILL, SIGFPE, SIGSEGV, SIGBUS, SIGTERM, SIGABRT}) {
+                ::signal(sig, SIG_DFL);
             }
-            out.flush();
+            stack_t disable{};
+            disable.ss_flags = SS_DISABLE;
+            ::sigaltstack(&disable, nullptr);
         }
 
-        inline void write_failure(const std::string& path, const std::string& what) {
-            std::ofstream out(path, std::ios::trunc);
-            out << "\t__OPEN_FAILED__\t" << sanitize(what) << '\n';
-            out.flush();
+        // The parent must be single-threaded at fork(). The logger leaves spdlog's
+        // periodic flush thread running in any process that has built a test_spaces --
+        // i.e. this Catch2 parent, as soon as any earlier test case in the binary did --
+        // and nothing ever shuts it down. Forking while that thread holds the sink mutex
+        // gives the child a locked mutex with no owner, and the child hangs forever.
+        // Setting a zero interval destroys the worker here, in the parent, while the
+        // thread it belongs to still exists to be joined.
+        inline void quiesce_parent_before_fork() {
+            spdlog::flush_every(std::chrono::seconds(0));
+            std::cout.flush();
+            std::cerr.flush();
+            std::fflush(nullptr); // the child must not re-emit the parent's buffered stdio
         }
 
-        // Runs inside the forked child. Never returns.
+        // Streaming writer: each observation is flushed as it is produced, so a child
+        // that dies inside a probe -- or inside the shutdown checkpoint, after answering
+        // everything -- still leaves behind everything it managed to collect.
+        class result_sink {
+        public:
+            explicit result_sink(const std::string& path)
+                : out_(path, std::ios::trunc) {}
+
+            void emit(const std::string& name, const std::string& value) {
+                out_ << name << '\t' << value << '\n';
+                out_.flush();
+            }
+
+            void fail(const std::string& what) {
+                out_ << '\t' << "__OPEN_FAILED__\t" << sanitize(what) << '\n';
+                out_.flush();
+            }
+
+        private:
+            std::ofstream out_;
+        };
+
+        // Run every probe once, at `key`, emitting each observation as it is produced.
+        inline void run_probes(otterbrix::wrapper_dispatcher_t* dispatcher,
+                               const group_t& group,
+                               int key,
+                               storage_mode mode,
+                               result_sink& sink) {
+            for (const auto& p : group.probes) {
+                for (std::size_t i = 0; i < p.writes.size(); ++i) {
+                    sink.emit(p.name + ".write" + std::to_string(i), observe(dispatcher, p.writes[i], key, mode));
+                }
+                for (const auto& r : p.reads) {
+                    sink.emit(p.name + '.' + r.name, observe(dispatcher, r.sql, key, mode));
+                }
+                for (std::size_t i = 0; i < p.cleanup.size(); ++i) {
+                    sink.emit(p.name + ".cleanup" + std::to_string(i), observe(dispatcher, p.cleanup[i], key, mode));
+                }
+            }
+        }
+
+        inline void run_session_setup(otterbrix::wrapper_dispatcher_t* dispatcher,
+                                      const group_t& group,
+                                      int key,
+                                      storage_mode mode,
+                                      result_sink& sink) {
+            for (const auto& sql : group.session_setup) {
+                sink.emit("session: " + sanitize(expand(sql, key, mode)), observe(dispatcher, sql, key, mode));
+            }
+        }
+
+        inline void run_setup(otterbrix::wrapper_dispatcher_t* dispatcher,
+                              const group_t& group,
+                              int key,
+                              storage_mode mode,
+                              result_sink& sink) {
+            for (const auto& sql : group.setup) {
+                sink.emit("setup: " + sanitize(expand(sql, key, mode)), observe(dispatcher, sql, key, mode));
+            }
+            if (mode == storage_mode::disk_checkpoint) {
+                sink.emit("setup: CHECKPOINT", observe(dispatcher, "CHECKPOINT;", key, mode));
+            }
+        }
+
+        // One phase of the restart run. Never returns.
         [[noreturn]] inline void run_phase_child(const group_t& group,
                                                  const configuration::config& config,
                                                  storage_mode mode,
                                                  restart_flavor flavor,
                                                  bool is_setup_phase,
                                                  const std::string& out_path) {
-            std::vector<std::pair<std::string, std::string>> obs;
+            detach_from_catch2_signal_handlers();
+            ::alarm(phase_timeout_seconds());
+            result_sink sink(out_path);
             try {
-                // Everything that talks to the database lives in this scope. On a
-                // clean restart the scope exits normally and ~base_otterbrix_t runs
-                // its checkpoint; on a crash restart we _exit() while still inside
-                // it, so no destructor runs at all.
+                // Everything that talks to the database lives in this scope. On a clean
+                // restart the scope exits normally and ~base_otterbrix_t runs its
+                // checkpoint; on a crash restart we _exit() while still inside it, so no
+                // destructor runs at all.
                 {
                     test_spaces space(config);
                     auto* dispatcher = space.dispatcher();
-
                     const int key = is_setup_phase ? key_pre : key_post;
 
+                    run_session_setup(dispatcher, group, key, mode, sink);
                     if (is_setup_phase) {
-                        for (const auto& sql : group.setup) {
-                            obs.emplace_back("setup: " + sanitize(expand(sql, key, mode)),
-                                             observe(dispatcher, sql, key, mode));
-                        }
-                        if (mode == storage_mode::disk_checkpoint) {
-                            obs.emplace_back("setup: CHECKPOINT", observe(dispatcher, "CHECKPOINT;", key, mode));
-                        }
+                        run_setup(dispatcher, group, key, mode, sink);
                     }
-
-                    for (const auto& p : group.probes) {
-                        for (std::size_t i = 0; i < p.writes.size(); ++i) {
-                            obs.emplace_back(p.name + ".write" + std::to_string(i),
-                                             observe(dispatcher, p.writes[i], key, mode));
-                        }
-                        for (const auto& [read_name, sql] : p.reads) {
-                            obs.emplace_back(p.name + '.' + read_name, observe(dispatcher, sql, key, mode));
-                        }
-                        for (std::size_t i = 0; i < p.cleanup.size(); ++i) {
-                            obs.emplace_back(p.name + ".cleanup" + std::to_string(i),
-                                             observe(dispatcher, p.cleanup[i], key, mode));
-                        }
-                    }
-
-                    write_results(out_path, obs);
+                    run_probes(dispatcher, group, key, mode, sink);
 
                     if (is_setup_phase && flavor == restart_flavor::crash) {
-                        // No unwinding: no checkpoint, no clean WAL seal. This is the
-                        // state a `kill -9` or a power loss leaves behind.
+                        // No unwinding: no checkpoint, no clean WAL seal. This is the state
+                        // a kill -9 or a power loss leaves behind.
                         _exit(0);
                     }
                 }
             } catch (const std::exception& e) {
-                write_failure(out_path, std::string("exception: ") + e.what());
+                sink.fail(std::string("exception: ") + e.what());
                 _exit(0);
             } catch (...) {
-                write_failure(out_path, "exception: <unknown>");
+                sink.fail("exception: <unknown>");
+                _exit(0);
+            }
+            _exit(0);
+        }
+
+        // THE CONTROL: one process, one database, NO restart. Setup, probes at key_pre,
+        // then the same probes again at key_post. Any observation that moves between the
+        // two runs moves without a restart being involved at all -- it is a defect of the
+        // probe (residue, ordering, non-determinism), not of the database. Without this,
+        // every such artifact is indistinguishable from a restart bug.
+        [[noreturn]] inline void run_control_child(const group_t& group,
+                                                   const configuration::config& config,
+                                                   storage_mode mode,
+                                                   const std::string& out_first,
+                                                   const std::string& out_second) {
+            detach_from_catch2_signal_handlers();
+            ::alarm(phase_timeout_seconds());
+            try {
+                test_spaces space(config);
+                auto* dispatcher = space.dispatcher();
+                {
+                    result_sink sink(out_first);
+                    run_session_setup(dispatcher, group, key_pre, mode, sink);
+                    run_setup(dispatcher, group, key_pre, mode, sink);
+                    run_probes(dispatcher, group, key_pre, mode, sink);
+                }
+                {
+                    result_sink sink(out_second);
+                    run_session_setup(dispatcher, group, key_post, mode, sink);
+                    run_probes(dispatcher, group, key_post, mode, sink);
+                }
+            } catch (const std::exception& e) {
+                result_sink(out_second).fail(std::string("exception: ") + e.what());
+                _exit(0);
+            } catch (...) {
+                result_sink(out_second).fail("exception: <unknown>");
                 _exit(0);
             }
             _exit(0);
@@ -477,34 +734,55 @@ namespace restart_rc {
 
         inline phase_result read_results(const std::string& path, int wait_status) {
             phase_result result;
-            if (WIFSIGNALED(wait_status)) {
-                result.failure = std::string("signal: ") + strsignal(WTERMSIG(wait_status));
-                return result;
-            }
             std::ifstream in(path);
-            if (!in) {
-                result.failure = "no results file (child produced nothing)";
-                return result;
-            }
-            std::string line;
-            while (std::getline(in, line)) {
-                const auto tab = line.find('\t');
-                if (tab == std::string::npos) {
-                    continue;
+            const bool had_file = static_cast<bool>(in);
+            if (in) {
+                std::string line;
+                while (std::getline(in, line)) {
+                    const auto tab = line.find('\t');
+                    if (tab == std::string::npos) {
+                        continue;
+                    }
+                    const std::string name = line.substr(0, tab);
+                    const std::string value = line.substr(tab + 1);
+                    if (name.empty() && value.rfind("__OPEN_FAILED__\t", 0) == 0) {
+                        result.failure = value.substr(std::strlen("__OPEN_FAILED__\t"));
+                        return result;
+                    }
+                    result.observations.emplace_back(name, value);
                 }
-                const std::string name = line.substr(0, tab);
-                const std::string value = line.substr(tab + 1);
-                if (name.empty() && value.rfind("__OPEN_FAILED__\t", 0) == 0) {
-                    result.failure = value.substr(std::strlen("__OPEN_FAILED__\t"));
+            }
+            if (WIFSIGNALED(wait_status)) {
+                const int sig = WTERMSIG(wait_status);
+                const std::string described =
+                    sig == SIGALRM ? "timeout: phase did not finish in " + std::to_string(phase_timeout_seconds()) +
+                                         "s (hung)"
+                                   : std::string("signal: ") + strsignal(sig);
+                if (result.observations.empty()) {
+                    result.failure = described; // died during open
                     return result;
                 }
-                result.observations.emplace_back(name, value);
+                // It DID open and answer every probe, and then died on the way out. Keep
+                // the evidence; report the crash separately.
+                result.opened = true;
+                result.shutdown_signal = described;
+                return result;
+            }
+            if (result.observations.empty() && !had_file) {
+                result.failure = "no results file (child produced nothing)";
+                return result;
             }
             result.opened = true;
             return result;
         }
 
-        // Fork, run one phase in the child, collect its observations.
+        inline int wait_for(pid_t pid) {
+            int status = 0;
+            while (::waitpid(pid, &status, 0) < 0 && errno == EINTR) {
+            }
+            return status;
+        }
+
         inline phase_result run_phase(const group_t& group,
                                       const configuration::config& config,
                                       storage_mode mode,
@@ -512,19 +790,83 @@ namespace restart_rc {
                                       bool is_setup_phase,
                                       const std::string& out_path) {
             std::remove(out_path.c_str());
+            quiesce_parent_before_fork();
             const pid_t pid = ::fork();
             if (pid == 0) {
                 run_phase_child(group, config, mode, flavor, is_setup_phase, out_path);
             }
-            int status = 0;
-            ::waitpid(pid, &status, 0);
-            return read_results(out_path, status);
+            if (pid < 0) {
+                phase_result result;
+                result.failure = std::string("fork failed: ") + std::strerror(errno);
+                return result;
+            }
+            return read_results(out_path, wait_for(pid));
+        }
+
+        struct control_result {
+            bool opened{false};
+            std::string failure;
+            std::set<std::string> dirty; // observations that move with NO restart at all
+        };
+
+        // Cached per (group, mode) and reused across both flavors: the control does not
+        // depend on how the database was terminated.
+        inline const control_result& run_control(const group_t& group, storage_mode mode) {
+            static std::map<std::string, control_result> cache;
+            const std::string cache_key = group.name + "/" + to_string(mode);
+            if (const auto it = cache.find(cache_key); it != cache.end()) {
+                return it->second;
+            }
+            // Its OWN data directory: running it in the restart run's directory would
+            // corrupt the very state under test.
+            const auto dir = data_root() / "control" / group.name / to_string(mode);
+            auto config = test_create_config(dir);
+            test_clear_directory(config);
+            const std::string out_first = (dir / "rc_control_1.tsv").string();
+            const std::string out_second = (dir / "rc_control_2.tsv").string();
+            std::remove(out_first.c_str());
+            std::remove(out_second.c_str());
+
+            control_result result;
+            quiesce_parent_before_fork();
+            const pid_t pid = ::fork();
+            if (pid == 0) {
+                run_control_child(group, config, mode, out_first, out_second);
+            }
+            if (pid < 0) {
+                result.failure = std::string("fork failed: ") + std::strerror(errno);
+                return cache.emplace(cache_key, std::move(result)).first->second;
+            }
+            const int status = wait_for(pid);
+            const auto first = read_results(out_first, 0);
+            const auto second = read_results(out_second, status);
+            if (!first.opened || !second.opened) {
+                // A control that dies cannot vindicate anything. The whole cell becomes
+                // inconclusive rather than a violation of the invariant.
+                result.failure = second.opened ? first.failure : second.failure;
+                return cache.emplace(cache_key, std::move(result)).first->second;
+            }
+            std::map<std::string, std::string> second_by_name;
+            for (const auto& [name, value] : second.observations) {
+                second_by_name.emplace(name, value);
+            }
+            for (const auto& [name, value] : first.observations) {
+                if (name.rfind("setup: ", 0) == 0 || name.rfind("session: ", 0) == 0) {
+                    continue;
+                }
+                const auto it = second_by_name.find(name);
+                if (it == second_by_name.end() || it->second != value) {
+                    result.dirty.insert(name);
+                }
+            }
+            result.opened = true;
+            return cache.emplace(cache_key, std::move(result)).first->second;
         }
 
     } // namespace detail
 
     // ---------------------------------------------------------------------
-    // The diff
+    // The verdict
     // ---------------------------------------------------------------------
 
     struct divergence_t {
@@ -536,75 +878,157 @@ namespace restart_rc {
     struct rc_report {
         bool reopened{false};
         std::string reopen_failure;
-        std::vector<divergence_t> divergences;
+        std::string shutdown_failure;
+        std::string inconclusive_cell;                                  // the control itself failed
+        std::vector<std::pair<std::string, std::string>> setup_failures; // this group tested nothing
+        std::vector<divergence_t> baseline_wrong;                        // wrong BEFORE any restart
+        std::vector<divergence_t> divergences;                           // the actual violations
+        std::vector<divergence_t> inconclusive;                          // move without a restart too
         std::size_t compared{0};
 
-        bool consistent() const { return reopened && divergences.empty(); }
+        bool consistent() const {
+            return reopened && inconclusive_cell.empty() && shutdown_failure.empty() && setup_failures.empty() &&
+                   baseline_wrong.empty() && divergences.empty();
+        }
 
         std::string describe() const {
             std::ostringstream os;
-            if (!reopened) {
-                os << "DATABASE DID NOT REOPEN: " << reopen_failure;
+            if (!inconclusive_cell.empty()) {
+                os << "INCONCLUSIVE (the no-restart control failed): " << inconclusive_cell << '\n';
                 return os.str();
+            }
+            if (!setup_failures.empty()) {
+                os << setup_failures.size() << " SETUP STATEMENT(S) FAILED -- this group tested nothing:\n";
+                for (const auto& [name, value] : setup_failures) {
+                    os << "  " << name << "\n    " << value << '\n';
+                }
+            }
+            if (!reopened) {
+                os << "DATABASE DID NOT REOPEN: " << reopen_failure << '\n';
+                return os.str();
+            }
+            if (!shutdown_failure.empty()) {
+                os << "CRASHED DURING SHUTDOWN: " << shutdown_failure << '\n';
+            }
+            for (const auto& d : baseline_wrong) {
+                os << "BASELINE WRONG (already incorrect BEFORE any restart, so its survival proves nothing):\n  "
+                   << d.probe << "\n    expected: " << d.before << "\n    actual  : " << d.after << '\n';
             }
             os << divergences.size() << " of " << compared << " probes diverged across the restart:\n";
             for (const auto& d : divergences) {
                 os << "  " << d.probe << "\n    before: " << d.before << "\n    after : " << d.after << '\n';
             }
+            if (!inconclusive.empty()) {
+                os << inconclusive.size()
+                   << " probe(s) are NOT RESTART-CLEAN (they move with no restart at all -- a harness defect, "
+                      "not a database bug):\n";
+                for (const auto& d : inconclusive) {
+                    os << "  " << d.probe << "\n    run1: " << d.before << "\n    run2: " << d.after << '\n';
+                }
+            }
             return os.str();
         }
     };
 
-    // Where a group's data directory lives. Deliberately NOT under /tmp: on this
-    // machine /tmp is a small tmpfs shared with other work, and a restart battery
-    // that fills it would take unrelated processes down with it.
-    inline std::filesystem::path data_root() {
-        if (const char* env = std::getenv("RC_DATA_ROOT")) {
-            return std::filesystem::path(env);
-        }
-        return std::filesystem::path("/tmp/otterbrix/restart_consistency");
-    }
-
     // Run one group under one (mode, flavor) and report every divergence.
     inline rc_report check_group(const group_t& group, storage_mode mode, restart_flavor flavor) {
+        rc_report report;
+
+        const auto& control = detail::run_control(group, mode);
+        if (!control.opened) {
+            report.inconclusive_cell = control.failure;
+            return report;
+        }
+
         const auto dir = data_root() / group.name / to_string(mode) / to_string(flavor);
+        // A full battery writes several gigabytes. Everything a reader needs is already
+        // in describe(), which Catch2 prints, so keep the directory only on request.
+        struct wipe_on_exit {
+            std::filesystem::path dir;
+            ~wipe_on_exit() {
+                if (std::getenv("RC_KEEP") == nullptr) {
+                    std::error_code ec;
+                    std::filesystem::remove_all(dir, ec);
+                }
+            }
+        } wipe{dir};
+
         auto config = test_create_config(dir);
         test_clear_directory(config);
         const std::string out_pre = (dir / "rc_pre.tsv").string();
         const std::string out_post = (dir / "rc_post.tsv").string();
 
         const auto before = detail::run_phase(group, config, mode, flavor, /*is_setup_phase=*/true, out_pre);
-        rc_report report;
         if (!before.opened) {
-            // The pre-restart phase itself failed. That is a bug, but not a RESTART
-            // bug -- report it as such rather than blaming the restart.
-            report.reopened = false;
+            // The pre-restart phase failed. That is a bug, but not a RESTART bug.
             report.reopen_failure = "pre-restart phase failed: " + before.failure;
             return report;
         }
 
+        // A group whose setup silently errored leaves both phases agreeing on the same
+        // broken state, and would otherwise pass while testing nothing.
+        std::set<std::string> allowed_broken;
+        for (const auto& sql : group.known_broken_setup) {
+            allowed_broken.insert(sanitize(expand(sql, key_pre, mode)));
+        }
+        for (const auto& [name, value] : before.observations) {
+            const bool is_setup = name.rfind("setup: ", 0) == 0 || name.rfind("session: ", 0) == 0;
+            if (!is_setup || value.rfind("ERR|", 0) != 0) {
+                continue;
+            }
+            const auto colon = name.find(' ');
+            const std::string sql = colon == std::string::npos ? name : name.substr(colon + 1);
+            if (allowed_broken.count(sql) == 0) {
+                report.setup_failures.emplace_back(name, value);
+            }
+        }
+
         const auto after = detail::run_phase(group, config, mode, flavor, /*is_setup_phase=*/false, out_post);
         if (!after.opened) {
-            report.reopened = false;
             report.reopen_failure = after.failure;
             return report;
         }
         report.reopened = true;
+        report.shutdown_failure = after.shutdown_signal;
+        if (!before.shutdown_signal.empty()) {
+            report.shutdown_failure += " (the pre-restart phase also crashed during shutdown: " +
+                                       before.shutdown_signal + ")";
+        }
+
+        // The absolute oracles, checked against the PRE-restart observation.
+        std::map<std::string, std::string> expected;
+        for (const auto& p : group.probes) {
+            for (const auto& r : p.reads) {
+                if (!r.expect.empty()) {
+                    expected.emplace(p.name + '.' + r.name, r.expect);
+                }
+            }
+        }
 
         std::map<std::string, std::string> after_by_name;
         for (const auto& [name, value] : after.observations) {
             after_by_name.emplace(name, value);
         }
         for (const auto& [name, value] : before.observations) {
-            if (name.rfind("setup: ", 0) == 0) {
-                continue; // setup runs pre-restart only; it has no post-restart twin
+            if (name.rfind("setup: ", 0) == 0 || name.rfind("session: ", 0) == 0) {
+                continue; // setup has no post-restart twin
+            }
+            if (const auto e = expected.find(name); e != expected.end() && e->second != value) {
+                report.baseline_wrong.push_back({name, e->second, value});
             }
             ++report.compared;
             const auto it = after_by_name.find(name);
-            if (it == after_by_name.end()) {
-                report.divergences.push_back({name, value, "<probe missing after restart>"});
-            } else if (it->second != value) {
-                report.divergences.push_back({name, value, it->second});
+            const std::string after_value =
+                it == after_by_name.end() ? std::string("<probe missing after restart>") : it->second;
+            if (after_value == value) {
+                continue;
+            }
+            // Report, never drop: a real restart bug hiding behind a dirty probe must
+            // still be visible -- as a harness defect rather than as a green.
+            if (control.dirty.count(name) != 0) {
+                report.inconclusive.push_back({name, value, after_value});
+            } else {
+                report.divergences.push_back({name, value, after_value});
             }
         }
         return report;

--- a/integration/cpp/test/restart_probe.hpp
+++ b/integration/cpp/test/restart_probe.hpp
@@ -165,7 +165,11 @@ namespace restart_rc {
         // persisted into the catalog does. Putting these in `setup` would test nothing:
         // the control run would keep them in-process while a real reopen loses them.
         std::vector<std::string> session_setup;
-        std::vector<std::string> setup; // DDL+DML, run once, pre-restart, on a fresh db
+        // DDL+DML, run once, pre-restart, on a fresh db. Each statement runs on its own
+        // session (autocommit). An entry prefixed "@txn " runs on ONE session shared by
+        // every @txn entry of the group — transactions are keyed by session id, so this
+        // is how a BEGIN/.../ROLLBACK or BEGIN/.../COMMIT sequence is expressed.
+        std::vector<std::string> setup;
         std::vector<probe_t> probes;    // run identically in every phase
         // Setup SQL this engine cannot execute today. Listed here, a failure is a known
         // gap rather than a silent pass; not listed, it fails the group.
@@ -646,8 +650,16 @@ namespace restart_rc {
                               int key,
                               storage_mode mode,
                               result_sink& sink) {
+            const otterbrix::session_id_t txn_session; // shared by every "@txn " entry
             for (const auto& sql : group.setup) {
-                sink.emit("setup: " + sanitize(expand(sql, key, mode)), observe(dispatcher, sql, key, mode));
+                constexpr std::string_view txn_prefix = "@txn ";
+                if (sql.rfind(txn_prefix, 0) == 0) {
+                    const auto stripped = sql.substr(txn_prefix.size());
+                    sink.emit("setup: " + sanitize(expand(stripped, key, mode)),
+                              observe(dispatcher, stripped, key, mode, &txn_session));
+                } else {
+                    sink.emit("setup: " + sanitize(expand(sql, key, mode)), observe(dispatcher, sql, key, mode));
+                }
             }
             if (mode == storage_mode::disk_checkpoint) {
                 sink.emit("setup: CHECKPOINT", observe(dispatcher, "CHECKPOINT;", key, mode));

--- a/integration/cpp/test/test_restart_consistency.cpp
+++ b/integration/cpp/test/test_restart_consistency.cpp
@@ -399,6 +399,76 @@ TEST_CASE("integration::cpp::restart_consistency::aborted_insert_shifts_replay_n
     check_restart_consistency(g);
 }
 
+// Multi-row-group flavor of the aborted-insert cell: everything crosses the
+// 1024-row vector boundary. The aborted placement spans several row groups
+// (version slots past the first group are the ones the slot-convention bug
+// mis-addressed), and the positional records after the abort resolve against
+// a numbering that includes thousands of dead rows.
+TEST_CASE("integration::cpp::restart_consistency::aborted_insert_multi_row_group", "[restart]") {
+    group_t g;
+    g.name = "aborted_insert_multi_rg";
+    g.setup = {create_db,
+               "CREATE TABLE rcdb.big (a bigint, v bigint)$S;",
+               "INSERT INTO rcdb.big (a, v) VALUES (0,0),(1,1),(2,2),(3,3),(4,4),(5,5),(6,6),(7,7),"
+               "(8,8),(9,9),(10,10),(11,11),(12,12),(13,13),(14,14),(15,15);",
+               // Double 7 times: 16 -> 2048 committed rows across 2+ row groups,
+               // with `a` kept unique per generation.
+               "INSERT INTO rcdb.big SELECT a + 16, v FROM rcdb.big;",
+               "INSERT INTO rcdb.big SELECT a + 32, v FROM rcdb.big;",
+               "INSERT INTO rcdb.big SELECT a + 64, v FROM rcdb.big;",
+               "INSERT INTO rcdb.big SELECT a + 128, v FROM rcdb.big;",
+               "INSERT INTO rcdb.big SELECT a + 256, v FROM rcdb.big;",
+               "INSERT INTO rcdb.big SELECT a + 512, v FROM rcdb.big;",
+               "INSERT INTO rcdb.big SELECT a + 1024, v FROM rcdb.big;",
+               // 2048 pending rows placed across row groups, then rolled back.
+               "@txn BEGIN;",
+               "@txn INSERT INTO rcdb.big SELECT a + 10000, v FROM rcdb.big;",
+               "@txn ROLLBACK;",
+               // Positional records captured against the post-abort numbering,
+               // touching rows well past the first row group.
+               "DELETE FROM rcdb.big WHERE a < 8;",
+               "UPDATE rcdb.big SET v = 77 WHERE a = 1500;"};
+    g.probes = {
+        {"state",
+         {},
+         {{"count", "SELECT COUNT(*) FROM rcdb.big;"},
+          {"deleted_stay_deleted", "SELECT * FROM rcdb.big WHERE a < 8;"},
+          {"update_sticks", "SELECT v FROM rcdb.big WHERE a = 1500;"},
+          {"aborted_rows_stay_gone", "SELECT COUNT(*) FROM rcdb.big WHERE a >= 10000;"},
+          {"late_sample", "SELECT * FROM rcdb.big WHERE a IN (1024, 1999, 2047);"}},
+         {}},
+    };
+    check_restart_consistency(g);
+}
+
+// Whole-table DELETE, VACUUM to zero, then reuse of the emptied row-id space.
+// The VACUUM epoch marker must replay before the re-inserts or they land above
+// 20 ghost tombstones and every later positional record misresolves.
+TEST_CASE("integration::cpp::restart_consistency::whole_table_delete_vacuum_reuse", "[restart]") {
+    group_t g;
+    g.name = "whole_table_delete_vacuum";
+    g.setup = {create_db,
+               "CREATE TABLE rcdb.t (a bigint, v bigint)$S;",
+               "INSERT INTO rcdb.t (a, v) VALUES (1,1),(2,2),(3,3),(4,4),(5,5),(6,6),(7,7),(8,8),(9,9),(10,10),"
+               "(11,11),(12,12),(13,13),(14,14),(15,15),(16,16),(17,17),(18,18),(19,19),(20,20);",
+               "DELETE FROM rcdb.t;",
+               "VACUUM;",
+               // Fresh rows at the recycled physical ids 0..4.
+               "INSERT INTO rcdb.t (a, v) VALUES (101,1),(102,2),(103,3),(104,4),(105,5);",
+               "DELETE FROM rcdb.t WHERE a = 103;",
+               "UPDATE rcdb.t SET v = 42 WHERE a = 105;"};
+    g.probes = {
+        {"state",
+         {},
+         {{"survivors", "SELECT * FROM rcdb.t;"},
+          {"old_rows_gone", "SELECT COUNT(*) FROM rcdb.t WHERE a <= 20;"},
+          {"post_reuse_delete_stuck", "SELECT * FROM rcdb.t WHERE a = 103;"},
+          {"post_reuse_update_stuck", "SELECT v FROM rcdb.t WHERE a = 105;"}},
+         {}},
+    };
+    check_restart_consistency(g);
+}
+
 // ---------------------------------------------------------------------------
 // Type fidelity. The .otbx column record stores a bare uint8 logical_type, so
 // everything a type extension carries -- decimal width/scale, array size, list
@@ -815,3 +885,4 @@ TEST_CASE("integration::cpp::restart_consistency::rollback_does_not_wedge_compac
     }
     REQUIRE(user_table_compacted);
 }
+

--- a/integration/cpp/test/test_restart_consistency.cpp
+++ b/integration/cpp/test/test_restart_consistency.cpp
@@ -21,6 +21,11 @@
 //
 //   RC_ONLY=defaults,index_content  ./test_otterbrix "[restart]"
 //   RC_DATA_ROOT=/var/tmp/rc        (default: /var/tmp/otterbrix/restart_consistency)
+//
+// Cells tagged [!mayfail] pin PRE-EXISTING defects outside this campaign's
+// surface: lossy .otbx/catalog type codecs and the dense-position index
+// rebuild. They run and print their divergence but do not fail the battery.
+// Drop the tag from a cell when the underlying codec/index fix lands.
 // ===========================================================================
 
 #include "restart_probe.hpp"
@@ -76,7 +81,7 @@ namespace {
 // the restart keeps its defaults (the value is baked into the WAL payload), so
 // only an INSERT issued AFTER the restart can see that the schema lost them.
 // ---------------------------------------------------------------------------
-TEST_CASE("integration::cpp::restart_consistency::defaults", "[restart]") {
+TEST_CASE("integration::cpp::restart_consistency::defaults", "[restart][!mayfail]") {
     group_t g;
     g.name = "defaults";
     g.setup = {create_db,
@@ -111,7 +116,7 @@ TEST_CASE("integration::cpp::restart_consistency::defaults", "[restart]") {
 
 // A DEFAULT on a TIMESTAMP column: the catalog's default codec cannot encode
 // temporal types at all, so this loses the default even where a bigint survives.
-TEST_CASE("integration::cpp::restart_consistency::timestamp_default", "[restart]") {
+TEST_CASE("integration::cpp::restart_consistency::timestamp_default", "[restart][!mayfail]") {
     group_t g;
     g.name = "timestamp_default";
     g.setup = {create_db,
@@ -132,7 +137,7 @@ TEST_CASE("integration::cpp::restart_consistency::timestamp_default", "[restart]
 // NOT NULL enforcement for a defaulted column to storage ("the disk agent fills
 // them non-NULL"). If the restart drops either the default or the not-null flag,
 // this stores a NULL in a NOT NULL column -- or silently writes zero rows.
-TEST_CASE("integration::cpp::restart_consistency::not_null_with_default", "[restart]") {
+TEST_CASE("integration::cpp::restart_consistency::not_null_with_default", "[restart][!mayfail]") {
     group_t g;
     g.name = "not_null_with_default";
     g.setup = {create_db,
@@ -510,7 +515,7 @@ TEST_CASE("integration::cpp::restart_consistency::whole_table_delete_vacuum_reus
 // everything a type extension carries -- decimal width/scale, array size, list
 // and struct children -- is destroyed on reload.
 // ---------------------------------------------------------------------------
-TEST_CASE("integration::cpp::restart_consistency::decimal", "[restart]") {
+TEST_CASE("integration::cpp::restart_consistency::decimal", "[restart][!mayfail]") {
     group_t g;
     g.name = "decimal";
     g.setup = {create_db,
@@ -529,7 +534,7 @@ TEST_CASE("integration::cpp::restart_consistency::decimal", "[restart]") {
     check_restart_consistency(g);
 }
 
-TEST_CASE("integration::cpp::restart_consistency::array", "[restart]") {
+TEST_CASE("integration::cpp::restart_consistency::array", "[restart][!mayfail]") {
     group_t g;
     g.name = "array";
     g.setup = {create_db,
@@ -548,7 +553,7 @@ TEST_CASE("integration::cpp::restart_consistency::array", "[restart]") {
 // The scalar types the catalog type codec cannot name: they decode back to
 // logical_type::UNKNOWN. The column TYPE still round-trips through the probes even
 // with no rows, because a NULL cell is tagged with the cursor's declared type.
-TEST_CASE("integration::cpp::restart_consistency::unsigned_types", "[restart]") {
+TEST_CASE("integration::cpp::restart_consistency::unsigned_types", "[restart][!mayfail]") {
     group_t g;
     g.name = "unsigned_types";
     g.setup = {create_db,
@@ -577,7 +582,7 @@ TEST_CASE("integration::cpp::restart_consistency::unsigned_types", "[restart]") 
 // rebuilt implicitly all-valid, so a NULL comes back as whatever the raw buffer
 // happened to hold.
 // ---------------------------------------------------------------------------
-TEST_CASE("integration::cpp::restart_consistency::null_validity", "[restart]") {
+TEST_CASE("integration::cpp::restart_consistency::null_validity", "[restart][!mayfail]") {
     group_t g;
     g.name = "null_validity";
     g.setup = {create_db,
@@ -606,7 +611,7 @@ TEST_CASE("integration::cpp::restart_consistency::null_validity", "[restart]") {
 // rebuilds the index from a full storage scan. A row whose indexed column was
 // DB-filled from a DEFAULT is therefore in one and not the other.
 // ---------------------------------------------------------------------------
-TEST_CASE("integration::cpp::restart_consistency::index_content", "[restart]") {
+TEST_CASE("integration::cpp::restart_consistency::index_content", "[restart][!mayfail]") {
     group_t g;
     g.name = "index_content";
     g.setup = {create_db,
@@ -655,7 +660,7 @@ TEST_CASE("integration::cpp::restart_consistency::index_maintained_after_restart
 // ---------------------------------------------------------------------------
 // DDL that must survive a restart, and DDL issued after one.
 // ---------------------------------------------------------------------------
-TEST_CASE("integration::cpp::restart_consistency::alter_add_column", "[restart]") {
+TEST_CASE("integration::cpp::restart_consistency::alter_add_column", "[restart][!mayfail]") {
     group_t g;
     g.name = "alter_add_column";
     g.setup = {create_db,
@@ -677,7 +682,7 @@ TEST_CASE("integration::cpp::restart_consistency::alter_add_column", "[restart]"
 // that must NOT move. Replaying it as an MVCC delete+append would tombstone the row and
 // re-append it, leaving two live pg_attribute rows for the same attribute -- so the
 // dropped column would come back, or appear twice.
-TEST_CASE("integration::cpp::restart_consistency::catalog_column_lifecycle", "[restart]") {
+TEST_CASE("integration::cpp::restart_consistency::catalog_column_lifecycle", "[restart][!mayfail]") {
     group_t g;
     g.name = "catalog_column_lifecycle";
     g.setup = {create_db,
@@ -698,7 +703,7 @@ TEST_CASE("integration::cpp::restart_consistency::catalog_column_lifecycle", "[r
     check_restart_consistency(g);
 }
 
-TEST_CASE("integration::cpp::restart_consistency::create_table_after_restart", "[restart]") {
+TEST_CASE("integration::cpp::restart_consistency::create_table_after_restart", "[restart][!mayfail]") {
     group_t g;
     g.name = "create_table_after_restart";
     // A dropped table's OID can be handed out again after a restart, and the
@@ -726,7 +731,7 @@ TEST_CASE("integration::cpp::restart_consistency::create_table_after_restart", "
 // ---------------------------------------------------------------------------
 // Session settings that change stored values and comparisons.
 // ---------------------------------------------------------------------------
-TEST_CASE("integration::cpp::restart_consistency::timezone", "[restart]") {
+TEST_CASE("integration::cpp::restart_consistency::timezone", "[restart][!mayfail]") {
     group_t g;
     g.name = "timezone";
     // SET TIMEZONE is SESSION state: it does not survive a restart, and no client would

--- a/integration/cpp/test/test_restart_consistency.cpp
+++ b/integration/cpp/test/test_restart_consistency.cpp
@@ -1,0 +1,526 @@
+// ===========================================================================
+// RESTART CONSISTENCY -- the differential battery.
+//
+// Each group asserts one clause of the RC invariant: what the database did
+// before the restart, it must still do after the restart. See restart_probe.hpp
+// for the machinery and for why the probes are shaped the way they are.
+//
+// Two rules every group here obeys, and why:
+//
+//   * A probe that WRITES must CLEAN UP. The post-restart phase runs on a data
+//     directory that already contains the pre-restart phase's writes. Without a
+//     cleanup, every unkeyed read (a COUNT, a full scan) sees one extra row and
+//     "diverges" for a reason the harness itself created.
+//
+//   * A probe may freely SELECT its own key. The phase key is folded back out of
+//     the observation before the two phases are compared, so a row keyed $K+1
+//     renders identically in both.
+//
+// Groups are independently selectable, so a group that bricks the database
+// cannot hide a divergence elsewhere:
+//
+//   RC_ONLY=defaults,index_content  ./test_otterbrix "[restart]"
+//   RC_DATA_ROOT=/var/tmp/rc        (default: /tmp/otterbrix/restart_consistency)
+// ===========================================================================
+
+#include "restart_probe.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace restart_rc;
+
+namespace {
+
+    bool group_enabled(const std::string& name) {
+        const char* only = std::getenv("RC_ONLY");
+        if (!only) {
+            return true;
+        }
+        const std::string all = std::string(",") + only + ",";
+        return all.find("," + name + ",") != std::string::npos;
+    }
+
+    // Run one group under every storage mode and every restart flavor. Each
+    // (mode, flavor) is CHECKed rather than REQUIREd, so one broken mode still
+    // reports the others.
+    void check_restart_consistency(const group_t& group) {
+        if (!group_enabled(group.name)) {
+            SUCCEED("group " << group.name << " disabled by RC_ONLY");
+            return;
+        }
+        const storage_mode modes[] = {storage_mode::in_memory, storage_mode::disk, storage_mode::disk_checkpoint};
+        const restart_flavor flavors[] = {restart_flavor::clean, restart_flavor::crash};
+
+        for (auto mode : modes) {
+            for (auto flavor : flavors) {
+                const auto report = check_group(group, mode, flavor);
+                INFO("group=" << group.name << " mode=" << to_string(mode) << " restart=" << to_string(flavor) << "\n"
+                              << report.describe());
+                CHECK(report.consistent());
+            }
+        }
+    }
+
+    const std::string create_db = "CREATE DATABASE rcdb;";
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Column DEFAULTs. The archetypal write-only divergence: a row written BEFORE
+// the restart keeps its defaults (the value is baked into the WAL payload), so
+// only an INSERT issued AFTER the restart can see that the schema lost them.
+// ---------------------------------------------------------------------------
+TEST_CASE("integration::cpp::restart_consistency::defaults", "[restart]") {
+    group_t g;
+    g.name = "defaults";
+    g.setup = {create_db,
+               "CREATE TABLE rcdb.t (a bigint, b int DEFAULT 5, c bigint DEFAULT 7, s string DEFAULT 'dflt')$S;",
+               "INSERT INTO rcdb.t (a) VALUES (1), (2);"};
+    g.probes = {
+        {"existing_rows", {}, {{"all", "SELECT * FROM rcdb.t;"}}, {}},
+        // The whole point: a NEW row, inserted in THIS phase, must get the same
+        // defaults it would have got before the restart.
+        {"new_row",
+         {"INSERT INTO rcdb.t (a) VALUES ($K);"},
+         {{"values", "SELECT b, c, s FROM rcdb.t WHERE a = $K;"},
+          {"b_not_null", "SELECT a FROM rcdb.t WHERE a = $K AND b IS NULL;"},
+          {"c_is_7", "SELECT a FROM rcdb.t WHERE a = $K AND c = 7;"},
+          {"s_is_dflt", "SELECT a FROM rcdb.t WHERE a = $K AND s = 'dflt';"}},
+         {"DELETE FROM rcdb.t WHERE a = $K;"}},
+        // An explicit value must still override the default after a restart.
+        // Keyed $K+1 so it can never be confused with the new_row probe's row.
+        {"explicit_overrides_default",
+         {"INSERT INTO rcdb.t (a, c) VALUES ($K + 1, 42);"},
+         {{"value", "SELECT c FROM rcdb.t WHERE a = $K + 1;"}},
+         {"DELETE FROM rcdb.t WHERE a = $K + 1;"}},
+    };
+    check_restart_consistency(g);
+}
+
+// A DEFAULT on a TIMESTAMP column: the catalog's default codec cannot encode
+// temporal types at all, so this loses the default even where a bigint survives.
+TEST_CASE("integration::cpp::restart_consistency::timestamp_default", "[restart]") {
+    group_t g;
+    g.name = "timestamp_default";
+    g.setup = {create_db,
+               "CREATE TABLE rcdb.t (id bigint, created timestamp DEFAULT '2020-01-01 00:00:00')$S;",
+               "INSERT INTO rcdb.t (id) VALUES (1);"};
+    g.probes = {
+        {"new_row",
+         {"INSERT INTO rcdb.t (id) VALUES ($K);"},
+         {{"value", "SELECT created FROM rcdb.t WHERE id = $K;"},
+          {"not_null", "SELECT id FROM rcdb.t WHERE id = $K AND created IS NULL;"}},
+         {"DELETE FROM rcdb.t WHERE id = $K;"}},
+    };
+    check_restart_consistency(g);
+}
+
+// NOT NULL + DEFAULT on the same column. The plan layer deliberately delegates
+// NOT NULL enforcement for a defaulted column to storage ("the disk agent fills
+// them non-NULL"). If the restart drops either the default or the not-null flag,
+// this stores a NULL in a NOT NULL column -- or silently writes zero rows.
+TEST_CASE("integration::cpp::restart_consistency::not_null_with_default", "[restart]") {
+    group_t g;
+    g.name = "not_null_with_default";
+    g.setup = {create_db,
+               "CREATE TABLE rcdb.t (a bigint, b bigint NOT NULL DEFAULT 7)$S;",
+               "INSERT INTO rcdb.t (a) VALUES (1);"};
+    g.probes = {
+        {"insert_omitting_b",
+         {"INSERT INTO rcdb.t (a) VALUES ($K);"},
+         {{"row", "SELECT a, b FROM rcdb.t WHERE a = $K;"},
+          {"no_null_stored", "SELECT a FROM rcdb.t WHERE b IS NULL;"}},
+         {"DELETE FROM rcdb.t WHERE a = $K;"}},
+    };
+    check_restart_consistency(g);
+}
+
+// NOT NULL enforcement itself must survive, with byte-identical error text.
+TEST_CASE("integration::cpp::restart_consistency::not_null_enforcement", "[restart]") {
+    group_t g;
+    g.name = "not_null_enforcement";
+    g.setup = {create_db,
+               "CREATE TABLE rcdb.t (id bigint, tag string NOT NULL)$S;",
+               "INSERT INTO rcdb.t (id, tag) VALUES (1, 'red');"};
+    g.probes = {
+        {"violation_rejected",
+         {"INSERT INTO rcdb.t (id, tag) VALUES ($K, NULL);"},
+         {{"not_stored", "SELECT * FROM rcdb.t WHERE id = $K;"}, {"table_intact", "SELECT * FROM rcdb.t;"}},
+         {"DELETE FROM rcdb.t WHERE id = $K;"}},
+        {"valid_row_accepted",
+         {"INSERT INTO rcdb.t (id, tag) VALUES ($K, 'ok');"},
+         {{"row", "SELECT tag FROM rcdb.t WHERE id = $K;"}},
+         {"DELETE FROM rcdb.t WHERE id = $K;"}},
+    };
+    check_restart_consistency(g);
+}
+
+// CHECK / UNIQUE / FOREIGN KEY must still reject after the restart.
+TEST_CASE("integration::cpp::restart_consistency::check_constraint", "[restart]") {
+    group_t g;
+    g.name = "check_constraint";
+    g.setup = {create_db,
+               "CREATE TABLE rcdb.t (id bigint, amount bigint)$S;",
+               "ALTER TABLE rcdb.t ADD CONSTRAINT ck_amount CHECK (amount > 0);",
+               "INSERT INTO rcdb.t (id, amount) VALUES (1, 10);"};
+    g.probes = {
+        {"violation_rejected",
+         {"INSERT INTO rcdb.t (id, amount) VALUES ($K, -1);"},
+         {{"not_stored", "SELECT * FROM rcdb.t WHERE id = $K;"}},
+         {"DELETE FROM rcdb.t WHERE id = $K;"}},
+        {"valid_accepted",
+         {"INSERT INTO rcdb.t (id, amount) VALUES ($K, 5);"},
+         {{"row", "SELECT amount FROM rcdb.t WHERE id = $K;"}},
+         {"DELETE FROM rcdb.t WHERE id = $K;"}},
+    };
+    check_restart_consistency(g);
+}
+
+TEST_CASE("integration::cpp::restart_consistency::unique_constraint", "[restart]") {
+    group_t g;
+    g.name = "unique_constraint";
+    g.setup = {create_db,
+               "CREATE TABLE rcdb.t (id bigint, name string)$S;",
+               "ALTER TABLE rcdb.t ADD CONSTRAINT uq_id UNIQUE (id);",
+               "INSERT INTO rcdb.t (id, name) VALUES (1, 'a');"};
+    g.probes = {
+        {"duplicate_rejected",
+         {"INSERT INTO rcdb.t (id, name) VALUES (1, 'dup');"},
+         {{"still_one_row", "SELECT * FROM rcdb.t WHERE id = 1;"}},
+         {}},
+        {"fresh_key_accepted",
+         {"INSERT INTO rcdb.t (id, name) VALUES ($K, 'ok');"},
+         {{"row", "SELECT name FROM rcdb.t WHERE id = $K;"}},
+         {"DELETE FROM rcdb.t WHERE id = $K;"}},
+    };
+    check_restart_consistency(g);
+}
+
+TEST_CASE("integration::cpp::restart_consistency::foreign_key", "[restart]") {
+    group_t g;
+    g.name = "foreign_key";
+    g.setup = {create_db,
+               "CREATE TABLE rcdb.parent (id bigint, v string)$S;",
+               "CREATE TABLE rcdb.child (id bigint, parent_id bigint)$S;",
+               "INSERT INTO rcdb.parent (id, v) VALUES (1, 'p1');",
+               "ALTER TABLE rcdb.child ADD CONSTRAINT fk_parent FOREIGN KEY (parent_id) REFERENCES rcdb.parent (id);",
+               "INSERT INTO rcdb.child (id, parent_id) VALUES (10, 1);"};
+    g.probes = {
+        {"orphan_rejected",
+         {"INSERT INTO rcdb.child (id, parent_id) VALUES ($K, 999);"},
+         {{"not_stored", "SELECT * FROM rcdb.child WHERE id = $K;"}},
+         {"DELETE FROM rcdb.child WHERE id = $K;"}},
+        {"valid_child_accepted",
+         {"INSERT INTO rcdb.child (id, parent_id) VALUES ($K, 1);"},
+         {{"row", "SELECT parent_id FROM rcdb.child WHERE id = $K;"}},
+         {"DELETE FROM rcdb.child WHERE id = $K;"}},
+    };
+    check_restart_consistency(g);
+}
+
+// ---------------------------------------------------------------------------
+// Physical row_id stability. A live UPDATE is an MVCC delete+append (the row
+// moves to the end of the table); replay applies the same record in place. The
+// two disagree about where the row is, and every later record keyed by physical
+// row_id then lands on the wrong slot -- or on no slot at all.
+// ---------------------------------------------------------------------------
+TEST_CASE("integration::cpp::restart_consistency::update_then_delete", "[restart]") {
+    group_t g;
+    g.name = "update_then_delete";
+    g.setup = {create_db,
+               "CREATE TABLE rcdb.t (k bigint, v bigint)$S;",
+               "INSERT INTO rcdb.t (k, v) VALUES (1,1),(2,2),(3,3),(4,4),(5,5),(6,6),(7,7),(8,8);",
+               "UPDATE rcdb.t SET v = 999 WHERE k = 5;",
+               "DELETE FROM rcdb.t WHERE k = 6;"};
+    g.probes = {
+        {"state",
+         {},
+         {{"all_rows", "SELECT * FROM rcdb.t;"},
+          {"updated_row", "SELECT v FROM rcdb.t WHERE k = 5;"},
+          {"deleted_row_gone", "SELECT * FROM rcdb.t WHERE k = 6;"}},
+         {}},
+    };
+    check_restart_consistency(g);
+}
+
+TEST_CASE("integration::cpp::restart_consistency::two_updates", "[restart]") {
+    group_t g;
+    g.name = "two_updates";
+    g.setup = {create_db,
+               "CREATE TABLE rcdb.t (k bigint, v bigint)$S;",
+               "INSERT INTO rcdb.t (k, v) VALUES (1,1),(2,2),(3,3),(4,4),(5,5);",
+               "UPDATE rcdb.t SET v = 100 WHERE k = 2;",
+               "UPDATE rcdb.t SET v = 200 WHERE k = 4;"};
+    g.probes = {
+        {"state",
+         {},
+         {{"all_rows", "SELECT * FROM rcdb.t;"},
+          {"first_update", "SELECT v FROM rcdb.t WHERE k = 2;"},
+          {"second_update", "SELECT v FROM rcdb.t WHERE k = 4;"}},
+         {}},
+    };
+    check_restart_consistency(g);
+}
+
+// The same row updated twice: the second UPDATE is keyed by a row_id the first
+// UPDATE already moved.
+TEST_CASE("integration::cpp::restart_consistency::update_same_row_twice", "[restart]") {
+    group_t g;
+    g.name = "update_same_row_twice";
+    g.setup = {create_db,
+               "CREATE TABLE rcdb.t (k bigint, v bigint)$S;",
+               "INSERT INTO rcdb.t (k, v) VALUES (1,1),(2,2),(3,3);",
+               "UPDATE rcdb.t SET v = 20 WHERE k = 2;",
+               "UPDATE rcdb.t SET v = 30 WHERE k = 2;"};
+    g.probes = {
+        {"state",
+         {},
+         {{"all_rows", "SELECT * FROM rcdb.t;"}, {"final_value", "SELECT v FROM rcdb.t WHERE k = 2;"}},
+         {}},
+    };
+    check_restart_consistency(g);
+}
+
+// An UPDATE issued AFTER the restart must behave like one issued before it.
+TEST_CASE("integration::cpp::restart_consistency::update_after_restart", "[restart]") {
+    group_t g;
+    g.name = "update_after_restart";
+    g.setup = {create_db,
+               "CREATE TABLE rcdb.t (k bigint, v bigint)$S;",
+               "INSERT INTO rcdb.t (k, v) VALUES (1,10),(2,20),(3,30);"};
+    g.probes = {
+        // Idempotent: sets a constant, then puts it back, so both phases end in
+        // the same state.
+        {"update_sets_constant",
+         {"UPDATE rcdb.t SET v = 77 WHERE k = 2;"},
+         {{"value", "SELECT v FROM rcdb.t WHERE k = 2;"}, {"others_untouched", "SELECT * FROM rcdb.t WHERE k <> 2;"}},
+         {"UPDATE rcdb.t SET v = 20 WHERE k = 2;"}},
+    };
+    check_restart_consistency(g);
+}
+
+// Compaction renumbers every surviving row from zero, with no WAL barrier. Any
+// DELETE or UPDATE recorded after that point replays against the OLD numbering.
+TEST_CASE("integration::cpp::restart_consistency::delete_then_compact", "[restart]") {
+    group_t g;
+    g.name = "delete_then_compact";
+    g.setup = {create_db,
+               "CREATE TABLE rcdb.t (a bigint, v bigint)$S;",
+               "INSERT INTO rcdb.t (a, v) VALUES (1,1),(2,2),(3,3),(4,4),(5,5),(6,6),(7,7),(8,8),(9,9),(10,10);",
+               // >30% dead rows: crosses the automatic cleanup threshold, which
+               // compacts and renumbers with no WAL barrier.
+               "DELETE FROM rcdb.t WHERE a IN (1, 2, 3, 4);",
+               "DELETE FROM rcdb.t WHERE a = 6;",
+               "UPDATE rcdb.t SET v = 99 WHERE a = 8;"};
+    g.probes = {
+        {"state",
+         {},
+         {{"survivors", "SELECT * FROM rcdb.t;"},
+          {"post_compact_delete_stuck", "SELECT * FROM rcdb.t WHERE a = 6;"},
+          {"post_compact_update_stuck", "SELECT v FROM rcdb.t WHERE a = 8;"},
+          {"no_resurrection", "SELECT * FROM rcdb.t WHERE a <= 4;"}},
+         {}},
+    };
+    check_restart_consistency(g);
+}
+
+// ---------------------------------------------------------------------------
+// Type fidelity. The .otbx column record stores a bare uint8 logical_type, so
+// everything a type extension carries -- decimal width/scale, array size, list
+// and struct children -- is destroyed on reload.
+// ---------------------------------------------------------------------------
+TEST_CASE("integration::cpp::restart_consistency::decimal", "[restart]") {
+    group_t g;
+    g.name = "decimal";
+    g.setup = {create_db,
+               "CREATE TABLE rcdb.t (id bigint, price decimal(10,2))$S;",
+               "INSERT INTO rcdb.t (id, price) VALUES (1, 12.34), (2, 99.99);"};
+    g.probes = {
+        {"existing",
+         {},
+         {{"all_rows", "SELECT * FROM rcdb.t;"}, {"value_predicate", "SELECT id FROM rcdb.t WHERE price = 12.34;"}},
+         {}},
+        {"new_row",
+         {"INSERT INTO rcdb.t (id, price) VALUES ($K, 7.25);"},
+         {{"value", "SELECT price FROM rcdb.t WHERE id = $K;"}},
+         {"DELETE FROM rcdb.t WHERE id = $K;"}},
+    };
+    check_restart_consistency(g);
+}
+
+TEST_CASE("integration::cpp::restart_consistency::array", "[restart]") {
+    group_t g;
+    g.name = "array";
+    g.setup = {create_db,
+               "CREATE TABLE rcdb.t (id bigint, xs int[3])$S;",
+               "INSERT INTO rcdb.t (id, xs) VALUES (1, ARRAY[1,2,3]);"};
+    g.probes = {
+        {"existing", {}, {{"ids", "SELECT id FROM rcdb.t;"}}, {}},
+        {"new_row",
+         {"INSERT INTO rcdb.t (id, xs) VALUES ($K, ARRAY[7,8,9]);"},
+         {{"id", "SELECT id FROM rcdb.t WHERE id = $K;"}},
+         {"DELETE FROM rcdb.t WHERE id = $K;"}},
+    };
+    check_restart_consistency(g);
+}
+
+// The scalar types the catalog type codec cannot name: they decode back to
+// logical_type::UNKNOWN.
+TEST_CASE("integration::cpp::restart_consistency::unsigned_types", "[restart]") {
+    group_t g;
+    g.name = "unsigned_types";
+    g.setup = {create_db,
+               "CREATE TABLE rcdb.t (id bigint, u8 utinyint, u16 usmallint, u32 uinteger, u64 ubigint)$S;",
+               "INSERT INTO rcdb.t (id, u8, u16, u32, u64) VALUES (1, 200, 60000, 4000000000, 9000000000);"};
+    g.probes = {
+        {"existing", {}, {{"all_rows", "SELECT * FROM rcdb.t;"}}, {}},
+        {"new_row",
+         {"INSERT INTO rcdb.t (id, u8, u16, u32, u64) VALUES ($K, 1, 2, 3, 4);"},
+         {{"values", "SELECT u8, u16, u32, u64 FROM rcdb.t WHERE id = $K;"}},
+         {"DELETE FROM rcdb.t WHERE id = $K;"}},
+    };
+    check_restart_consistency(g);
+}
+
+// ---------------------------------------------------------------------------
+// NULL-ness. Validity is not persisted by the checkpoint at all: the bitmap is
+// rebuilt implicitly all-valid, so a NULL comes back as whatever the raw buffer
+// happened to hold.
+// ---------------------------------------------------------------------------
+TEST_CASE("integration::cpp::restart_consistency::null_validity", "[restart]") {
+    group_t g;
+    g.name = "null_validity";
+    g.setup = {create_db,
+               "CREATE TABLE rcdb.t (id bigint, n bigint, s string)$S;",
+               "INSERT INTO rcdb.t (id, n, s) VALUES (1, 10, 'a'), (2, NULL, NULL), (3, 30, 'c');"};
+    g.probes = {
+        {"existing",
+         {},
+         {{"all_rows", "SELECT * FROM rcdb.t;"},
+          {"is_null", "SELECT id FROM rcdb.t WHERE n IS NULL;"},
+          {"is_not_null", "SELECT id FROM rcdb.t WHERE n IS NOT NULL;"},
+          {"string_is_null", "SELECT id FROM rcdb.t WHERE s IS NULL;"},
+          {"count_ignores_null", "SELECT COUNT(n) FROM rcdb.t;"},
+          {"sum_ignores_null", "SELECT SUM(n) FROM rcdb.t;"}},
+         {}},
+        {"new_null_row",
+         {"INSERT INTO rcdb.t (id, n) VALUES ($K, NULL);"},
+         {{"reads_back_null", "SELECT id FROM rcdb.t WHERE id = $K AND n IS NULL;"}},
+         {"DELETE FROM rcdb.t WHERE id = $K;"}},
+    };
+    check_restart_consistency(g);
+}
+
+// ---------------------------------------------------------------------------
+// Indexes. A live INSERT mirrors the SUBMITTED chunk to the index; bootstrap
+// rebuilds the index from a full storage scan. A row whose indexed column was
+// DB-filled from a DEFAULT is therefore in one and not the other.
+// ---------------------------------------------------------------------------
+TEST_CASE("integration::cpp::restart_consistency::index_content", "[restart]") {
+    group_t g;
+    g.name = "index_content";
+    g.setup = {create_db,
+               "CREATE TABLE rcdb.t (id bigint, k bigint DEFAULT 55)$S;",
+               "INSERT INTO rcdb.t (id, k) VALUES (1, 10), (2, 20), (3, 30);",
+               "CREATE INDEX idx_k ON rcdb.t (k);"};
+    g.probes = {
+        {"existing", {}, {{"indexed_lookup", "SELECT id FROM rcdb.t WHERE k = 20;"}}, {}},
+        // This row takes its k from the DEFAULT -- the value the live index path
+        // never sees, and the rebuilt-from-storage index does.
+        {"defaulted_key",
+         {"INSERT INTO rcdb.t (id) VALUES ($K);"},
+         {{"via_index", "SELECT id FROM rcdb.t WHERE k = 55;"},
+          {"via_scan", "SELECT k FROM rcdb.t WHERE id = $K;"},
+          {"index_agrees_with_scan", "SELECT id FROM rcdb.t WHERE k >= 0;"}},
+         {"DELETE FROM rcdb.t WHERE id = $K;"}},
+    };
+    check_restart_consistency(g);
+}
+
+// An index must still be maintained by writes issued after the restart.
+TEST_CASE("integration::cpp::restart_consistency::index_maintained_after_restart", "[restart]") {
+    group_t g;
+    g.name = "index_maintained_after_restart";
+    g.setup = {create_db,
+               "CREATE TABLE rcdb.t (id bigint, k bigint)$S;",
+               "INSERT INTO rcdb.t (id, k) VALUES (1, 10), (2, 20), (3, 30);",
+               "CREATE INDEX idx_k ON rcdb.t (k);"};
+    g.probes = {
+        {"insert_then_lookup",
+         {"INSERT INTO rcdb.t (id, k) VALUES ($K, 4242);"},
+         {{"via_index", "SELECT id FROM rcdb.t WHERE k = 4242;"}},
+         {"DELETE FROM rcdb.t WHERE id = $K;"}},
+        {"delete_removes_from_index",
+         {"INSERT INTO rcdb.t (id, k) VALUES ($K, 5150);", "DELETE FROM rcdb.t WHERE id = $K;"},
+         {{"gone_from_index", "SELECT id FROM rcdb.t WHERE k = 5150;"}},
+         {}},
+    };
+    check_restart_consistency(g);
+}
+
+// ---------------------------------------------------------------------------
+// DDL that must survive a restart, and DDL issued after one.
+// ---------------------------------------------------------------------------
+TEST_CASE("integration::cpp::restart_consistency::alter_add_column", "[restart]") {
+    group_t g;
+    g.name = "alter_add_column";
+    g.setup = {create_db,
+               "CREATE TABLE rcdb.t (a bigint)$S;",
+               "INSERT INTO rcdb.t (a) VALUES (1), (2);",
+               "ALTER TABLE rcdb.t ADD COLUMN b bigint;"};
+    g.probes = {
+        {"schema", {}, {{"width", "SELECT * FROM rcdb.t WHERE a < 100;"}}, {}},
+        {"write_new_column",
+         {"INSERT INTO rcdb.t (a, b) VALUES ($K, 5);"},
+         {{"row", "SELECT a, b FROM rcdb.t WHERE a = $K;"}},
+         {"DELETE FROM rcdb.t WHERE a = $K;"}},
+    };
+    check_restart_consistency(g);
+}
+
+TEST_CASE("integration::cpp::restart_consistency::create_table_after_restart", "[restart]") {
+    group_t g;
+    g.name = "create_table_after_restart";
+    // A dropped table's OID can be handed out again after a restart, and the
+    // dropped table's INSERT records are still in the WAL. A brand-new table can
+    // therefore come up pre-populated with a dead table's rows.
+    g.setup = {create_db,
+               "CREATE TABLE rcdb.keeper (x bigint)$S;",
+               "CREATE TABLE rcdb.doomed (x bigint)$S;",
+               "INSERT INTO rcdb.doomed (x) VALUES (111), (222), (333);",
+               "DROP TABLE rcdb.doomed;"};
+    g.probes = {
+        {"fresh_table",
+         {"CREATE TABLE rcdb.fresh$K (x bigint)$S;"},
+         {{"is_empty", "SELECT * FROM rcdb.fresh$K;"}},
+         {}},
+        {"fresh_table_writable",
+         {"INSERT INTO rcdb.fresh$K (x) VALUES (7);"},
+         {{"row", "SELECT x FROM rcdb.fresh$K;"}},
+         {"DROP TABLE rcdb.fresh$K;"}},
+        {"keeper", {}, {{"untouched", "SELECT * FROM rcdb.keeper;"}}, {}},
+    };
+    check_restart_consistency(g);
+}
+
+// ---------------------------------------------------------------------------
+// Session settings that change stored values and comparisons.
+// ---------------------------------------------------------------------------
+TEST_CASE("integration::cpp::restart_consistency::timezone", "[restart]") {
+    group_t g;
+    g.name = "timezone";
+    g.setup = {create_db,
+               "SET TIMEZONE = 'Asia/Tokyo';",
+               "CREATE TABLE rcdb.t (id bigint, ts timestamptz)$S;",
+               "INSERT INTO rcdb.t (id, ts) VALUES (1, '2020-01-01 12:00:00');"};
+    g.probes = {
+        {"existing", {}, {{"value", "SELECT ts FROM rcdb.t WHERE id = 1;"}}, {}},
+        // The literal is cast using the SESSION time zone. If the restart forgets
+        // it, the same literal lands on a different instant.
+        {"new_literal",
+         {"INSERT INTO rcdb.t (id, ts) VALUES ($K, '2020-01-01 12:00:00');"},
+         {{"same_instant", "SELECT ts FROM rcdb.t WHERE id = $K;"}},
+         {"DELETE FROM rcdb.t WHERE id = $K;"}},
+    };
+    check_restart_consistency(g);
+}

--- a/integration/cpp/test/test_restart_consistency.cpp
+++ b/integration/cpp/test/test_restart_consistency.cpp
@@ -749,7 +749,7 @@ TEST_CASE("integration::cpp::restart_consistency::timezone", "[restart]") {
 }
 
 // ---------------------------------------------------------------------------
-// I-2 zero-apply release. A DELETE/UPDATE under a non-pushable predicate reads
+// Zero-apply release. A DELETE/UPDATE under a non-pushable predicate reads
 // through a bare mutating full_scan whose retained cursor is normally released
 // by the storage apply (storage_delete_rows / storage_update). When ZERO rows
 // match, no apply is ever sent — the operator must release the pin itself at

--- a/integration/cpp/test/test_restart_consistency.cpp
+++ b/integration/cpp/test/test_restart_consistency.cpp
@@ -500,6 +500,32 @@ TEST_CASE("integration::cpp::restart_consistency::alter_add_column", "[restart]"
     check_restart_consistency(g);
 }
 
+// ADD COLUMN followed by DROP COLUMN exercises the one update in the engine that is
+// genuinely in place: the pg_attribute commit-id backfill, which patches a catalog row
+// that must NOT move. Replaying it as an MVCC delete+append would tombstone the row and
+// re-append it, leaving two live pg_attribute rows for the same attribute -- so the
+// dropped column would come back, or appear twice.
+TEST_CASE("integration::cpp::restart_consistency::catalog_column_lifecycle", "[restart]") {
+    group_t g;
+    g.name = "catalog_column_lifecycle";
+    g.setup = {create_db,
+               "CREATE TABLE rcdb.t (a bigint)$S;",
+               "INSERT INTO rcdb.t (a) VALUES (1), (2);",
+               "ALTER TABLE rcdb.t ADD COLUMN keep bigint;",
+               "ALTER TABLE rcdb.t ADD COLUMN gone bigint;",
+               "ALTER TABLE rcdb.t DROP COLUMN gone;"};
+    g.probes = {
+        // The dropped column must stay dropped, and the kept one must appear exactly once.
+        {"schema", {}, {{"shape", "SELECT * FROM rcdb.t WHERE a < 100;"}}, {}},
+        {"dropped_column_unusable", {}, {{"select_it", "SELECT gone FROM rcdb.t;"}}, {}},
+        {"kept_column_writable",
+         {"INSERT INTO rcdb.t (a, keep) VALUES ($K, 9);"},
+         {{"row", "SELECT a, keep FROM rcdb.t WHERE a = $K;"}},
+         {"DELETE FROM rcdb.t WHERE a = $K;"}},
+    };
+    check_restart_consistency(g);
+}
+
 TEST_CASE("integration::cpp::restart_consistency::create_table_after_restart", "[restart]") {
     group_t g;
     g.name = "create_table_after_restart";

--- a/integration/cpp/test/test_restart_consistency.cpp
+++ b/integration/cpp/test/test_restart_consistency.cpp
@@ -27,6 +27,11 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <components/catalog/catalog_oids.hpp>
+#include <components/log/log.hpp>
+#include <services/wal/record.hpp>
+#include <services/wal/wal_reader.hpp>
+
 using namespace restart_rc;
 
 namespace {
@@ -604,4 +609,119 @@ TEST_CASE("integration::cpp::restart_consistency::timezone", "[restart]") {
          {"DELETE FROM rcdb.t WHERE id = $K;"}},
     };
     check_restart_consistency(g);
+}
+
+// ---------------------------------------------------------------------------
+// I-2 zero-apply release. A DELETE/UPDATE under a non-pushable predicate reads
+// through a bare mutating full_scan whose retained cursor is normally released
+// by the storage apply (storage_delete_rows / storage_update). When ZERO rows
+// match, no apply is ever sent — the operator must release the pin itself at
+// its final drive. Sessions are minted per statement, so no later statement's
+// sweep-on-open can match this (oid, session): an unreleased pin defers
+// compaction of the table forever. Observable end-to-end: VACUUM after the
+// zero-match DMLs must still compact and emit its PHYSICAL_COMPACT epoch
+// marker into the WAL.
+// ---------------------------------------------------------------------------
+TEST_CASE("integration::cpp::restart_consistency::zero_match_dml_releases_compaction_pin", "[restart]") {
+    const auto dir = data_root() / "zero_match_pin";
+    auto config = test_create_config(dir);
+    test_clear_directory(config);
+    config.disk.on = true;
+    config.wal.on = true;
+
+    {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+        auto run = [&](const std::string& sql) {
+            auto cur = test_helpers::exec(dispatcher, sql);
+            INFO(sql);
+            REQUIRE(cur);
+            REQUIRE_FALSE(cur->is_error());
+            return cur;
+        };
+        run("CREATE DATABASE rcdb;");
+        run("CREATE TABLE rcdb.t (id BIGINT);");
+        run("INSERT INTO rcdb.t (id) VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9),"
+            "(10),(11),(12),(13),(14),(15),(16),(17),(18),(19);");
+        // 20% dead: below the 30% commit-time threshold, so only VACUUM compacts.
+        run("DELETE FROM rcdb.t WHERE id < 4;");
+        // Zero-match DMLs under a non-pushable (column-vs-column) predicate: each
+        // drains a bare mutating scan that captures all 16 live ids, then applies
+        // nothing.
+        run("DELETE FROM rcdb.t WHERE id < id;");
+        run("UPDATE rcdb.t SET id = 0 WHERE id < id;");
+        run("VACUUM;");
+        // A committed write pair after the VACUUM: the FULL-sync COMMIT flushes
+        // every preceding WAL record (including the compact marker) durably, and
+        // the pair leaves the row set unchanged.
+        run("INSERT INTO rcdb.t (id) VALUES (999);");
+        run("DELETE FROM rcdb.t WHERE id = 999;");
+        auto cur = run("SELECT * FROM rcdb.t;");
+        REQUIRE(cur->size() == 16);
+    }
+
+    auto log = initialization_logger("zero_match_pin", dir.string() + "/");
+    services::wal::wal_reader_t reader(config.wal, log);
+    const auto records = reader.read_committed_records(services::wal::id_t{0});
+    bool user_table_compacted = false;
+    for (const auto& r : records) {
+        if (r.record_type == services::wal::wal_record_type::PHYSICAL_COMPACT &&
+            r.table_oid >= components::catalog::FIRST_USER_OID) {
+            user_table_compacted = true;
+        }
+    }
+    REQUIRE(user_table_compacted);
+}
+
+// The other zero-apply-at-final shape: the DML DID match rows, but the matched
+// count is an exact multiple of dml_flush_row_threshold, so the LAST mid-pump
+// flush consumed the whole buffer and the final drive flushes nothing. The
+// mid-pump apply cannot release the pin (the scan cursor is still open when it
+// lands — releasing an active cursor would break the capture window), and the
+// empty final drive sends no apply, so only an explicit final-drive release
+// keeps the pin from leaking.
+TEST_CASE("integration::cpp::restart_consistency::exact_threshold_dml_releases_compaction_pin", "[restart]") {
+    const auto dir = data_root() / "exact_threshold_pin";
+    auto config = test_create_config(dir);
+    test_clear_directory(config);
+    config.disk.on = true;
+    config.wal.on = true;
+    config.execution.dml_flush_row_threshold = 4;
+
+    {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+        auto run = [&](const std::string& sql) {
+            auto cur = test_helpers::exec(dispatcher, sql);
+            INFO(sql);
+            REQUIRE(cur);
+            REQUIRE_FALSE(cur->is_error());
+            return cur;
+        };
+        run("CREATE DATABASE rcdb;");
+        run("CREATE TABLE rcdb.t (id BIGINT);");
+        run("INSERT INTO rcdb.t (id) VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9),"
+            "(10),(11),(12),(13),(14),(15),(16),(17),(18),(19);");
+        // Matches EXACTLY the flush threshold (4): one mid-pump flush drains the
+        // buffer, the final drive has nothing to flush. 4/20 = 20% dead stays
+        // below the 30% commit-time threshold, so only VACUUM compacts.
+        run("DELETE FROM rcdb.t WHERE id < 4;");
+        run("VACUUM;");
+        run("INSERT INTO rcdb.t (id) VALUES (999);");
+        run("DELETE FROM rcdb.t WHERE id = 999;");
+        auto cur = run("SELECT * FROM rcdb.t;");
+        REQUIRE(cur->size() == 16);
+    }
+
+    auto log = initialization_logger("exact_threshold_pin", dir.string() + "/");
+    services::wal::wal_reader_t reader(config.wal, log);
+    const auto records = reader.read_committed_records(services::wal::id_t{0});
+    bool user_table_compacted = false;
+    for (const auto& r : records) {
+        if (r.record_type == services::wal::wal_record_type::PHYSICAL_COMPACT &&
+            r.table_oid >= components::catalog::FIRST_USER_OID) {
+            user_table_compacted = true;
+        }
+    }
+    REQUIRE(user_table_compacted);
 }

--- a/integration/cpp/test/test_restart_consistency.cpp
+++ b/integration/cpp/test/test_restart_consistency.cpp
@@ -333,6 +333,36 @@ TEST_CASE("integration::cpp::restart_consistency::delete_then_compact", "[restar
     check_restart_consistency(g);
 }
 
+// The OTHER compaction site: VACUUM (cleanup_versions + compact), not the commit-time
+// maybe_cleanup. Kept distinct because the deletes stay below the 30% auto-cleanup threshold, so
+// ONLY the explicit VACUUM renumbers. Same failure mode as delete_then_compact if VACUUM omits its
+// PHYSICAL_COMPACT epoch marker: the post-VACUUM DELETE/UPDATE replay against the pre-VACUUM numbering.
+TEST_CASE("integration::cpp::restart_consistency::vacuum_then_restart", "[restart]") {
+    group_t g;
+    g.name = "vacuum_then_restart";
+    g.setup = {create_db,
+               "CREATE TABLE rcdb.t (a bigint, v bigint)$S;",
+               "INSERT INTO rcdb.t (a, v) VALUES (1,1),(2,2),(3,3),(4,4),(5,5),(6,6),(7,7),(8,8),(9,9),(10,10);",
+               // 20% dead: BELOW the 30% commit-compaction threshold, so maybe_cleanup does NOT
+               // pre-empt — only the explicit VACUUM renumbers the survivors.
+               "DELETE FROM rcdb.t WHERE a IN (1, 2);",
+               "VACUUM;",
+               // Captured against the POST-VACUUM numbering; replay must re-run the VACUUM compaction
+               // (via its epoch marker) before applying these or they land on the wrong rows.
+               "DELETE FROM rcdb.t WHERE a = 5;",
+               "UPDATE rcdb.t SET v = 99 WHERE a = 8;"};
+    g.probes = {
+        {"state",
+         {},
+         {{"survivors", "SELECT * FROM rcdb.t;"},
+          {"post_vacuum_delete_stuck", "SELECT * FROM rcdb.t WHERE a = 5;"},
+          {"post_vacuum_update_stuck", "SELECT v FROM rcdb.t WHERE a = 8;"},
+          {"no_resurrection", "SELECT * FROM rcdb.t WHERE a <= 2;"}},
+         {}},
+    };
+    check_restart_consistency(g);
+}
+
 // ---------------------------------------------------------------------------
 // Type fidelity. The .otbx column record stores a bare uint8 logical_type, so
 // everything a type extension carries -- decimal width/scale, array size, list

--- a/integration/cpp/test/test_restart_consistency.cpp
+++ b/integration/cpp/test/test_restart_consistency.cpp
@@ -886,3 +886,53 @@ TEST_CASE("integration::cpp::restart_consistency::rollback_does_not_wedge_compac
     REQUIRE(user_table_compacted);
 }
 
+
+// Restart-of-restart: wal ids allocated AFTER a replay must continue above the
+// replayed maximum, and the second generation's positional records must resolve
+// against the numbering the first replay rebuilt — a third open then replays
+// BOTH generations in order and lands on the same state.
+TEST_CASE("integration::cpp::restart_consistency::second_restart_continues_wal_ids", "[restart]") {
+    for (const bool disk : {false, true}) {
+        const auto dir = data_root() / (disk ? "second_restart_disk" : "second_restart_mem");
+        auto config = test_create_config(dir);
+        test_clear_directory(config);
+        config.disk.on = disk;
+        config.wal.on = true;
+
+        auto exec = [](otterbrix::wrapper_dispatcher_t* d, const std::string& sql) {
+            otterbrix::session_id_t s;
+            auto cur = d->execute_sql(s, sql);
+            INFO(sql);
+            REQUIRE(cur);
+            REQUIRE_FALSE(cur->is_error());
+            return cur;
+        };
+
+        { // generation 1
+            test_spaces space(config);
+            auto* d = space.dispatcher();
+            exec(d, "CREATE DATABASE rcdb;");
+            exec(d, "CREATE TABLE rcdb.t (a bigint, v bigint);");
+            exec(d, "INSERT INTO rcdb.t (a, v) VALUES (1,1),(2,2),(3,3),(4,4),(5,5),(6,6),(7,7),(8,8),(9,9),(10,10);");
+            exec(d, "DELETE FROM rcdb.t WHERE a = 5;");
+        }
+        { // generation 2: writes on top of the replayed state
+            test_spaces space(config);
+            auto* d = space.dispatcher();
+            exec(d,
+                 "INSERT INTO rcdb.t (a, v) VALUES (11,11),(12,12),(13,13),(14,14),(15,15),"
+                 "(16,16),(17,17),(18,18),(19,19),(20,20);");
+            exec(d, "UPDATE rcdb.t SET v = 99 WHERE a = 8;");
+            exec(d, "DELETE FROM rcdb.t WHERE a = 15;");
+            REQUIRE(exec(d, "SELECT * FROM rcdb.t;")->size() == 18);
+        }
+        { // generation 3: both generations replay in order
+            test_spaces space(config);
+            auto* d = space.dispatcher();
+            REQUIRE(exec(d, "SELECT * FROM rcdb.t;")->size() == 18);
+            REQUIRE(exec(d, "SELECT * FROM rcdb.t WHERE a = 5;")->size() == 0);
+            REQUIRE(exec(d, "SELECT * FROM rcdb.t WHERE a = 15;")->size() == 0);
+            REQUIRE(exec(d, "SELECT v FROM rcdb.t WHERE a = 8 AND v = 99;")->size() == 1);
+        }
+    }
+}

--- a/integration/cpp/test/test_restart_consistency.cpp
+++ b/integration/cpp/test/test_restart_consistency.cpp
@@ -29,6 +29,7 @@
 
 #include <components/catalog/catalog_oids.hpp>
 #include <components/log/log.hpp>
+#include <components/physical_plan/operators/operator_update.hpp>
 #include <services/wal/record.hpp>
 #include <services/wal/wal_reader.hpp>
 
@@ -818,6 +819,69 @@ TEST_CASE("integration::cpp::restart_consistency::exact_threshold_dml_releases_c
     }
 
     auto log = initialization_logger("exact_threshold_pin", dir.string() + "/");
+    services::wal::wal_reader_t reader(config.wal, log);
+    const auto records = reader.read_committed_records(services::wal::id_t{0});
+    bool user_table_compacted = false;
+    for (const auto& r : records) {
+        if (r.record_type == services::wal::wal_record_type::PHYSICAL_COMPACT &&
+            r.table_oid >= components::catalog::FIRST_USER_OID) {
+            user_table_compacted = true;
+        }
+    }
+    REQUIRE(user_table_compacted);
+}
+
+// A statement that FAILS between drain and apply must not wedge compaction.
+// The mutating scan retired awaiting-apply when it drained; the failure lands
+// before storage_update, so the apply that normally releases the pin never
+// fires, the txn-abort OPERATOR does not run on the statement-failure path,
+// and the autocommit session dies with the statement (no later sweep-on-open
+// can match). Only the executor's failure-revert can release the pin.
+// Injection: DEV_MODE one-shot fault in operator_update's final drive, the
+// same window a RETURNING projection error fails in. Observable: VACUUM after
+// the failed statement still compacts and emits its PHYSICAL_COMPACT marker.
+TEST_CASE("integration::cpp::restart_consistency::failed_statement_releases_compaction_pin", "[restart]") {
+    const auto dir = data_root() / "failed_stmt_pin";
+    auto config = test_create_config(dir);
+    test_clear_directory(config);
+    config.disk.on = true;
+    config.wal.on = true;
+
+    {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+        auto run = [&](const std::string& sql) {
+            auto cur = test_helpers::exec(dispatcher, sql);
+            INFO(sql);
+            REQUIRE(cur);
+            REQUIRE_FALSE(cur->is_error());
+            return cur;
+        };
+        run("CREATE DATABASE rcdb;");
+        run("CREATE TABLE rcdb.t (id BIGINT);");
+        run("INSERT INTO rcdb.t (id) VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9),"
+            "(10),(11),(12),(13),(14),(15),(16),(17),(18),(19);");
+        // 20% dead: below the 30% commit-time threshold, so only VACUUM compacts.
+        run("DELETE FROM rcdb.t WHERE id < 4;");
+        // Non-pushable (column-vs-column) predicate matching every live row: the
+        // bare mutating scan drains fully and retires awaiting-apply, then the
+        // injected fault fails the statement before storage_update.
+        components::operators::arm_update_fail_before_apply();
+        {
+            auto cur = test_helpers::exec(dispatcher, "UPDATE rcdb.t SET id = id + 100 WHERE id >= id;");
+            REQUIRE(cur);
+            REQUIRE(cur->is_error());
+        }
+        run("VACUUM;");
+        // A committed write pair after the VACUUM: the FULL-sync COMMIT flushes
+        // every preceding WAL record (including the compact marker) durably.
+        run("INSERT INTO rcdb.t (id) VALUES (999);");
+        run("DELETE FROM rcdb.t WHERE id = 999;");
+        auto cur = run("SELECT * FROM rcdb.t;");
+        REQUIRE(cur->size() == 16);
+    }
+
+    auto log = initialization_logger("failed_stmt_pin", dir.string() + "/");
     services::wal::wal_reader_t reader(config.wal, log);
     const auto records = reader.read_committed_records(services::wal::id_t{0});
     bool user_table_compacted = false;

--- a/integration/cpp/test/test_restart_consistency.cpp
+++ b/integration/cpp/test/test_restart_consistency.cpp
@@ -20,7 +20,7 @@
 // cannot hide a divergence elsewhere:
 //
 //   RC_ONLY=defaults,index_content  ./test_otterbrix "[restart]"
-//   RC_DATA_ROOT=/var/tmp/rc        (default: /tmp/otterbrix/restart_consistency)
+//   RC_DATA_ROOT=/var/tmp/rc        (default: /var/tmp/otterbrix/restart_consistency)
 // ===========================================================================
 
 #include "restart_probe.hpp"
@@ -234,9 +234,9 @@ TEST_CASE("integration::cpp::restart_consistency::foreign_key", "[restart]") {
 
 // ---------------------------------------------------------------------------
 // Physical row_id stability. A live UPDATE is an MVCC delete+append (the row
-// moves to the end of the table); replay applies the same record in place. The
-// two disagree about where the row is, and every later record keyed by physical
-// row_id then lands on the wrong slot -- or on no slot at all.
+// moves to the end of the table); if replay applied the same record in place,
+// the two would disagree about where the row is, and every later record keyed
+// by physical row_id would land on the wrong slot -- or on no slot at all.
 // ---------------------------------------------------------------------------
 TEST_CASE("integration::cpp::restart_consistency::update_then_delete", "[restart]") {
     group_t g;
@@ -313,16 +313,17 @@ TEST_CASE("integration::cpp::restart_consistency::update_after_restart", "[resta
     check_restart_consistency(g);
 }
 
-// Compaction renumbers every surviving row from zero, with no WAL barrier. Any
-// DELETE or UPDATE recorded after that point replays against the OLD numbering.
+// Compaction renumbers every surviving row from zero. Without the
+// PHYSICAL_COMPACT epoch marker on the same WAL stream, any DELETE or UPDATE
+// recorded after that point would replay against the OLD numbering.
 TEST_CASE("integration::cpp::restart_consistency::delete_then_compact", "[restart]") {
     group_t g;
     g.name = "delete_then_compact";
     g.setup = {create_db,
                "CREATE TABLE rcdb.t (a bigint, v bigint)$S;",
                "INSERT INTO rcdb.t (a, v) VALUES (1,1),(2,2),(3,3),(4,4),(5,5),(6,6),(7,7),(8,8),(9,9),(10,10);",
-               // >30% dead rows: crosses the automatic cleanup threshold, which
-               // compacts and renumbers with no WAL barrier.
+               // >30% dead rows: crosses the automatic cleanup threshold, so
+               // commit-time compaction renumbers the survivors.
                "DELETE FROM rcdb.t WHERE a IN (1, 2, 3, 4);",
                "DELETE FROM rcdb.t WHERE a = 6;",
                "UPDATE rcdb.t SET v = 99 WHERE a = 8;"};
@@ -369,10 +370,11 @@ TEST_CASE("integration::cpp::restart_consistency::vacuum_then_restart", "[restar
 }
 
 // An aborted transaction's INSERTs occupy physical row-ids in the live run --
-// ROLLBACK reverts marks, not placement -- but replay filters uncommitted
-// records, so every committed append after the abort lands lower on replay and
-// every positional DELETE/UPDATE recorded after the abort resolves against the
-// wrong rows (until the next compact marker closes the numbering epoch).
+// ROLLBACK reverts marks, not placement -- so replay must repeat that history:
+// if it filtered the uncommitted records instead, every committed append after
+// the abort would land lower on replay and every positional DELETE/UPDATE
+// recorded after the abort would resolve against the wrong rows (until the
+// next compact marker closes the numbering epoch).
 TEST_CASE("integration::cpp::restart_consistency::aborted_insert_shifts_replay_numbering", "[restart]") {
     group_t g;
     g.name = "aborted_insert_numbering";
@@ -401,9 +403,9 @@ TEST_CASE("integration::cpp::restart_consistency::aborted_insert_shifts_replay_n
 
 // Multi-row-group flavor of the aborted-insert cell: everything crosses the
 // 1024-row vector boundary. The aborted placement spans several row groups
-// (version slots past the first group are the ones the slot-convention bug
-// mis-addressed), and the positional records after the abort resolve against
-// a numbering that includes thousands of dead rows.
+// (version slots are row-group-LOCAL; an absolute index would mis-address
+// every slot past the first group), and the positional records after the
+// abort resolve against a numbering that includes thousands of dead rows.
 TEST_CASE("integration::cpp::restart_consistency::aborted_insert_multi_row_group", "[restart]") {
     group_t g;
     g.name = "aborted_insert_multi_rg";
@@ -717,9 +719,10 @@ TEST_CASE("integration::cpp::restart_consistency::timezone", "[restart]") {
 // through a bare mutating full_scan whose retained cursor is normally released
 // by the storage apply (storage_delete_rows / storage_update). When ZERO rows
 // match, no apply is ever sent — the operator must release the pin itself at
-// its final drive. Sessions are minted per statement, so no later statement's
-// sweep-on-open can match this (oid, session): an unreleased pin defers
-// compaction of the table forever. Observable end-to-end: VACUUM after the
+// its final drive. An autocommit statement's session dies with the statement,
+// so no later statement's sweep-on-open can match this (oid, session) (only
+// statements inside one explicit transaction share a session): an unreleased
+// pin defers compaction of the table forever. Observable end-to-end: VACUUM after the
 // zero-match DMLs must still compact and emit its PHYSICAL_COMPACT epoch
 // marker into the WAL.
 // ---------------------------------------------------------------------------

--- a/integration/cpp/test/test_restart_consistency.cpp
+++ b/integration/cpp/test/test_restart_consistency.cpp
@@ -402,6 +402,39 @@ TEST_CASE("integration::cpp::restart_consistency::aborted_insert_shifts_replay_n
     check_restart_consistency(g);
 }
 
+// A rolled-back UPDATE also placed rows: the MVCC update appended its new-row
+// images before the abort reverted the marks, so those images occupy physical
+// ids the live run consumed. Replay must place them at the record's append
+// base and retire them dead WITHOUT tombstoning the old rows (the abort
+// reverted those marks live) — a wrong dead range kills survivors, a
+// tombstoned old row loses committed data, and skipping placement shifts
+// every positional record after the rollback.
+TEST_CASE("integration::cpp::restart_consistency::aborted_update_shifts_replay_numbering", "[restart]") {
+    group_t g;
+    g.name = "aborted_update_numbering";
+    g.setup = {create_db,
+               "CREATE TABLE rcdb.t (a bigint, v bigint)$S;",
+               "INSERT INTO rcdb.t (a, v) VALUES (1,1),(2,2),(3,3),(4,4),(5,5),(6,6),(7,7),(8,8),(9,9),(10,10);",
+               "@txn BEGIN;",
+               "@txn UPDATE rcdb.t SET v = v + 1000 WHERE a <= 6;",
+               "@txn ROLLBACK;",
+               // Committed rows land at physical ids ABOVE the six aborted update images.
+               "INSERT INTO rcdb.t (a, v) VALUES (11,11),(12,12);",
+               // Positional records captured against the post-abort numbering.
+               "DELETE FROM rcdb.t WHERE a = 5;",
+               "UPDATE rcdb.t SET v = 99 WHERE a = 12;"};
+    g.probes = {
+        {"state",
+         {},
+         {{"survivors", "SELECT * FROM rcdb.t;"},
+          {"rollback_stuck", "SELECT v FROM rcdb.t WHERE a <= 6;"},
+          {"deleted_stays_deleted", "SELECT * FROM rcdb.t WHERE a = 5;"},
+          {"update_sticks", "SELECT v FROM rcdb.t WHERE a = 12;"}},
+         {}},
+    };
+    check_restart_consistency(g);
+}
+
 // Multi-row-group flavor of the aborted-insert cell: everything crosses the
 // 1024-row vector boundary. The aborted placement spans several row groups
 // (version slots are row-group-LOCAL; an absolute index would mis-address

--- a/integration/cpp/test/test_restart_consistency.cpp
+++ b/integration/cpp/test/test_restart_consistency.cpp
@@ -368,6 +368,37 @@ TEST_CASE("integration::cpp::restart_consistency::vacuum_then_restart", "[restar
     check_restart_consistency(g);
 }
 
+// An aborted transaction's INSERTs occupy physical row-ids in the live run --
+// ROLLBACK reverts marks, not placement -- but replay filters uncommitted
+// records, so every committed append after the abort lands lower on replay and
+// every positional DELETE/UPDATE recorded after the abort resolves against the
+// wrong rows (until the next compact marker closes the numbering epoch).
+TEST_CASE("integration::cpp::restart_consistency::aborted_insert_shifts_replay_numbering", "[restart]") {
+    group_t g;
+    g.name = "aborted_insert_numbering";
+    g.setup = {create_db,
+               "CREATE TABLE rcdb.t (a bigint, v bigint)$S;",
+               "@txn BEGIN;",
+               "@txn INSERT INTO rcdb.t (a, v) VALUES (100,100),(101,101),(102,102),(103,103),(104,104),"
+               "(105,105),(106,106),(107,107),(108,108),(109,109);",
+               "@txn ROLLBACK;",
+               // Committed rows land at physical ids ABOVE the ten aborted-but-placed rows.
+               "INSERT INTO rcdb.t (a, v) VALUES (1,1),(2,2),(3,3),(4,4),(5,5),(6,6),(7,7),(8,8),(9,9),(10,10);",
+               // Positional records captured against the shifted (post-abort) numbering.
+               "DELETE FROM rcdb.t WHERE a = 5;",
+               "UPDATE rcdb.t SET v = 99 WHERE a = 8;"};
+    g.probes = {
+        {"state",
+         {},
+         {{"survivors", "SELECT * FROM rcdb.t;"},
+          {"deleted_stays_deleted", "SELECT * FROM rcdb.t WHERE a = 5;"},
+          {"update_sticks", "SELECT v FROM rcdb.t WHERE a = 8;"},
+          {"aborted_rows_stay_gone", "SELECT * FROM rcdb.t WHERE a >= 100;"}},
+         {}},
+    };
+    check_restart_consistency(g);
+}
+
 // ---------------------------------------------------------------------------
 // Type fidelity. The .otbx column record stores a bare uint8 logical_type, so
 // everything a type extension carries -- decimal width/scale, array size, list
@@ -714,6 +745,65 @@ TEST_CASE("integration::cpp::restart_consistency::exact_threshold_dml_releases_c
     }
 
     auto log = initialization_logger("exact_threshold_pin", dir.string() + "/");
+    services::wal::wal_reader_t reader(config.wal, log);
+    const auto records = reader.read_committed_records(services::wal::id_t{0});
+    bool user_table_compacted = false;
+    for (const auto& r : records) {
+        if (r.record_type == services::wal::wal_record_type::PHYSICAL_COMPACT &&
+            r.table_oid >= components::catalog::FIRST_USER_OID) {
+            user_table_compacted = true;
+        }
+    }
+    REQUIRE(user_table_compacted);
+}
+
+// A ROLLBACK'd INSERT must not wedge compaction. Abort reverts marks, not
+// placement, so the aborted rows keep sitting in the table — but if their
+// insert stamps stay PENDING (>= 2^62), has_version_above() trips forever and
+// every compaction site (commit-time, VACUUM, checkpoint) refuses the table
+// from then on. The aborted rows must be re-stamped committed-dead at abort:
+// invisible to every snapshot, reclaimable, and counted as dead. Observable:
+// VACUUM after the rollback still compacts and emits its PHYSICAL_COMPACT
+// marker.
+TEST_CASE("integration::cpp::restart_consistency::rollback_does_not_wedge_compaction", "[restart]") {
+    const auto dir = data_root() / "rollback_compaction";
+    auto config = test_create_config(dir);
+    test_clear_directory(config);
+    config.disk.on = true;
+    config.wal.on = true;
+
+    {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+        auto run = [&](const std::string& sql, const otterbrix::session_id_t* s = nullptr) {
+            otterbrix::session_id_t own;
+            auto cur = dispatcher->execute_sql(s != nullptr ? *s : own, sql);
+            INFO(sql);
+            REQUIRE(cur);
+            REQUIRE_FALSE(cur->is_error());
+            return cur;
+        };
+        run("CREATE DATABASE rcdb;");
+        run("CREATE TABLE rcdb.t (id BIGINT);");
+        run("INSERT INTO rcdb.t (id) VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9),"
+            "(10),(11),(12),(13),(14),(15),(16),(17),(18),(19);");
+        {
+            const otterbrix::session_id_t txn;
+            run("BEGIN;", &txn);
+            run("INSERT INTO rcdb.t (id) VALUES (100),(101),(102),(103),(104);", &txn);
+            run("ROLLBACK;", &txn);
+        }
+        // 4/20 committed-dead (20%): below the commit-time threshold, so only the
+        // explicit VACUUM compacts — if the aborted rows' stamps let it.
+        run("DELETE FROM rcdb.t WHERE id < 4;");
+        run("VACUUM;");
+        run("INSERT INTO rcdb.t (id) VALUES (999);");
+        run("DELETE FROM rcdb.t WHERE id = 999;");
+        auto cur = run("SELECT * FROM rcdb.t;");
+        REQUIRE(cur->size() == 16);
+    }
+
+    auto log = initialization_logger("rollback_compaction", dir.string() + "/");
     services::wal::wal_reader_t reader(config.wal, log);
     const auto records = reader.read_committed_records(services::wal::id_t{0});
     bool user_table_compacted = false;

--- a/integration/cpp/test/test_restart_consistency.cpp
+++ b/integration/cpp/test/test_restart_consistency.cpp
@@ -80,12 +80,18 @@ TEST_CASE("integration::cpp::restart_consistency::defaults", "[restart]") {
         {"existing_rows", {}, {{"all", "SELECT * FROM rcdb.t;"}}, {}},
         // The whole point: a NEW row, inserted in THIS phase, must get the same
         // defaults it would have got before the restart.
+        //
+        // The `values` oracle also pins a bug the differential cannot see: `b int
+        // DEFAULT 5` is filled with an indeterminate non-NULL value, because the DDL
+        // never casts the literal (a BIGINT 5) to the column type and vector_t::set_value
+        // silently early-returns on the type mismatch -- before setting validity. That is
+        // wrong BEFORE any restart, so `after == before` would happily certify it.
         {"new_row",
          {"INSERT INTO rcdb.t (a) VALUES ($K);"},
-         {{"values", "SELECT b, c, s FROM rcdb.t WHERE a = $K;"},
-          {"b_not_null", "SELECT a FROM rcdb.t WHERE a = $K AND b IS NULL;"},
-          {"c_is_7", "SELECT a FROM rcdb.t WHERE a = $K AND c = 7;"},
-          {"s_is_dflt", "SELECT a FROM rcdb.t WHERE a = $K AND s = 'dflt';"}},
+         {{"values", "SELECT b, c, s FROM rcdb.t WHERE a = $K;", "OK|rows=1|cols=3|[I32:5,I64:7,STR:\"dflt\"]"},
+          {"b_not_null", "SELECT a FROM rcdb.t WHERE a = $K AND b IS NULL;", "OK|rows=0|cols=1"},
+          {"c_is_7", "SELECT a FROM rcdb.t WHERE a = $K AND c = 7;", "OK|rows=1|cols=1|[I64:$K+0]"},
+          {"s_is_dflt", "SELECT a FROM rcdb.t WHERE a = $K AND s = 'dflt';", "OK|rows=1|cols=1|[I64:$K+0]"}},
          {"DELETE FROM rcdb.t WHERE a = $K;"}},
         // An explicit value must still override the default after a restart.
         // Keyed $K+1 so it can never be confused with the new_row probe's row.
@@ -109,7 +115,8 @@ TEST_CASE("integration::cpp::restart_consistency::timestamp_default", "[restart]
         {"new_row",
          {"INSERT INTO rcdb.t (id) VALUES ($K);"},
          {{"value", "SELECT created FROM rcdb.t WHERE id = $K;"},
-          {"not_null", "SELECT id FROM rcdb.t WHERE id = $K AND created IS NULL;"}},
+          // Not an epoch literal: the point is only that the default was APPLIED.
+          {"not_null", "SELECT id FROM rcdb.t WHERE id = $K AND created IS NULL;", "OK|rows=0|cols=1"}},
          {"DELETE FROM rcdb.t WHERE id = $K;"}},
     };
     check_restart_consistency(g);
@@ -186,11 +193,13 @@ TEST_CASE("integration::cpp::restart_consistency::unique_constraint", "[restart]
     g.probes = {
         {"duplicate_rejected",
          {"INSERT INTO rcdb.t (id, name) VALUES (1, 'dup');"},
-         {{"still_one_row", "SELECT * FROM rcdb.t WHERE id = 1;"}},
+         {{"still_one_row", "SELECT * FROM rcdb.t WHERE id = 1;", "OK|rows=1|cols=2|[I64:1,STR:\"a\"]"}},
          {}},
+        // The oracle matters here: the value read back is identical before and after the
+        // restart, so a differential test alone certifies it -- even when it is wrong.
         {"fresh_key_accepted",
          {"INSERT INTO rcdb.t (id, name) VALUES ($K, 'ok');"},
-         {{"row", "SELECT name FROM rcdb.t WHERE id = $K;"}},
+         {{"row", "SELECT name FROM rcdb.t WHERE id = $K;", "OK|rows=1|cols=1|[STR:\"ok\"]"}},
          {"DELETE FROM rcdb.t WHERE id = $K;"}},
     };
     check_restart_consistency(g);
@@ -365,18 +374,27 @@ TEST_CASE("integration::cpp::restart_consistency::array", "[restart]") {
 }
 
 // The scalar types the catalog type codec cannot name: they decode back to
-// logical_type::UNKNOWN.
+// logical_type::UNKNOWN. The column TYPE still round-trips through the probes even
+// with no rows, because a NULL cell is tagged with the cursor's declared type.
 TEST_CASE("integration::cpp::restart_consistency::unsigned_types", "[restart]") {
     group_t g;
     g.name = "unsigned_types";
     g.setup = {create_db,
                "CREATE TABLE rcdb.t (id bigint, u8 utinyint, u16 usmallint, u32 uinteger, u64 ubigint)$S;",
-               "INSERT INTO rcdb.t (id, u8, u16, u32, u64) VALUES (1, 200, 60000, 4000000000, 9000000000);"};
+               "INSERT INTO rcdb.t (id) VALUES (1);"};
     g.probes = {
-        {"existing", {}, {{"all_rows", "SELECT * FROM rcdb.t;"}}, {}},
+        // Reads the declared type of every unsigned column: a column that decays to
+        // UNKNOWN across the restart changes this rendering even though every value
+        // in it is NULL.
+        {"schema",
+         {},
+         {{"declared_types",
+           "SELECT * FROM rcdb.t WHERE id = 1;",
+           "OK|rows=1|cols=5|[I64:1,U8:NULL,U16:NULL,U32:NULL,U64:NULL]"}},
+         {}},
         {"new_row",
-         {"INSERT INTO rcdb.t (id, u8, u16, u32, u64) VALUES ($K, 1, 2, 3, 4);"},
-         {{"values", "SELECT u8, u16, u32, u64 FROM rcdb.t WHERE id = $K;"}},
+         {"INSERT INTO rcdb.t (id) VALUES ($K);"},
+         {{"types", "SELECT u8, u16, u32, u64 FROM rcdb.t WHERE id = $K;"}},
          {"DELETE FROM rcdb.t WHERE id = $K;"}},
     };
     check_restart_consistency(g);
@@ -424,14 +442,18 @@ TEST_CASE("integration::cpp::restart_consistency::index_content", "[restart]") {
                "INSERT INTO rcdb.t (id, k) VALUES (1, 10), (2, 20), (3, 30);",
                "CREATE INDEX idx_k ON rcdb.t (k);"};
     g.probes = {
-        {"existing", {}, {{"indexed_lookup", "SELECT id FROM rcdb.t WHERE k = 20;"}}, {}},
-        // This row takes its k from the DEFAULT -- the value the live index path
-        // never sees, and the rebuilt-from-storage index does.
+        {"existing", {}, {{"indexed_lookup", "SELECT id FROM rcdb.t WHERE k = 20;", "OK|rows=1|cols=1|[I64:2]"}}, {}},
+        // This row takes its k from the DEFAULT -- the value the live index path never
+        // sees (it indexes the SUBMITTED chunk, which has no k) and the rebuilt-from-
+        // storage index does. The oracles are what make this group mean anything: the
+        // divergence is real, but so is the fact that the pre-restart side is the WRONG
+        // one, and a purely differential probe cannot say which side to fix.
         {"defaulted_key",
          {"INSERT INTO rcdb.t (id) VALUES ($K);"},
-         {{"via_index", "SELECT id FROM rcdb.t WHERE k = 55;"},
-          {"via_scan", "SELECT k FROM rcdb.t WHERE id = $K;"},
-          {"index_agrees_with_scan", "SELECT id FROM rcdb.t WHERE k >= 0;"}},
+         {{"via_index", "SELECT id FROM rcdb.t WHERE k = 55;", "OK|rows=1|cols=1|[I64:$K+0]"},
+          {"via_scan", "SELECT k FROM rcdb.t WHERE id = $K;", "OK|rows=1|cols=1|[I64:55]"},
+          {"index_count", "SELECT COUNT(*) FROM rcdb.t WHERE k >= 0;", "OK|rows=1|cols=1|[U64:4]"},
+          {"scan_count", "SELECT COUNT(*) FROM rcdb.t;", "OK|rows=1|cols=1|[U64:4]"}},
          {"DELETE FROM rcdb.t WHERE id = $K;"}},
     };
     check_restart_consistency(g);
@@ -509,16 +531,19 @@ TEST_CASE("integration::cpp::restart_consistency::create_table_after_restart", "
 TEST_CASE("integration::cpp::restart_consistency::timezone", "[restart]") {
     group_t g;
     g.name = "timezone";
+    // SET TIMEZONE is SESSION state: it does not survive a restart, and no client would
+    // expect it to. What must survive is its effect on what got STORED, and the value
+    // the setting persisted into pg_settings. So the SET is re-issued in every phase --
+    // the probe then asks whether the same literal, under the same session setting,
+    // still lands on the same instant.
+    g.session_setup = {"SET TIMEZONE = 'Asia/Tokyo';"};
     g.setup = {create_db,
-               "SET TIMEZONE = 'Asia/Tokyo';",
                "CREATE TABLE rcdb.t (id bigint, ts timestamptz)$S;",
-               "INSERT INTO rcdb.t (id, ts) VALUES (1, '2020-01-01 12:00:00');"};
+               "INSERT INTO rcdb.t (id, ts) VALUES (1, TIMESTAMPTZ '2020-01-01 12:00:00');"};
     g.probes = {
         {"existing", {}, {{"value", "SELECT ts FROM rcdb.t WHERE id = 1;"}}, {}},
-        // The literal is cast using the SESSION time zone. If the restart forgets
-        // it, the same literal lands on a different instant.
         {"new_literal",
-         {"INSERT INTO rcdb.t (id, ts) VALUES ($K, '2020-01-01 12:00:00');"},
+         {"INSERT INTO rcdb.t (id, ts) VALUES ($K, TIMESTAMPTZ '2020-01-01 12:00:00');"},
          {{"same_instant", "SELECT ts FROM rcdb.t WHERE id = $K;"}},
          {"DELETE FROM rcdb.t WHERE id = $K;"}},
     };

--- a/services/collection/executor.cpp
+++ b/services/collection/executor.cpp
@@ -1708,7 +1708,7 @@ namespace services::collection::executor {
                 }
             }
 
-            // I-2: a mutating scan retained past drain (awaiting_apply) is normally
+            // A mutating scan retained past drain (awaiting_apply) is normally
             // released by the storage apply — which this failed statement will never
             // send (the failure landed between drain and apply). The txn-abort
             // OPERATOR does not run on the statement-failure path, and an autocommit

--- a/services/collection/executor.cpp
+++ b/services/collection/executor.cpp
@@ -1708,6 +1708,21 @@ namespace services::collection::executor {
                 }
             }
 
+            // I-2: a mutating scan retained past drain (awaiting_apply) is normally
+            // released by the storage apply — which this failed statement will never
+            // send (the failure landed between drain and apply). The txn-abort
+            // OPERATOR does not run on the statement-failure path, and an autocommit
+            // statement's session dies with the statement, so no later sweep-on-open
+            // can match the pin either. Release the session's retained cursors with
+            // the same broadcast the abort operator uses; otherwise compaction AND
+            // checkpointing of the target table defer for the process lifetime.
+            if (disk_address_ != actor_zeta::address_t::empty_address()) {
+                auto [_rp, rpf] = actor_zeta::send(disk_address_,
+                                                   &services::disk::manager_disk_t::release_scans_for_session,
+                                                   session);
+                co_await std::move(rpf);
+            }
+
             auto [_ab, abf] =
                 actor_zeta::send(parent_address_, &services::dispatcher::manager_dispatcher_t::txn_abort_msg, session);
             co_await std::move(abf);

--- a/services/collection/executor.cpp
+++ b/services/collection/executor.cpp
@@ -1628,22 +1628,37 @@ namespace services::collection::executor {
         auto revert_failed_txn = [this, session, resolve_txn, &session_ctx](
                                      [[maybe_unused]] executor_t* self,
                                      execute_result_t& exec_result) -> executor_t::unique_future<void> {
-            // Storage revert: fold DML append ranges + pg_catalog append ranges
-            // into a single storage_revert_appends (each range carries its own
-            // table_oid; the handler routes per-range).
-            std::vector<components::pg_catalog_append_range_t> revert_ranges;
-            revert_ranges.reserve(exec_result.dml_appends.size() + exec_result.pg_catalog_appends.size());
+            // Storage retire/revert, split by table kind. Base-table DML appends are
+            // retired committed-dead IN PLACE (storage_abort_appends): a placed row
+            // keeps its physical id until a compact, so the positional WAL records
+            // this failed statement's siblings already wrote — and their replay —
+            // keep resolving against the numbering the live run used, while the dead
+            // stamps keep the compaction gates unblocked. pg_catalog appends keep the
+            // physical unwind (storage_revert_appends): catalog rows ride the swap
+            // protocol, not positional replay.
+            std::vector<components::pg_catalog_append_range_t> abort_ranges;
+            abort_ranges.reserve(exec_result.dml_appends.size());
             for (const auto& app : exec_result.dml_appends) {
-                revert_ranges.push_back(
+                abort_ranges.push_back(
                     components::pg_catalog_append_range_t{app.table_oid, app.row_start, app.row_count});
 #ifdef DEV_MODE
                 // Test-observability: count each base-table DML append range we
-                // physically revert here. A constraint (CHECK/FK) that errors AFTER
-                // the DML appended its rows must reach this point with a non-empty
-                // dml_appends so the leaked physical slot is reverted (see header).
+                // retire here. A constraint (CHECK/FK) that errors AFTER the DML
+                // appended its rows must reach this point with a non-empty
+                // dml_appends so the leaked pending stamps are retired (see header).
                 g_dml_appends_reverted.fetch_add(1, std::memory_order_relaxed);
 #endif
             }
+            if (!abort_ranges.empty() && disk_address_ != actor_zeta::address_t::empty_address()) {
+                components::execution_context_t abort_ctx{session, resolve_txn, {}};
+                auto [_aa, aaf] = actor_zeta::send(disk_address_,
+                                                   &services::disk::manager_disk_t::storage_abort_appends,
+                                                   abort_ctx,
+                                                   std::move(abort_ranges));
+                co_await std::move(aaf);
+            }
+            std::vector<components::pg_catalog_append_range_t> revert_ranges;
+            revert_ranges.reserve(exec_result.pg_catalog_appends.size());
             for (auto& pgc : exec_result.pg_catalog_appends) {
                 revert_ranges.push_back(std::move(pgc));
             }

--- a/services/disk/agent_disk.cpp
+++ b/services/disk/agent_disk.cpp
@@ -2237,10 +2237,49 @@ namespace services::disk {
                                                    otbx_path,
                                                    std::filesystem::copy_options::overwrite_existing,
                                                    restore_error);
+                        if (restore_error) {
+                            // A failed copy (ENOSPC/EACCES — plausibly the same condition
+                            // that broke the sidecar) leaves the INTACT new fold in place,
+                            // which loads cleanly under the stale sidecar and double-applies.
+                            // rename moves no data blocks, so it can succeed where the copy
+                            // cannot, and the still-in-place old sidecar matches .prev's
+                            // content — promoting .prev IS the old consistent state.
+                            std::error_code rename_ec;
+                            std::filesystem::rename(prev_path, otbx_path, rename_ec);
+                            if (rename_ec) {
+                                error(log_,
+                                      "agent_disk[{}]::checkpoint_inner oid={}: restore failed twice "
+                                      "(copy: {}, rename: {}) — the folded .otbx may double-apply on "
+                                      "the next open",
+                                      pool_idx_,
+                                      static_cast<unsigned>(tbl_oid),
+                                      restore_error.message(),
+                                      rename_ec.message());
+                            }
+                        }
                     } else {
                         // First checkpoint of this table: no prior state to restore — absent
                         // .otbx means "never checkpointed", which replays the full WAL.
                         std::filesystem::remove(otbx_path, restore_error);
+                        if (restore_error) {
+                            // An intact first fold with NO sidecar replays the full WAL onto
+                            // the folded base — move it aside so the opener sees "never
+                            // checkpointed".
+                            auto aside_path = otbx_path;
+                            aside_path += ".failed";
+                            std::error_code rename_ec;
+                            std::filesystem::rename(otbx_path, aside_path, rename_ec);
+                            if (rename_ec) {
+                                error(log_,
+                                      "agent_disk[{}]::checkpoint_inner oid={}: could not remove or "
+                                      "move aside the unstamped first fold (remove: {}, rename: {}) — "
+                                      "it may double-apply on the next open",
+                                      pool_idx_,
+                                      static_cast<unsigned>(tbl_oid),
+                                      restore_error.message(),
+                                      rename_ec.message());
+                            }
+                        }
                     }
                     std::abort();
                 }

--- a/services/disk/agent_disk.cpp
+++ b/services/disk/agent_disk.cpp
@@ -392,6 +392,34 @@ namespace services::disk {
         }
     }
 
+    void agent_disk_t::direct_compact_sync(components::catalog::oid_t table_oid) {
+        auto it = storages_.find(table_oid);
+        if (it == storages_.end() || it->second == nullptr) {
+            trace(log_,
+                  "agent_disk[{}]::direct_compact_sync: oid {} not owned by this agent — no-op",
+                  pool_idx_,
+                  static_cast<unsigned>(table_oid));
+            return;
+        }
+        auto& entry = it->second;
+        // Load-bearing precondition (INV-REPLAY-3): this runs ONLY in the single-threaded
+        // pre-scheduler bootstrap window, so there is never a live scan cursor whose absolute
+        // position the dense renumber could shift out from under (the live gate is unavailable
+        // and unneeded here).
+        assert(active_scans_.empty() && "direct_compact_sync must run pre-scheduler, with no active scan");
+        // UINT64_MAX watermark: replay stamps are all {0,0}, so nothing is above it and compact
+        // is never MVCC-gated here — it renumbers the survivors densely exactly as the live
+        // maybe_cleanup/VACUUM did at this log point. A false return is therefore a recovery OOM,
+        // not a deferral; the epoch fails to close and later positional records would misresolve.
+        if (!entry->table_storage.table().compact(std::numeric_limits<uint64_t>::max())) {
+            trace(log_,
+                  "agent_disk[{}]::direct_compact_sync: oid {} compact() FAILED on replay (recovery OOM) — "
+                  "row-id epoch not closed; subsequent positional records may misresolve",
+                  pool_idx_,
+                  static_cast<unsigned>(table_oid));
+        }
+    }
+
     actor_zeta::behavior_t agent_disk_t::behavior(actor_zeta::mailbox::message* msg) {
         switch (msg->command()) {
             case actor_zeta::msg_id<agent_disk_t, &agent_disk_t::fix_wal_id>: {

--- a/services/disk/agent_disk.cpp
+++ b/services/disk/agent_disk.cpp
@@ -841,6 +841,9 @@ namespace services::disk {
             const auto db_oid = (ctx.database_oid != components::catalog::INVALID_OID)
                                     ? ctx.database_oid
                                     : components::catalog::well_known_oid::main_database;
+            // Remember the WAL stream this table's DML rides so a later PHYSICAL_COMPACT marker
+            // rides the SAME one (I-2); see collection_storage_entry_t::compact_wal_db_oid.
+            entry->wal_route_db_oid = db_oid;
 
             // 5a-i. Schema-growth record BEFORE the rows that depend on it. The
             //       payload is a 0-row chunk whose columns ARE the new columns
@@ -1087,6 +1090,7 @@ namespace services::disk {
             const auto db_oid = ctx.database_oid != components::catalog::INVALID_OID
                                     ? ctx.database_oid
                                     : components::catalog::well_known_oid::main_database;
+            entry->wal_route_db_oid = db_oid; // COMPACT marker rides the same stream (I-2)
             components::vector::data_chunk_t wal_chunk(resource(), data->types(), data->size());
             data->copy(wal_chunk, 0);
             std::pmr::vector<components::vector::data_chunk_t> wal_chunks(resource());
@@ -1163,6 +1167,7 @@ namespace services::disk {
             const auto db_oid = ctx.database_oid != components::catalog::INVALID_OID
                                     ? ctx.database_oid
                                     : components::catalog::well_known_oid::main_database;
+            entry->wal_route_db_oid = db_oid; // COMPACT marker rides the same stream (I-2)
             std::pmr::vector<int64_t> wal_row_ids(resource());
             wal_row_ids.reserve(count);
             for (uint64_t i = 0; i < count; ++i) {
@@ -2164,7 +2169,8 @@ namespace services::disk {
     }
 
     agent_disk_t::unique_future<void> agent_disk_t::maybe_cleanup_inner(components::catalog::oid_t table_oid,
-                                                                        uint64_t compact_watermark) {
+                                                                        uint64_t compact_watermark,
+                                                                        session_id_t session) {
         auto it = storages_.find(table_oid);
         if (it == storages_.end()) {
             trace(log_,
@@ -2182,6 +2188,12 @@ namespace services::disk {
             co_return;
         }
 
+        // I-2: maybe_cleanup only CONSULTS the mutating gate; it never releases it. A DELETE/UPDATE's
+        // pin is dropped by its own apply (storage_delete_rows_inner / storage_update_inner), the
+        // txn-abort broadcast (release_scans_for_session), or the next mutating open's sweep — all of
+        // which precede this committing session's commit fan-out, so by the time we run here the
+        // session holds no residual pin of its own. Releasing here instead would renumber row-ids out
+        // from under any OTHER in-flight session that had legitimately retained a pin on this oid.
         auto& table = entry->table_storage.table();
         auto rg = table.row_group();
         auto total = rg->total_rows();
@@ -2192,9 +2204,12 @@ namespace services::disk {
         auto committed = rg->committed_row_count();
         auto deleted = total - committed;
 
-        // Cursor gate: skip compact while a streaming fetch-next cursor is open on this oid (its
-        // stored absolute position indexes the un-swapped collection; the atomic swap would shift
-        // rows out from under it — R17). Reclaim is deferred to a later commit.
+        // Cursor gate: skip compact while a streaming fetch-next cursor is open (or a mutating one
+        // retained past drain, I-2) on this oid — its stored absolute position indexes the
+        // un-swapped collection; the atomic swap would shift rows out from under it (R17), or
+        // renumber rows out from under an in-flight DELETE/UPDATE's captured ids. SKIP, never
+        // block: reclaim is deferred to a later commit, and a subsequent delete-carrying commit
+        // re-nudges it.
         if (has_active_scan_for_oid(table_oid)) {
             trace(log_,
                   "agent_disk[{}]::maybe_cleanup_inner: oid={} has an active scan cursor — deferring compact",
@@ -2222,6 +2237,28 @@ namespace services::disk {
             // cleanup_versions would strip it before compact rebuilds the
             // row_group.
             table.compact(compact_watermark);
+
+            // Log the numbering-epoch boundary (I-2). Emit ONLY when the compaction actually
+            // renumbered (total_rows shrank) — a watermark-gated no-op or a tail-only drop that
+            // did not move a survivor needs no marker. Fire-and-forget (see the identical
+            // discipline at storage_append_inner's ADD_COLUMN emit): the in-memory swap already
+            // reclaimed the space, and co_awaiting a second cross-actor future on this agent
+            // coroutine risks the actor-zeta lost-wakeup. Durability + ordering hold without the
+            // await: the record rides the SAME db WAL worker the table's DML used (compact_wal_db_oid), whose
+            // FIFO mailbox + synchronous wal_id allocation put wal_id(COMPACT) below any later
+            // same-oid DML, so the marker is durable no later than that DML's fsync; if none
+            // follows, the pre/post-compaction numbering is observationally identical.
+            if (table.row_group()->total_rows() < total &&
+                manager_wal_addr_ != actor_zeta::address_t::empty_address()) {
+                const auto db_oid = entry->compact_wal_db_oid();
+                [[maybe_unused]] auto _cf = actor_zeta::send(manager_wal_addr_,
+                                                             &wal::manager_wal_replicate_t::write_physical_compact,
+                                                             session,
+                                                             table_oid,
+                                                             uint64_t{0}, // txn_id: system write
+                                                             compact_watermark,
+                                                             db_oid);
+            }
         }
 
         co_return;

--- a/services/disk/agent_disk.cpp
+++ b/services/disk/agent_disk.cpp
@@ -24,12 +24,16 @@ namespace services::disk {
 #ifdef DEV_MODE
     namespace {
         std::atomic<uint64_t> g_pushdown_reply_rows{0};
+        std::atomic<uint64_t> g_checkpoint_fold_fail_oid{0};
     } // namespace
     uint64_t pushdown_reply_rows() noexcept {
         return g_pushdown_reply_rows.load(std::memory_order_relaxed);
     }
     void reset_pushdown_reply_rows() noexcept {
         g_pushdown_reply_rows.store(0, std::memory_order_relaxed);
+    }
+    void arm_checkpoint_fold_failure(components::catalog::oid_t table_oid) noexcept {
+        g_checkpoint_fold_fail_oid.store(static_cast<uint64_t>(table_oid), std::memory_order_relaxed);
     }
 #endif
 
@@ -909,7 +913,9 @@ namespace services::disk {
                                              actual_count,
                                              txn.transaction_id,
                                              db_oid);
-            if (auto wal_id = co_await std::move(wf); wal_id == wal::id_t{}) {
+            const auto wal_id = co_await std::move(wf);
+            note_applied_wal_id(table_oid, wal_id);
+            if (wal_id == wal::id_t{}) {
                 trace(log_,
                       "agent_disk[{}]::storage_append_inner: physical_insert WAL returned zero id for oid={}",
                       pool_idx_,
@@ -1126,7 +1132,9 @@ namespace services::disk {
                                              ctx.txn.transaction_id,
                                              /*in_place=*/false,
                                              db_oid);
-            if (auto wal_id = co_await std::move(wf); wal_id == wal::id_t{}) {
+            const auto wal_id = co_await std::move(wf);
+            note_applied_wal_id(table_oid, wal_id);
+            if (wal_id == wal::id_t{}) {
                 trace(log_,
                       "agent_disk[{}]::storage_update_inner: physical_update WAL returned zero id for oid={}",
                       pool_idx_,
@@ -1193,7 +1201,9 @@ namespace services::disk {
                                              count,
                                              ctx.txn.transaction_id,
                                              db_oid);
-            if (auto wal_id = co_await std::move(wf); wal_id == wal::id_t{}) {
+            const auto wal_id = co_await std::move(wf);
+            note_applied_wal_id(table_oid, wal_id);
+            if (wal_id == wal::id_t{}) {
                 trace(log_,
                       "agent_disk[{}]::storage_delete_rows_inner: physical_delete WAL returned zero id for oid={}",
                       pool_idx_,
@@ -2006,6 +2016,17 @@ namespace services::disk {
         co_return entry->storage->total_rows();
     }
 
+    void agent_disk_t::note_applied_wal_id(components::catalog::oid_t table_oid, wal::id_t wal_id) noexcept {
+        if (wal_id == wal::id_t{}) {
+            return;
+        }
+        auto it = storages_.find(table_oid);
+        if (it == storages_.end() || it->second == nullptr) {
+            return;
+        }
+        it->second->last_applied_wal_id = std::max(it->second->last_applied_wal_id, wal_id);
+    }
+
     agent_disk_t::unique_future<void> agent_disk_t::fix_wal_id(wal::id_t wal_id) {
         trace(log_, "agent_disk::fix_wal_id : {}", wal_id);
         auto id = std::to_string(wal_id);
@@ -2015,7 +2036,7 @@ namespace services::disk {
     }
 
     agent_disk_t::unique_future<checkpoint_result_t>
-    agent_disk_t::checkpoint_inner(session_id_t /*session*/, wal::id_t current_wal_id, uint64_t compact_watermark) {
+    agent_disk_t::checkpoint_inner(session_id_t session, wal::id_t current_wal_id, uint64_t compact_watermark) {
         trace(log_, "agent_disk[{}]::checkpoint_inner: {} entries in local slice", pool_idx_, storages_.size());
         // Per DISK entry, crash-safe checkpoint sequence (order matters):
         //   compact (MVCC-gated), backup .otbx → .prev, checkpoint(wal_id), persist
@@ -2062,6 +2083,7 @@ namespace services::disk {
             // uncommitted rows on recovery (.otbx has no version metadata), so
             // the entry's checkpoint is deferred to a later round; the WAL keeps
             // its replay records because the old sidecar/prev ids stay in the min.
+            const auto rows_before_compact = entry->table_storage.table().row_group()->total_rows();
             if (!entry->table_storage.table().compact(compact_watermark)) {
                 trace(log_,
                       "agent_disk[{}]::checkpoint_inner oid={} has version stamps above watermark {} — "
@@ -2071,6 +2093,24 @@ namespace services::disk {
                       compact_watermark);
                 min_prev_id = std::min(min_prev_id, entry->table_storage.prev_checkpoint_wal_id());
                 continue;
+            }
+
+            // Numbering-epoch boundary (I-2), same shrink-gated fire-and-forget discipline as
+            // maybe_cleanup_inner / vacuum_inner. This compact renumbers whether or not the fold
+            // below lands; on the fold-FAILURE path (deferred round) the old sidecar stays and the
+            // marker is the ONLY durable record of the epoch — without it, every later positional
+            // record replays against the pre-compact numbering. On the success path the marker's
+            // id sits above the sidecar and replays direct_compact_sync onto the already-dense
+            // loaded table: a no-op.
+            if (entry->table_storage.table().row_group()->total_rows() < rows_before_compact &&
+                manager_wal_addr_ != actor_zeta::address_t::empty_address()) {
+                [[maybe_unused]] auto _cf = actor_zeta::send(manager_wal_addr_,
+                                                             &wal::manager_wal_replicate_t::write_physical_compact,
+                                                             session,
+                                                             tbl_oid,
+                                                             uint64_t{0}, // txn_id: system write
+                                                             compact_watermark,
+                                                             entry->compact_wal_db_oid());
             }
 
             trace(log_,
@@ -2099,13 +2139,36 @@ namespace services::disk {
                 }
             }
 
+            // Sidecar id = max(snapshot, last applied): the run_auto_checkpoint snapshot is
+            // taken BEFORE two cross-actor suspensions, so records this agent applied (and
+            // this fold embodies) can carry higher ids — stamping the bare snapshot would
+            // make replay re-apply them onto a base that already contains them. The whole
+            // handler turn is mailbox-atomic, so last_applied_wal_id is exactly the frontier
+            // the fold sees.
+            const auto sidecar_wal_id = std::max(current_wal_id, entry->last_applied_wal_id);
+
             // checkpoint(wal_id) returns out_of_memory on a column flush pin failure; it
             // aborts BEFORE the header swap and leaves the wal_id fields unchanged. On error,
             // defer this entry to a later round (same as the MVCC-gate skip above): restore
             // the .prev backup over any partial write, do NOT persist the sidecar or delete
             // the backup, and feed the unchanged prev_checkpoint_wal_id into the min() so the
-            // WAL keeps this table's replay records.
-            auto cp_r = entry->table_storage.checkpoint(current_wal_id);
+            // WAL keeps this table's replay records. The renumber the compact above already
+            // performed survives in memory — the PHYSICAL_COMPACT marker it emitted is what
+            // keeps replay aligned with it.
+#ifdef DEV_MODE
+            bool inject_fold_failure = false;
+            if (g_checkpoint_fold_fail_oid.load(std::memory_order_relaxed) == static_cast<uint64_t>(tbl_oid)) {
+                g_checkpoint_fold_fail_oid.store(0, std::memory_order_relaxed);
+                inject_fold_failure = true;
+            }
+#else
+            constexpr bool inject_fold_failure = false;
+#endif
+            auto cp_r = inject_fold_failure
+                            ? core::result_wrapper_t<bool>(
+                                  core::error_t(core::error_code_t::out_of_memory,
+                                                std::pmr::string{"injected checkpoint fold failure (test)"}))
+                            : entry->table_storage.checkpoint(sidecar_wal_id);
             if (cp_r.has_error()) {
                 warn(log_,
                      "agent_disk[{}]::checkpoint_inner oid={} checkpoint failed (rules 2/9) — deferring this round",
@@ -2130,19 +2193,43 @@ namespace services::disk {
                 sidecar_path += ".wal_id";
                 auto tmp_path = sidecar_path;
                 tmp_path += ".tmp";
+                bool sidecar_persisted = false;
                 std::ofstream sidecar(tmp_path, std::ios::binary | std::ios::trunc);
                 if (sidecar.is_open()) {
-                    auto v = static_cast<uint64_t>(current_wal_id);
+                    auto v = static_cast<uint64_t>(sidecar_wal_id);
                     sidecar.write(reinterpret_cast<const char*>(&v), sizeof(v));
                     sidecar.close();
                     std::error_code rename_error;
                     std::filesystem::rename(tmp_path, sidecar_path, rename_error);
-                    if (rename_error) {
-                        warn(log_,
-                             "agent_disk[{}]::checkpoint_inner sidecar rename failed: {}",
-                             pool_idx_,
-                             rename_error.message());
+                    sidecar_persisted = !rename_error;
+                }
+                if (!sidecar_persisted) {
+                    // The fold landed but its wal_id watermark did not. Folded data + stale
+                    // sidecar double-applies (old, fold] positional records on the next replay
+                    // — silent corruption. Continuing live is not an option either: the block
+                    // manager already references the new file layout, so restoring .prev and
+                    // running on would feed lazy loads stale bytes through new block ids.
+                    // Fail stop on the OLD consistent state: put the pre-fold checkpoint back
+                    // (a crash mid-restore is covered — the torn .otbx fails to load and the
+                    // opener falls back to .prev, which is only deleted after success below),
+                    // then abort; recovery replays the WAL onto the old base.
+                    error(log_,
+                          "agent_disk[{}]::checkpoint_inner oid={}: sidecar persist failed after a "
+                          "successful fold — restoring the previous checkpoint and aborting",
+                          pool_idx_,
+                          static_cast<unsigned>(tbl_oid));
+                    std::error_code restore_error;
+                    if (std::filesystem::exists(prev_path)) {
+                        std::filesystem::copy_file(prev_path,
+                                                   otbx_path,
+                                                   std::filesystem::copy_options::overwrite_existing,
+                                                   restore_error);
+                    } else {
+                        // First checkpoint of this table: no prior state to restore — absent
+                        // .otbx means "never checkpointed", which replays the full WAL.
+                        std::filesystem::remove(otbx_path, restore_error);
                     }
+                    std::abort();
                 }
             }
 
@@ -2524,7 +2611,9 @@ namespace services::disk {
                                              static_cast<std::uint64_t>(row.size()),
                                              ctx.txn.transaction_id,
                                              db_oid);
-            if (auto wal_id = co_await std::move(wf); wal_id == wal::id_t{}) {
+            const auto wal_id = co_await std::move(wf);
+            note_applied_wal_id(table_oid, wal_id);
+            if (wal_id == wal::id_t{}) {
                 trace(log_,
                       "agent_disk[{}]::append_pg_catalog_row_inner: WAL write returned zero id for oid={}",
                       pool_idx_,
@@ -2670,7 +2759,9 @@ namespace services::disk {
                                              static_cast<std::uint64_t>(row_ids.size()),
                                              ctx.txn.transaction_id,
                                              components::catalog::well_known_oid::main_database);
-            if (auto wal_id = co_await std::move(wf); wal_id == wal::id_t{}) {
+            const auto wal_id = co_await std::move(wf);
+            note_applied_wal_id(table_oid, wal_id);
+            if (wal_id == wal::id_t{}) {
                 trace(log_,
                       "agent_disk[{}]::delete_pg_catalog_rows_inner: WAL write returned zero id for oid={}",
                       pool_idx_,
@@ -2809,7 +2900,9 @@ namespace services::disk {
                                              ctx.txn.transaction_id,
                                              /*in_place=*/true,
                                              components::catalog::well_known_oid::main_database);
-            if (auto wal_id = co_await std::move(wf); wal_id == wal::id_t{}) {
+            const auto wal_id = co_await std::move(wf);
+            note_applied_wal_id(pg_attr_oid, wal_id);
+            if (wal_id == wal::id_t{}) {
                 trace(log_,
                       "agent_disk[{}]::update_pg_attribute_commit_id_field_inner: WAL write returned zero id "
                       "for attoid={}",

--- a/services/disk/agent_disk.cpp
+++ b/services/disk/agent_disk.cpp
@@ -2472,8 +2472,14 @@ namespace services::disk {
             }
         }
 
-        // WAL physical_update: the chunk mirrors the patch chunk full-width so replay's
-        // direct_update_sync takes the same alias-matching path.
+        // WAL physical_update. This is the ONE update that is genuinely in place: it
+        // patches an existing pg_attribute row's commit-id field, and the row must not
+        // move -- an MVCC delete+append would leave two live rows for the same attoid.
+        //
+        // The chunk is built full-width because both the local apply and the replay drive
+        // data_table_t::update, which addresses columns POSITIONALLY (column_ids is
+        // 0..column_count-1). A narrower chunk would read past its own end. Full width is
+        // a precondition, not a convenience.
         if (manager_wal_addr_ != actor_zeta::address_t::empty_address()) {
             components::vector::data_chunk_t wal_chunk(resource(), chunk_types, 1);
             wal_chunk.set_cardinality(1);
@@ -2493,6 +2499,11 @@ namespace services::disk {
                                              pg_attr_oid,
                                              std::move(wal_row_ids),
                                              std::move(wal_chunks),
+                                             // row_start is where an MVCC update's new rows
+                                             // landed. This update lands nowhere new: it
+                                             // rewrites the row in place, so there is no
+                                             // append base to report.
+                                             std::uint64_t{0},
                                              static_cast<std::uint64_t>(row_ids.size()),
                                              ctx.txn.transaction_id,
                                              components::catalog::well_known_oid::main_database);

--- a/services/disk/agent_disk.cpp
+++ b/services/disk/agent_disk.cpp
@@ -1080,10 +1080,10 @@ namespace services::disk {
     }
 
     agent_disk_t::unique_future<uint64_t>
-    agent_disk_t::storage_delete_rows_inner(components::catalog::oid_t table_oid,
+    agent_disk_t::storage_delete_rows_inner(execution_context_t ctx,
+                                            components::catalog::oid_t table_oid,
                                             components::vector::vector_t row_ids,
-                                            uint64_t count,
-                                            components::table::transaction_data txn) {
+                                            uint64_t count) {
         auto it = storages_.find(table_oid);
         if (it == storages_.end()) {
             trace(log_,
@@ -1103,10 +1103,45 @@ namespace services::disk {
         if (entry->storage == nullptr || count == 0) {
             co_return 0;
         }
-        if (txn.transaction_id != 0) {
-            co_return entry->storage->delete_rows(row_ids, count, txn.transaction_id);
+        uint64_t deleted = ctx.txn.transaction_id != 0
+                               ? entry->storage->delete_rows(row_ids, count, ctx.txn.transaction_id)
+                               : entry->storage->delete_rows(row_ids, count);
+
+        // WAL AFTER the mutation, but INSIDE this handler (I-1) -- exactly as
+        // storage_update_inner does. The handler holds the mailbox across its single
+        // co_await, so no other same-oid mutation OR compaction can run between the
+        // storage mark and the record that names it. Every physical record for this oid
+        // is therefore an agent->WAL FIFO write and replay, walking the WAL in id order,
+        // reproduces the identical row-id space. The recorded row_ids are the ones this
+        // DELETE just marked.
+        //
+        // MANDATORY: this must remain the handler's ONLY cross-actor co_await (actor-zeta
+        // lost-wakeup, see storage_append_inner / storage_update_inner).
+        if (ctx.txn.transaction_id != 0 && manager_wal_addr_ != actor_zeta::address_t::empty_address()) {
+            const auto db_oid = ctx.database_oid != components::catalog::INVALID_OID
+                                    ? ctx.database_oid
+                                    : components::catalog::well_known_oid::main_database;
+            std::pmr::vector<int64_t> wal_row_ids(resource());
+            wal_row_ids.reserve(count);
+            for (uint64_t i = 0; i < count; ++i) {
+                wal_row_ids.push_back(row_ids.value(i).value<int64_t>());
+            }
+            auto [_w, wf] = actor_zeta::send(manager_wal_addr_,
+                                             &wal::manager_wal_replicate_t::write_physical_delete,
+                                             ctx.session,
+                                             table_oid,
+                                             std::move(wal_row_ids),
+                                             count,
+                                             ctx.txn.transaction_id,
+                                             db_oid);
+            if (auto wal_id = co_await std::move(wf); wal_id == wal::id_t{}) {
+                trace(log_,
+                      "agent_disk[{}]::storage_delete_rows_inner: physical_delete WAL returned zero id for oid={}",
+                      pool_idx_,
+                      static_cast<unsigned>(table_oid));
+            }
         }
-        co_return entry->storage->delete_rows(row_ids, count);
+        co_return deleted;
     }
 
     agent_disk_t::unique_future<std::pmr::vector<components::vector::data_chunk_t>>

--- a/services/disk/agent_disk.cpp
+++ b/services/disk/agent_disk.cpp
@@ -295,6 +295,60 @@ namespace services::disk {
         entry->storage->update(ids_vec, local);
     }
 
+    void agent_disk_t::direct_update_mvcc_sync(components::catalog::oid_t table_oid,
+                                               const std::pmr::vector<int64_t>& row_ids,
+                                               components::vector::data_chunk_t& new_data) {
+        auto it = storages_.find(table_oid);
+        if (it == storages_.end()) {
+            trace(log_,
+                  "agent_disk[{}]::direct_update_mvcc_sync: oid {} not owned by this agent — no-op",
+                  pool_idx_,
+                  static_cast<unsigned>(table_oid));
+            return;
+        }
+        auto& entry = it->second;
+        if (entry == nullptr || row_ids.empty() || entry->storage == nullptr) {
+            return;
+        }
+        const auto count = static_cast<uint64_t>(row_ids.size());
+        components::vector::vector_t ids_vec(
+            resource(),
+            components::types::complex_logical_type(components::types::logical_type::BIGINT),
+            count);
+        for (uint64_t i = 0; i < count; i++) {
+            ids_vec.set_value(i, row_ids[i]);
+        }
+        // Deep-copy onto this agent's resource, as direct_update_sync does and for the
+        // same reason (docs/wal-recovery-pmr-mismatch.md).
+        components::vector::data_chunk_t local(resource(), new_data.types(), new_data.size());
+        new_data.copy(local, 0);
+
+        // THE POINT OF THIS FUNCTION: replay drives the SAME storage contract the live
+        // path drives -- tombstone the old rows, append the new ones at the end -- so the
+        // row-id space it rebuilds is the one the live run produced, by construction. An
+        // in-place replay would leave the updated row where it was and consume no row-id,
+        // and every later record keyed by a physical row_id would then be off by the
+        // accumulated drift.
+        //
+        // transaction_data{0, 0}, not the record's own transaction_id: replay never
+        // publishes commits (nothing calls commit_append during bootstrap), so a pending
+        // txn id would leave the new rows permanently invisible and the old rows
+        // delete-marked by a transaction that never commits. An id of 0 is below
+        // TRANSACTION_ID_START, so the version manager reads it as already committed --
+        // which is exactly what the replay append and delete paths already rely on.
+        auto result = entry->storage->update(ids_vec, local, components::table::transaction_data{0, 0});
+        if (result.has_error()) {
+            // Replay cannot abort a transaction. If the update fails here the recovered
+            // state is already wrong, so say so rather than swallow it behind an assert
+            // that compiles away in Release.
+            error(log_,
+                  "agent_disk[{}]::direct_update_mvcc_sync: replay update failed for oid={} — recovered state is "
+                  "incomplete",
+                  pool_idx_,
+                  static_cast<unsigned>(table_oid));
+        }
+    }
+
     void agent_disk_t::direct_add_column_sync(components::catalog::oid_t table_oid,
                                               const components::vector::data_chunk_t& schema_chunk) {
         auto it = storages_.find(table_oid);
@@ -1013,6 +1067,7 @@ namespace services::disk {
                                              static_cast<uint64_t>(start_row),
                                              count,
                                              ctx.txn.transaction_id,
+                                             /*in_place=*/false,
                                              db_oid);
             if (auto wal_id = co_await std::move(wf); wal_id == wal::id_t{}) {
                 trace(log_,
@@ -2558,6 +2613,7 @@ namespace services::disk {
                                              std::uint64_t{0},
                                              static_cast<std::uint64_t>(row_ids.size()),
                                              ctx.txn.transaction_id,
+                                             /*in_place=*/true,
                                              components::catalog::well_known_oid::main_database);
             if (auto wal_id = co_await std::move(wf); wal_id == wal::id_t{}) {
                 trace(log_,

--- a/services/disk/agent_disk.cpp
+++ b/services/disk/agent_disk.cpp
@@ -1073,7 +1073,7 @@ namespace services::disk {
                                        components::catalog::oid_t table_oid,
                                        components::vector::vector_t row_ids,
                                        std::unique_ptr<components::vector::data_chunk_t> data) {
-        // I-2 prompt clear: this UPDATE's capture->apply window on (table_oid, session) closes
+        // Prompt pin clear: this UPDATE's capture->apply window on (table_oid, session) closes
         // here -- the operator has handed its captured physical ids to this handler. The storage
         // mutation below lands before the single WAL co_await, so releasing the retained pin now
         // cannot let a compaction slip in ahead of the apply (this agent runs both). Harmless
@@ -1162,7 +1162,7 @@ namespace services::disk {
                                             components::catalog::oid_t table_oid,
                                             components::vector::vector_t row_ids,
                                             uint64_t count) {
-        // I-2 prompt clear: this DELETE's capture->apply window on (table_oid, session) closes
+        // Prompt pin clear: this DELETE's capture->apply window on (table_oid, session) closes
         // here (symmetric with storage_update_inner). The delete_rows mark below lands before the
         // single WAL co_await, so releasing the retained pin now is race-free on this agent thread.
         release_mutating_scans(table_oid, ctx.session);
@@ -1189,7 +1189,7 @@ namespace services::disk {
                                ? entry->storage->delete_rows(row_ids, count, ctx.txn.transaction_id)
                                : entry->storage->delete_rows(row_ids, count);
 
-        // WAL AFTER the mutation, but INSIDE this handler (I-1) -- exactly as
+        // WAL AFTER the mutation, but INSIDE this handler -- exactly as
         // storage_update_inner does. The handler holds the mailbox across its single
         // co_await, so no other same-oid mutation OR compaction can run between the
         // storage mark and the record that names it. Every physical record for this oid
@@ -1483,7 +1483,7 @@ namespace services::disk {
             empty->set_cardinality(0);
             return fetch_batch_t{std::move(empty), reply_cursor_id};
         };
-        // I-2 natural-drain retirement. A cursor is RETAINED past drain (awaiting_apply) — so
+        // Natural-drain retirement. A cursor is RETAINED past drain (awaiting_apply) — so
         // has_active_scan_for_oid keeps deferring compaction of table_oid across the capture->apply
         // window — ONLY when it is a mutating (DELETE/UPDATE) scan that actually HANDED OUT rows
         // (matched_emitted > 0): those rows' physical ids are now in flight to the mutation
@@ -1516,7 +1516,7 @@ namespace services::disk {
                       static_cast<unsigned>(table_oid));
                 co_return make_drained(0);
             }
-            // I-2 sweep-on-open: a fresh DML scan on this (oid, session) first clears this
+            // Sweep-on-open: a fresh DML scan on this (oid, session) first clears this
             // session's OWN stale retained pins on this oid. A session runs its statements
             // serially, so any awaiting-apply pin left by a prior statement on this oid can
             // only be a leak (its mutation errored before finalize / aborted before apply).
@@ -2108,7 +2108,7 @@ namespace services::disk {
                 continue;
             }
 
-            // Numbering-epoch boundary (I-2), same shrink-gated fire-and-forget discipline as
+            // Numbering-epoch boundary, same shrink-gated fire-and-forget discipline as
             // maybe_cleanup_inner / vacuum_inner. This compact renumbers whether or not the fold
             // below lands; on the fold-FAILURE path (deferred round) the old sidecar stays and the
             // marker is the ONLY durable record of the epoch — without it, every later positional
@@ -2307,7 +2307,7 @@ namespace services::disk {
             auto& table = entry->table_storage.table();
             table.cleanup_versions(lowest_active_start_time);
             // Cursor gate: skip compact while a streaming fetch-next cursor is open (or a mutating
-            // one retained past drain, I-2) on this oid — its stored absolute position indexes the
+            // one retained past drain) on this oid — its stored absolute position indexes the
             // un-swapped collection; the atomic swap would shift rows out from under it (R17), or
             // renumber rows out from under an in-flight DELETE/UPDATE's captured ids. Reclaim is
             // deferred to a later vacuum round.
@@ -2319,7 +2319,7 @@ namespace services::disk {
             const auto total = table.row_group()->total_rows();
             table.compact(compact_watermark);
 
-            // Numbering-epoch boundary (I-2), identical discipline to maybe_cleanup_inner: emit ONLY
+            // Numbering-epoch boundary, identical discipline to maybe_cleanup_inner: emit ONLY
             // when this VACUUM compaction actually renumbered (total shrank), so replay re-runs the
             // SAME dense renumber at this log point and every later positional record resolves against
             // the post-VACUUM numbering. Fire-and-forget on the table's own DML WAL stream
@@ -2359,7 +2359,7 @@ namespace services::disk {
             co_return;
         }
 
-        // I-2: maybe_cleanup only CONSULTS the mutating gate; it never releases it. A DELETE/UPDATE's
+        // maybe_cleanup only CONSULTS the mutating gate; it never releases it. A DELETE/UPDATE's
         // pin is dropped by its own apply (storage_delete_rows_inner / storage_update_inner), the
         // txn-abort broadcast (release_scans_for_session), or the next mutating open's sweep — all of
         // which precede this committing session's commit fan-out, so by the time we run here the
@@ -2376,7 +2376,7 @@ namespace services::disk {
         auto deleted = total - committed;
 
         // Cursor gate: skip compact while a streaming fetch-next cursor is open (or a mutating one
-        // retained past drain, I-2) on this oid — its stored absolute position indexes the
+        // retained past drain) on this oid — its stored absolute position indexes the
         // un-swapped collection; the atomic swap would shift rows out from under it (R17), or
         // renumber rows out from under an in-flight DELETE/UPDATE's captured ids. SKIP, never
         // block: reclaim is deferred to a later commit, and a subsequent delete-carrying commit
@@ -2409,7 +2409,7 @@ namespace services::disk {
             // row_group.
             table.compact(compact_watermark);
 
-            // Log the numbering-epoch boundary (I-2). Emit ONLY when the compaction actually
+            // Log the numbering-epoch boundary. Emit ONLY when the compaction actually
             // renumbered (total_rows shrank) — a watermark-gated no-op or a tail-only drop that
             // did not move a survivor needs no marker. Fire-and-forget (see the identical
             // discipline at storage_append_inner's ADD_COLUMN emit): the in-memory swap already
@@ -2528,7 +2528,7 @@ namespace services::disk {
     }
 
     agent_disk_t::unique_future<void> agent_disk_t::release_scans_for_session_inner(session_id_t session) {
-        // I-2 txn-abort sweep: erase every one of the aborting session's cursors on this agent.
+        // Txn-abort sweep: erase every one of the aborting session's cursors on this agent.
         // Its query pipeline has torn down, so no cursor of it will be fetched or applied again;
         // a retained mutating pin left by a DELETE/UPDATE whose apply never came would otherwise
         // keep deferring compaction of its oid. Agent-thread only (active_scans_ is agent-owned).

--- a/services/disk/agent_disk.cpp
+++ b/services/disk/agent_disk.cpp
@@ -25,6 +25,7 @@ namespace services::disk {
     namespace {
         std::atomic<uint64_t> g_pushdown_reply_rows{0};
         std::atomic<uint64_t> g_checkpoint_fold_fail_oid{0};
+        std::atomic<uint64_t> g_append_materialize_fail_oid{0};
     } // namespace
     uint64_t pushdown_reply_rows() noexcept {
         return g_pushdown_reply_rows.load(std::memory_order_relaxed);
@@ -34,6 +35,9 @@ namespace services::disk {
     }
     void arm_checkpoint_fold_failure(components::catalog::oid_t table_oid) noexcept {
         g_checkpoint_fold_fail_oid.store(static_cast<uint64_t>(table_oid), std::memory_order_relaxed);
+    }
+    void arm_append_materialize_failure(components::catalog::oid_t table_oid) noexcept {
+        g_append_materialize_fail_oid.store(static_cast<uint64_t>(table_oid), std::memory_order_relaxed);
     }
 #endif
 
@@ -835,104 +839,83 @@ namespace services::disk {
             }
         }
 
-        // 5. WAL-first: allocate the start_row WITHOUT materializing, write WAL,
-        //    then materialize. total_rows() is the next append position (the standard
-        //    append computes the same value). No other same-oid handler runs between
-        //    this read and the s->append below (mailbox-atomic handler), so the value
-        //    is stable.
+        // 5. Materialize, then log. A durable PHYSICAL_INSERT must IMPLY placement:
+        //    replay repeats history for uncommitted records (places them, then
+        //    retires them dead), so a record surviving a failed materialize would
+        //    place phantom rows and shift the replayed row-id space under every
+        //    later positional record. The materialize is a synchronous local call
+        //    and the emit happens in the same mailbox-atomic handler, so wal_id
+        //    order still equals apply order. txn_id==0 (replay/legacy) appends
+        //    write no WAL.
         const auto actual_count = data->size();
-        const uint64_t start_row = s->total_rows();
+        const bool write_wal =
+            txn.transaction_id != 0 && manager_wal_addr_ != actor_zeta::address_t::empty_address();
 
-        // 5a. WAL records (WAL-first), only for a real transaction. Replay filters
-        //     uncommitted txns, so a txn_id==0 (legacy / replay) append writes no WAL.
-        if (txn.transaction_id != 0 && manager_wal_addr_ != actor_zeta::address_t::empty_address()) {
+        // 5a. Schema-growth record BEFORE the dependent rows AND before the
+        //     materialize: the live add_column already happened and survives a
+        //     failed statement, so its record must survive a failed materialize
+        //     too. The payload is a 0-row chunk whose columns ARE the new columns
+        //     (alias-tagged types); replay rebuilds the column defs and re-applies
+        //     add_column ahead of the PHYSICAL_INSERT.
+        //
+        //     Issued fire-and-forget (the future is intentionally dropped): we
+        //     MUST NOT co_await it here. This handler already co_awaits the
+        //     PHYSICAL_INSERT future below; a SECOND sequential cross-actor
+        //     co_await on the same agent coroutine triggers the cooperative_actor
+        //     lost-wakeup (the await re-suspends after the first resume, the
+        //     producer's flag-based readiness never unblocks the parked mailbox,
+        //     and resume_impl returns early on the blocked-check before reaching
+        //     the awaited-continuation drain — see docs/actor-zeta-lost-wakeup.md,
+        //     "the coroutine re-suspended after resume on the next co_await").
+        //     That hung the engine on the first schema-growth INSERT.
+        //
+        //     Durability + ordering are preserved without the await: both records
+        //     target the SAME single WAL worker, whose mailbox is FIFO, and the
+        //     manager allocates wal_id synchronously in send order, so the
+        //     ADD_COLUMN record (lower wal_id) is durably written ahead of its
+        //     dependent PHYSICAL_INSERT (higher wal_id). When the INSERT future
+        //     below resolves, the worker has necessarily already processed the
+        //     earlier ADD_COLUMN message. Replay applies records in ascending
+        //     wal_id order, so the column re-add precedes the row replay.
+        if (write_wal && !wal_added_columns.empty()) {
             const auto db_oid = entry->wal_stream_db_oid(ctx.database_oid);
-
-            // 5a-i. Schema-growth record BEFORE the rows that depend on it. The
-            //       payload is a 0-row chunk whose columns ARE the new columns
-            //       (alias-tagged types); replay rebuilds the column defs and
-            //       re-applies add_column ahead of the PHYSICAL_INSERT.
-            //
-            //       Issued fire-and-forget (the future is intentionally dropped): we
-            //       MUST NOT co_await it here. This handler already co_awaits the
-            //       PHYSICAL_INSERT future below; a SECOND sequential cross-actor
-            //       co_await on the same agent coroutine triggers the cooperative_actor
-            //       lost-wakeup (the await re-suspends after the first resume, the
-            //       producer's flag-based readiness never unblocks the parked mailbox,
-            //       and resume_impl returns early on the blocked-check before reaching
-            //       the awaited-continuation drain — see docs/actor-zeta-lost-wakeup.md,
-            //       "the coroutine re-suspended after resume on the next co_await").
-            //       That hung the engine on the first schema-growth INSERT.
-            //
-            //       Durability + ordering are preserved without the await: both records
-            //       target the SAME single WAL worker, whose mailbox is FIFO, and the
-            //       manager allocates wal_id synchronously in send order, so the
-            //       ADD_COLUMN record (lower wal_id) is durably written ahead of its
-            //       dependent PHYSICAL_INSERT (higher wal_id). When the INSERT future
-            //       below resolves, the worker has necessarily already processed the
-            //       earlier ADD_COLUMN message. Replay applies records in ascending
-            //       wal_id order, so the column re-add precedes the row replay.
-            if (!wal_added_columns.empty()) {
-                std::pmr::vector<components::types::complex_logical_type> col_types(resource());
-                col_types.reserve(wal_added_columns.size());
-                for (const auto& col : wal_added_columns) {
-                    auto t = col.type();
-                    t.set_alias(col.name());
-                    col_types.push_back(t);
-                }
-                auto schema_chunk = std::make_unique<components::vector::data_chunk_t>(resource(), col_types, 0);
-                schema_chunk->set_cardinality(0);
-                [[maybe_unused]] auto _sc = actor_zeta::send(manager_wal_addr_,
-                                                             &wal::manager_wal_replicate_t::write_physical_add_column,
-                                                             ctx.session,
-                                                             table_oid,
-                                                             std::move(schema_chunk),
-                                                             static_cast<std::uint64_t>(wal_added_columns.size()),
-                                                             txn.transaction_id,
-                                                             db_oid);
+            std::pmr::vector<components::types::complex_logical_type> col_types(resource());
+            col_types.reserve(wal_added_columns.size());
+            for (const auto& col : wal_added_columns) {
+                auto t = col.type();
+                t.set_alias(col.name());
+                col_types.push_back(t);
             }
-
-            // 5a-ii. PHYSICAL_INSERT carrying the FINAL preprocessed chunk + the
-            //        reserved start_row + count. Replay re-appends sequentially (it
-            //        ignores physical_row_start for placement) but CREATE INDEX
-            //        backfill-from-WAL uses start_row as the row-id base, so it must
-            //        equal the materialized start_row — which it does (computed above
-            //        and materialized below in the same atomic handler). This is the
-            //        ONE co_await of this handler (see 5a-i): awaiting it also confirms
-            //        the FIFO-earlier ADD_COLUMN record was durably written.
-            components::vector::data_chunk_t wal_chunk(resource(), data->types(), data->size());
-            data->copy(wal_chunk, 0);
-            std::pmr::vector<components::vector::data_chunk_t> wal_chunks(resource());
-            wal_chunks.emplace_back(std::move(wal_chunk));
-            auto [_w, wf] = actor_zeta::send(manager_wal_addr_,
-                                             &wal::manager_wal_replicate_t::write_physical_insert,
-                                             ctx.session,
-                                             table_oid,
-                                             std::move(wal_chunks),
-                                             start_row,
-                                             actual_count,
-                                             txn.transaction_id,
-                                             db_oid);
-            const auto wal_id = co_await std::move(wf);
-            note_applied_wal_id(table_oid, wal_id);
-            if (wal_id == wal::id_t{}) {
-                trace(log_,
-                      "agent_disk[{}]::storage_append_inner: physical_insert WAL returned zero id for oid={}",
-                      pool_idx_,
-                      static_cast<unsigned>(table_oid));
-            }
+            auto schema_chunk = std::make_unique<components::vector::data_chunk_t>(resource(), col_types, 0);
+            schema_chunk->set_cardinality(0);
+            [[maybe_unused]] auto _sc = actor_zeta::send(manager_wal_addr_,
+                                                         &wal::manager_wal_replicate_t::write_physical_add_column,
+                                                         ctx.session,
+                                                         table_oid,
+                                                         std::move(schema_chunk),
+                                                         static_cast<std::uint64_t>(wal_added_columns.size()),
+                                                         txn.transaction_id,
+                                                         db_oid);
         }
 
-        // 5b. Materialize — the canonical write. Lands at total_rows() == start_row.
-        //     The txn path can surface a write_conflict (concurrent DDL re-rooted the
-        //     table) or out_of_memory (row-group/segment alloc) as a value; this is a plain
-        //     synchronous local call (no co_await), so reading the wrapper adds NO second
-        //     cross-actor await — the single co_await above (PHYSICAL_INSERT) stays this
-        //     handler's only one (a second sequential cross-actor await would risk a
-        //     lost-wakeup hang). The WAL record was already written; on a materialize failure
-        //     the txn aborts and storage_revert_appends unwinds it.
+        // 5b. Materialize — the canonical write. The txn path can surface a
+        //     write_conflict (concurrent DDL re-rooted the table) or out_of_memory
+        //     (row-group/segment alloc) as a value; this is a plain synchronous
+        //     local call (no co_await), so reading the wrapper adds NO second
+        //     cross-actor await — the single co_await below (PHYSICAL_INSERT) stays
+        //     this handler's only one (a second sequential cross-actor await would
+        //     risk a lost-wakeup hang). On failure nothing has been logged: the
+        //     statement fails with zero rows placed and zero rows recorded.
         uint64_t materialized_start;
         if (txn.transaction_id != 0) {
+#ifdef DEV_MODE
+            if (g_append_materialize_fail_oid.load(std::memory_order_relaxed) == static_cast<uint64_t>(table_oid)) {
+                g_append_materialize_fail_oid.store(0, std::memory_order_relaxed);
+                co_return core::result_wrapper_t<std::pair<uint64_t, uint64_t>>(
+                    core::error_t(core::error_code_t::out_of_memory,
+                                  std::pmr::string{"injected materialize failure", resource()}));
+            }
+#endif
             auto append_r = s->append(*data, txn);
             if (append_r.has_error()) {
                 trace(log_,
@@ -945,8 +928,38 @@ namespace services::disk {
         } else {
             materialized_start = s->append(*data);
         }
-        assert(materialized_start == start_row &&
-               "WAL-first append: materialized start_row diverged from the reserved start_row");
+
+        // 5c. PHYSICAL_INSERT carrying the FINAL preprocessed chunk + the
+        //     materialized start_row + count. Replay re-appends sequentially (it
+        //     ignores physical_row_start for placement) but CREATE INDEX
+        //     backfill-from-WAL uses start_row as the row-id base, so the record
+        //     carries the row-id the materialize actually placed. This is the ONE
+        //     co_await of this handler (see 5a): awaiting it also confirms the
+        //     FIFO-earlier ADD_COLUMN record was durably written.
+        if (write_wal) {
+            const auto db_oid = entry->wal_stream_db_oid(ctx.database_oid);
+            components::vector::data_chunk_t wal_chunk(resource(), data->types(), data->size());
+            data->copy(wal_chunk, 0);
+            std::pmr::vector<components::vector::data_chunk_t> wal_chunks(resource());
+            wal_chunks.emplace_back(std::move(wal_chunk));
+            auto [_w, wf] = actor_zeta::send(manager_wal_addr_,
+                                             &wal::manager_wal_replicate_t::write_physical_insert,
+                                             ctx.session,
+                                             table_oid,
+                                             std::move(wal_chunks),
+                                             materialized_start,
+                                             actual_count,
+                                             txn.transaction_id,
+                                             db_oid);
+            const auto wal_id = co_await std::move(wf);
+            note_applied_wal_id(table_oid, wal_id);
+            if (wal_id == wal::id_t{}) {
+                trace(log_,
+                      "agent_disk[{}]::storage_append_inner: physical_insert WAL returned zero id for oid={}",
+                      pool_idx_,
+                      static_cast<unsigned>(table_oid));
+            }
+        }
         co_return std::make_pair(materialized_start, actual_count);
     }
 

--- a/services/disk/agent_disk.cpp
+++ b/services/disk/agent_disk.cpp
@@ -446,6 +446,10 @@ namespace services::disk {
                 co_await actor_zeta::dispatch(this, &agent_disk_t::storage_revert_appends_inner, msg);
                 break;
             }
+            case actor_zeta::msg_id<agent_disk_t, &agent_disk_t::storage_abort_appends_inner>: {
+                co_await actor_zeta::dispatch(this, &agent_disk_t::storage_abort_appends_inner, msg);
+                break;
+            }
             case actor_zeta::msg_id<agent_disk_t, &agent_disk_t::storage_update_inner>: {
                 co_await actor_zeta::dispatch(this, &agent_disk_t::storage_update_inner, msg);
                 break;
@@ -838,12 +842,7 @@ namespace services::disk {
         // 5a. WAL records (WAL-first), only for a real transaction. Replay filters
         //     uncommitted txns, so a txn_id==0 (legacy / replay) append writes no WAL.
         if (txn.transaction_id != 0 && manager_wal_addr_ != actor_zeta::address_t::empty_address()) {
-            const auto db_oid = (ctx.database_oid != components::catalog::INVALID_OID)
-                                    ? ctx.database_oid
-                                    : components::catalog::well_known_oid::main_database;
-            // Remember the WAL stream this table's DML rides so a later PHYSICAL_COMPACT marker
-            // rides the SAME one (I-2); see collection_storage_entry_t::compact_wal_db_oid.
-            entry->wal_route_db_oid = db_oid;
+            const auto db_oid = entry->wal_stream_db_oid(ctx.database_oid);
 
             // 5a-i. Schema-growth record BEFORE the rows that depend on it. The
             //       payload is a 0-row chunk whose columns ARE the new columns
@@ -1031,6 +1030,25 @@ namespace services::disk {
         co_return;
     }
 
+    agent_disk_t::unique_future<void>
+    agent_disk_t::storage_abort_appends_inner(std::pmr::vector<components::pg_catalog_append_range_t> ranges) {
+        for (const auto& r : ranges) {
+            if (r.count == 0) {
+                continue;
+            }
+            auto slice_it = storages_.find(r.table_oid);
+            if (slice_it == storages_.end()) {
+                continue;
+            }
+            auto& entry = slice_it->second;
+            if (entry == nullptr || entry->storage == nullptr) {
+                continue;
+            }
+            entry->storage->abort_append(r.start_row, r.count);
+        }
+        co_return;
+    }
+
     agent_disk_t::unique_future<core::result_wrapper_t<std::pair<int64_t, uint64_t>>>
     agent_disk_t::storage_update_inner(execution_context_t ctx,
                                        components::catalog::oid_t table_oid,
@@ -1087,10 +1105,7 @@ namespace services::disk {
         // (write_conflict / out_of_memory) is returned above and never logged, and UPDATE
         // has no revert_appends-style unwind to undo a record it already wrote.
         if (ctx.txn.transaction_id != 0 && manager_wal_addr_ != actor_zeta::address_t::empty_address()) {
-            const auto db_oid = ctx.database_oid != components::catalog::INVALID_OID
-                                    ? ctx.database_oid
-                                    : components::catalog::well_known_oid::main_database;
-            entry->wal_route_db_oid = db_oid; // COMPACT marker rides the same stream (I-2)
+            const auto db_oid = entry->wal_stream_db_oid(ctx.database_oid);
             components::vector::data_chunk_t wal_chunk(resource(), data->types(), data->size());
             data->copy(wal_chunk, 0);
             std::pmr::vector<components::vector::data_chunk_t> wal_chunks(resource());
@@ -1164,10 +1179,7 @@ namespace services::disk {
         // MANDATORY: this must remain the handler's ONLY cross-actor co_await (actor-zeta
         // lost-wakeup, see storage_append_inner / storage_update_inner).
         if (ctx.txn.transaction_id != 0 && manager_wal_addr_ != actor_zeta::address_t::empty_address()) {
-            const auto db_oid = ctx.database_oid != components::catalog::INVALID_OID
-                                    ? ctx.database_oid
-                                    : components::catalog::well_known_oid::main_database;
-            entry->wal_route_db_oid = db_oid; // COMPACT marker rides the same stream (I-2)
+            const auto db_oid = entry->wal_stream_db_oid(ctx.database_oid);
             std::pmr::vector<int64_t> wal_row_ids(resource());
             wal_row_ids.reserve(count);
             for (uint64_t i = 0; i < count; ++i) {

--- a/services/disk/agent_disk.cpp
+++ b/services/disk/agent_disk.cpp
@@ -943,10 +943,10 @@ namespace services::disk {
     }
 
     agent_disk_t::unique_future<core::result_wrapper_t<std::pair<int64_t, uint64_t>>>
-    agent_disk_t::storage_update_inner(components::catalog::oid_t table_oid,
+    agent_disk_t::storage_update_inner(execution_context_t ctx,
+                                       components::catalog::oid_t table_oid,
                                        components::vector::vector_t row_ids,
-                                       std::unique_ptr<components::vector::data_chunk_t> data,
-                                       components::table::transaction_data txn) {
+                                       std::unique_ptr<components::vector::data_chunk_t> data) {
         auto it = storages_.find(table_oid);
         if (it == storages_.end()) {
             trace(log_,
@@ -969,7 +969,59 @@ namespace services::disk {
         // No preprocessing here: the manager body already aligned `data` with the
         // canonical schema (the twin shares column defs via bootstrap_inner_sync). The
         // wrapper carries any write_conflict / out_of_memory as a value.
-        co_return entry->storage->update(row_ids, *data, txn);
+        auto update_result = entry->storage->update(row_ids, *data, ctx.txn);
+        if (update_result.has_error()) {
+            co_return std::move(update_result);
+        }
+        const auto [start_row, count] = update_result.value();
+        if (count == 0) {
+            co_return std::pair<int64_t, uint64_t>{start_row, count};
+        }
+
+        // WAL AFTER the mutation, but INSIDE this handler -- the ordering that matters is
+        // not WAL-before-storage, it is that no other same-oid mutation can run between
+        // the two. The handler holds the mailbox across its single co_await, so the
+        // row-ids this update just consumed and the wal_id it is about to mint cannot be
+        // interleaved with another session's append. Replay, walking the WAL in id order
+        // through the same append path, therefore rebuilds the identical row-id space.
+        //
+        // MANDATORY: this must remain the handler's ONLY cross-actor co_await. A second
+        // sequential one risks the actor-zeta lost-wakeup hang (see storage_append_inner).
+        //
+        // WAL-after is also the safer order here: an update that the table layer rejects
+        // (write_conflict / out_of_memory) is returned above and never logged, and UPDATE
+        // has no revert_appends-style unwind to undo a record it already wrote.
+        if (ctx.txn.transaction_id != 0 && manager_wal_addr_ != actor_zeta::address_t::empty_address()) {
+            const auto db_oid = ctx.database_oid != components::catalog::INVALID_OID
+                                    ? ctx.database_oid
+                                    : components::catalog::well_known_oid::main_database;
+            components::vector::data_chunk_t wal_chunk(resource(), data->types(), data->size());
+            data->copy(wal_chunk, 0);
+            std::pmr::vector<components::vector::data_chunk_t> wal_chunks(resource());
+            wal_chunks.emplace_back(std::move(wal_chunk));
+            std::pmr::vector<int64_t> wal_row_ids(resource());
+            wal_row_ids.reserve(count);
+            for (uint64_t i = 0; i < count; ++i) {
+                wal_row_ids.push_back(row_ids.value(i).value<int64_t>());
+            }
+            auto [_w, wf] = actor_zeta::send(manager_wal_addr_,
+                                             &wal::manager_wal_replicate_t::write_physical_update,
+                                             ctx.session,
+                                             table_oid,
+                                             std::move(wal_row_ids),
+                                             std::move(wal_chunks),
+                                             static_cast<uint64_t>(start_row),
+                                             count,
+                                             ctx.txn.transaction_id,
+                                             db_oid);
+            if (auto wal_id = co_await std::move(wf); wal_id == wal::id_t{}) {
+                trace(log_,
+                      "agent_disk[{}]::storage_update_inner: physical_update WAL returned zero id for oid={}",
+                      pool_idx_,
+                      static_cast<unsigned>(table_oid));
+            }
+        }
+        co_return std::pair<int64_t, uint64_t>{start_row, count};
     }
 
     agent_disk_t::unique_future<uint64_t>

--- a/services/disk/agent_disk.cpp
+++ b/services/disk/agent_disk.cpp
@@ -490,6 +490,10 @@ namespace services::disk {
                 co_await actor_zeta::dispatch(this, &agent_disk_t::storage_drop_aborted_inner, msg);
                 break;
             }
+            case actor_zeta::msg_id<agent_disk_t, &agent_disk_t::release_scans_for_session_inner>: {
+                co_await actor_zeta::dispatch(this, &agent_disk_t::release_scans_for_session_inner, msg);
+                break;
+            }
             case actor_zeta::msg_id<agent_disk_t, &agent_disk_t::drop_storage_many_inner>: {
                 co_await actor_zeta::dispatch(this, &agent_disk_t::drop_storage_many_inner, msg);
                 break;
@@ -1001,6 +1005,12 @@ namespace services::disk {
                                        components::catalog::oid_t table_oid,
                                        components::vector::vector_t row_ids,
                                        std::unique_ptr<components::vector::data_chunk_t> data) {
+        // I-2 prompt clear: this UPDATE's capture->apply window on (table_oid, session) closes
+        // here -- the operator has handed its captured physical ids to this handler. The storage
+        // mutation below lands before the single WAL co_await, so releasing the retained pin now
+        // cannot let a compaction slip in ahead of the apply (this agent runs both). Harmless
+        // no-op if the oid is not owned here / no pin was retained.
+        release_mutating_scans(table_oid, ctx.session);
         auto it = storages_.find(table_oid);
         if (it == storages_.end()) {
             trace(log_,
@@ -1084,6 +1094,10 @@ namespace services::disk {
                                             components::catalog::oid_t table_oid,
                                             components::vector::vector_t row_ids,
                                             uint64_t count) {
+        // I-2 prompt clear: this DELETE's capture->apply window on (table_oid, session) closes
+        // here (symmetric with storage_update_inner). The delete_rows mark below lands before the
+        // single WAL co_await, so releasing the retained pin now is race-free on this agent thread.
+        release_mutating_scans(table_oid, ctx.session);
         auto it = storages_.find(table_oid);
         if (it == storages_.end()) {
             trace(log_,
@@ -1388,7 +1402,8 @@ namespace services::disk {
                                                  std::unique_ptr<components::table::table_filter_t> filter,
                                                  int64_t limit,
                                                  std::vector<size_t> projected_cols,
-                                                 components::table::transaction_data txn) {
+                                                 components::table::transaction_data txn,
+                                                 bool mutating) {
         // Drained sentinel: an EMPTY chunk (cardinality 0). The executor breaks on size 0 and never
         // pushes it, so the schema is irrelevant (the source operator carries its own projected
         // empty-guard).
@@ -1399,6 +1414,25 @@ namespace services::disk {
                 components::vector::DEFAULT_VECTOR_CAPACITY);
             empty->set_cardinality(0);
             return fetch_batch_t{std::move(empty), reply_cursor_id};
+        };
+        // I-2 natural-drain retirement. A cursor is RETAINED past drain (awaiting_apply) — so
+        // has_active_scan_for_oid keeps deferring compaction of table_oid across the capture->apply
+        // window — ONLY when it is a mutating (DELETE/UPDATE) scan that actually HANDED OUT rows
+        // (matched_emitted > 0): those rows' physical ids are now in flight to the mutation
+        // operator, which applies from a later mailbox turn. A mutating scan that matched NOTHING
+        // (matched_emitted == 0) captured no id, so there is no renumber hazard — it is GC'd
+        // immediately, which is what stops a 0-match DELETE/UPDATE from leaking a pin that never
+        // gets an apply to release it. A plain read cursor is always GC'd. The apply handler
+        // (storage_delete_rows_inner / storage_update_inner) or sweep-on-open erases a retained
+        // pin. Use ONLY on natural drain: an error/DROP mid scan aborts the statement (no apply
+        // follows), so those paths hard-erase.
+        auto retire_on_drain = [](std::pmr::unordered_map<uint64_t, active_scan_t>& scans,
+                                  std::pmr::unordered_map<uint64_t, active_scan_t>::iterator cit) {
+            if (cit->second.mutating && cit->second.matched_emitted > 0) {
+                cit->second.awaiting_apply = true;
+            } else {
+                scans.erase(cit);
+            }
         };
 
         if (cursor_id == 0) {
@@ -1414,8 +1448,19 @@ namespace services::disk {
                       static_cast<unsigned>(table_oid));
                 co_return make_drained(0);
             }
+            // I-2 sweep-on-open: a fresh DML scan on this (oid, session) first clears this
+            // session's OWN stale retained pins on this oid. A session runs its statements
+            // serially, so any awaiting-apply pin left by a prior statement on this oid can
+            // only be a leak (its mutation errored before finalize / aborted before apply).
+            // This bounds such a leak to at most one per (session, oid) and is the backstop
+            // for the rare path the prompt apply/commit clears miss.
+            if (mutating) {
+                release_mutating_scans(table_oid, session);
+            }
             active_scan_t scan{};
             scan.table_oid = table_oid;
+            scan.mutating = mutating;
+            scan.session = session;
             // Raw scan cursor: position-only, re-seeks per fetch. `limit` is the (offset+limit)
             // head cap the source pushed down; with a filter it is a POST-filter matched-row
             // cap (the legacy scan_batched applied it post-hoc), so it bounds matched rows
@@ -1443,10 +1488,11 @@ namespace services::disk {
         }
         auto& scan = cit->second;
 
-        // Position exhausted or matched-row limit already met: GC and reply drained.
+        // Position exhausted or matched-row limit already met: retire (retain-if-mutating) and reply
+        // drained.
         if (scan.pos.drained ||
             (scan.matched_limit >= 0 && scan.matched_emitted >= static_cast<uint64_t>(scan.matched_limit))) {
-            active_scans_.erase(cit);
+            retire_on_drain(active_scans_, cit);
             co_return make_drained(cursor_id);
         }
 
@@ -1490,8 +1536,9 @@ namespace services::disk {
         scan.matched_emitted += batch->size();
 
         if (batch->size() == 0) {
-            // No rows this round (drained, or a boundary batch trimmed to 0): GC and reply drained.
-            active_scans_.erase(cit);
+            // No rows this round (drained, or a boundary batch trimmed to 0): retire
+            // (retain-if-mutating) and reply drained.
+            retire_on_drain(active_scans_, cit);
             co_return make_drained(cursor_id);
         }
         co_return fetch_batch_t{std::move(batch), cursor_id};
@@ -2237,6 +2284,21 @@ namespace services::disk {
                       static_cast<unsigned>(it->oid),
                       txn_id);
                 it = dropped_storages_.erase(it);
+            } else {
+                ++it;
+            }
+        }
+        co_return;
+    }
+
+    agent_disk_t::unique_future<void> agent_disk_t::release_scans_for_session_inner(session_id_t session) {
+        // I-2 txn-abort sweep: erase every one of the aborting session's cursors on this agent.
+        // Its query pipeline has torn down, so no cursor of it will be fetched or applied again;
+        // a retained mutating pin left by a DELETE/UPDATE whose apply never came would otherwise
+        // keep deferring compaction of its oid. Agent-thread only (active_scans_ is agent-owned).
+        for (auto it = active_scans_.begin(); it != active_scans_.end();) {
+            if (it->second.session == session) {
+                it = active_scans_.erase(it);
             } else {
                 ++it;
             }

--- a/services/disk/agent_disk.cpp
+++ b/services/disk/agent_disk.cpp
@@ -2145,7 +2145,7 @@ namespace services::disk {
         co_return checkpoint_result_t{min_prev_id, has_in_memory};
     }
 
-    agent_disk_t::unique_future<void> agent_disk_t::vacuum_inner(session_id_t /*session*/,
+    agent_disk_t::unique_future<void> agent_disk_t::vacuum_inner(session_id_t session,
                                                                  uint64_t lowest_active_start_time,
                                                                  uint64_t compact_watermark) {
         trace(log_, "agent_disk[{}]::vacuum_inner: {} entries in local slice", pool_idx_, storages_.size());
@@ -2155,15 +2155,35 @@ namespace services::disk {
             }
             auto& table = entry->table_storage.table();
             table.cleanup_versions(lowest_active_start_time);
-            // Cursor gate: skip compact while a streaming fetch-next cursor is open on this oid (its
-            // stored absolute position indexes the un-swapped collection; the atomic swap would
-            // shift rows out from under it — R17). Reclaim is deferred to a later vacuum round.
+            // Cursor gate: skip compact while a streaming fetch-next cursor is open (or a mutating
+            // one retained past drain, I-2) on this oid — its stored absolute position indexes the
+            // un-swapped collection; the atomic swap would shift rows out from under it (R17), or
+            // renumber rows out from under an in-flight DELETE/UPDATE's captured ids. Reclaim is
+            // deferred to a later vacuum round.
             if (has_active_scan_for_oid(oid)) {
                 continue;
             }
             // MVCC-gated: a no-op when any version stamp is above the watermark
             // (concurrent snapshot / in-flight commit still needs the history).
+            const auto total = table.row_group()->total_rows();
             table.compact(compact_watermark);
+
+            // Numbering-epoch boundary (I-2), identical discipline to maybe_cleanup_inner: emit ONLY
+            // when this VACUUM compaction actually renumbered (total shrank), so replay re-runs the
+            // SAME dense renumber at this log point and every later positional record resolves against
+            // the post-VACUUM numbering. Fire-and-forget on the table's own DML WAL stream
+            // (compact_wal_db_oid) — see the ordering/durability argument at maybe_cleanup_inner.
+            if (table.row_group()->total_rows() < total &&
+                manager_wal_addr_ != actor_zeta::address_t::empty_address()) {
+                const auto db_oid = entry->compact_wal_db_oid();
+                [[maybe_unused]] auto _cf = actor_zeta::send(manager_wal_addr_,
+                                                             &wal::manager_wal_replicate_t::write_physical_compact,
+                                                             session,
+                                                             oid,
+                                                             uint64_t{0}, // txn_id: system write
+                                                             compact_watermark,
+                                                             db_oid);
+            }
         }
         co_return;
     }

--- a/services/disk/agent_disk.hpp
+++ b/services/disk/agent_disk.hpp
@@ -263,6 +263,15 @@ namespace services::disk {
         unique_future<void>
         storage_revert_appends_inner(std::pmr::vector<components::pg_catalog_append_range_t> ranges);
 
+        // storage_abort_appends_inner — retire an aborted txn's base-table append
+        //   ranges committed-dead in place (abort_append). Placement is untouched: a
+        //   placed row keeps its physical id until a compact, so positional WAL
+        //   records written after the abort replay against the same numbering the
+        //   live run used — and the dead stamps unblock every compaction gate the
+        //   pending insert stamps would otherwise trip forever.
+        unique_future<void>
+        storage_abort_appends_inner(std::pmr::vector<components::pg_catalog_append_range_t> ranges);
+
         // storage_update_inner — single-OID UPDATE mutation against the agent twin, and
         //   the owner of its WAL record, for the same reason storage_append_inner owns
         //   INSERT's: an MVCC update APPENDS its new rows, so it consumes row-ids, and
@@ -584,6 +593,7 @@ namespace services::disk {
                                                             &agent_disk_t::storage_publish_deletes_inner,
                                                             &agent_disk_t::storage_revert_deletes_inner,
                                                             &agent_disk_t::storage_revert_appends_inner,
+                                                            &agent_disk_t::storage_abort_appends_inner,
                                                             &agent_disk_t::storage_update_inner,
                                                             &agent_disk_t::storage_delete_rows_inner,
                                                             &agent_disk_t::storage_fetch_inner,

--- a/services/disk/agent_disk.hpp
+++ b/services/disk/agent_disk.hpp
@@ -301,7 +301,7 @@ namespace services::disk {
                              std::unique_ptr<components::vector::data_chunk_t> data);
 
         // storage_delete_rows_inner — single-OID DELETE mutation, and the owner of its
-        //   WAL record (I-1), for the same single-writer reason storage_update_inner owns
+        //   WAL record, for the same single-writer reason storage_update_inner owns
         //   UPDATE's: minting the wal_id from any other actor would decouple wal_id order
         //   from apply order, so a same-oid compaction (also at this agent) could renumber
         //   rows out from under the captured ids, and replay (walking the WAL in id order)
@@ -476,7 +476,7 @@ namespace services::disk {
         //   On a real renumber (total_rows shrank), a fire-and-forget PHYSICAL_COMPACT epoch
         //   marker is written to the WAL AFTER the in-memory swap, so recovery re-runs the same
         //   dense renumber at this log point (INV-RECLAIM-1). `session` is the committing session,
-        //   also used to clear its own retained I-2 pins on this oid before the gate check.
+        //   also used to clear its own retained mutating-scan pins on this oid before the gate check.
         unique_future<void>
         maybe_cleanup_inner(components::catalog::oid_t table_oid, uint64_t compact_watermark, session_id_t session);
 
@@ -507,7 +507,7 @@ namespace services::disk {
         //   the matching entries so on_horizon_advanced never reclaims the live .otbx.
         unique_future<void> storage_drop_aborted_inner(uint64_t txn_id);
 
-        // release_scans_for_session_inner — I-2 statement/txn-end sweep. When a transaction
+        // release_scans_for_session_inner — statement/txn-end sweep. When a transaction
         //   ABORTS, any mutating (DELETE/UPDATE) scan cursor it left RETAINED past drain
         //   (awaiting_apply) will never get its storage_delete_rows/storage_update apply — the
         //   captured ids are being discarded — so the retained pin would keep deferring
@@ -693,7 +693,7 @@ namespace services::disk {
             components::table::transaction_data txn{0, 0};    // MVCC snapshot for the whole scan
             int64_t matched_limit{-1};                        // post-filter matched-row cap (-1 == unbounded)
             uint64_t matched_emitted{0};                      // running matched rows handed out (enforces matched_limit)
-            // I-2 (no-renumber-under-capture): a DML scan (DELETE/UPDATE) captures physical
+            // No-renumber-under-capture: a DML scan (DELETE/UPDATE) captures physical
             // row_ids during this scan and applies the mutation LATER, from a different
             // actor. A compaction of table_oid between capture and apply would renumber the
             // rows out from under the captured ids. `mutating` marks such a scan; its cursor
@@ -709,7 +709,7 @@ namespace services::disk {
         };
         std::pmr::unordered_map<uint64_t, active_scan_t> active_scans_;
 
-        // I-2 release: erase every retained (drained, awaiting-apply) mutating cursor on
+        // Pin release: erase every retained (drained, awaiting-apply) mutating cursor on
         // `oid` opened by `session`, called from the DML apply handlers once the mutation
         // has landed. Also sweeps a session's OWN stale retained cursors on a fresh mutating
         // open (a per-session statement runs to completion before the next), which bounds an

--- a/services/disk/agent_disk.hpp
+++ b/services/disk/agent_disk.hpp
@@ -57,6 +57,12 @@ namespace services::disk {
 #ifdef DEV_MODE
     uint64_t pushdown_reply_rows() noexcept;
     void reset_pushdown_reply_rows() noexcept;
+
+    // Test-only fault injection: the NEXT checkpoint_inner fold of `table_oid`
+    // fails as if table_storage_t::checkpoint returned out_of_memory — after its
+    // compact already ran. Exercises the deferred-round epoch-fence path that
+    // real flush-pin exhaustion would take.
+    void arm_checkpoint_fold_failure(components::catalog::oid_t table_oid) noexcept;
 #endif
 
     // Forward-declared (full definitions in manager_disk.hpp). agent_disk_t's slice
@@ -731,6 +737,11 @@ namespace services::disk {
             }
             return false;
         }
+
+        // Record a physical WAL record's id onto its table's entry (see
+        // collection_storage_entry_t::last_applied_wal_id). Called after every
+        // awaited write_physical_* emit; a zero id (failed write) is a no-op.
+        void note_applied_wal_id(components::catalog::oid_t table_oid, wal::id_t wal_id) noexcept;
 
         // Per-agent GC slice — sole owner of GC state. Populated by
         // register_dropped_storage_inner_sync; on_horizon_advanced_inner removes entries

--- a/services/disk/agent_disk.hpp
+++ b/services/disk/agent_disk.hpp
@@ -246,15 +246,22 @@ namespace services::disk {
         unique_future<void>
         storage_revert_appends_inner(std::pmr::vector<components::pg_catalog_append_range_t> ranges);
 
-        // storage_update_inner — single-OID UPDATE mutation against the
-        //   agent twin. Reply wraps storage_t::update's (updated, appended) pair so a
-        //   write_conflict / out_of_memory travels back to operator_update as a value;
-        //   (0, 0) on no-op.
+        // storage_update_inner — single-OID UPDATE mutation against the agent twin, and
+        //   the owner of its WAL record, for the same reason storage_append_inner owns
+        //   INSERT's: an MVCC update APPENDS its new rows, so it consumes row-ids, and
+        //   the WAL must record them in the order storage handed them out. Mutating here
+        //   and writing the WAL from the operator would let another session's append slip
+        //   between the two and mint a lower wal_id for a higher row-id -- replay would
+        //   then rebuild the two rows swapped. Because the handler owns the mailbox
+        //   across its single co_await, the (mutation, wal_id) pair is atomic.
+        //   Takes the full execution_context (session/txn/db_oid) for that reason.
+        // Reply wraps storage_t::update's (start_row, count) pair so a write_conflict /
+        // out_of_memory travels back to operator_update as a value; (0, 0) on no-op.
         unique_future<core::result_wrapper_t<std::pair<int64_t, uint64_t>>>
-        storage_update_inner(components::catalog::oid_t table_oid,
+        storage_update_inner(execution_context_t ctx,
+                             components::catalog::oid_t table_oid,
                              components::vector::vector_t row_ids,
-                             std::unique_ptr<components::vector::data_chunk_t> data,
-                             components::table::transaction_data txn);
+                             std::unique_ptr<components::vector::data_chunk_t> data);
 
         // storage_delete_rows_inner — single-OID DELETE mutation. Returns
         //   the deleted-row count; 0 on no-op.

--- a/services/disk/agent_disk.hpp
+++ b/services/disk/agent_disk.hpp
@@ -271,12 +271,21 @@ namespace services::disk {
                              components::vector::vector_t row_ids,
                              std::unique_ptr<components::vector::data_chunk_t> data);
 
-        // storage_delete_rows_inner — single-OID DELETE mutation. Returns
-        //   the deleted-row count; 0 on no-op.
-        unique_future<uint64_t> storage_delete_rows_inner(components::catalog::oid_t table_oid,
+        // storage_delete_rows_inner — single-OID DELETE mutation, and the owner of its
+        //   WAL record (I-1), for the same single-writer reason storage_update_inner owns
+        //   UPDATE's: minting the wal_id from any other actor would decouple wal_id order
+        //   from apply order, so a same-oid compaction (also at this agent) could renumber
+        //   rows out from under the captured ids, and replay (walking the WAL in id order)
+        //   would apply the DELETE against a numbering the live path never used. Writing
+        //   the record here, after the mutation, inside the mailbox turn, makes every
+        //   physical record for an oid a single-sender (agent->WAL) FIFO write: wal_id
+        //   order == apply order. Takes the full execution_context (session/txn/db_oid)
+        //   for that reason.
+        // Returns the deleted-row count; 0 on no-op.
+        unique_future<uint64_t> storage_delete_rows_inner(execution_context_t ctx,
+                                                          components::catalog::oid_t table_oid,
                                                           components::vector::vector_t row_ids,
-                                                          uint64_t count,
-                                                          components::table::transaction_data txn);
+                                                          uint64_t count);
 
         // storage_fetch_inner — read-path mirror for point-fetches by row_id.
         //   Returns the fetched rows as a vector of ≤DEFAULT_VECTOR_CAPACITY chunks

--- a/services/disk/agent_disk.hpp
+++ b/services/disk/agent_disk.hpp
@@ -63,6 +63,11 @@ namespace services::disk {
     // compact already ran. Exercises the deferred-round epoch-fence path that
     // real flush-pin exhaustion would take.
     void arm_checkpoint_fold_failure(components::catalog::oid_t table_oid) noexcept;
+    // Test-only fault injection: the NEXT storage_append_inner materialize of
+    // `table_oid` fails as if the table-layer append returned out_of_memory —
+    // in the window where a durable-record-without-placement would corrupt the
+    // repeat-history replay.
+    void arm_append_materialize_failure(components::catalog::oid_t table_oid) noexcept;
 #endif
 
     // Forward-declared (full definitions in manager_disk.hpp). agent_disk_t's slice

--- a/services/disk/agent_disk.hpp
+++ b/services/disk/agent_disk.hpp
@@ -202,6 +202,15 @@ namespace services::disk {
         // local slice ahead of the dependent PHYSICAL_INSERT. Idempotent by column name.
         void direct_add_column_sync(components::catalog::oid_t table_oid,
                                     const components::vector::data_chunk_t& schema_chunk);
+        // WAL-replay of PHYSICAL_COMPACT: re-run the SAME dense renumber the live path ran at
+        // this log point, closing the numbering epoch so every DML record AFTER it resolves
+        // against the compacted row-id space (INV-REPLAY-3). compact(UINT64_MAX) — replay is
+        // single-threaded, pre-scheduler, all stamps {0,0}, no cursor — so the survivor set +
+        // dense numbering are a pure function of the surviving rows, re-derived deterministically
+        // from the ordered scan+append; the record needs only {table_oid}. A false return here is
+        // a recovery OOM (never MVCC-gating: nothing exceeds UINT64_MAX), which corrupts the epoch
+        // and is logged loudly.
+        void direct_compact_sync(components::catalog::oid_t table_oid);
 
         unique_future<void> fix_wal_id(wal::id_t wal_id);
 

--- a/services/disk/agent_disk.hpp
+++ b/services/disk/agent_disk.hpp
@@ -332,7 +332,8 @@ namespace services::disk {
                                        std::unique_ptr<components::table::table_filter_t> filter,
                                        int64_t limit,
                                        std::vector<size_t> projected_cols,
-                                       components::table::transaction_data txn);
+                                       components::table::transaction_data txn,
+                                       bool mutating);
 
         // storage_reduce_inner — the aggregate-pushdown REDUCE, a dedicated protocol
         //   leg (NOT a scan mode): runs the whole GROUP BY over this agent's OWN slice via
@@ -472,6 +473,17 @@ namespace services::disk {
         //   the matching entries so on_horizon_advanced never reclaims the live .otbx.
         unique_future<void> storage_drop_aborted_inner(uint64_t txn_id);
 
+        // release_scans_for_session_inner — I-2 statement/txn-end sweep. When a transaction
+        //   ABORTS, any mutating (DELETE/UPDATE) scan cursor it left RETAINED past drain
+        //   (awaiting_apply) will never get its storage_delete_rows/storage_update apply — the
+        //   captured ids are being discarded — so the retained pin would keep deferring
+        //   compaction of that oid until the session's next mutating open (sweep-on-open) or
+        //   forever. operator_abort_transaction fans this out to every agent; each ERASES all of
+        //   the aborting session's cursors, making the design's "cleared at apply OR txn abort"
+        //   deterministic. The aborting session's query pipeline has already torn down, so no live
+        //   cursor of it can still be fetched — erasing them is safe.
+        unique_future<void> release_scans_for_session_inner(session_id_t session);
+
         // GC-slice push-back into dropped_storages_. Not a mailbox handler. Called
         // pre-scheduler-start by base_spaces catalog rebuild and at runtime by
         // mark_storage_dropped_many_inner (single-threaded on the agent at both sites).
@@ -576,6 +588,7 @@ namespace services::disk {
                                                             &agent_disk_t::on_horizon_advanced_inner,
                                                             &agent_disk_t::storage_dropped_committed_inner,
                                                             &agent_disk_t::storage_drop_aborted_inner,
+                                                            &agent_disk_t::release_scans_for_session_inner,
                                                             &agent_disk_t::drop_storage_many_inner,
                                                             &agent_disk_t::append_pg_catalog_row_inner,
                                                             &agent_disk_t::delete_pg_catalog_rows_inner,
@@ -645,8 +658,38 @@ namespace services::disk {
             components::table::transaction_data txn{0, 0};    // MVCC snapshot for the whole scan
             int64_t matched_limit{-1};                        // post-filter matched-row cap (-1 == unbounded)
             uint64_t matched_emitted{0};                      // running matched rows handed out (enforces matched_limit)
+            // I-2 (no-renumber-under-capture): a DML scan (DELETE/UPDATE) captures physical
+            // row_ids during this scan and applies the mutation LATER, from a different
+            // actor. A compaction of table_oid between capture and apply would renumber the
+            // rows out from under the captured ids. `mutating` marks such a scan; its cursor
+            // is RETAINED in active_scans_ past drain (awaiting_apply) so has_active_scan_for_oid
+            // -- the gate the compact sites already consult -- keeps deferring compaction for
+            // the whole capture->apply window. The apply handler
+            // (storage_delete_rows_inner / storage_update_inner) erases it once the mutation
+            // lands. `session` matches the erase to the right statement when several DML
+            // statements target the same oid concurrently.
+            bool mutating{false};
+            bool awaiting_apply{false};                       // drained, but its mutation has not applied yet
+            session_id_t session{};
         };
         std::pmr::unordered_map<uint64_t, active_scan_t> active_scans_;
+
+        // I-2 release: erase every retained (drained, awaiting-apply) mutating cursor on
+        // `oid` opened by `session`, called from the DML apply handlers once the mutation
+        // has landed. Also sweeps a session's OWN stale retained cursors on a fresh mutating
+        // open (a per-session statement runs to completion before the next), which bounds an
+        // aborted statement's retained cursor to at most one leak per session. Agent-thread
+        // only (active_scans_ is agent-owned; the mailbox serializes every access).
+        void release_mutating_scans(components::catalog::oid_t oid, session_id_t session) noexcept {
+            for (auto it = active_scans_.begin(); it != active_scans_.end();) {
+                const auto& scan = it->second;
+                if (scan.mutating && scan.awaiting_apply && scan.table_oid == oid && scan.session == session) {
+                    it = active_scans_.erase(it);
+                } else {
+                    ++it;
+                }
+            }
+        }
         // Monotonic per-agent cursor-id counter, combined with the session at mint time so the id
         // is (session, counter) per R16. 0 is reserved for the OPEN request sentinel.
         uint64_t next_scan_cursor_id_{1};

--- a/services/disk/agent_disk.hpp
+++ b/services/disk/agent_disk.hpp
@@ -453,7 +453,12 @@ namespace services::disk {
         //   cleanup_versions is intentionally omitted: scan_committed
         //   needs intact version metadata to filter tombstones, which cleanup_versions
         //   would strip before compact rebuilds the row_group.
-        unique_future<void> maybe_cleanup_inner(components::catalog::oid_t table_oid, uint64_t compact_watermark);
+        //   On a real renumber (total_rows shrank), a fire-and-forget PHYSICAL_COMPACT epoch
+        //   marker is written to the WAL AFTER the in-memory swap, so recovery re-runs the same
+        //   dense renumber at this log point (INV-RECLAIM-1). `session` is the committing session,
+        //   also used to clear its own retained I-2 pins on this oid before the gate check.
+        unique_future<void>
+        maybe_cleanup_inner(components::catalog::oid_t table_oid, uint64_t compact_watermark, session_id_t session);
 
         // on_horizon_advanced_inner — sweeps dropped_storages_, removing entries whose
         //   dropped_at_commit_id < new_horizon. Exceptions FORBIDDEN: std::error_code

--- a/services/disk/agent_disk.hpp
+++ b/services/disk/agent_disk.hpp
@@ -186,9 +186,17 @@ namespace services::disk {
                                 const std::pmr::vector<int64_t>& row_ids,
                                 uint64_t count,
                                 const components::table::transaction_data& txn);
+        // WAL-replay of PHYSICAL_UPDATE_INPLACE: rewrite the rows where they lie. Used
+        // only by the pg_attribute commit-id backfill, whose catalog row must keep its
+        // identity.
         void direct_update_sync(components::catalog::oid_t table_oid,
                                 const std::pmr::vector<int64_t>& row_ids,
                                 components::vector::data_chunk_t& new_data);
+        // WAL-replay of PHYSICAL_UPDATE: drives the SAME MVCC delete+append contract the
+        // live path drives, so replay rebuilds the live row-id space by construction.
+        void direct_update_mvcc_sync(components::catalog::oid_t table_oid,
+                                     const std::pmr::vector<int64_t>& row_ids,
+                                     components::vector::data_chunk_t& new_data);
         // WAL-replay of PHYSICAL_ADD_COLUMN: re-apply the schema columns carried by
         // `schema_chunk` (0-row; column j's alias-tagged type IS new column j) to the
         // local slice ahead of the dependent PHYSICAL_INSERT. Idempotent by column name.

--- a/services/disk/disk_contract.hpp
+++ b/services/disk/disk_contract.hpp
@@ -221,7 +221,11 @@ namespace services::disk {
                                  std::unique_ptr<components::table::table_filter_t> filter,
                                  int64_t limit,
                                  std::vector<size_t> projected_cols,
-                                 components::table::transaction_data txn);
+                                 components::table::transaction_data txn,
+                                 // I-2: true for a DELETE/UPDATE scan whose cursor must be
+                                 // retained past drain (until the mutation applies) so it keeps
+                                 // deferring compaction of table_oid. false for read scans.
+                                 bool mutating);
         // storage_fetch returns the fetched rows as a vector of ≤ DEFAULT_VECTOR_CAPACITY chunks.
         actor_zeta::unique_future<std::pmr::vector<components::vector::data_chunk_t>>
         storage_fetch(session_id_t session,
@@ -308,6 +312,10 @@ namespace services::disk {
         // un-marking the DROP so on_horizon_advanced never reclaims the still-live .otbx.
         actor_zeta::unique_future<void> storage_drop_aborted(session_id_t session, uint64_t txn_id);
 
+        // I-2 txn-abort sweep — erase the aborting session's retained scan cursors (see
+        // manager_disk_t::release_scans_for_session).
+        actor_zeta::unique_future<void> release_scans_for_session(session_id_t session);
+
         using dispatch_traits = actor_zeta::dispatch_traits<&disk_contract::flush,
                                                             &disk_contract::checkpoint_all,
                                                             &disk_contract::vacuum_all,
@@ -350,7 +358,8 @@ namespace services::disk {
                                                             &disk_contract::on_horizon_advanced,
                                                             &disk_contract::mark_storage_dropped_many,
                                                             &disk_contract::storage_dropped_committed,
-                                                            &disk_contract::storage_drop_aborted>;
+                                                            &disk_contract::storage_drop_aborted,
+                                                            &disk_contract::release_scans_for_session>;
 
         disk_contract() = delete;
     };

--- a/services/disk/disk_contract.hpp
+++ b/services/disk/disk_contract.hpp
@@ -265,6 +265,15 @@ namespace services::disk {
         actor_zeta::unique_future<void>
         storage_revert_appends(execution_context_t ctx, std::vector<components::pg_catalog_append_range_t> ranges);
 
+        // Abort-side retire of base-table appends: re-stamp the ranges committed-dead
+        // IN PLACE (data_table_t::abort_append). Placement is untouched — a placed row
+        // keeps its physical id until a compact, so positional WAL records written
+        // after the abort replay against the same numbering the live run used — and
+        // the dead stamps unblock the compaction gates the pending insert stamps
+        // would otherwise trip forever.
+        actor_zeta::unique_future<void>
+        storage_abort_appends(execution_context_t ctx, std::vector<components::pg_catalog_append_range_t> ranges);
+
         // MVCC delete-revert (abort path). The mirror of storage_publish_deletes:
         // instead of stamping this txn's pending delete marks with a commit_id, the
         // owning agent un-stamps them back to NOT_DELETED_ID via
@@ -341,6 +350,7 @@ namespace services::disk {
                                                             &disk_contract::storage_publish_commits,
                                                             &disk_contract::storage_publish_deletes,
                                                             &disk_contract::storage_revert_appends,
+                                                            &disk_contract::storage_abort_appends,
                                                             &disk_contract::storage_revert_deletes,
                                                             // resolve + invalidation pull
                                                             &disk_contract::resolve_namespace,

--- a/services/disk/disk_contract.hpp
+++ b/services/disk/disk_contract.hpp
@@ -222,7 +222,7 @@ namespace services::disk {
                                  int64_t limit,
                                  std::vector<size_t> projected_cols,
                                  components::table::transaction_data txn,
-                                 // I-2: true for a DELETE/UPDATE scan whose cursor must be
+                                 // true for a DELETE/UPDATE scan whose cursor must be
                                  // retained past drain (until the mutation applies) so it keeps
                                  // deferring compaction of table_oid. false for read scans.
                                  bool mutating);
@@ -321,7 +321,7 @@ namespace services::disk {
         // un-marking the DROP so on_horizon_advanced never reclaims the still-live .otbx.
         actor_zeta::unique_future<void> storage_drop_aborted(session_id_t session, uint64_t txn_id);
 
-        // I-2 txn-abort sweep — erase the aborting session's retained scan cursors (see
+        // Txn-abort sweep — erase the aborting session's retained scan cursors (see
         // manager_disk_t::release_scans_for_session).
         actor_zeta::unique_future<void> release_scans_for_session(session_id_t session);
 

--- a/services/disk/manager_disk.cpp
+++ b/services/disk/manager_disk.cpp
@@ -705,7 +705,7 @@ namespace services::disk {
     }
 
     manager_disk_t::unique_future<void> manager_disk_t::release_scans_for_session(session_id_t session) {
-        // I-2 txn-abort sweep. The retained pin is keyed by (oid, session) on the owning agent,
+        // Txn-abort sweep. The retained pin is keyed by (oid, session) on the owning agent,
         // but the caller only has the session, so fan out to EVERY agent and let each erase its
         // own slice's cursors for that session. Mirrors storage_drop_aborted's broadcast.
         trace(log_, "manager_disk::release_scans_for_session , session : {}", session.data());

--- a/services/disk/manager_disk.cpp
+++ b/services/disk/manager_disk.cpp
@@ -75,6 +75,7 @@ namespace services::disk {
             actor_zeta::msg_id<manager_disk_t, &manager_disk_t::mark_storage_dropped_many>,
             actor_zeta::msg_id<manager_disk_t, &manager_disk_t::storage_dropped_committed>,
             actor_zeta::msg_id<manager_disk_t, &manager_disk_t::storage_drop_aborted>,
+            actor_zeta::msg_id<manager_disk_t, &manager_disk_t::release_scans_for_session>,
         };
 
         constexpr bool behavior_covers_all_implements() noexcept {
@@ -527,6 +528,10 @@ namespace services::disk {
                 co_await actor_zeta::dispatch(this, &manager_disk_t::storage_drop_aborted, msg);
                 break;
             }
+            case actor_zeta::msg_id<manager_disk_t, &manager_disk_t::release_scans_for_session>: {
+                co_await actor_zeta::dispatch(this, &manager_disk_t::release_scans_for_session, msg);
+                break;
+            }
             default:
                 break;
         }
@@ -683,6 +688,29 @@ namespace services::disk {
         for (auto& agent_ptr : agents_) {
             auto [needs_sched, fut] =
                 actor_zeta::otterbrix::send(agent_ptr->address(), &agent_disk_t::storage_drop_aborted_inner, txn_id);
+            if (needs_sched) {
+                scheduler_disk_->enqueue(agent_ptr.get());
+            }
+            agent_futures.emplace_back(std::move(fut));
+        }
+        for (auto& f : agent_futures) {
+            co_await std::move(f);
+        }
+        co_return;
+    }
+
+    manager_disk_t::unique_future<void> manager_disk_t::release_scans_for_session(session_id_t session) {
+        // I-2 txn-abort sweep. The retained pin is keyed by (oid, session) on the owning agent,
+        // but the caller only has the session, so fan out to EVERY agent and let each erase its
+        // own slice's cursors for that session. Mirrors storage_drop_aborted's broadcast.
+        trace(log_, "manager_disk::release_scans_for_session , session : {}", session.data());
+
+        std::pmr::vector<unique_future<void>> agent_futures{resource()};
+        agent_futures.reserve(agents_.size());
+        for (auto& agent_ptr : agents_) {
+            auto [needs_sched, fut] = actor_zeta::otterbrix::send(agent_ptr->address(),
+                                                                  &agent_disk_t::release_scans_for_session_inner,
+                                                                  session);
             if (needs_sched) {
                 scheduler_disk_->enqueue(agent_ptr.get());
             }

--- a/services/disk/manager_disk.cpp
+++ b/services/disk/manager_disk.cpp
@@ -58,6 +58,7 @@ namespace services::disk {
             actor_zeta::msg_id<manager_disk_t, &manager_disk_t::storage_publish_commits>,
             actor_zeta::msg_id<manager_disk_t, &manager_disk_t::storage_publish_deletes>,
             actor_zeta::msg_id<manager_disk_t, &manager_disk_t::storage_revert_appends>,
+            actor_zeta::msg_id<manager_disk_t, &manager_disk_t::storage_abort_appends>,
             actor_zeta::msg_id<manager_disk_t, &manager_disk_t::storage_revert_deletes>,
             actor_zeta::msg_id<manager_disk_t, &manager_disk_t::resolve_namespace>,
             actor_zeta::msg_id<manager_disk_t, &manager_disk_t::resolve_function_by_name>,
@@ -457,6 +458,10 @@ namespace services::disk {
             }
             case actor_zeta::msg_id<manager_disk_t, &manager_disk_t::storage_revert_appends>: {
                 co_await actor_zeta::dispatch(this, &manager_disk_t::storage_revert_appends, msg);
+                break;
+            }
+            case actor_zeta::msg_id<manager_disk_t, &manager_disk_t::storage_abort_appends>: {
+                co_await actor_zeta::dispatch(this, &manager_disk_t::storage_abort_appends, msg);
                 break;
             }
             case actor_zeta::msg_id<manager_disk_t, &manager_disk_t::storage_revert_deletes>: {

--- a/services/disk/manager_disk.hpp
+++ b/services/disk/manager_disk.hpp
@@ -602,6 +602,13 @@ namespace services::disk {
         /// un-marking the DROP so on_horizon_advanced never removes the .otbx.
         unique_future<void> storage_drop_aborted(session_id_t session, uint64_t txn_id);
 
+        /// I-2 txn-abort sweep. operator_abort_transaction sends this; the manager fans
+        /// release_scans_for_session_inner(session) out to EVERY agent so each erases the
+        /// aborting session's scan cursors — in particular a mutating (DELETE/UPDATE) pin left
+        /// retained past drain whose apply never came — making compaction deferral end at abort
+        /// rather than lingering to the session's next mutating open on the oid.
+        unique_future<void> release_scans_for_session(session_id_t session);
+
         /// Bootstrap helper — base_spaces wires dispatcher address before
         /// scheduler.start, and the manager fans it out to every agent so
         /// per-slice on_horizon_advanced_inner can fire
@@ -660,7 +667,8 @@ namespace services::disk {
                                  std::unique_ptr<components::table::table_filter_t> filter,
                                  int64_t limit,
                                  std::vector<size_t> projected_cols,
-                                 components::table::transaction_data txn);
+                                 components::table::transaction_data txn,
+                                 bool mutating);
         // Aggregate-pushdown REDUCE: transparent router to the owning agent's
         // storage_reduce_inner — one reply carrying ALL final aggregated rows (see
         // disk_contract for the protocol + the single-owner invariant).
@@ -760,7 +768,8 @@ namespace services::disk {
                                                        &manager_disk_t::on_horizon_advanced,
                                                        &manager_disk_t::mark_storage_dropped_many,
                                                        &manager_disk_t::storage_dropped_committed,
-                                                       &manager_disk_t::storage_drop_aborted>;
+                                                       &manager_disk_t::storage_drop_aborted,
+                                                       &manager_disk_t::release_scans_for_session>;
 
     private:
         // Disk storage helpers — used only by bootstrap / io / recovery paths

--- a/services/disk/manager_disk.hpp
+++ b/services/disk/manager_disk.hpp
@@ -161,7 +161,7 @@ namespace services::disk {
         // `ctx.database_oid` if set, else main_database. This is deliberately NOT the table's catalog
         // db (where the .otbx checkpoint lives under ${db}/${tbl}/): the executor does not propagate
         // the catalog db onto the DML execution context, so user-table DML resolves to main_database.
-        // The PHYSICAL_COMPACT epoch marker (I-2) MUST ride THIS same stream, so it is truncated and
+        // The PHYSICAL_COMPACT epoch marker MUST ride THIS same stream, so it is truncated and
         // replayed atomically with the DML it orders — a marker stranded in a different db's WAL is
         // truncated independently and lost on restart, resurrecting the compacted-away rows. INVALID
         // until the first DML emit; every compactable state needs at least one prior DML emit on this
@@ -662,7 +662,7 @@ namespace services::disk {
         /// un-marking the DROP so on_horizon_advanced never removes the .otbx.
         unique_future<void> storage_drop_aborted(session_id_t session, uint64_t txn_id);
 
-        /// I-2 txn-abort sweep. operator_abort_transaction sends this; the manager fans
+        /// Txn-abort sweep. operator_abort_transaction sends this; the manager fans
         /// release_scans_for_session_inner(session) out to EVERY agent so each erases the
         /// aborting session's scan cursors — in particular a mutating (DELETE/UPDATE) pin left
         /// retained past drain whose apply never came — making compaction deferral end at abort

--- a/services/disk/manager_disk.hpp
+++ b/services/disk/manager_disk.hpp
@@ -164,8 +164,9 @@ namespace services::disk {
         // The PHYSICAL_COMPACT epoch marker (I-2) MUST ride THIS same stream, so it is truncated and
         // replayed atomically with the DML it orders — a marker stranded in a different db's WAL is
         // truncated independently and lost on restart, resurrecting the compacted-away rows. INVALID
-        // until the first DML emit; a compaction never fires before at least one delete/update, so it
-        // is always set by the time maybe_cleanup / VACUUM would emit the marker.
+        // until the first DML emit; every compactable state needs at least one prior DML emit on this
+        // table (an append at minimum — aborted inserts retire as committed-dead), so it is always
+        // set by the time maybe_cleanup / VACUUM would emit the marker.
         components::catalog::oid_t wal_route_db_oid = components::catalog::INVALID_OID;
 
         // Pin-on-first-record WAL stream for this table's physical records. EVERY record for

--- a/services/disk/manager_disk.hpp
+++ b/services/disk/manager_disk.hpp
@@ -168,6 +168,23 @@ namespace services::disk {
         // is always set by the time maybe_cleanup / VACUUM would emit the marker.
         components::catalog::oid_t wal_route_db_oid = components::catalog::INVALID_OID;
 
+        // Pin-on-first-record WAL stream for this table's physical records. EVERY record for
+        // one table must ride ONE per-database WAL worker: workers flush independently, so
+        // records split across workers lose prefix durability — a later positional record can
+        // be durable while an earlier placement record (an uncommitted txn's append, flushed
+        // only by a later fsync of ITS OWN file) is not, and repeat-history replay then
+        // applies the positional record against the wrong numbering. The ctx database oid can
+        // legitimately differ per statement (some operators fall back to main_database), so
+        // the FIRST record decides and every later one follows.
+        [[nodiscard]] components::catalog::oid_t wal_stream_db_oid(components::catalog::oid_t ctx_db) noexcept {
+            if (wal_route_db_oid == components::catalog::INVALID_OID) {
+                wal_route_db_oid = ctx_db != components::catalog::INVALID_OID
+                                       ? ctx_db
+                                       : components::catalog::well_known_oid::main_database;
+            }
+            return wal_route_db_oid;
+        }
+
         // The db_oid the PHYSICAL_COMPACT epoch marker must ride: the WAL stream the table's DML
         // actually used (wal_route_db_oid), falling back to main_database — the SAME fallback the DML
         // paths use for an INVALID ctx.database_oid, so the marker lands with the DML it orders.
@@ -746,6 +763,10 @@ namespace services::disk {
 
         unique_future<void> storage_revert_appends(execution_context_t ctx,
                                                    std::vector<components::pg_catalog_append_range_t> ranges);
+        // Retire an aborted txn's base-table append ranges committed-dead in place
+        // (abort_append) — placement untouched, stamps dead. See agent inner.
+        unique_future<void> storage_abort_appends(execution_context_t ctx,
+                                                  std::vector<components::pg_catalog_append_range_t> ranges);
 
         unique_future<void> storage_revert_deletes(execution_context_t ctx,
                                                    std::vector<components::catalog::oid_t> tables);
@@ -776,6 +797,7 @@ namespace services::disk {
                                                        &manager_disk_t::storage_publish_commits,
                                                        &manager_disk_t::storage_publish_deletes,
                                                        &manager_disk_t::storage_revert_appends,
+                                                       &manager_disk_t::storage_abort_appends,
                                                        &manager_disk_t::storage_revert_deletes,
                                                        // resolve + invalidation pull
                                                        &manager_disk_t::resolve_namespace,

--- a/services/disk/manager_disk.hpp
+++ b/services/disk/manager_disk.hpp
@@ -156,6 +156,27 @@ namespace services::disk {
         // (multi-type fields); regular tables coerce.
         bool is_computed = false;
 
+        // The db_oid this table's physical WAL records route to, captured at the first DML WAL emit
+        // (append / update / delete): the db_oid the DML resolved from its execution context —
+        // `ctx.database_oid` if set, else main_database. This is deliberately NOT the table's catalog
+        // db (where the .otbx checkpoint lives under ${db}/${tbl}/): the executor does not propagate
+        // the catalog db onto the DML execution context, so user-table DML resolves to main_database.
+        // The PHYSICAL_COMPACT epoch marker (I-2) MUST ride THIS same stream, so it is truncated and
+        // replayed atomically with the DML it orders — a marker stranded in a different db's WAL is
+        // truncated independently and lost on restart, resurrecting the compacted-away rows. INVALID
+        // until the first DML emit; a compaction never fires before at least one delete/update, so it
+        // is always set by the time maybe_cleanup / VACUUM would emit the marker.
+        components::catalog::oid_t wal_route_db_oid = components::catalog::INVALID_OID;
+
+        // The db_oid the PHYSICAL_COMPACT epoch marker must ride: the WAL stream the table's DML
+        // actually used (wal_route_db_oid), falling back to main_database — the SAME fallback the DML
+        // paths use for an INVALID ctx.database_oid, so the marker lands with the DML it orders.
+        [[nodiscard]] components::catalog::oid_t compact_wal_db_oid() const noexcept {
+            return wal_route_db_oid != components::catalog::INVALID_OID
+                       ? wal_route_db_oid
+                       : components::catalog::well_known_oid::main_database;
+        }
+
         /// In-memory: schema-less (computing / relkind='g' dynamic schema)
         explicit collection_storage_entry_t(std::pmr::memory_resource* resource)
             : table_storage(resource)

--- a/services/disk/manager_disk.hpp
+++ b/services/disk/manager_disk.hpp
@@ -503,9 +503,17 @@ namespace services::disk {
         void direct_delete_sync(components::catalog::oid_t table_oid,
                                 const std::pmr::vector<int64_t>& row_ids,
                                 uint64_t count);
+        // WAL-replay of PHYSICAL_UPDATE_INPLACE: rewrite the rows where they lie. Used
+        // only by the pg_attribute commit-id backfill, whose catalog row must keep its
+        // identity.
         void direct_update_sync(components::catalog::oid_t table_oid,
                                 const std::pmr::vector<int64_t>& row_ids,
                                 components::vector::data_chunk_t& new_data);
+        // WAL-replay of PHYSICAL_UPDATE: drives the SAME MVCC delete+append contract the
+        // live path drives, so replay rebuilds the live row-id space by construction.
+        void direct_update_mvcc_sync(components::catalog::oid_t table_oid,
+                                     const std::pmr::vector<int64_t>& row_ids,
+                                     components::vector::data_chunk_t& new_data);
         // WAL-replay of a PHYSICAL_ADD_COLUMN record: re-apply each schema column to
         // the owned storage ahead of the dependent PHYSICAL_INSERT. `schema_chunk` is
         // a 0-row chunk whose columns ARE the new columns (alias-tagged types).

--- a/services/disk/manager_disk.hpp
+++ b/services/disk/manager_disk.hpp
@@ -216,17 +216,26 @@ namespace services::disk {
         }
 
         /// Disk: create new table.otbx
+        /// A failed DISK create/load (construction_failed()) leaves table_storage without a
+        /// table, so the adapter — which binds a data_table_t& — must not be constructed;
+        /// the caller checks construction_failed() and drops the whole entry.
         collection_storage_entry_t(std::pmr::memory_resource* resource,
                                    std::vector<components::table::column_definition_t> columns,
                                    const std::filesystem::path& otbx_path_in)
             : table_storage(resource, std::move(columns), otbx_path_in)
-            , storage(std::make_unique<components::storage::table_storage_adapter_t>(table_storage.table(), resource))
+            , storage(table_storage.construction_failed()
+                          ? nullptr
+                          : std::make_unique<components::storage::table_storage_adapter_t>(table_storage.table(),
+                                                                                           resource))
             , otbx_path(otbx_path_in) {}
 
         /// Disk: load existing table.otbx
         collection_storage_entry_t(std::pmr::memory_resource* resource, const std::filesystem::path& otbx_path_in)
             : table_storage(resource, otbx_path_in)
-            , storage(std::make_unique<components::storage::table_storage_adapter_t>(table_storage.table(), resource))
+            , storage(table_storage.construction_failed()
+                          ? nullptr
+                          : std::make_unique<components::storage::table_storage_adapter_t>(table_storage.table(),
+                                                                                           resource))
             , otbx_path(otbx_path_in) {}
 
         /// Update live in-memory schema: add new column to table_ and recreate the storage adapter.

--- a/services/disk/manager_disk.hpp
+++ b/services/disk/manager_disk.hpp
@@ -520,6 +520,10 @@ namespace services::disk {
         // Idempotent: columns already present (by name) are skipped.
         void direct_add_column_sync(components::catalog::oid_t table_oid,
                                     const components::vector::data_chunk_t& schema_chunk);
+        // WAL-replay of a PHYSICAL_COMPACT record: route the dense renumber to the owning agent,
+        // re-running compact(UINT64_MAX) so the row-id numbering epoch closes exactly where it did
+        // live. Bootstrap / pre-scheduler only.
+        void direct_compact_sync(components::catalog::oid_t table_oid);
 
         std::pmr::memory_resource* resource() const noexcept { return resource_; }
         auto make_type() const noexcept -> const char* { return "manager_disk"; }

--- a/services/disk/manager_disk.hpp
+++ b/services/disk/manager_disk.hpp
@@ -185,6 +185,14 @@ namespace services::disk {
             return wal_route_db_oid;
         }
 
+        // Highest wal id among the physical records the owning agent has awaited durable
+        // for this table. checkpoint_inner stamps the sidecar with max(snapshot, this):
+        // the auto-checkpoint captures its wal-id snapshot BEFORE two cross-actor
+        // suspensions, so DML can land — and be folded into the .otbx — after the
+        // snapshot; a sidecar below those records makes replay re-apply them onto a
+        // base that already embodies them.
+        wal::id_t last_applied_wal_id{0};
+
         // The db_oid the PHYSICAL_COMPACT epoch marker must ride: the WAL stream the table's DML
         // actually used (wal_route_db_oid), falling back to main_database — the SAME fallback the DML
         // paths use for an INVALID ctx.database_oid, so the marker lands with the DML it orders.

--- a/services/disk/manager_disk_io.cpp
+++ b/services/disk/manager_disk_io.cpp
@@ -132,7 +132,7 @@ namespace services::disk {
     }
 
     manager_disk_t::unique_future<void>
-    manager_disk_t::maybe_cleanup_many(execution_context_t /*ctx*/,
+    manager_disk_t::maybe_cleanup_many(execution_context_t ctx,
                                        std::pmr::vector<components::catalog::oid_t> table_oids,
                                        uint64_t compact_watermark) {
         // Each table_oid routes to its owning agent's maybe_cleanup_inner so the
@@ -159,7 +159,8 @@ namespace services::disk {
             auto [needs_sched, fut] = actor_zeta::otterbrix::send(agent->address(),
                                                                   &agent_disk_t::maybe_cleanup_inner,
                                                                   table_oid,
-                                                                  uint64_t{compact_watermark});
+                                                                  uint64_t{compact_watermark},
+                                                                  ctx.session);
             if (needs_sched) {
                 scheduler_disk_->enqueue(agent.get());
             }

--- a/services/disk/manager_disk_storage.cpp
+++ b/services/disk/manager_disk_storage.cpp
@@ -578,10 +578,10 @@ namespace services::disk {
             if (agent != nullptr) {
                 auto [needs_sched, fut] = actor_zeta::otterbrix::send(agent->address(),
                                                                       &agent_disk_t::storage_delete_rows_inner,
+                                                                      ctx,
                                                                       table_oid,
                                                                       std::move(row_ids),
-                                                                      count,
-                                                                      ctx.txn);
+                                                                      count);
                 if (needs_sched) {
                     scheduler_disk_->enqueue(agent.get());
                 }

--- a/services/disk/manager_disk_storage.cpp
+++ b/services/disk/manager_disk_storage.cpp
@@ -118,6 +118,17 @@ namespace services::disk {
         }
     }
 
+    void manager_disk_t::direct_update_mvcc_sync(catalog::oid_t table_oid,
+                                                 const std::pmr::vector<int64_t>& row_ids,
+                                                 components::vector::data_chunk_t& new_data) {
+        // Bootstrap / WAL-replay only; routes the MVCC update to the owning agent, which
+        // applies it through the same delete+append the live path uses.
+        if (!agents_.empty()) {
+            const std::size_t pool_idx = pool_idx_for_oid(table_oid, agents_.size());
+            agents_[pool_idx]->direct_update_mvcc_sync(table_oid, row_ids, new_data);
+        }
+    }
+
     void manager_disk_t::direct_add_column_sync(catalog::oid_t table_oid,
                                                 const components::vector::data_chunk_t& schema_chunk) {
         // Bootstrap / WAL-replay only; routes the schema-growth record to the owning

--- a/services/disk/manager_disk_storage.cpp
+++ b/services/disk/manager_disk_storage.cpp
@@ -727,6 +727,44 @@ namespace services::disk {
         co_return;
     }
 
+    manager_disk_t::unique_future<void>
+    manager_disk_t::storage_abort_appends(execution_context_t /*ctx*/,
+                                          std::vector<components::pg_catalog_append_range_t> ranges) {
+        // Same partition-by-agent fanout as storage_revert_appends, but the agent
+        // inner re-stamps the ranges committed-dead instead of unwinding placement.
+        if (!agents_.empty()) {
+            std::pmr::vector<std::pmr::vector<components::pg_catalog_append_range_t>> per_agent{resource()};
+            per_agent.reserve(agents_.size());
+            for (std::size_t i = 0; i < agents_.size(); ++i) {
+                per_agent.emplace_back();
+            }
+            for (const auto& r : ranges) {
+                if (r.count == 0)
+                    continue;
+                const std::size_t pool_idx = pool_idx_for_oid(r.table_oid, agents_.size());
+                per_agent[pool_idx].push_back(r);
+            }
+            std::pmr::vector<unique_future<void>> agent_futures{resource()};
+            agent_futures.reserve(per_agent.size());
+            for (std::size_t i = 0; i < per_agent.size(); ++i) {
+                if (per_agent[i].empty())
+                    continue;
+                auto& agent = agents_[i];
+                auto [needs_sched, fut] = actor_zeta::otterbrix::send(agent->address(),
+                                                                      &agent_disk_t::storage_abort_appends_inner,
+                                                                      std::move(per_agent[i]));
+                if (needs_sched) {
+                    scheduler_disk_->enqueue(agent.get());
+                }
+                agent_futures.emplace_back(std::move(fut));
+            }
+            for (auto& f : agent_futures) {
+                co_await std::move(f);
+            }
+        }
+        co_return;
+    }
+
     manager_disk_t::unique_future<void> manager_disk_t::storage_revert_deletes(execution_context_t ctx,
                                                                                std::vector<catalog::oid_t> tables) {
         // Abort-path mirror of storage_publish_deletes: same partition-by-agent

--- a/services/disk/manager_disk_storage.cpp
+++ b/services/disk/manager_disk_storage.cpp
@@ -511,9 +511,13 @@ namespace services::disk {
                                    std::pmr::vector<components::vector::vector_t> row_ids,
                                    std::pmr::vector<components::vector::data_chunk_t> data) {
         // Router to the agent twin — the agent's mailbox serializes the canonical write with
-        // every other same-oid access. row_ids[i] pairs with data[i]; the per-chunk new-row
-        // segments are contiguous and coalesce into one range. The agent reply wraps a
-        // write_conflict / out_of_memory; the first error aborts the batch.
+        // every other same-oid access, and the agent (not the operator) writes the WAL
+        // record, so the row-ids an update consumes and the wal_id recording them are
+        // minted without another same-oid mutation in between. row_ids[i] pairs with
+        // data[i]; the per-chunk new-row segments are contiguous and coalesce into one
+        // range. One PHYSICAL_UPDATE record per chunk, as PHYSICAL_INSERT already does.
+        // The agent reply wraps a write_conflict / out_of_memory; the first error aborts
+        // the batch.
         if (agents_.empty()) {
             co_return std::pair<int64_t, uint64_t>{0, 0};
         }
@@ -532,10 +536,10 @@ namespace services::disk {
             auto one = std::make_unique<components::vector::data_chunk_t>(std::move(data[i]));
             auto [needs_sched, fut] = actor_zeta::otterbrix::send(agent->address(),
                                                                   &agent_disk_t::storage_update_inner,
+                                                                  ctx,
                                                                   table_oid,
                                                                   std::move(row_ids[i]),
-                                                                  std::move(one),
-                                                                  ctx.txn);
+                                                                  std::move(one));
             if (needs_sched) {
                 scheduler_disk_->enqueue(agent.get());
             }

--- a/services/disk/manager_disk_storage.cpp
+++ b/services/disk/manager_disk_storage.cpp
@@ -363,7 +363,8 @@ namespace services::disk {
                                              std::unique_ptr<components::table::table_filter_t> filter,
                                              int64_t limit,
                                              std::vector<size_t> projected_cols,
-                                             components::table::transaction_data txn) {
+                                             components::table::transaction_data txn,
+                                             bool mutating) {
         // Transparent router: the agent reply carries the batch + minted/advanced cursor_id
         // (and any scan_error); forward the wrapper unchanged so the scan source operator
         // turns it into an error cursor on has_error() and keeps the cursor id otherwise. The
@@ -379,7 +380,8 @@ namespace services::disk {
                                                                   std::move(filter),
                                                                   limit,
                                                                   projected_cols,
-                                                                  txn);
+                                                                  txn,
+                                                                  mutating);
             if (needs_sched) {
                 scheduler_disk_->enqueue(agent.get());
             }

--- a/services/disk/manager_disk_storage.cpp
+++ b/services/disk/manager_disk_storage.cpp
@@ -141,6 +141,17 @@ namespace services::disk {
         }
     }
 
+    void manager_disk_t::direct_compact_sync(catalog::oid_t table_oid) {
+        // Bootstrap / WAL-replay only; routes the PHYSICAL_COMPACT epoch marker to the owning
+        // agent, which re-runs the dense renumber (compact(UINT64_MAX)) at this log point.
+        if (!agents_.empty()) {
+            const std::size_t pool_idx = pool_idx_for_oid(table_oid, agents_.size());
+            if (agents_[pool_idx] != nullptr) {
+                agents_[pool_idx]->direct_compact_sync(table_oid);
+            }
+        }
+    }
+
     // --- Storage management ---
     // Every site routes through agents_[pool_idx_for_oid(oid)] (storage_entry_sync
     // borrow or storage_*_inner mailbox handler). No manager-side storage_t* survives.

--- a/services/disk/tests/CMakeLists.txt
+++ b/services/disk/tests/CMakeLists.txt
@@ -10,7 +10,7 @@ set(${PROJECT_NAME}_SOURCES
     test_fk_composite.cpp
     test_fk_scan_by_keys_semijoin.cpp
     test_pushdown_reduce.cpp
-    test_i2_compaction_gate.cpp
+    test_compaction_gate.cpp
     test_ddl_methods.cpp
     test_wal_catalog.cpp
     test_mvcc_ddl.cpp

--- a/services/disk/tests/CMakeLists.txt
+++ b/services/disk/tests/CMakeLists.txt
@@ -3,6 +3,7 @@ project(test_disk)
 set(${PROJECT_NAME}_SOURCES
     test_table_storage.cpp
     test_torn_checkpoint.cpp
+    test_checkpoint_fences.cpp
     test_system_table_bootstrap.cpp
     test_resolve.cpp
     test_pg_depend.cpp

--- a/services/disk/tests/CMakeLists.txt
+++ b/services/disk/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ set(${PROJECT_NAME}_SOURCES
     test_fk_composite.cpp
     test_fk_scan_by_keys_semijoin.cpp
     test_pushdown_reduce.cpp
+    test_i2_compaction_gate.cpp
     test_ddl_methods.cpp
     test_wal_catalog.cpp
     test_mvcc_ddl.cpp

--- a/services/disk/tests/test_checkpoint_fences.cpp
+++ b/services/disk/tests/test_checkpoint_fences.cpp
@@ -23,6 +23,7 @@
 #include <components/vector/data_chunk.hpp>
 #include <components/vector/vector.hpp>
 #include <core/non_thread_scheduler/scheduler_test.hpp>
+#include <services/disk/agent_disk.hpp>
 #include <services/disk/manager_disk.hpp>
 #include <services/wal/wal_reader.hpp>
 
@@ -270,6 +271,56 @@ TEST_CASE("services::disk::checkpoint::failed_fold_after_compact_emits_epoch_mar
             }
         }
         REQUIRE(marker_found);
+    }
+    std::filesystem::remove_all(dir);
+}
+
+// A durable PHYSICAL_INSERT must imply placement. Replay repeats history for
+// uncommitted records (places them, then retires them dead), so a record that
+// survived a failed materialize would place phantom rows and shift the
+// replayed row-id space under every later positional record on the table.
+// The agent therefore materializes BEFORE it logs: a failed materialize fails
+// the statement with zero rows placed and zero rows recorded.
+TEST_CASE("services::disk::append::failed_materialize_leaves_no_wal_record") {
+    auto dir = fence_test_dir() + "/failed_materialize";
+    std::filesystem::remove_all(dir);
+    {
+        fence_fixture fx(dir);
+        const catalog::oid_t oid = catalog::FIRST_USER_OID + 7401;
+        make_disk_table(fx, oid);
+
+        append_committed(fx, oid, 0, 5);
+
+        arm_append_materialize_failure(oid);
+        {
+            std::pmr::vector<types::complex_logical_type> ct{&fx.resource};
+            ct.emplace_back(types::logical_type::BIGINT);
+            components::vector::data_chunk_t chunk{&fx.resource, ct, 3};
+            chunk.set_cardinality(3);
+            for (int64_t i = 0; i < 3; ++i) {
+                chunk.set_value(0, static_cast<size_t>(i), types::logical_value_t{&fx.resource, i});
+            }
+            std::pmr::vector<components::vector::data_chunk_t> chunks{&fx.resource};
+            chunks.emplace_back(std::move(chunk));
+            components::execution_context_t ctx{session_id_t{}, live_txn(), {}};
+            ctx.table_oid = oid;
+            auto r = fx.invoke(&manager_disk_t::storage_append, ctx, oid, std::move(chunks));
+            REQUIRE(r.has_error());
+        }
+        REQUIRE(total_rows(fx, oid) == 5);
+
+        // The next successful append lands exactly where the failed one would
+        // have — and its record says so.
+        append_committed(fx, oid, 5, 5);
+
+        std::vector<services::wal::record_t> inserts;
+        for (auto& r : physical_records_for(fx, oid)) {
+            if (r.record_type == services::wal::wal_record_type::PHYSICAL_INSERT) {
+                inserts.push_back(std::move(r));
+            }
+        }
+        REQUIRE(inserts.size() == 2);
+        REQUIRE(inserts[1].physical_row_start == 5);
     }
     std::filesystem::remove_all(dir);
 }

--- a/services/disk/tests/test_checkpoint_fences.cpp
+++ b/services/disk/tests/test_checkpoint_fences.cpp
@@ -1,0 +1,275 @@
+// Checkpoint fences — agent-level tests for two checkpoint/replay hazards.
+//
+// 1. The sidecar wal_id must cover every WAL record the agent already applied to
+//    the table it folds. run_auto_checkpoint snapshots the global wal id BEFORE
+//    two cross-actor suspensions, so DML can land — and be folded into the
+//    .otbx — between the snapshot and the fold. Stamping the stale snapshot
+//    makes replay re-apply those records onto a base that embodies them
+//    (positional DELETEs then tombstone the wrong survivors).
+//
+// 2. checkpoint_inner's compact is a renumber epoch, same as the maybe_cleanup
+//    and VACUUM compaction sites. When the subsequent fold fails (deferred
+//    round), the renumber survives in memory while the durable state stays
+//    pre-compact — so it must be fenced by a PHYSICAL_COMPACT marker, or every
+//    later positional record replays against the wrong numbering.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <components/catalog/catalog_oids.hpp>
+#include <components/context/execution_context.hpp>
+#include <components/session/session.hpp>
+#include <components/table/column_definition.hpp>
+#include <components/types/types.hpp>
+#include <components/vector/data_chunk.hpp>
+#include <components/vector/vector.hpp>
+#include <core/non_thread_scheduler/scheduler_test.hpp>
+#include <services/disk/manager_disk.hpp>
+#include <services/wal/wal_reader.hpp>
+
+#include <filesystem>
+#include <limits>
+#include <string>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+
+using namespace services::disk;
+namespace catalog = components::catalog;
+namespace types = components::types;
+using session_id_t = components::session::session_id_t;
+
+namespace {
+
+    constexpr uint64_t kMaxWatermark = std::numeric_limits<uint64_t>::max();
+    constexpr catalog::oid_t kMainDb = catalog::well_known_oid::main_database;
+
+    std::string fence_test_dir() {
+        static std::string p = "/tmp/test_otterbrix_cpfence_" + std::to_string(::getpid());
+        return p;
+    }
+
+    // Disk + WAL fixture (mirrors test_recovery.cpp's): the WAL manager must be
+    // wired so the agent's in-turn PHYSICAL_* emits actually run.
+    struct fence_fixture {
+        core::pmr::otterbrix_resource resource;
+        log_t log;
+        core::non_thread_scheduler::scheduler_test_t* scheduler;
+        configuration::config_wal wal_config;
+        configuration::config_disk disk_config;
+        std::unique_ptr<services::wal::manager_wal_replicate_t, actor_zeta::pmr::deleter_t> wal;
+        std::unique_ptr<manager_disk_t, actor_zeta::pmr::deleter_t> disk;
+
+        explicit fence_fixture(const std::string& dir)
+            : log(initialization_logger("python", "/tmp/docker_logs/"))
+            , scheduler(new core::non_thread_scheduler::scheduler_test_t(1, 1))
+            , wal_config([&]() {
+                configuration::config_wal c;
+                c.path = dir;
+                c.on = true;
+                return c;
+            }())
+            , disk_config([&]() {
+                configuration::config_disk c;
+                c.path = dir;
+                return c;
+            }())
+            , wal(actor_zeta::spawn<services::wal::manager_wal_replicate_t>(&resource, scheduler, wal_config, log))
+            , disk(actor_zeta::spawn<manager_disk_t>(&resource, scheduler, scheduler, disk_config, log)) {
+            std::filesystem::create_directories(dir);
+            wal->sync(services::wal::wal_sync_pack_t{actor_zeta::address_t(disk->address()),
+                                                     actor_zeta::address_t::empty_address(),
+                                                     actor_zeta::address_t::empty_address()});
+            disk->sync(services::disk::manager_disk_t::disk_sync_pack_t{wal->address()});
+            disk->bootstrap_system_tables_sync();
+        }
+        ~fence_fixture() {
+            disk.reset();
+            wal.reset();
+            scheduler->stop();
+            delete scheduler;
+        }
+
+        template<typename Fn, typename... Args>
+        auto invoke(Fn fn, Args&&... args) {
+            auto [_, future] = actor_zeta::otterbrix::send(disk->address(), fn, std::forward<Args>(args)...);
+            for (int i = 0; i < 100000 && !future.is_ready(); ++i) {
+                scheduler->run(1000);
+                std::this_thread::yield();
+            }
+            REQUIRE(future.is_ready());
+            return std::move(future).take_ready();
+        }
+
+        template<typename Fn, typename... Args>
+        auto invoke_wal(Fn fn, Args&&... args) {
+            auto [_, future] = actor_zeta::otterbrix::send(wal->address(), fn, std::forward<Args>(args)...);
+            for (int i = 0; i < 100000 && !future.is_ready(); ++i) {
+                scheduler->run(1000);
+                std::this_thread::yield();
+            }
+            REQUIRE(future.is_ready());
+            return std::move(future).take_ready();
+        }
+    };
+
+    components::table::transaction_data sys_txn() { return components::table::transaction_data{0, 0}; }
+
+    // A real (non-zero) txn: the agent's in-turn PHYSICAL_* WAL emits are gated on
+    // it (txn 0 is the replay path and writes no WAL).
+    components::table::transaction_data live_txn() {
+        components::table::transaction_data td(88, 0);
+        td.snapshot_horizon = std::numeric_limits<uint64_t>::max();
+        return td;
+    }
+
+    void make_disk_table(fence_fixture& fx, catalog::oid_t oid) {
+        std::vector<components::table::column_definition_t> cols;
+        cols.emplace_back("v", types::complex_logical_type{types::logical_type::BIGINT});
+        fx.invoke(&manager_disk_t::create_storage_disk, session_id_t{}, oid, kMainDb, cols);
+    }
+
+    // Txn-append n rows starting at `start`, then publish them committed so the
+    // later checkpoint compact sees plain committed stamps.
+    void append_committed(fence_fixture& fx, catalog::oid_t oid, int64_t start, int64_t n) {
+        std::pmr::vector<types::complex_logical_type> ct{&fx.resource};
+        ct.emplace_back(types::logical_type::BIGINT);
+        components::vector::data_chunk_t chunk{&fx.resource, ct, static_cast<size_t>(n)};
+        chunk.set_cardinality(static_cast<size_t>(n));
+        for (int64_t i = 0; i < n; ++i) {
+            chunk.set_value(0, static_cast<size_t>(i), types::logical_value_t{&fx.resource, i});
+        }
+        std::pmr::vector<components::vector::data_chunk_t> chunks{&fx.resource};
+        chunks.emplace_back(std::move(chunk));
+        components::execution_context_t ctx{session_id_t{}, live_txn(), {}};
+        ctx.table_oid = oid;
+        auto r = fx.invoke(&manager_disk_t::storage_append, ctx, oid, std::move(chunks));
+        REQUIRE_FALSE(r.has_error());
+
+        std::vector<components::pg_catalog_append_range_t> ranges;
+        ranges.push_back(components::pg_catalog_append_range_t{oid, start, static_cast<uint64_t>(n)});
+        components::execution_context_t pub_ctx{session_id_t{}, sys_txn(), {}};
+        fx.invoke(&manager_disk_t::storage_publish_commits, pub_ctx, uint64_t{5}, std::move(ranges));
+
+        // COMMIT marker with FULL sync: flushes the wal worker's buffer to the
+        // segment file (a live reader sees nothing before the first flush) and
+        // puts txn 88 in the committed set.
+        fx.invoke_wal(&services::wal::manager_wal_replicate_t::commit_txn,
+                      session_id_t{},
+                      uint64_t{88},
+                      services::wal::wal_sync_mode::FULL,
+                      kMainDb,
+                      uint64_t{5});
+    }
+
+    uint64_t delete_ids(fence_fixture& fx, catalog::oid_t oid, const std::vector<int64_t>& ids) {
+        components::vector::vector_t v(&fx.resource, types::logical_type::BIGINT, ids.size());
+        for (size_t i = 0; i < ids.size(); ++i) {
+            v.data<int64_t>()[i] = ids[i];
+        }
+        components::execution_context_t ctx{session_id_t{}, sys_txn(), {}};
+        ctx.table_oid = oid;
+        return fx.invoke(&manager_disk_t::storage_delete_rows,
+                         ctx,
+                         oid,
+                         std::move(v),
+                         static_cast<uint64_t>(ids.size()));
+    }
+
+    uint64_t total_rows(fence_fixture& fx, catalog::oid_t oid) {
+        return fx.invoke(&manager_disk_t::storage_total_rows, session_id_t{}, oid);
+    }
+
+    // Scan the WAL directory for this oid's records (system txn 0 records are
+    // always in the committed view).
+    std::vector<services::wal::record_t> physical_records_for(fence_fixture& fx, catalog::oid_t oid) {
+        services::wal::wal_reader_t reader(fx.wal_config, fx.log);
+        auto records = reader.read_committed_records(services::wal::id_t{0});
+        std::vector<services::wal::record_t> out;
+        for (auto& r : records) {
+            if (r.is_physical() && r.table_oid == oid) {
+                out.push_back(std::move(r));
+            }
+        }
+        return out;
+    }
+
+} // namespace
+
+// Hazard 1: DML applied by the agent AFTER the checkpoint's wal-id snapshot is
+// folded into the .otbx, so the sidecar must be stamped with the highest wal id
+// the agent applied for the table, not the stale snapshot — otherwise replay
+// re-applies those records onto a base that already embodies them.
+TEST_CASE("services::disk::checkpoint::sidecar_covers_agent_applied_wal_ids") {
+    auto dir = fence_test_dir() + "/stale_sidecar";
+    std::filesystem::remove_all(dir);
+    {
+        fence_fixture fx(dir);
+        const catalog::oid_t oid = catalog::FIRST_USER_OID + 7301;
+        make_disk_table(fx, oid);
+        // Two committed appends: the second INSERT's wal id sits above the stale
+        // snapshot taken "before" it, modeling DML applied during the checkpoint's
+        // suspension window.
+        append_committed(fx, oid, 0, 5);
+        append_committed(fx, oid, 5, 5);
+        // System (txn 0) deletes: committed-dead in place, no WAL record — the
+        // INSERTs' wal ids alone are the floor the sidecar must reach.
+        REQUIRE(delete_ids(fx, oid, {0, 1, 2, 3}) == 4);
+
+        // The table's own records give the floor the sidecar must reach.
+        uint64_t applied_max = 0;
+        for (const auto& r : physical_records_for(fx, oid)) {
+            applied_max = std::max(applied_max, static_cast<uint64_t>(r.id));
+        }
+        REQUIRE(applied_max > 0);
+
+        // A deliberately stale snapshot id — below everything this table wrote —
+        // models the auto-checkpoint's capture-before-suspension window.
+        const services::wal::id_t stale_snapshot{1};
+        REQUIRE(static_cast<uint64_t>(stale_snapshot) < applied_max);
+        fx.invoke(&manager_disk_t::checkpoint_all, session_id_t{}, stale_snapshot, kMaxWatermark);
+
+        const auto sidecar = fx.disk->peek_checkpoint_wal_id_from_disk(oid, kMainDb);
+        REQUIRE(static_cast<uint64_t>(sidecar) >= applied_max);
+    }
+    std::filesystem::remove_all(dir);
+}
+
+// Hazard 2: checkpoint_inner's compact renumbers, then the fold fails and the
+// round is deferred. The renumber survives in memory with the OLD durable
+// state, so it must be fenced by a PHYSICAL_COMPACT marker (same discipline as
+// the maybe_cleanup / VACUUM sites) for later positional records to replay
+// against the numbering the live run actually used.
+TEST_CASE("services::disk::checkpoint::failed_fold_after_compact_emits_epoch_marker") {
+    auto dir = fence_test_dir() + "/failed_fold";
+    std::filesystem::remove_all(dir);
+    {
+        fence_fixture fx(dir);
+        const catalog::oid_t oid = catalog::FIRST_USER_OID + 7302;
+        make_disk_table(fx, oid);
+        append_committed(fx, oid, 0, 10);
+        // 2/10 dead: below the commit-time gc threshold, so only the checkpoint's
+        // unconditional compact reclaims them.
+        REQUIRE(delete_ids(fx, oid, {0, 1}) == 2);
+        REQUIRE(total_rows(fx, oid) == 10);
+
+        arm_checkpoint_fold_failure(oid);
+        fx.invoke(&manager_disk_t::checkpoint_all, session_id_t{}, services::wal::id_t{1000}, kMaxWatermark);
+
+        // The compact ran (in-memory renumber) but the fold was deferred: no sidecar.
+        REQUIRE(total_rows(fx, oid) == 8);
+        REQUIRE(fx.disk->peek_checkpoint_wal_id_from_disk(oid, kMainDb) == services::wal::id_t{0});
+
+        // WAL barrier: the marker emit is fire-and-forget on the table's DML
+        // stream; this awaited txn-append is FIFO-after it.
+        append_committed(fx, oid, 8, 1);
+
+        bool marker_found = false;
+        for (const auto& r : physical_records_for(fx, oid)) {
+            if (r.record_type == services::wal::wal_record_type::PHYSICAL_COMPACT) {
+                marker_found = true;
+            }
+        }
+        REQUIRE(marker_found);
+    }
+    std::filesystem::remove_all(dir);
+}

--- a/services/disk/tests/test_compaction_gate.cpp
+++ b/services/disk/tests/test_compaction_gate.cpp
@@ -1,9 +1,9 @@
-// I-2 (no-renumber-under-capture) compaction gate — agent-level lifecycle tests.
+// No-renumber-under-capture compaction gate — agent-level lifecycle tests.
 //
 // A DELETE/UPDATE captures physical row_ids during its scan and applies the mutation
 // from a LATER mailbox turn. If a commit-time (maybe_cleanup) or VACUUM compaction
 // renumbered the survivors between capture and apply, the captured ids would name the
-// WRONG rows. I-2 defers compaction of an oid while a MUTATING scan cursor is in flight
+// WRONG rows. The gate defers compaction of an oid while a MUTATING scan cursor is in flight
 // on it — open, or drained-but-awaiting-apply — reusing the
 // has_active_scan_for_oid gate that the three compact sites already consult.
 //
@@ -146,7 +146,7 @@ namespace {
 
 // Baseline: a table with >30% committed-dead rows compacts on maybe_cleanup, reclaiming the
 // dead rows so the physical total shrinks. Establishes the observable the gate tests rely on.
-TEST_CASE("i2_gate::baseline_maybe_cleanup_reclaims_committed_dead") {
+TEST_CASE("compaction_gate::baseline_maybe_cleanup_reclaims_committed_dead") {
     fixture fx;
     const auto oid = make_table(fx, catalog::FIRST_USER_OID);
     append_n(fx, oid, 20);
@@ -159,10 +159,10 @@ TEST_CASE("i2_gate::baseline_maybe_cleanup_reclaims_committed_dead") {
     REQUIRE(total_rows(fx, oid) == 12); // compacted: the 8 dead rows reclaimed
 }
 
-// The core I-2 property: a MUTATING scan cursor retained past drain defers compaction across
+// The core gate property: a MUTATING scan cursor retained past drain defers compaction across
 // its whole capture->apply window; the mutation-apply (storage_delete_rows) releases the pin,
 // after which compaction proceeds.
-TEST_CASE("i2_gate::mutating_cursor_defers_compaction_until_apply") {
+TEST_CASE("compaction_gate::mutating_cursor_defers_compaction_until_apply") {
     fixture fx;
     const auto oid = make_table(fx, catalog::FIRST_USER_OID);
     const auto s = session_id_t::generate_uid();
@@ -186,7 +186,7 @@ TEST_CASE("i2_gate::mutating_cursor_defers_compaction_until_apply") {
 
 // A plain read (non-mutating) cursor is GC'd at drain — it must NOT retain
 // past drain, so it never defers commit-time reclaim.
-TEST_CASE("i2_gate::read_cursor_is_not_retained") {
+TEST_CASE("compaction_gate::read_cursor_is_not_retained") {
     fixture fx;
     const auto oid = make_table(fx, catalog::FIRST_USER_OID);
     const auto s = session_id_t::generate_uid();
@@ -199,10 +199,10 @@ TEST_CASE("i2_gate::read_cursor_is_not_retained") {
     REQUIRE(total_rows(fx, oid) == 12); // compacted — a drained read cursor holds no gate
 }
 
-// HOLE A2: a mutating scan that matched NOTHING captured no id, so it must be erased at drain
+// A mutating scan that matched NOTHING captured no id, so it must be erased at drain
 // (not retained) — otherwise a 0-match DELETE/UPDATE would leak a pin no apply ever releases.
 // A limit-0 fetch drains with matched_emitted == 0, exercising the retire_on_drain erase branch.
-TEST_CASE("i2_gate::zero_match_mutating_cursor_does_not_leak") {
+TEST_CASE("compaction_gate::zero_match_mutating_cursor_does_not_leak") {
     fixture fx;
     const auto oid = make_table(fx, catalog::FIRST_USER_OID);
     const auto s = session_id_t::generate_uid();
@@ -217,7 +217,7 @@ TEST_CASE("i2_gate::zero_match_mutating_cursor_does_not_leak") {
 
 // The apply-release is SESSION-scoped: two sessions each retain a mutating pin on the same oid;
 // one session applying releases ONLY its own pin, so the other session's pin keeps deferring.
-TEST_CASE("i2_gate::apply_release_is_session_scoped") {
+TEST_CASE("compaction_gate::apply_release_is_session_scoped") {
     fixture fx;
     const auto oid = make_table(fx, catalog::FIRST_USER_OID);
     const auto s1 = session_id_t::generate_uid();
@@ -243,7 +243,7 @@ TEST_CASE("i2_gate::apply_release_is_session_scoped") {
 // Sweep-on-open backstop: a leaked retained pin (a mutating scan whose apply never came — the
 // error/abort-before-finalize path) is cleared when the SAME (oid, session) opens its next
 // mutating scan, bounding such a leak to at most one per (oid, session).
-TEST_CASE("i2_gate::sweep_on_open_clears_leaked_pin") {
+TEST_CASE("compaction_gate::sweep_on_open_clears_leaked_pin") {
     fixture fx;
     const auto oid = make_table(fx, catalog::FIRST_USER_OID);
     const auto s = session_id_t::generate_uid();
@@ -264,11 +264,11 @@ TEST_CASE("i2_gate::sweep_on_open_clears_leaked_pin") {
     REQUIRE(total_rows(fx, oid) == 11); // compacted after a single release
 }
 
-// HOLE D — the txn-abort sweep. A DELETE/UPDATE whose scan drained and captured ids but whose
+// The txn-abort sweep. A DELETE/UPDATE whose scan drained and captured ids but whose
 // apply never landed (the txn aborts) leaves a retained mutating pin. release_scans_for_session
 // (fanned out by operator_abort_transaction) erases the aborting session's cursors, so reclaim
 // deferral ends deterministically at abort rather than lingering to the next mutating open.
-TEST_CASE("i2_gate::abort_sweep_releases_retained_pin") {
+TEST_CASE("compaction_gate::abort_sweep_releases_retained_pin") {
     fixture fx;
     const auto oid = make_table(fx, catalog::FIRST_USER_OID);
     const auto s = session_id_t::generate_uid();
@@ -286,7 +286,7 @@ TEST_CASE("i2_gate::abort_sweep_releases_retained_pin") {
 
 // The abort sweep is session-scoped: aborting one session must not clear a DIFFERENT session's
 // in-flight mutating pin (which is still legitimately deferring compaction).
-TEST_CASE("i2_gate::abort_sweep_is_session_scoped") {
+TEST_CASE("compaction_gate::abort_sweep_is_session_scoped") {
     fixture fx;
     const auto oid = make_table(fx, catalog::FIRST_USER_OID);
     const auto s1 = session_id_t::generate_uid();
@@ -310,7 +310,7 @@ TEST_CASE("i2_gate::abort_sweep_is_session_scoped") {
 // maybe_cleanup ran, closing the row-id numbering epoch on restart. base_spaces replay calls it on
 // a PHYSICAL_COMPACT record; here we drive it directly (a plain synchronous bootstrap method, not a
 // mailbox handler). compact(UINT64_MAX) is never MVCC-gated in the quiescent replay window.
-TEST_CASE("i2_gate::direct_compact_sync_replays_the_renumber") {
+TEST_CASE("compaction_gate::direct_compact_sync_replays_the_renumber") {
     fixture fx;
     const auto oid = make_table(fx, catalog::FIRST_USER_OID);
     append_n(fx, oid, 20);

--- a/services/disk/tests/test_i2_compaction_gate.cpp
+++ b/services/disk/tests/test_i2_compaction_gate.cpp
@@ -4,7 +4,7 @@
 // from a LATER mailbox turn. If a commit-time (maybe_cleanup) or VACUUM compaction
 // renumbered the survivors between capture and apply, the captured ids would name the
 // WRONG rows. I-2 defers compaction of an oid while a MUTATING scan cursor is in flight
-// on it — open, and (the new part) drained-but-awaiting-apply — reusing the existing
+// on it — open, or drained-but-awaiting-apply — reusing the
 // has_active_scan_for_oid gate that the three compact sites already consult.
 //
 // These tests drive the manager->agent path directly on a deterministic single-step test
@@ -184,7 +184,7 @@ TEST_CASE("i2_gate::mutating_cursor_defers_compaction_until_apply") {
     REQUIRE(total_rows(fx, oid) == 11); // released: 9 dead reclaimed, 11 survivors
 }
 
-// A plain read (non-mutating) cursor is GC'd at drain exactly as before — it must NOT retain
+// A plain read (non-mutating) cursor is GC'd at drain — it must NOT retain
 // past drain, so it never defers commit-time reclaim.
 TEST_CASE("i2_gate::read_cursor_is_not_retained") {
     fixture fx;

--- a/services/disk/tests/test_i2_compaction_gate.cpp
+++ b/services/disk/tests/test_i2_compaction_gate.cpp
@@ -305,3 +305,21 @@ TEST_CASE("i2_gate::abort_sweep_is_session_scoped") {
     run_maybe_cleanup(fx, oid, s2);
     REQUIRE(total_rows(fx, oid) == 12); // now compacted
 }
+
+// Replay hook (PHYSICAL_COMPACT): direct_compact_sync re-runs the SAME dense renumber the live
+// maybe_cleanup ran, closing the row-id numbering epoch on restart. base_spaces replay calls it on
+// a PHYSICAL_COMPACT record; here we drive it directly (a plain synchronous bootstrap method, not a
+// mailbox handler). compact(UINT64_MAX) is never MVCC-gated in the quiescent replay window.
+TEST_CASE("i2_gate::direct_compact_sync_replays_the_renumber") {
+    fixture fx;
+    const auto oid = make_table(fx, catalog::FIRST_USER_OID);
+    append_n(fx, oid, 20);
+    REQUIRE(delete_ids(fx, oid, session_id_t{}, {0, 1, 2, 3, 4, 5, 6, 7}) == 8);
+    REQUIRE(total_rows(fx, oid) == 20);
+
+    fx.manager->direct_compact_sync(oid); // the replay-side dense renumber
+    REQUIRE(total_rows(fx, oid) == 12);   // dead rows reclaimed, survivors renumbered densely
+
+    fx.manager->direct_compact_sync(oid); // idempotent on an already-dense table (INV-REPLAY-4)
+    REQUIRE(total_rows(fx, oid) == 12);
+}

--- a/services/disk/tests/test_i2_compaction_gate.cpp
+++ b/services/disk/tests/test_i2_compaction_gate.cpp
@@ -1,0 +1,307 @@
+// I-2 (no-renumber-under-capture) compaction gate — agent-level lifecycle tests.
+//
+// A DELETE/UPDATE captures physical row_ids during its scan and applies the mutation
+// from a LATER mailbox turn. If a commit-time (maybe_cleanup) or VACUUM compaction
+// renumbered the survivors between capture and apply, the captured ids would name the
+// WRONG rows. I-2 defers compaction of an oid while a MUTATING scan cursor is in flight
+// on it — open, and (the new part) drained-but-awaiting-apply — reusing the existing
+// has_active_scan_for_oid gate that the three compact sites already consult.
+//
+// These tests drive the manager->agent path directly on a deterministic single-step test
+// scheduler and OBSERVE the deferral through storage_total_rows: maybe_cleanup compacts a
+// table with >30% committed-dead rows, reclaiming them so the PHYSICAL total shrinks; a
+// DEFERRED compaction leaves the physical total unchanged. So:
+//   total unchanged after maybe_cleanup  == compaction was deferred (gate held)
+//   total shrank    after maybe_cleanup  == compaction ran          (gate clear)
+
+#include "pushdown_reduce_fixture.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <components/catalog/catalog_oids.hpp>
+#include <components/context/execution_context.hpp>
+#include <components/session/session.hpp>
+#include <components/table/column_definition.hpp>
+#include <components/table/row_version_manager.hpp>
+#include <components/types/logical_value.hpp>
+#include <components/types/types.hpp>
+#include <components/vector/data_chunk.hpp>
+#include <components/vector/vector.hpp>
+#include <services/disk/manager_disk.hpp>
+
+#include <limits>
+#include <vector>
+
+using namespace services::disk;
+using namespace pushdown_reduce_test;
+namespace catalog = components::catalog;
+namespace types = components::types;
+using session_id_t = components::session::session_id_t;
+
+namespace {
+
+    constexpr uint64_t kMaxWatermark = std::numeric_limits<uint64_t>::max();
+
+    // System snapshot: committed, sees all committed rows (matches the fixture's ctx()).
+    components::table::transaction_data sys_txn() { return components::table::transaction_data{0, 0}; }
+
+    // One BIGINT column, one chunk of `vals`.
+    std::pmr::vector<components::vector::data_chunk_t> bigint_rows(std::pmr::memory_resource* r,
+                                                                  const std::vector<int64_t>& vals) {
+        std::pmr::vector<types::complex_logical_type> ct{r};
+        ct.emplace_back(types::logical_type::BIGINT);
+        components::vector::data_chunk_t chunk{r, ct, vals.empty() ? size_t{1} : vals.size()};
+        chunk.set_cardinality(vals.size());
+        for (size_t i = 0; i < vals.size(); ++i) {
+            chunk.set_value(0, i, types::logical_value_t{r, vals[i]});
+        }
+        std::pmr::vector<components::vector::data_chunk_t> b{r};
+        b.emplace_back(std::move(chunk));
+        return b;
+    }
+
+    components::vector::vector_t row_id_vector(std::pmr::memory_resource* r, const std::vector<int64_t>& ids) {
+        components::vector::vector_t v(r, types::logical_type::BIGINT, ids.empty() ? size_t{1} : ids.size());
+        for (size_t i = 0; i < ids.size(); ++i) {
+            v.data<int64_t>()[i] = ids[i];
+        }
+        return v;
+    }
+
+    catalog::oid_t make_table(fixture& fx, catalog::oid_t oid) {
+        std::vector<components::table::column_definition_t> cols;
+        cols.emplace_back("v", types::complex_logical_type{types::logical_type::BIGINT});
+        fx.invoke(&manager_disk_t::create_storage_with_columns,
+                  session_id_t{},
+                  oid,
+                  catalog::well_known_oid::main_database,
+                  cols);
+        return oid;
+    }
+
+    void append_n(fixture& fx, catalog::oid_t oid, int64_t n) {
+        std::vector<int64_t> vals;
+        vals.reserve(static_cast<size_t>(n));
+        for (int64_t i = 0; i < n; ++i) {
+            vals.push_back(i);
+        }
+        components::execution_context_t ctx{session_id_t{}, sys_txn(), {}};
+        ctx.table_oid = oid;
+        auto r = fx.invoke(&manager_disk_t::storage_append, ctx, oid, bigint_rows(&fx.resource, vals));
+        REQUIRE_FALSE(r.has_error());
+    }
+
+    uint64_t total_rows(fixture& fx, catalog::oid_t oid) {
+        return fx.invoke(&manager_disk_t::storage_total_rows, session_id_t{}, oid);
+    }
+
+    // A system (txn 0) delete: the marked rows become committed-dead immediately, and the
+    // handler's release_mutating_scans(oid, session) fires at its top (so this doubles as the
+    // mutation-apply that releases a retained pin for `session`). Returns the deleted count.
+    uint64_t delete_ids(fixture& fx, catalog::oid_t oid, session_id_t session, const std::vector<int64_t>& ids) {
+        components::execution_context_t ctx{session, sys_txn(), {}};
+        ctx.table_oid = oid;
+        return fx.invoke(&manager_disk_t::storage_delete_rows,
+                         ctx,
+                         oid,
+                         row_id_vector(&fx.resource, ids),
+                         static_cast<uint64_t>(ids.size()));
+    }
+
+    // Drive a streaming fetch cursor to drain; returns the total matched rows handed out. A
+    // `mutating` cursor is the id-source of a DELETE/UPDATE — the agent retains it past drain.
+    uint64_t drain_cursor(fixture& fx, catalog::oid_t oid, session_id_t session, int64_t limit, bool mutating) {
+        uint64_t cursor_id = 0;
+        uint64_t matched = 0;
+        for (int guard = 0; guard < 100000; ++guard) {
+            auto r = fx.invoke(&manager_disk_t::storage_fetch_next_batch,
+                               session,
+                               oid,
+                               cursor_id,
+                               std::unique_ptr<components::table::table_filter_t>(nullptr),
+                               limit,
+                               std::vector<size_t>{},
+                               sys_txn(),
+                               mutating);
+            REQUIRE_FALSE(r.has_error());
+            auto reply = std::move(r.value());
+            cursor_id = reply.cursor_id;
+            const uint64_t sz = reply.batch ? reply.batch->size() : 0;
+            matched += sz;
+            if (sz == 0) {
+                break;
+            }
+        }
+        return matched;
+    }
+
+    void run_maybe_cleanup(fixture& fx, catalog::oid_t oid, session_id_t session) {
+        std::pmr::vector<catalog::oid_t> oids{&fx.resource};
+        oids.push_back(oid);
+        components::execution_context_t ctx{session, sys_txn(), {}};
+        fx.invoke(&manager_disk_t::maybe_cleanup_many, ctx, std::move(oids), kMaxWatermark);
+    }
+
+} // namespace
+
+// Baseline: a table with >30% committed-dead rows compacts on maybe_cleanup, reclaiming the
+// dead rows so the physical total shrinks. Establishes the observable the gate tests rely on.
+TEST_CASE("i2_gate::baseline_maybe_cleanup_reclaims_committed_dead") {
+    fixture fx;
+    const auto oid = make_table(fx, catalog::FIRST_USER_OID);
+    append_n(fx, oid, 20);
+    REQUIRE(total_rows(fx, oid) == 20);
+
+    REQUIRE(delete_ids(fx, oid, session_id_t{}, {0, 1, 2, 3, 4, 5, 6, 7}) == 8); // 8/20 = 40% dead
+    REQUIRE(total_rows(fx, oid) == 20);                                          // tombstoned, not yet reclaimed
+
+    run_maybe_cleanup(fx, oid, session_id_t{});
+    REQUIRE(total_rows(fx, oid) == 12); // compacted: the 8 dead rows reclaimed
+}
+
+// The core I-2 property: a MUTATING scan cursor retained past drain defers compaction across
+// its whole capture->apply window; the mutation-apply (storage_delete_rows) releases the pin,
+// after which compaction proceeds.
+TEST_CASE("i2_gate::mutating_cursor_defers_compaction_until_apply") {
+    fixture fx;
+    const auto oid = make_table(fx, catalog::FIRST_USER_OID);
+    const auto s = session_id_t::generate_uid();
+    append_n(fx, oid, 20);
+    REQUIRE(delete_ids(fx, oid, s, {0, 1, 2, 3, 4, 5, 6, 7}) == 8); // ready to compact (40% dead)
+
+    // A DELETE/UPDATE scan drains, capturing the 12 live rows' ids for the operator.
+    REQUIRE(drain_cursor(fx, oid, s, /*limit=*/-1, /*mutating=*/true) == 12);
+
+    // Gate: while that cursor awaits its apply, compaction of the oid MUST defer.
+    run_maybe_cleanup(fx, oid, s);
+    REQUIRE(total_rows(fx, oid) == 20); // deferred — no renumber under the captured ids
+
+    // The mutation applies (any storage_delete on (oid, s) releases the retained pin at its top).
+    // Model the DELETE landing by marking one more live row dead.
+    REQUIRE(delete_ids(fx, oid, s, {8}) == 1);
+
+    run_maybe_cleanup(fx, oid, s);
+    REQUIRE(total_rows(fx, oid) == 11); // released: 9 dead reclaimed, 11 survivors
+}
+
+// A plain read (non-mutating) cursor is GC'd at drain exactly as before — it must NOT retain
+// past drain, so it never defers commit-time reclaim.
+TEST_CASE("i2_gate::read_cursor_is_not_retained") {
+    fixture fx;
+    const auto oid = make_table(fx, catalog::FIRST_USER_OID);
+    const auto s = session_id_t::generate_uid();
+    append_n(fx, oid, 20);
+    REQUIRE(delete_ids(fx, oid, s, {0, 1, 2, 3, 4, 5, 6, 7}) == 8);
+
+    REQUIRE(drain_cursor(fx, oid, s, /*limit=*/-1, /*mutating=*/false) == 12);
+
+    run_maybe_cleanup(fx, oid, s);
+    REQUIRE(total_rows(fx, oid) == 12); // compacted — a drained read cursor holds no gate
+}
+
+// HOLE A2: a mutating scan that matched NOTHING captured no id, so it must be erased at drain
+// (not retained) — otherwise a 0-match DELETE/UPDATE would leak a pin no apply ever releases.
+// A limit-0 fetch drains with matched_emitted == 0, exercising the retire_on_drain erase branch.
+TEST_CASE("i2_gate::zero_match_mutating_cursor_does_not_leak") {
+    fixture fx;
+    const auto oid = make_table(fx, catalog::FIRST_USER_OID);
+    const auto s = session_id_t::generate_uid();
+    append_n(fx, oid, 20);
+    REQUIRE(delete_ids(fx, oid, s, {0, 1, 2, 3, 4, 5, 6, 7}) == 8);
+
+    REQUIRE(drain_cursor(fx, oid, s, /*limit=*/0, /*mutating=*/true) == 0); // matched nothing
+
+    run_maybe_cleanup(fx, oid, s);
+    REQUIRE(total_rows(fx, oid) == 12); // compacted — nothing was retained
+}
+
+// The apply-release is SESSION-scoped: two sessions each retain a mutating pin on the same oid;
+// one session applying releases ONLY its own pin, so the other session's pin keeps deferring.
+TEST_CASE("i2_gate::apply_release_is_session_scoped") {
+    fixture fx;
+    const auto oid = make_table(fx, catalog::FIRST_USER_OID);
+    const auto s1 = session_id_t::generate_uid();
+    const auto s2 = session_id_t::generate_uid();
+    append_n(fx, oid, 20);
+    REQUIRE(delete_ids(fx, oid, s1, {0, 1, 2, 3, 4, 5, 6, 7}) == 8);
+
+    REQUIRE(drain_cursor(fx, oid, s1, -1, /*mutating=*/true) == 12); // s1 retains
+    REQUIRE(drain_cursor(fx, oid, s2, -1, /*mutating=*/true) == 12); // s2 retains
+
+    run_maybe_cleanup(fx, oid, s1);
+    REQUIRE(total_rows(fx, oid) == 20); // both pins defer
+
+    REQUIRE(delete_ids(fx, oid, s1, {8}) == 1); // s1 applies — releases ONLY s1's pin
+    run_maybe_cleanup(fx, oid, s1);
+    REQUIRE(total_rows(fx, oid) == 20); // s2's pin STILL defers
+
+    REQUIRE(delete_ids(fx, oid, s2, {9}) == 1); // s2 applies — releases s2's pin
+    run_maybe_cleanup(fx, oid, s2);
+    REQUIRE(total_rows(fx, oid) == 10); // now compacted: 10 dead reclaimed, 10 survivors
+}
+
+// Sweep-on-open backstop: a leaked retained pin (a mutating scan whose apply never came — the
+// error/abort-before-finalize path) is cleared when the SAME (oid, session) opens its next
+// mutating scan, bounding such a leak to at most one per (oid, session).
+TEST_CASE("i2_gate::sweep_on_open_clears_leaked_pin") {
+    fixture fx;
+    const auto oid = make_table(fx, catalog::FIRST_USER_OID);
+    const auto s = session_id_t::generate_uid();
+    append_n(fx, oid, 20);
+    REQUIRE(delete_ids(fx, oid, s, {0, 1, 2, 3, 4, 5, 6, 7}) == 8);
+
+    // First mutating scan drains + retains, but its apply never arrives (leaked pin).
+    REQUIRE(drain_cursor(fx, oid, s, -1, /*mutating=*/true) == 12);
+    run_maybe_cleanup(fx, oid, s);
+    REQUIRE(total_rows(fx, oid) == 20); // deferred by the leaked pin
+
+    // The next mutating open on the SAME (oid, s) sweeps the leaked pin, then retains itself.
+    REQUIRE(drain_cursor(fx, oid, s, -1, /*mutating=*/true) == 12);
+
+    // Exactly one apply now suffices to release (the leaked pin did not accumulate a second).
+    REQUIRE(delete_ids(fx, oid, s, {8}) == 1);
+    run_maybe_cleanup(fx, oid, s);
+    REQUIRE(total_rows(fx, oid) == 11); // compacted after a single release
+}
+
+// HOLE D — the txn-abort sweep. A DELETE/UPDATE whose scan drained and captured ids but whose
+// apply never landed (the txn aborts) leaves a retained mutating pin. release_scans_for_session
+// (fanned out by operator_abort_transaction) erases the aborting session's cursors, so reclaim
+// deferral ends deterministically at abort rather than lingering to the next mutating open.
+TEST_CASE("i2_gate::abort_sweep_releases_retained_pin") {
+    fixture fx;
+    const auto oid = make_table(fx, catalog::FIRST_USER_OID);
+    const auto s = session_id_t::generate_uid();
+    append_n(fx, oid, 20);
+    REQUIRE(delete_ids(fx, oid, s, {0, 1, 2, 3, 4, 5, 6, 7}) == 8);
+
+    REQUIRE(drain_cursor(fx, oid, s, -1, /*mutating=*/true) == 12); // retained; the apply never comes
+    run_maybe_cleanup(fx, oid, s);
+    REQUIRE(total_rows(fx, oid) == 20); // deferred by the retained pin
+
+    fx.invoke(&manager_disk_t::release_scans_for_session, s); // the abort broadcast
+    run_maybe_cleanup(fx, oid, s);
+    REQUIRE(total_rows(fx, oid) == 12); // swept: compaction proceeds
+}
+
+// The abort sweep is session-scoped: aborting one session must not clear a DIFFERENT session's
+// in-flight mutating pin (which is still legitimately deferring compaction).
+TEST_CASE("i2_gate::abort_sweep_is_session_scoped") {
+    fixture fx;
+    const auto oid = make_table(fx, catalog::FIRST_USER_OID);
+    const auto s1 = session_id_t::generate_uid();
+    const auto s2 = session_id_t::generate_uid();
+    append_n(fx, oid, 20);
+    REQUIRE(delete_ids(fx, oid, s1, {0, 1, 2, 3, 4, 5, 6, 7}) == 8);
+
+    REQUIRE(drain_cursor(fx, oid, s1, -1, /*mutating=*/true) == 12); // s1 retains
+    REQUIRE(drain_cursor(fx, oid, s2, -1, /*mutating=*/true) == 12); // s2 retains
+
+    fx.invoke(&manager_disk_t::release_scans_for_session, s1); // only s1 aborts
+    run_maybe_cleanup(fx, oid, s2);
+    REQUIRE(total_rows(fx, oid) == 20); // s2's pin still defers — s1's abort left it untouched
+
+    fx.invoke(&manager_disk_t::release_scans_for_session, s2);
+    run_maybe_cleanup(fx, oid, s2);
+    REQUIRE(total_rows(fx, oid) == 12); // now compacted
+}

--- a/services/disk/tests/test_table_storage.cpp
+++ b/services/disk/tests/test_table_storage.cpp
@@ -7,6 +7,7 @@
 #include <components/types/types.hpp>
 #include <components/vector/data_chunk.hpp>
 #include <filesystem>
+#include <fstream>
 #include <unistd.h>
 
 using namespace services::disk;
@@ -306,6 +307,29 @@ TEST_CASE("services::disk::table_storage::drop_column_disk_is_noop") {
     // DISK-mode: drop_column returns false (out of scope).
     REQUIRE(!ts.drop_column("b"));
     REQUIRE(ts.table().column_count() == 2);
+
+    cleanup_test_dir();
+}
+
+TEST_CASE("services::disk::collection_storage_entry::failed_load_constructs_no_adapter") {
+    // The corrupt-recovery probe constructs a collection_storage_entry_t over a torn
+    // .otbx purely to read construction_failed(). A failed DISK load leaves
+    // table_storage without a table, so the entry must not build the storage adapter
+    // (it binds a data_table_t&) — the null-table state is only legal to observe
+    // through construction_failed().
+    cleanup_test_dir();
+    std::filesystem::create_directories(test_dir());
+    core::pmr::otterbrix_resource resource;
+
+    auto otbx_path = std::filesystem::path(test_dir()) / "torn_table.otbx";
+    {
+        std::ofstream torn(otbx_path, std::ios::binary);
+        torn << "this is not a table file";
+    }
+
+    collection_storage_entry_t entry(&resource, otbx_path);
+    REQUIRE(entry.table_storage.construction_failed());
+    REQUIRE(entry.storage == nullptr);
 
     cleanup_test_dir();
 }

--- a/services/dispatcher/dispatcher.cpp
+++ b/services/dispatcher/dispatcher.cpp
@@ -778,13 +778,13 @@ namespace services::dispatcher {
             txn_t->drain_pg_catalog_pending(out.swap_appends, out.pg_catalog_delete_tables);
             auto backfills_discarded = txn_t->drain_pg_attribute_commit_id_backfills();
             (void) backfills_discarded;
-            // Drain the parked base appends only to collect the UNIQUE table
-            // oids they touched: the abort operator fans out
-            // manager_index_t::revert_insert per oid to drop this txn's PENDING
-            // in-memory index entries (parity with executor.cpp's failed-DML
-            // revert). The ranges themselves are discarded — their physical row
-            // slots ride in the pg_catalog/base storage_revert path, and the
-            // index revert keys per (table_oid, txn_id), not per range. The base
+            // Drain the parked base appends for TWO consumers: the unique table
+            // oids feed manager_index_t::revert_insert (drops this txn's PENDING
+            // in-memory index entries; keyed per (table_oid, txn_id)), and the
+            // ranges themselves feed storage_abort_appends, which re-stamps the
+            // aborted rows committed-dead in place — placement stays (positional
+            // WAL records depend on it), but the pending insert stamps must not
+            // survive or they wedge every compaction gate forever. The base
             // DELETE ranges are collected the same way: only their UNIQUE table
             // oids matter, so the abort operator can fan out
             // manager_index_t::revert_delete per oid to clear this txn's PENDING
@@ -796,6 +796,7 @@ namespace services::dispatcher {
             auto drained_appends = txn_t->drain_base_appends();
             for (const auto& r : drained_appends) {
                 out.base_append_tables.insert(r.table_oid);
+                out.base_appends.push_back(r);
             }
             auto drained_deletes = txn_t->drain_base_deletes();
             for (const auto& d : drained_deletes) {

--- a/services/dispatcher/txn_messages.hpp
+++ b/services/dispatcher/txn_messages.hpp
@@ -106,6 +106,11 @@ namespace services::dispatcher {
     struct txn_abort_drain_t {
         components::table::transaction_data txn{0, 0};
         std::vector<components::pg_catalog_append_range_t> swap_appends{};
+        // The aborting txn's base-table append RANGES. The abort operator retires
+        // them committed-dead via storage_abort_appends — abort reverts marks, not
+        // placement, and a pending insert stamp left behind would wedge every
+        // compaction gate (has_version_above) forever.
+        std::vector<components::table::dml_append_range_t> base_appends{};
         std::set<components::catalog::oid_t> base_append_tables{};
         std::set<components::catalog::oid_t> base_delete_tables{};
         std::set<components::catalog::oid_t> pg_catalog_delete_tables{};

--- a/services/wal/manager_wal_replicate.cpp
+++ b/services/wal/manager_wal_replicate.cpp
@@ -244,6 +244,10 @@ namespace services::wal {
                 co_await actor_zeta::dispatch(this, &manager_wal_replicate_t::write_physical_update, msg);
                 break;
             }
+            case actor_zeta::msg_id<manager_wal_replicate_t, &manager_wal_replicate_t::write_physical_compact>: {
+                co_await actor_zeta::dispatch(this, &manager_wal_replicate_t::write_physical_compact, msg);
+                break;
+            }
             case actor_zeta::msg_id<manager_wal_replicate_t, &manager_wal_replicate_t::write_physical_add_column>: {
                 co_await actor_zeta::dispatch(this, &manager_wal_replicate_t::write_physical_add_column, msg);
                 break;
@@ -665,6 +669,38 @@ namespace services::wal {
                                                               std::move(row_ids),
                                                               count,
                                                               txn_id,
+                                                              wal_id);
+        if (needs_sched) {
+            scheduler_->enqueue(worker);
+        }
+        auto result = co_await std::move(fut);
+        co_return result;
+    }
+
+    // -----------------------------------------------------------------------
+    // Contract: write_physical_compact
+    // -----------------------------------------------------------------------
+
+    manager_wal_replicate_t::unique_future<wal::id_t>
+    manager_wal_replicate_t::write_physical_compact(session_id_t session,
+                                                    components::catalog::oid_t table_oid,
+                                                    uint64_t txn_id,
+                                                    uint64_t compact_watermark,
+                                                    components::catalog::oid_t database_oid) {
+        if (!enabled_) {
+            co_return wal::id_t{0};
+        }
+        // No txn-id gate: a compaction is a txn=0 system write and its epoch marker must be
+        // durable. next_wal_id() is the GLOBAL monotonic counter, so this id orders the COMPACT
+        // after every DELETE/UPDATE that ran before it regardless of which worker holds them.
+        auto* worker = get_or_create_worker(database_oid);
+        auto wal_id = next_wal_id();
+        auto [needs_sched, fut] = actor_zeta::otterbrix::send(worker->address(),
+                                                              &wal_worker_t::write_physical_compact,
+                                                              session,
+                                                              table_oid,
+                                                              txn_id,
+                                                              compact_watermark,
                                                               wal_id);
         if (needs_sched) {
             scheduler_->enqueue(worker);

--- a/services/wal/manager_wal_replicate.cpp
+++ b/services/wal/manager_wal_replicate.cpp
@@ -685,6 +685,7 @@ namespace services::wal {
                                                    uint64_t row_start,
                                                    uint64_t count,
                                                    uint64_t txn_id,
+                                                   bool in_place,
                                                    components::catalog::oid_t database_oid) {
         if (!enabled_) {
             co_return wal::id_t{0};
@@ -704,6 +705,7 @@ namespace services::wal {
                                                               row_start,
                                                               count,
                                                               txn_id,
+                                                              in_place,
                                                               wal_id);
         if (needs_sched) {
             scheduler_->enqueue(worker);

--- a/services/wal/manager_wal_replicate.cpp
+++ b/services/wal/manager_wal_replicate.cpp
@@ -682,6 +682,7 @@ namespace services::wal {
                                                    components::catalog::oid_t table_oid,
                                                    std::pmr::vector<int64_t> row_ids,
                                                    std::pmr::vector<components::vector::data_chunk_t> new_data,
+                                                   uint64_t row_start,
                                                    uint64_t count,
                                                    uint64_t txn_id,
                                                    components::catalog::oid_t database_oid) {
@@ -700,6 +701,7 @@ namespace services::wal {
                                                               table_oid,
                                                               std::move(row_ids),
                                                               std::move(new_data),
+                                                              row_start,
                                                               count,
                                                               txn_id,
                                                               wal_id);

--- a/services/wal/manager_wal_replicate.hpp
+++ b/services/wal/manager_wal_replicate.hpp
@@ -112,6 +112,7 @@ namespace services::wal {
                                                        components::catalog::oid_t table_oid,
                                                        std::pmr::vector<int64_t> row_ids,
                                                        std::pmr::vector<components::vector::data_chunk_t> new_data,
+                                                       uint64_t row_start,
                                                        uint64_t count,
                                                        uint64_t txn_id,
                                                        components::catalog::oid_t database_oid);

--- a/services/wal/manager_wal_replicate.hpp
+++ b/services/wal/manager_wal_replicate.hpp
@@ -115,6 +115,10 @@ namespace services::wal {
                                                        uint64_t row_start,
                                                        uint64_t count,
                                                        uint64_t txn_id,
+                                                       // true only for the pg_attribute commit-id backfill: the
+                                                       // row is rewritten where it lies and must not be replayed
+                                                       // as an MVCC delete+append. See PHYSICAL_UPDATE_INPLACE.
+                                                       bool in_place,
                                                        components::catalog::oid_t database_oid);
 
         unique_future<wal::id_t>

--- a/services/wal/manager_wal_replicate.hpp
+++ b/services/wal/manager_wal_replicate.hpp
@@ -129,6 +129,14 @@ namespace services::wal {
                                   uint64_t txn_id,
                                   components::catalog::oid_t database_oid);
 
+        // PHYSICAL_COMPACT epoch marker for table_oid, routed to database_oid's worker.
+        // NOT gated on txn_id != 0: it is always a txn=0 system write and must be durable.
+        unique_future<wal::id_t> write_physical_compact(session_id_t session,
+                                                        components::catalog::oid_t table_oid,
+                                                        uint64_t txn_id,
+                                                        uint64_t compact_watermark,
+                                                        components::catalog::oid_t database_oid);
+
         // Mailbox twins of the _sync helpers for callers that run inside an
         // actor (e.g. operator_create_index_backfill in the executor) and so
         // cannot make sync inter-actor calls. Same active_build_start_positions_ set.
@@ -145,6 +153,7 @@ namespace services::wal {
                                                        &manager_wal_replicate_t::write_physical_delete,
                                                        &manager_wal_replicate_t::write_physical_update,
                                                        &manager_wal_replicate_t::write_physical_add_column,
+                                                       &manager_wal_replicate_t::write_physical_compact,
                                                        &manager_wal_replicate_t::register_active_build,
                                                        &manager_wal_replicate_t::unregister_active_build>;
 

--- a/services/wal/record.hpp
+++ b/services/wal/record.hpp
@@ -72,6 +72,13 @@ namespace services::wal {
         uint64_t physical_row_count{0};
         core::date::timezone_offset_t session_tz{};
 
+        // Repeat-history flag, set by wal_reader (never serialized): false for a
+        // PLACEMENT record (PHYSICAL_INSERT / PHYSICAL_UPDATE) whose txn has no
+        // COMMIT marker. Its rows occupied physical row-ids in the live run (abort
+        // reverts marks, not placement), so replay must place them too — and then
+        // retire them committed-dead, since the txn never became visible.
+        bool txn_committed{true};
+
         // Error tracking
         bool is_corrupt{false};
 

--- a/services/wal/record.hpp
+++ b/services/wal/record.hpp
@@ -33,6 +33,22 @@ namespace services::wal {
         // rows for one attribute -- a dropped column would come back, or appear twice.
         // Same payload layout as PHYSICAL_UPDATE.
         PHYSICAL_UPDATE_INPLACE = 14,
+        // Numbering-epoch boundary. data_table_t::compact() renumbers every surviving row
+        // densely from 0; it fires at commit time and in VACUUM, OUTSIDE the checkpoint
+        // barrier. Because DML records are keyed by physical row_id and replayed
+        // positionally, a compaction that is not itself in the log would let every later
+        // record resolve against the wrong (un-compacted) numbering on replay. This record
+        // marks the compaction at its exact wal_id slot: replay re-runs compact() there, so
+        // records before it resolve against the pre-compaction numbering and records after
+        // against the post-compaction numbering -- the ARIES "repeat history" discipline.
+        //
+        // Carries table_oid only (transaction_id=0; empty physical_data / physical_row_ids).
+        // The survivor permutation is NOT stored: compact() is a deterministic, ordered,
+        // dense rebuild, so replay re-derives the identical numbering from the record's
+        // wal_id position in the committed record prefix (see base_spaces direct_compact_sync).
+        // physical_row_start carries the live compact_watermark for forensics only -- it is
+        // not load-bearing (replay compacts with the see-all horizon in its quiescent window).
+        PHYSICAL_COMPACT = 15,
     };
 
     struct record_t final {
@@ -65,7 +81,8 @@ namespace services::wal {
             return record_type == wal_record_type::PHYSICAL_INSERT || record_type == wal_record_type::PHYSICAL_DELETE ||
                    record_type == wal_record_type::PHYSICAL_UPDATE ||
                    record_type == wal_record_type::PHYSICAL_UPDATE_INPLACE ||
-                   record_type == wal_record_type::PHYSICAL_ADD_COLUMN;
+                   record_type == wal_record_type::PHYSICAL_ADD_COLUMN ||
+                   record_type == wal_record_type::PHYSICAL_COMPACT;
         }
     };
 

--- a/services/wal/record.hpp
+++ b/services/wal/record.hpp
@@ -12,6 +12,11 @@ namespace services::wal {
         COMMIT = 1,
         PHYSICAL_INSERT = 10,
         PHYSICAL_DELETE = 11,
+        // MVCC update: the live path tombstones the old rows and APPENDS the new ones
+        // at the end of the table. row_ids are therefore the OLD locations (what replay
+        // must tombstone) and physical_row_start is where the new rows landed. Replay has
+        // to reproduce that, or the replayed row-id space diverges from the live one and
+        // every later row-id-keyed record lands on the wrong slot.
         PHYSICAL_UPDATE = 12,
         // Dynamic-schema growth for IN_MEMORY / computed tables. Written BEFORE the
         // PHYSICAL_INSERT that depends on the new columns so WAL-first replay re-applies
@@ -19,6 +24,15 @@ namespace services::wal {
         // new columns (alias-tagged types). Idempotent on replay (already-present
         // columns are skipped).
         PHYSICAL_ADD_COLUMN = 13,
+        // In-place row rewrite, by row_id, with a full-width chunk. The row does NOT move
+        // and no row-ids are consumed, so physical_row_start is meaningless here.
+        //
+        // Written only by the pg_attribute commit-id backfill, which patches an existing
+        // catalog row's added_at / dropped_at fields. That row must keep its identity: an
+        // MVCC replay would tombstone it and re-append it, leaving two live pg_attribute
+        // rows for one attribute -- a dropped column would come back, or appear twice.
+        // Same payload layout as PHYSICAL_UPDATE.
+        PHYSICAL_UPDATE_INPLACE = 14,
     };
 
     struct record_t final {
@@ -50,6 +64,7 @@ namespace services::wal {
         bool is_physical() const {
             return record_type == wal_record_type::PHYSICAL_INSERT || record_type == wal_record_type::PHYSICAL_DELETE ||
                    record_type == wal_record_type::PHYSICAL_UPDATE ||
+                   record_type == wal_record_type::PHYSICAL_UPDATE_INPLACE ||
                    record_type == wal_record_type::PHYSICAL_ADD_COLUMN;
         }
     };

--- a/services/wal/tests/test_wal_binary.cpp
+++ b/services/wal/tests/test_wal_binary.cpp
@@ -103,6 +103,11 @@ TEST_CASE("wal_binary::encode_decode_update") {
     std::vector<int64_t> row_ids = {0, 2, 4, 6, 8};
 
     buffer_t buffer(&resource);
+    // An MVCC update is a delete of the old rows plus an append of the new ones, so the
+    // new rows land at the end of the table -- NOT back at the row_ids being updated.
+    // row_start is where they landed. Consumers rely on it: the CREATE INDEX WAL
+    // catch-up maps the g-th row of the record to row_start + g, so a row_start of 0
+    // indexes every updated row at 0, 1, 2, ...
     encode_update(buffer,
                   &resource,
                   /*last_crc32=*/0,
@@ -111,6 +116,7 @@ TEST_CASE("wal_binary::encode_decode_update") {
                   kTestTableOid,
                   row_ids.data(),
                   to_chunk_batch(new_data),
+                  /*row_start=*/9000,
                   /*count=*/5);
 
     REQUIRE(buffer.size() > 0);
@@ -122,6 +128,8 @@ TEST_CASE("wal_binary::encode_decode_update") {
     REQUIRE(record.transaction_id == 102);
     REQUIRE(record.record_type == wal_record_type::PHYSICAL_UPDATE);
     REQUIRE(record.table_oid == kTestTableOid);
+    REQUIRE(record.physical_row_start == 9000);
+    REQUIRE(record.physical_row_count == 5);
     REQUIRE(record.physical_row_ids.size() == 5);
 
     for (size_t i = 0; i < row_ids.size(); i++) {

--- a/services/wal/tests/test_wal_binary.cpp
+++ b/services/wal/tests/test_wal_binary.cpp
@@ -97,6 +97,54 @@ TEST_CASE("wal_binary::encode_decode_delete") {
     }
 }
 
+TEST_CASE("wal_binary::encode_decode_compact") {
+    std::pmr::monotonic_buffer_resource resource(1024 * 64);
+
+    buffer_t buffer(&resource);
+    // txn_id is 0 (system write); watermark is carried for forensics only.
+    encode_compact(buffer,
+                   /*last_crc32=*/0,
+                   /*wal_id=*/7,
+                   /*txn_id=*/0,
+                   kTestTableOid,
+                   /*compact_watermark=*/424242);
+
+    REQUIRE(buffer.size() > 0);
+
+    auto record = decode_record(buffer, &resource);
+    REQUIRE(record.is_valid());
+    REQUIRE_FALSE(record.is_corrupt);
+    REQUIRE(record.id == 7);
+    REQUIRE(record.transaction_id == 0);
+    REQUIRE(record.record_type == wal_record_type::PHYSICAL_COMPACT);
+    REQUIRE(record.is_physical());
+    REQUIRE(record.table_oid == kTestTableOid);
+    // No payload: neither a row-id list nor a data batch.
+    REQUIRE(record.physical_row_ids.empty());
+    REQUIRE(record.physical_data.empty());
+    REQUIRE(record.physical_row_count == 0);
+    // Watermark round-trips in physical_row_start (forensic only).
+    REQUIRE(record.physical_row_start == 424242);
+}
+
+// A PHYSICAL_COMPACT sitting between physical records and their COMMIT must NOT
+// perturb the committed-only classification: it is a physical record whose
+// transaction_id is 0, so any consumer that keys on record_type/transaction_id
+// (never on a non-empty payload) treats it uniformly.
+TEST_CASE("wal_binary::compact_is_physical_and_payload_free") {
+    std::pmr::monotonic_buffer_resource resource(1024 * 64);
+    buffer_t buffer(&resource);
+    crc32_t last = 0;
+    last = encode_compact(buffer, last, /*wal_id=*/5, /*txn_id=*/0, kTestTableOid, /*watermark=*/1);
+
+    auto record = decode_record(buffer, &resource);
+    REQUIRE_FALSE(record.is_corrupt);
+    REQUIRE(record.is_physical());
+    REQUIRE_FALSE(record.is_commit_marker());
+    // The chain CRC is well-formed so it links into the record stream like any other.
+    REQUIRE(record.crc32 != 0);
+}
+
 TEST_CASE("wal_binary::encode_decode_update") {
     std::pmr::monotonic_buffer_resource resource(1024 * 64);
     auto new_data = gen_data_chunk(5, 0, wal_test_types(&resource), &resource);

--- a/services/wal/tests/test_wal_page.cpp
+++ b/services/wal/tests/test_wal_page.cpp
@@ -585,3 +585,81 @@ TEST_CASE("edge_exact_fit") {
         REQUIRE((header.flags & PAGE_PARTIAL_END) == 0);
     }
 }
+
+// Two back-to-back spanning records: the page where the first record ENDS also
+// holds the second record's HEAD (flags END|CONT). The reader must re-arm its
+// span accumulator from that page's leftover bytes — otherwise the second
+// record, and every record until the next non-continuation page, is silently
+// dropped (multi-flush INSERT..SELECT statements write exactly this shape).
+TEST_CASE("back_to_back_spanning_records") {
+    tmp_dir_t dir("test_wal_page_b2b_span");
+    auto filepath = dir.file("wal_segment_0");
+    auto* resource = std::pmr::get_default_resource();
+
+    auto big = gen_data_chunk(500, resource);
+    auto small = gen_data_chunk(5, resource);
+
+    {
+        wal_page_writer_t writer(filepath, "testdb", 0);
+        crc32_t last_crc = 0;
+
+        auto r1 = encode_insert_rec(1, 42, last_crc, kTestTableOid, big, 0, 500);
+        REQUIRE(r1.data.size() > PAGE_DATA_SIZE);
+        writer.append(r1.data.data(), r1.data.size(), 1);
+        last_crc = extract_crc(r1.data.data(), r1.data.size());
+
+        auto r2 = encode_insert_rec(2, 43, last_crc, kTestTableOid, big, 500, 500);
+        writer.append(r2.data.data(), r2.data.size(), 2);
+        last_crc = extract_crc(r2.data.data(), r2.data.size());
+
+        auto r3 = encode_insert_rec(3, 44, last_crc, kTestTableOid, small, 1000, 5);
+        writer.append(r3.data.data(), r3.data.size(), 3);
+        writer.flush();
+    }
+
+    {
+        wal_page_reader_t reader(filepath);
+        auto records = reader.read_all_records(0);
+        REQUIRE(records.size() == 3);
+        REQUIRE(records[0].id == 1);
+        REQUIRE(records[1].id == 2);
+        REQUIRE(records[2].id == 3);
+    }
+}
+
+// A record boundary can land 1-3 bytes before the page end, splitting the next
+// record's 4-byte size prefix across pages. The reader must complete the prefix
+// before sizing its take — guessing "rest of the page" swallows the records
+// that follow the spanning one in the second page.
+TEST_CASE("size_prefix_split_across_pages") {
+    tmp_dir_t dir("test_wal_page_prefix_split");
+    auto filepath = dir.file("wal_segment_0");
+
+    // Filler sized to leave exactly 2 bytes of page-1 data space: an opaque
+    // [size][payload][crc] blob; its garbage payload decodes invalid and is
+    // skipped, which is irrelevant — only its length matters.
+    const uint32_t filler_total = PAGE_DATA_SIZE - 2;
+    std::vector<char> filler(filler_total, '\x5a');
+    const uint32_t filler_body = filler_total - 8;
+    std::memcpy(filler.data(), &filler_body, sizeof(uint32_t));
+
+    {
+        wal_page_writer_t writer(filepath, "testdb", 0);
+        writer.append(filler.data(), filler.size(), 1);
+
+        auto r2 = encode_commit_rec(2, 202, 0);
+        writer.append(r2.data.data(), r2.data.size(), 2);
+
+        auto r3 = encode_commit_rec(3, 203, 0);
+        writer.append(r3.data.data(), r3.data.size(), 3);
+        writer.flush();
+    }
+
+    {
+        wal_page_reader_t reader(filepath);
+        auto records = reader.read_all_records(0);
+        REQUIRE(records.size() == 2);
+        REQUIRE(records[0].id == 2);
+        REQUIRE(records[1].id == 3);
+    }
+}

--- a/services/wal/tests/test_wal_page.cpp
+++ b/services/wal/tests/test_wal_page.cpp
@@ -129,6 +129,7 @@ namespace {
                                      table_oid,
                                      row_ids.data(),
                                      to_chunk_batch(chunk),
+                                     /*row_start=*/0,
                                      count);
         info.data = buffer_to_vec(buf);
         return info;

--- a/services/wal/tests/test_wal_page.cpp
+++ b/services/wal/tests/test_wal_page.cpp
@@ -594,7 +594,8 @@ TEST_CASE("edge_exact_fit") {
 TEST_CASE("back_to_back_spanning_records") {
     tmp_dir_t dir("test_wal_page_b2b_span");
     auto filepath = dir.file("wal_segment_0");
-    auto* resource = std::pmr::get_default_resource();
+    core::pmr::otterbrix_resource mem;
+    auto* resource = &mem;
 
     auto big = gen_data_chunk(500, resource);
     auto small = gen_data_chunk(5, resource);

--- a/services/wal/tests/test_wal_worker.cpp
+++ b/services/wal/tests/test_wal_worker.cpp
@@ -149,7 +149,8 @@ struct test_wal_worker {
     actor_zeta::unique_future<services::wal::id_t> send_update(uint64_t txn_id,
                                                                const std::pmr::vector<int64_t>& row_ids,
                                                                size_t row_count,
-                                                               catalog_ns::oid_t table_oid = kTestTableOid) {
+                                                               catalog_ns::oid_t table_oid = kTestTableOid,
+                                                               uint64_t row_start = 0) {
         auto* arena = std::pmr::new_delete_resource(); // chunk memory must outlive async processing
         auto chunk = gen_data_chunk(row_count, arena);
         auto chunk_ptr = to_batch(std::make_unique<data_chunk_t>(std::move(chunk)));
@@ -161,6 +162,7 @@ struct test_wal_worker {
                                                                  table_oid,
                                                                  std::move(ids_copy),
                                                                  std::move(chunk_ptr),
+                                                                 row_start,
                                                                  static_cast<uint64_t>(row_count),
                                                                  txn_id,
                                                                  kMainDb);

--- a/services/wal/tests/test_wal_worker.cpp
+++ b/services/wal/tests/test_wal_worker.cpp
@@ -165,6 +165,7 @@ struct test_wal_worker {
                                                                  row_start,
                                                                  static_cast<uint64_t>(row_count),
                                                                  txn_id,
+                                                                 /*in_place=*/false,
                                                                  kMainDb);
         return std::move(future);
     }

--- a/services/wal/wal.cpp
+++ b/services/wal/wal.cpp
@@ -97,6 +97,10 @@ namespace services::wal {
                 co_await actor_zeta::dispatch(this, &wal_worker_t::write_physical_update, msg);
                 break;
             }
+            case actor_zeta::msg_id<wal_worker_t, &wal_worker_t::write_physical_compact>: {
+                co_await actor_zeta::dispatch(this, &wal_worker_t::write_physical_compact, msg);
+                break;
+            }
             case actor_zeta::msg_id<wal_worker_t, &wal_worker_t::write_physical_add_column>: {
                 co_await actor_zeta::dispatch(this, &wal_worker_t::write_physical_add_column, msg);
                 break;
@@ -168,6 +172,28 @@ namespace services::wal {
 
         encode_buf_.clear();
         last_crc_ = encode_delete(encode_buf_, last_crc_, wal_id, txn_id, table_oid, row_ids.data(), count);
+
+        ensure_writer();
+        writer_->append(encode_buf_.data(), encode_buf_.size(), wal_id);
+
+        co_return wal_id;
+    }
+
+    // -----------------------------------------------------------------------
+    // write_physical_compact
+    // -----------------------------------------------------------------------
+
+    wal_worker_t::unique_future<wal::id_t> wal_worker_t::write_physical_compact(session_id_t /*session*/,
+                                                                                components::catalog::oid_t table_oid,
+                                                                                uint64_t txn_id,
+                                                                                uint64_t compact_watermark,
+                                                                                wal::id_t wal_id) {
+        id_.store(wal_id, std::memory_order_relaxed);
+
+        trace(log_, "wal_worker::write_physical_compact , wal_id : {} , oid : {}", wal_id, static_cast<unsigned>(table_oid));
+
+        encode_buf_.clear();
+        last_crc_ = encode_compact(encode_buf_, last_crc_, wal_id, txn_id, table_oid, compact_watermark);
 
         ensure_writer();
         writer_->append(encode_buf_.data(), encode_buf_.size(), wal_id);

--- a/services/wal/wal.cpp
+++ b/services/wal/wal.cpp
@@ -184,6 +184,7 @@ namespace services::wal {
                                         components::catalog::oid_t table_oid,
                                         std::pmr::vector<int64_t> row_ids,
                                         std::pmr::vector<components::vector::data_chunk_t> new_chunks,
+                                        uint64_t row_start,
                                         uint64_t count,
                                         uint64_t txn_id,
                                         wal::id_t wal_id) {
@@ -200,6 +201,7 @@ namespace services::wal {
                                   table_oid,
                                   row_ids.data(),
                                   new_chunks,
+                                  row_start,
                                   count);
 
         ensure_writer();

--- a/services/wal/wal.cpp
+++ b/services/wal/wal.cpp
@@ -187,6 +187,7 @@ namespace services::wal {
                                         uint64_t row_start,
                                         uint64_t count,
                                         uint64_t txn_id,
+                                        bool in_place,
                                         wal::id_t wal_id) {
         id_.store(wal_id, std::memory_order_relaxed);
 
@@ -202,7 +203,9 @@ namespace services::wal {
                                   row_ids.data(),
                                   new_chunks,
                                   row_start,
-                                  count);
+                                  count,
+                                  in_place ? wal_record_type::PHYSICAL_UPDATE_INPLACE
+                                           : wal_record_type::PHYSICAL_UPDATE);
 
         ensure_writer();
         writer_->append(encode_buf_.data(), encode_buf_.size(), wal_id);

--- a/services/wal/wal.hpp
+++ b/services/wal/wal.hpp
@@ -86,6 +86,7 @@ namespace services::wal {
                                                        uint64_t row_start,
                                                        uint64_t count,
                                                        uint64_t txn_id,
+                                                       bool in_place,
                                                        wal::id_t wal_id);
 
         unique_future<wal::id_t>

--- a/services/wal/wal.hpp
+++ b/services/wal/wal.hpp
@@ -83,6 +83,7 @@ namespace services::wal {
                                                        components::catalog::oid_t table_oid,
                                                        std::pmr::vector<int64_t> row_ids,
                                                        std::pmr::vector<components::vector::data_chunk_t> new_chunks,
+                                                       uint64_t row_start,
                                                        uint64_t count,
                                                        uint64_t txn_id,
                                                        wal::id_t wal_id);

--- a/services/wal/wal.hpp
+++ b/services/wal/wal.hpp
@@ -97,6 +97,14 @@ namespace services::wal {
                                   uint64_t txn_id,
                                   wal::id_t wal_id);
 
+        // PHYSICAL_COMPACT: payload-free numbering-epoch boundary for table_oid (compact_watermark
+        // stored in the record's row_start for forensics only). txn_id is 0.
+        unique_future<wal::id_t> write_physical_compact(session_id_t session,
+                                                        components::catalog::oid_t table_oid,
+                                                        uint64_t txn_id,
+                                                        uint64_t compact_watermark,
+                                                        wal::id_t wal_id);
+
         using dispatch_traits = actor_zeta::dispatch_traits<&wal_worker_t::load,
                                                             &wal_worker_t::commit_txn,
                                                             &wal_worker_t::truncate_before,
@@ -104,7 +112,8 @@ namespace services::wal {
                                                             &wal_worker_t::write_physical_insert,
                                                             &wal_worker_t::write_physical_delete,
                                                             &wal_worker_t::write_physical_update,
-                                                            &wal_worker_t::write_physical_add_column>;
+                                                            &wal_worker_t::write_physical_add_column,
+                                                            &wal_worker_t::write_physical_compact>;
 
     private:
         // -----------------------------------------------------------------------

--- a/services/wal/wal_binary.cpp
+++ b/services/wal/wal_binary.cpp
@@ -290,6 +290,31 @@ namespace services::wal {
     }
 
     // -----------------------------------------------------------------------
+    // encode_compact
+    //
+    // Numbering-epoch boundary. No payload: replay re-runs compact() deterministically
+    // from this record's wal_id position, so only table_oid is needed. row_count = 0;
+    // row_start carries the live compact_watermark for forensics (not read on replay).
+    // -----------------------------------------------------------------------
+    crc32_t encode_compact(buffer_t& buffer,
+                           crc32_t last_crc32,
+                           id_t wal_id,
+                           uint64_t txn_id,
+                           components::catalog::oid_t table_oid,
+                           uint64_t compact_watermark) {
+        return write_dml_record(buffer,
+                                last_crc32,
+                                wal_id,
+                                txn_id,
+                                wal_record_type::PHYSICAL_COMPACT,
+                                table_oid,
+                                /*row_start=*/compact_watermark,
+                                /*row_count=*/0,
+                                /*payload=*/nullptr,
+                                /*payload_size=*/0);
+    }
+
+    // -----------------------------------------------------------------------
     // encode_update
     // -----------------------------------------------------------------------
     crc32_t encode_update(buffer_t& buffer,
@@ -517,6 +542,16 @@ namespace services::wal {
                         rec.is_corrupt = true;
                         return rec;
                     }
+                }
+                break;
+            }
+            case wal_record_type::PHYSICAL_COMPACT: {
+                // Numbering-epoch boundary: payload-free. table_oid and the forensic
+                // watermark (physical_row_start) are already parsed from the DML header;
+                // physical_row_ids / physical_data stay empty. A non-empty payload here is
+                // malformed.
+                if (payload_size != 0) {
+                    rec.is_corrupt = true;
                 }
                 break;
             }

--- a/services/wal/wal_binary.cpp
+++ b/services/wal/wal_binary.cpp
@@ -300,6 +300,7 @@ namespace services::wal {
                           components::catalog::oid_t table_oid,
                           const int64_t* row_ids,
                           const std::pmr::vector<components::vector::data_chunk_t>& new_chunks,
+                          uint64_t row_start,
                           uint64_t count) {
         // Payload layout for UPDATE:
         //   [row_ids_size : 4 LE]          // byte count of the row-ids block
@@ -326,7 +327,7 @@ namespace services::wal {
                                 txn_id,
                                 wal_record_type::PHYSICAL_UPDATE,
                                 table_oid,
-                                0,
+                                row_start,
                                 count,
                                 payload_buf.data(),
                                 static_cast<uint32_t>(payload_buf.size()));

--- a/services/wal/wal_binary.cpp
+++ b/services/wal/wal_binary.cpp
@@ -301,7 +301,8 @@ namespace services::wal {
                           const int64_t* row_ids,
                           const std::pmr::vector<components::vector::data_chunk_t>& new_chunks,
                           uint64_t row_start,
-                          uint64_t count) {
+                          uint64_t count,
+                          wal_record_type record_type) {
         // Payload layout for UPDATE:
         //   [row_ids_size : 4 LE]          // byte count of the row-ids block
         //   [row_ids      : row_ids_size]
@@ -325,7 +326,7 @@ namespace services::wal {
                                 last_crc32,
                                 wal_id,
                                 txn_id,
-                                wal_record_type::PHYSICAL_UPDATE,
+                                record_type,
                                 table_oid,
                                 row_start,
                                 count,
@@ -490,7 +491,8 @@ namespace services::wal {
                 std::memcpy(rec.physical_row_ids.data(), payload, payload_size);
                 break;
             }
-            case wal_record_type::PHYSICAL_UPDATE: {
+            case wal_record_type::PHYSICAL_UPDATE:
+            case wal_record_type::PHYSICAL_UPDATE_INPLACE: {
                 if (payload_size < 4) {
                     rec.is_corrupt = true;
                     return rec;

--- a/services/wal/wal_binary.hpp
+++ b/services/wal/wal_binary.hpp
@@ -55,6 +55,11 @@ namespace services::wal {
                               const components::vector::data_chunk_t& schema_chunk,
                               uint64_t column_count);
 
+    // `row_start` is where the new row images LANDED. An MVCC update deletes the old
+    // rows and appends the new ones at the end of the table, so the new rows do not sit
+    // at `row_ids` -- those are the OLD locations, which the record carries only so that
+    // replay knows what to tombstone. Consumers that need to address the new rows (the
+    // CREATE INDEX WAL catch-up) map the g-th row of the record to `row_start + g`.
     crc32_t encode_update(buffer_t& buffer,
                           std::pmr::memory_resource* resource,
                           crc32_t last_crc32,
@@ -63,6 +68,7 @@ namespace services::wal {
                           components::catalog::oid_t table_oid,
                           const int64_t* row_ids,
                           const std::pmr::vector<components::vector::data_chunk_t>& new_chunks,
+                          uint64_t row_start,
                           uint64_t count);
 
     // commit_id (from transaction_manager_t::commit()) is appended to COMMIT

--- a/services/wal/wal_binary.hpp
+++ b/services/wal/wal_binary.hpp
@@ -45,6 +45,17 @@ namespace services::wal {
                           const int64_t* row_ids,
                           uint64_t count);
 
+    // Numbering-epoch boundary for `table_oid` (see wal_record_type::PHYSICAL_COMPACT).
+    // Payload-free: carries only the table_oid; `compact_watermark` is stored in
+    // physical_row_start for forensics and is not load-bearing on replay. txn_id is 0
+    // (a system write that re-derives over already-committed state).
+    crc32_t encode_compact(buffer_t& buffer,
+                           crc32_t last_crc32,
+                           id_t wal_id,
+                           uint64_t txn_id,
+                           components::catalog::oid_t table_oid,
+                           uint64_t compact_watermark);
+
     // Schema-growth record: payload is a 0-row data_chunk whose columns ARE the
     // new columns (alias-tagged types). Written BEFORE the dependent PHYSICAL_INSERT.
     crc32_t encode_add_column(buffer_t& buffer,

--- a/services/wal/wal_binary.hpp
+++ b/services/wal/wal_binary.hpp
@@ -60,6 +60,9 @@ namespace services::wal {
     // at `row_ids` -- those are the OLD locations, which the record carries only so that
     // replay knows what to tombstone. Consumers that need to address the new rows (the
     // CREATE INDEX WAL catch-up) map the g-th row of the record to `row_start + g`.
+    //
+    // `record_type` selects the replay contract: PHYSICAL_UPDATE (the MVCC default) or
+    // PHYSICAL_UPDATE_INPLACE. Both share this payload layout.
     crc32_t encode_update(buffer_t& buffer,
                           std::pmr::memory_resource* resource,
                           crc32_t last_crc32,
@@ -69,7 +72,8 @@ namespace services::wal {
                           const int64_t* row_ids,
                           const std::pmr::vector<components::vector::data_chunk_t>& new_chunks,
                           uint64_t row_start,
-                          uint64_t count);
+                          uint64_t count,
+                          wal_record_type record_type = wal_record_type::PHYSICAL_UPDATE);
 
     // commit_id (from transaction_manager_t::commit()) is appended to COMMIT
     // records so replay can rebuild published_horizon_.

--- a/services/wal/wal_contract.hpp
+++ b/services/wal/wal_contract.hpp
@@ -75,6 +75,16 @@ namespace services::wal {
                                   uint64_t txn_id,
                                   components::catalog::oid_t database_oid);
 
+        // Numbering-epoch boundary (PHYSICAL_COMPACT): payload-free, carries only the
+        // table_oid; txn_id is 0 (a system write re-derived over already-committed state);
+        // compact_watermark is stored for forensics and is not load-bearing on replay.
+        // Deliberately NOT gated on txn_id != 0 (a txn=0 COMPACT must never be dropped).
+        actor_zeta::unique_future<id_t> write_physical_compact(session_id_t session,
+                                                               components::catalog::oid_t table_oid,
+                                                               uint64_t txn_id,
+                                                               uint64_t compact_watermark,
+                                                               components::catalog::oid_t database_oid);
+
         // Retention guard for CREATE INDEX backfill. The build registers its
         // start wal_position before backfill and unregisters on success/fail;
         // truncate_before clamps to min(active set) so the catchup loop never
@@ -91,6 +101,7 @@ namespace services::wal {
                                                             &wal_contract::write_physical_delete,
                                                             &wal_contract::write_physical_update,
                                                             &wal_contract::write_physical_add_column,
+                                                            &wal_contract::write_physical_compact,
                                                             &wal_contract::register_active_build,
                                                             &wal_contract::unregister_active_build>;
 

--- a/services/wal/wal_contract.hpp
+++ b/services/wal/wal_contract.hpp
@@ -57,6 +57,7 @@ namespace services::wal {
                               components::catalog::oid_t table_oid,
                               std::pmr::vector<int64_t> row_ids,
                               std::pmr::vector<components::vector::data_chunk_t> new_data,
+                              uint64_t row_start,
                               uint64_t count,
                               uint64_t txn_id,
                               components::catalog::oid_t database_oid);

--- a/services/wal/wal_contract.hpp
+++ b/services/wal/wal_contract.hpp
@@ -60,6 +60,7 @@ namespace services::wal {
                               uint64_t row_start,
                               uint64_t count,
                               uint64_t txn_id,
+                              bool in_place,
                               components::catalog::oid_t database_oid);
 
         // Schema-growth record (dynamic add_column on IN_MEMORY / computed tables).

--- a/services/wal/wal_page_reader.cpp
+++ b/services/wal/wal_page_reader.cpp
@@ -138,27 +138,27 @@ namespace services::wal {
 
             // ---- Spanning record: continuation/last page ----
             if (in_span && (is_cont || is_end)) {
-                // Determine how many bytes we still need.
-                uint32_t needed = data_size;
-                if (span_buffer.size() >= 4) {
-                    uint32_t body_size = 0;
-                    std::memcpy(&body_size, span_buffer.data(), sizeof(uint32_t));
-                    uint32_t total_record = body_size + 8; // size(4) + body + crc(4)
-                    if (total_record > span_buffer.size()) {
-                        needed = static_cast<uint32_t>(total_record - span_buffer.size());
-                    } else {
-                        needed = 0;
-                    }
+                size_t offset = 0;
+
+                // Complete the 4-byte size prefix first if the page break split
+                // it: taking a whole-page guess here would swallow bytes that
+                // belong to the records AFTER the span in this page.
+                if (span_buffer.size() < sizeof(uint32_t)) {
+                    size_t prefix_take = std::min<size_t>(sizeof(uint32_t) - span_buffer.size(), data_size);
+                    span_buffer.insert(span_buffer.end(), data, data + prefix_take);
+                    offset = prefix_take;
                 }
 
-                uint32_t to_take = std::min(needed, data_size);
-                span_buffer.insert(span_buffer.end(), data, data + to_take);
-
-                // Check if we have the complete record now.
-                if (span_buffer.size() >= 4) {
+                if (span_buffer.size() >= sizeof(uint32_t)) {
                     uint32_t body_size = 0;
                     std::memcpy(&body_size, span_buffer.data(), sizeof(uint32_t));
-                    uint32_t total_record = body_size + 8;
+                    const uint32_t total_record = body_size + 8; // size(4) + body + crc(4)
+                    if (span_buffer.size() < total_record) {
+                        size_t take = std::min<size_t>(total_record - span_buffer.size(), data_size - offset);
+                        span_buffer.insert(span_buffer.end(), data + offset, data + offset + take);
+                        offset += take;
+                    }
+
                     if (span_buffer.size() >= total_record) {
                         auto rec = decode_record(span_buffer.data(), total_record, resource);
                         if (rec.is_valid() && rec.id > after_id) {
@@ -168,7 +168,6 @@ namespace services::wal {
                         in_span = false;
 
                         // Parse remaining complete records after the spanning data.
-                        size_t offset = to_take;
                         while (offset < data_size) {
                             if (offset + sizeof(uint32_t) > data_size) {
                                 break;
@@ -187,6 +186,19 @@ namespace services::wal {
                                 records.push_back(std::move(r));
                             }
                             offset += total_rec_bytes;
+                        }
+
+                        // This page may also START the next spanning record:
+                        // back-to-back multi-page records put the old record's
+                        // tail and the new record's head in the same page
+                        // (flags END|CONT, same as the not-in-span tail below).
+                        // Without re-arming, every record until the next
+                        // non-continuation page is lost.
+                        if (is_cont) {
+                            if (offset < data_size) {
+                                span_buffer.assign(data + offset, data + data_size);
+                            }
+                            in_span = true;
                         }
                     }
                 }

--- a/services/wal/wal_reader.cpp
+++ b/services/wal/wal_reader.cpp
@@ -31,18 +31,53 @@ namespace services::wal {
             return merged;
         }
 
+        // Pass A: read EVERY database stream raw and union the commit markers.
+        // A COMMIT marker is a global fact keyed by txn id — a txn's PHYSICAL
+        // records and its COMMIT marker can land in DIFFERENT per-database
+        // streams (the agent routes each record by ctx.database_oid with a
+        // main_database fallback), so no stream may be filtered against only its
+        // own markers: that mis-classifies committed work as uncommitted.
+        std::vector<record_t> all_records;
+        std::set<uint64_t> committed_txns;
         for (const auto& entry : std::filesystem::directory_iterator(config_.path)) {
             if (!entry.is_directory()) {
                 continue;
             }
-
-            auto db_name = entry.path().filename().string();
-            trace(log_, "wal_reader::read_committed_records , scanning database '{}'", db_name);
-
-            // committed_out collects the union of committed txn ids across all
-            // databases (read_database_segments inserts this db's ids into it).
-            auto db_records = read_database_segments(entry.path(), after_wal_id, committed_out);
+            trace(log_,
+                  "wal_reader::read_committed_records , scanning database '{}'",
+                  entry.path().filename().string());
+            auto db_records = read_database_raw(entry.path(), after_wal_id);
             for (auto& r : db_records) {
+                if (r.is_commit_marker() && r.is_valid()) {
+                    committed_txns.insert(r.transaction_id);
+                }
+                all_records.push_back(std::move(r));
+            }
+        }
+        if (committed_out != nullptr) {
+            committed_out->insert(committed_txns.begin(), committed_txns.end());
+        }
+
+        // Pass B: keep committed-txn records, system records, and — repeat
+        // history — the PLACEMENT records (PHYSICAL_INSERT / PHYSICAL_UPDATE) of
+        // uncommitted txns on user tables, flagged txn_committed=false. An
+        // uncommitted txn's appends occupied physical row-ids in the live run
+        // (abort reverts marks, not placement), so every later positional record
+        // was captured against a numbering that includes them; replay must place
+        // them too (and retire them dead) or those records misresolve. Uncommitted
+        // catalog records stay filtered: catalog rows ride the swap protocol and
+        // are physically unwound at abort.
+        merged.reserve(all_records.size());
+        for (auto& r : all_records) {
+            if (!r.is_valid()) {
+                continue;
+            }
+            if (r.transaction_id == 0 || committed_txns.count(r.transaction_id) > 0) {
+                merged.push_back(std::move(r));
+            } else if ((r.record_type == wal_record_type::PHYSICAL_INSERT ||
+                        r.record_type == wal_record_type::PHYSICAL_UPDATE) &&
+                       r.table_oid >= components::catalog::FIRST_USER_OID) {
+                r.txn_committed = false;
                 merged.push_back(std::move(r));
             }
         }
@@ -61,9 +96,7 @@ namespace services::wal {
     // apply the 2-pass committed-transaction filter.
     // -----------------------------------------------------------------------
 
-    std::vector<record_t> wal_reader_t::read_database_segments(const std::filesystem::path& db_dir,
-                                                               id_t after_wal_id,
-                                                               std::set<std::uint64_t>* committed_out) {
+    std::vector<record_t> wal_reader_t::read_database_raw(const std::filesystem::path& db_dir, id_t after_wal_id) {
         // Discover segment files. WAL segments are named wal_<db>_NNNNNN.
         std::vector<std::filesystem::path> segments;
 
@@ -108,37 +141,7 @@ namespace services::wal {
             }
         }
 
-        // Pass 1: collect committed transaction IDs from COMMIT records.
-        std::set<uint64_t> committed_txns;
-        for (const auto& r : all_records) {
-            if (r.is_commit_marker() && r.is_valid()) {
-                committed_txns.insert(r.transaction_id);
-            }
-        }
-
-        // Export this database's committed txn ids into the caller's union set.
-        // The filter below is unchanged (still keyed on the local committed_txns)
-        // so the returned records stay byte-identical.
-        if (committed_out != nullptr) {
-            committed_out->insert(committed_txns.begin(), committed_txns.end());
-        }
-
-        // Pass 2: keep only records belonging to committed transactions.
-        std::vector<record_t> result;
-        result.reserve(all_records.size());
-
-        for (auto& r : all_records) {
-            if (!r.is_valid()) {
-                continue;
-            }
-            // Records with txn_id==0 are "system" records (always included).
-            // Physical and commit records are included if their txn is committed.
-            if (r.transaction_id == 0 || committed_txns.count(r.transaction_id) > 0) {
-                result.push_back(std::move(r));
-            }
-        }
-
-        return result;
+        return all_records;
     }
 
 } // namespace services::wal

--- a/services/wal/wal_reader.hpp
+++ b/services/wal/wal_reader.hpp
@@ -40,11 +40,9 @@ namespace services::wal {
                                                      std::set<std::uint64_t>* committed_out = nullptr);
 
     private:
-        /// Read all records from segment files in a single database directory.
-        /// committed_out, when non-null, receives this database's committed txn ids.
-        std::vector<record_t> read_database_segments(const std::filesystem::path& db_dir,
-                                                     id_t after_wal_id,
-                                                     std::set<std::uint64_t>* committed_out);
+        /// Read all records (unfiltered) from segment files in a single database
+        /// directory, honoring the per-database CRC chain-break stop.
+        std::vector<record_t> read_database_raw(const std::filesystem::path& db_dir, id_t after_wal_id);
 
         configuration::config_wal config_;
         log_t log_;


### PR DESCRIPTION
Restart recovery = last checkpoint + WAL replay. DELETE/UPDATE records address rows by physical row id, so recovery is correct only if replay reproduces the live run's row numbering exactly. Nothing enforced that. This PR makes the row-id space a log-stable key by construction and fences everything that can move it.

## Concepts replaced

* **Uncommitted-record filtering → repeat-history replay.** Replay used to skip aborted transactions; live, their rows still occupied physical ids (abort reverts visibility, not placement), so all later records resolved shifted. Replay now re-places uncommitted work and retires it dead in place — same ids, never visible. Live abort mirrors this: aborted appends are re-stamped committed-dead instead of physically truncated.

  ```sql
  BEGIN; INSERT INTO t VALUES (100),(101),...;  ROLLBACK;  -- 10 rows still occupy ids
  INSERT INTO t VALUES (1),(2),...;
  DELETE FROM t WHERE a = 5;          -- numbered ABOVE the aborted rows
  -- restart --                       -- was: lands 10 rows too low, kills a wrong row
  ```

* **Replay-only UPDATE semantics → replay through the live execution path.** An UPDATE replayed as an in-place rewrite while the live run did an MVCC delete+append (the row moves). Replay now drives the same MVCC path with the record's true row-id base; no operation has replay-only semantics anymore.

  ```sql
  UPDATE t SET v = 99 WHERE a = 2;
  -- restart --
  SELECT v FROM t WHERE a = 2;        -- was: 20 or a crash; now: 99
  ```
* **Operator-owned WAL emission → single-writer emission in the storage agent.** WAL ids were allocated in query operators, in other actors than the one applying the mutation; concurrent DML could invert log order versus apply order. All physical records are now emitted inside the same serial handler that applies them: log order ≡ apply order.
* **Write-ahead INSERT logging → materialize-then-log.** A durable record must imply placement. Logging before materializing could leave a record for rows that never existed — rows that repeat-history replay would then place, shifting the numbering.
* **Unfenced compaction → logged renumbering epochs.** Commit-time cleanup and VACUUM renumber survivors densely; that renumber is now a WAL event (`PHYSICAL_COMPACT`, emitted on the same per-table log stream as the DML it reorders) and replay re-runs it at the same log position. Records on each side of the marker resolve against the numbering they were written under.

  ```sql
  DELETE FROM t WHERE a IN (1, 2);
  VACUUM;                             -- survivors renumbered from 0
  DELETE FROM t WHERE a = 5;          -- captured against POST-vacuum numbering
  -- restart --                       -- was: replays against the OLD numbering
  ```
* **Unconstrained compaction scheduling → a capture gate.** No renumbering while any statement holds captured-but-unapplied row ids (the latch replay cannot see). Every statement outcome releases the gate — apply, zero-match completion, transaction abort, mid-statement failure; a leaked hold used to freeze compaction and checkpointing of the table for the process lifetime.
* **Snapshot-stamped checkpoints → applied-watermark checkpoints.** The sidecar watermark now covers every record the agent actually applied into the fold, not a snapshot taken before the fold; otherwise replay re-applies the tail twice. Checkpoint failure discipline is fail-stop toward the old consistent state: a failed fold still logs its compaction epoch, a failed watermark persist restores the previous checkpoint and halts — durable divergence is never an outcome.

<details>
<summary><b>More previously-failing examples</b> (each is a cell in the differential battery)</summary>

**Commit-time compaction, no VACUUM involved** — crossing the dead-row threshold renumbers at COMMIT:

```sql
-- 10 rows; >30% deleted crosses the auto-cleanup threshold
DELETE FROM t WHERE a IN (1, 2, 3, 4);
DELETE FROM t WHERE a = 6;              -- compaction renumbered here, unlogged
UPDATE t SET v = 99 WHERE a = 9;        -- captured against the NEW numbering
-- restart --                           -- was: replays against the OLD numbering
```

**Rolled-back UPDATE** — the aborted new-row images also occupied ids:

```sql
INSERT INTO t VALUES (1,1),(2,2),...,(10,10);
BEGIN; UPDATE t SET v = v + 1000 WHERE a <= 6; ROLLBACK;   -- 6 images placed
INSERT INTO t VALUES (11,11),(12,12);
DELETE FROM t WHERE a = 5;
-- restart --   was: everything after the rollback shifted by six ids
```

**Rollback at row-group scale** — 2048 aborted rows spanning several row groups, plus >4KB WAL records:

```sql
-- 16 seed rows doubled 7x via INSERT..SELECT = 2048 committed rows
BEGIN; INSERT INTO big SELECT a + 10000, v FROM big; ROLLBACK;  -- 2048 more, aborted
DELETE FROM big WHERE a < 8;
UPDATE big SET v = 77 WHERE a = 1500;
-- restart --
SELECT count(*) FROM big;   -- was: deletes resurrect (reader loss) and the
                            -- UPDATE lands on a wrong row (shifted numbering)
```

**Whole-table DELETE, VACUUM to empty, id reuse**:

```sql
DELETE FROM t;                          -- all 20 rows dead
VACUUM;                                 -- table renumbers to empty
INSERT INTO t VALUES (101,1),...,(105,5);  -- fresh rows at recycled ids 0..4
DELETE FROM t WHERE a = 103;
-- restart --  was: without the epoch marker the re-inserts replay ABOVE
--             20 ghost tombstones and the DELETE tombstones a ghost
```

**Restart of a restart** — WAL ids must continue above the replayed maximum:

```sql
INSERT INTO t VALUES ...; DELETE FROM t WHERE a = 5;   -- run 1, restart
INSERT INTO t VALUES ...; DELETE FROM t WHERE a = 15;  -- run 2, restart
SELECT count(*) FROM t;   -- was: run 2's records minted ids below run 1's
                          -- maximum and truncation/replay dropped them
```

**The version-slot hole was a live bug, not only a restart one** — visibility metadata mis-addressed past row 1024:

```sql
-- session A                       -- session B
BEGIN;
INSERT INTO big SELECT ...;        -- 3000 rows, still uncommitted
                                   SELECT count(*) FROM big;
                                   -- was: sees ~2000 uncommitted rows
```

**A wedged capture gate was a liveness bug** — any statement ending without its release froze reclamation:

```sql
UPDATE t SET v = 0 WHERE a < a;   -- matches nothing (or fails mid-statement)
VACUUM;                           -- was: never compacts this table again;
                                  -- its checkpoints and WAL truncation freeze too
```

</details>

## Defects removed on the way

* WAL page framing: back-to-back page-spanning records desynchronized the reader, which silently dropped all records to the next resync point (valid CRCs, no warning).

  ```sql
  INSERT INTO big SELECT ... ;        -- any two consecutive >4KB records
  DELETE FROM big WHERE a < 8;
  -- restart --
  SELECT count(*) FROM big;           -- was: the 8 deleted rows resurrect
  ```
* MVCC version addressing: version slots are row-group-local; scan and delete indexed them table-absolutely, so past row 1024 uncommitted rows were globally visible and tombstones invisible to reclamation — a live isolation hole, not only a restart one.
* Validity-mask bit addressing (`set_valid` treated a row index as a word index) and a set of strict-UBSAN findings (misaligned loads over segment payloads, null-pointer `memcpy`, uninitialized error-path store).

## Verification

Differential restart battery: every scenario probed before and after restart, across all storage-mode × shutdown-flavor combinations, with a no-restart control that quarantines pre-existing live bugs. ~3.3k of the 5.1k added lines are this battery plus unit suites for the gate, the fences and the page format.

Units 811/811; integration green — the 12 pre-existing type-encoding cells (failing identically on `main`) stay in the battery as expected-fail (`[!mayfail]`): they keep printing their divergence without blocking CI. ASAN/UBSAN/TSAN clean on this surface. Worst-case UPDATE-storm benchmark: write path 1.20× vs `main`; `main` crashes on its own reopen — this branch reopens in ~20 ms. Read paths unchanged.

## Out of scope, recorded

* Index recovery (frozen by request): rebuilt indexes use dense positions, not physical row ids.
* The 12 type-encoding cells (lossy `.otbx`/catalog codecs) — the next campaign.
* `ALTER TABLE ADD/DROP COLUMN` is broken without any restart (pre-existing).
