### PR TITLE
Fix ORDER BY expression-key crash and priority

### DIFF
--- a/components/physical_plan/operators/arithmetic_eval.cpp
+++ b/components/physical_plan/operators/arithmetic_eval.cpp
@@ -96,15 +96,21 @@ namespace components::operators {
                         if (inner_op.has_error()) {
                             return inner_op;
                         }
-                        if (!types::is_arithmetic_numeric(operand_type(inner_op.value()))) {
-                            return unsupported_unary_minus_error(resource);
-                        }
-
+                        // A NULL literal (NA-typed operand) negates to NULL — three-valued
+                        // logic, never an operator error.
                         uint64_t count = chunk.size();
                         vector::vector_t computed(resource,
                                                   types::complex_logical_type(types::logical_type::BIGINT),
                                                   0);
-                        if (inner_op.value().vec) {
+                        if (operand_type(inner_op.value()) == types::logical_type::NA) {
+                            uint64_t out_count = count > 0 ? count : 1;
+                            computed = vector::vector_t(resource,
+                                                        types::complex_logical_type(types::logical_type::NA),
+                                                        out_count);
+                            computed.validity().set_all_invalid(out_count);
+                        } else if (!types::is_arithmetic_numeric(operand_type(inner_op.value()))) {
+                            return unsupported_unary_minus_error(resource);
+                        } else if (inner_op.value().vec) {
                             computed = vector::compute_unary_neg(resource, *inner_op.value().vec, count);
                         } else {
                             uint64_t out_count = count > 0 ? count : 1;
@@ -141,8 +147,13 @@ namespace components::operators {
                     if (right_op.has_error()) {
                         return right_op;
                     }
-                    if (types::arithmetic_result_type(operand_type(left_op.value()), operand_type(right_op.value()), op) ==
-                        types::logical_type::NA) {
+                    // A NULL literal answers NULL through the kernels' NA path; only a pair
+                    // of concrete types with no operator is an error.
+                    if (operand_type(left_op.value()) != types::logical_type::NA &&
+                        operand_type(right_op.value()) != types::logical_type::NA &&
+                        types::arithmetic_result_type(operand_type(left_op.value()),
+                                                      operand_type(right_op.value()),
+                                                      op) == types::logical_type::NA) {
                         return unsupported_arithmetic_error(resource);
                     }
                     uint64_t count = chunk.size();
@@ -247,7 +258,8 @@ namespace components::operators {
                         if (inner.has_error()) {
                             return inner;
                         }
-                        if (!types::is_arithmetic_numeric(inner.value().type().type())) {
+                        if (!inner.value().is_null() &&
+                            !types::is_arithmetic_numeric(inner.value().type().type())) {
                             return unsupported_unary_minus_error(resource);
                         }
                         return types::logical_value_t::subtract(types::logical_value_t(resource, int64_t(0)),
@@ -268,7 +280,10 @@ namespace components::operators {
                         return r;
                     }
                     vector::arithmetic_op arithmetic_op;
-                    if (!scalar_to_arithmetic_op(scalar->type(), arithmetic_op) ||
+                    if (!scalar_to_arithmetic_op(scalar->type(), arithmetic_op)) {
+                        return unsupported_arithmetic_error(resource);
+                    }
+                    if (!l.value().is_null() && !r.value().is_null() &&
                         types::arithmetic_result_type(l.value().type().type(),
                                                       r.value().type().type(),
                                                       arithmetic_op) == types::logical_type::NA) {
@@ -648,10 +663,16 @@ namespace components::operators {
             if (operand_res.has_error()) {
                 return operand_res.convert_error<vector::vector_t>();
             }
+            uint64_t count = chunk.size();
+            if (detail::operand_type(operand_res.value()) == types::logical_type::NA) {
+                uint64_t out_count = count > 0 ? count : 1;
+                vector::vector_t nulls(resource, types::complex_logical_type(types::logical_type::NA), out_count);
+                nulls.validity().set_all_invalid(out_count);
+                return nulls;
+            }
             if (!types::is_arithmetic_numeric(detail::operand_type(operand_res.value()))) {
                 return detail::unsupported_unary_minus_error(resource);
             }
-            uint64_t count = chunk.size();
             if (operand_res.value().vec) {
                 return vector::compute_unary_neg(resource, *operand_res.value().vec, count);
             } else {
@@ -685,7 +706,9 @@ namespace components::operators {
             return core::error_t(core::error_code_t::arithmetics_failure,
                                  std::pmr::string{"Not an arithmetic scalar_type", resource});
         }
-        if (types::arithmetic_result_type(detail::operand_type(left_op.value()),
+        if (detail::operand_type(left_op.value()) != types::logical_type::NA &&
+            detail::operand_type(right_op.value()) != types::logical_type::NA &&
+            types::arithmetic_result_type(detail::operand_type(left_op.value()),
                                           detail::operand_type(right_op.value()),
                                           arith_op) == types::logical_type::NA) {
             return detail::unsupported_arithmetic_error(resource);

--- a/components/physical_plan/operators/operator_sort.cpp
+++ b/components/physical_plan/operators/operator_sort.cpp
@@ -11,19 +11,27 @@ namespace components::operators {
 
     operator_sort_t::operator_sort_t(std::pmr::memory_resource* resource, log_t log)
         : read_only_operator_t(resource, log, operator_type::sort)
-        , computed_keys_(resource) {}
+        , key_specs_(resource) {}
 
     void operator_sort_t::add(size_t index, operator_sort_t::order order_, operator_sort_t::null_order null_order_) {
-        sorter_.add(index, order_, null_order_);
+        sort_key_spec_t spec(resource_);
+        spec.col_path.push_back(index);
+        spec.order_ = order_;
+        spec.null_order_ = null_order_;
+        key_specs_.push_back(std::move(spec));
     }
 
     void operator_sort_t::add(const std::pmr::vector<size_t>& col_path,
                               order order_,
                               operator_sort_t::null_order null_order_) {
-        sorter_.add(col_path, order_, null_order_);
+        sort_key_spec_t spec(resource_);
+        spec.col_path.assign(col_path.begin(), col_path.end());
+        spec.order_ = order_;
+        spec.null_order_ = null_order_;
+        key_specs_.push_back(std::move(spec));
     }
 
-    void operator_sort_t::add_computed(computed_sort_key_t&& key) { computed_keys_.push_back(std::move(key)); }
+    void operator_sort_t::add_computed(sort_key_spec_t&& key) { key_specs_.push_back(std::move(key)); }
 
     core::error_t
     operator_sort_t::push(pipeline::context_t* /*ctx*/, vector::data_chunk_t&& input, chunks_vector_t& /*out*/) {
@@ -55,28 +63,40 @@ namespace components::operators {
         std::vector<std::vector<uint32_t>> sorted_indices;
         sorted_indices.reserve(in_chunks.size());
 
-        bool computed_added = false;
+        bool keys_registered = false;
+        bool has_computed = false;
         for (auto& chunk : in_chunks) {
             if (chunk.size() == 0) {
                 sorted_indices.emplace_back();
                 continue;
             }
-            for (const auto& ck : computed_keys_) {
+            // Walk the specs in ORDER BY position: a computed key materializes into a temp
+            // column, a plain key references its input column — and each is registered with
+            // the sorter at exactly its spec position, so priority follows the ORDER BY
+            // list, never the plain-before-computed registration order.
+            for (const auto& spec : key_specs_) {
+                if (spec.op == expressions::scalar_type::invalid) {
+                    if (!keys_registered) {
+                        sorter_.add(spec.col_path, spec.order_, spec.null_order_);
+                    }
+                    continue;
+                }
+                has_computed = true;
                 auto result_vec = evaluate_arithmetic(resource_,
-                                                      ck.op,
-                                                      ck.operands,
+                                                      spec.op,
+                                                      spec.operands,
                                                       chunk,
                                                       pipeline_context->parameters,
                                                       pipeline_context->session_tz);
                 if (result_vec.has_error()) {
                     return result_vec.error();
                 }
-                if (!computed_added) {
-                    sorter_.add(chunk.data.size(), ck.order_, ck.null_order_);
+                if (!keys_registered) {
+                    sorter_.add(chunk.data.size(), spec.order_, spec.null_order_);
                 }
                 chunk.data.emplace_back(std::move(result_vec.value()));
             }
-            computed_added = true;
+            keys_registered = true;
 
             std::vector<uint32_t> idx(chunk.size());
             std::iota(idx.begin(), idx.end(), uint32_t{0});
@@ -87,7 +107,7 @@ namespace components::operators {
 
         // Output column count (drop computed sort-key columns).
         size_t out_cols_effective = expected_output_count_ > 0 ? expected_output_count_ : first_computed_col;
-        if (!computed_keys_.empty() && out_cols_effective > first_computed_col) {
+        if (has_computed && out_cols_effective > first_computed_col) {
             out_cols_effective = first_computed_col;
         }
         if (out_types.size() > out_cols_effective) {
@@ -165,7 +185,7 @@ namespace components::operators {
         flush_cur();
 
         // Restore input chunks: strip the temporary computed-key columns.
-        if (!computed_keys_.empty()) {
+        if (has_computed) {
             for (auto& chunk : in_chunks) {
                 if (chunk.data.size() > first_computed_col) {
                     chunk.data.erase(chunk.data.begin() + static_cast<ptrdiff_t>(first_computed_col), chunk.data.end());

--- a/components/physical_plan/operators/operator_sort.hpp
+++ b/components/physical_plan/operators/operator_sort.hpp
@@ -8,14 +8,17 @@
 
 namespace components::operators {
 
-    // A sort key that must be computed via an arithmetic expression.
-    // Used when ORDER BY references a SELECT alias like "ORDER BY a + b" or "ORDER BY c"
-    // where c is defined as "a + b AS c" in the SELECT list.
-    struct computed_sort_key_t {
-        explicit computed_sort_key_t(std::pmr::memory_resource* r)
-            : operands(r) {}
+    // One ORDER BY key, held at its ORDER BY position — the position in the spec list IS
+    // the key's priority. A plain key references an input column (op == invalid, col_path
+    // set); a computed key (op != invalid) evaluates an arithmetic expression — e.g.
+    // "ORDER BY a + b" — into a temporary column at sort time.
+    struct sort_key_spec_t {
+        explicit sort_key_spec_t(std::pmr::memory_resource* r)
+            : operands(r)
+            , col_path(r) {}
         expressions::scalar_type op{expressions::scalar_type::invalid};
         std::pmr::vector<expressions::param_storage> operands;
+        std::pmr::vector<size_t> col_path;
         sort::order order_{sort::order::ascending};
         sort::null_order null_order_{sort::null_order::last};
     };
@@ -31,7 +34,7 @@ namespace components::operators {
         void add(const std::pmr::vector<size_t>& col_path,
                  order order_ = order::ascending,
                  null_order null_order_ = null_order::last);
-        void add_computed(computed_sort_key_t&& key);
+        void add_computed(sort_key_spec_t&& key);
 
         void set_expected_output_count(size_t n) { expected_output_count_ = n; }
         void set_limit(logical_plan::limit_t limit) { limit_ = limit; }
@@ -47,8 +50,12 @@ namespace components::operators {
         [[nodiscard]] core::error_t finalize(pipeline::context_t* ctx, chunks_vector_t& out) override;
 
     private:
+        // The sorter is populated once, inside sort_merge, by walking key_specs_ in order —
+        // a computed key's temporary-column index is unknowable before the first chunk's
+        // width is seen, and registering plain keys any earlier would demote every computed
+        // key to a trailing tie-breaker.
         sort::columnar_sorter_t sorter_;
-        std::pmr::vector<computed_sort_key_t> computed_keys_;
+        std::pmr::vector<sort_key_spec_t> key_specs_;
         size_t expected_output_count_{0};
         logical_plan::limit_t limit_;
         chunks_vector_t buffered_input_{resource_};

--- a/components/physical_plan_generator/impl/create_plan_sort.cpp
+++ b/components/physical_plan_generator/impl/create_plan_sort.cpp
@@ -48,7 +48,7 @@ namespace services::planner::impl {
                 // Computed arithmetic sort key (from ORDER BY arithmetic expression).
                 // Sort order is encoded in key.path()[0]: 0 = ascending, 1 = descending.
                 const auto* scalar_expr = static_cast<const components::expressions::scalar_expression_t*>(expr.get());
-                components::operators::computed_sort_key_t ck(plan_resource);
+                components::operators::sort_key_spec_t ck(plan_resource);
                 ck.op = scalar_expr->type();
                 ck.operands = scalar_expr->params();
                 const auto& sort_path = scalar_expr->key().path();

--- a/components/sql/transformer/impl/transform_select.cpp
+++ b/components/sql/transformer/impl/transform_select.cpp
@@ -1595,7 +1595,7 @@ namespace components::sql::transform {
                     // Arithmetic ORDER BY: encode as scalar_expression_t with sort order in key.path()[0]
                     // (0 = ascending, 1 = descending) and the NULLS placement in key.path()[1]
                     // (0 = default, 1 = first, 2 = last). create_plan_sort detects this and builds a
-                    // computed_sort_key_t instead of a regular sort key.
+                    // computed sort-key spec instead of a regular sort key.
                     auto a_expr = pg_ptr_cast<A_Expr>(sort_node);
                     if (!a_expr->name || a_expr->name->lst.empty()) {
                         error_ = core::error_t(core::error_code_t::sql_parse_error,

--- a/components/sql/transformer/impl/transform_select.cpp
+++ b/components/sql/transformer/impl/transform_select.cpp
@@ -1561,12 +1561,29 @@ namespace components::sql::transform {
                 auto sortby = pg_ptr_cast<SortBy>(sort_it.data);
                 bool is_desc = sortby->sortby_dir == SORTBY_DESC;
                 auto null_ord = map_sortby_nulls(sortby->sortby_nulls);
-                if (nodeTag(sortby->node) == T_ColumnRef) {
-                    column_ref_t field = columnref_to_field(resource_, pg_ptr_cast<ColumnRef>(sortby->node), names);
+                // Unary plus is the identity: strip every `+`-layer and dispatch on what remains
+                // (`+v` sorts as v, `+(a+b)` as the expression, `+2` as the positional constant).
+                // A unary operator arrives as A_Expr{op, lexpr = NULL, rexpr = operand}.
+                Node* sort_node = sortby->node;
+                while (sort_node && nodeTag(sort_node) == T_A_Expr) {
+                    auto* plus = pg_ptr_cast<A_Expr>(sort_node);
+                    if (plus->lexpr != nullptr || !plus->name || plus->name->lst.empty() ||
+                        std::string_view(strVal(plus->name->lst.front().data)) != "+") {
+                        break;
+                    }
+                    sort_node = plus->rexpr;
+                }
+                if (!sort_node) {
+                    error_ = core::error_t(core::error_code_t::sql_parse_error,
+                                           std::pmr::string{"ORDER BY operator is missing its operand", resource_});
+                    return nullptr;
+                }
+                if (nodeTag(sort_node) == T_ColumnRef) {
+                    column_ref_t field = columnref_to_field(resource_, pg_ptr_cast<ColumnRef>(sort_node), names);
                     sort_exprs.emplace_back(
                         make_sort_expression(field.field, is_desc ? sort_order::desc : sort_order::asc, null_ord));
-                } else if (nodeTag(sortby->node) == T_A_Indirection) {
-                    auto res = indirection_to_field(resource_, pg_ptr_cast<A_Indirection>(sortby->node), names);
+                } else if (nodeTag(sort_node) == T_A_Indirection) {
+                    auto res = indirection_to_field(resource_, pg_ptr_cast<A_Indirection>(sort_node), names);
                     if (res.has_error()) {
                         error_ = res.error();
                         return nullptr;
@@ -1574,33 +1591,46 @@ namespace components::sql::transform {
                     column_ref_t field = std::move(res.value());
                     sort_exprs.emplace_back(
                         make_sort_expression(field.field, is_desc ? sort_order::desc : sort_order::asc, null_ord));
-                } else if (nodeTag(sortby->node) == T_A_Expr) {
+                } else if (nodeTag(sort_node) == T_A_Expr) {
                     // Arithmetic ORDER BY: encode as scalar_expression_t with sort order in key.path()[0]
                     // (0 = ascending, 1 = descending) and the NULLS placement in key.path()[1]
                     // (0 = default, 1 = first, 2 = last). create_plan_sort detects this and builds a
                     // computed_sort_key_t instead of a regular sort key.
-                    auto a_expr = pg_ptr_cast<A_Expr>(sortby->node);
+                    auto a_expr = pg_ptr_cast<A_Expr>(sort_node);
+                    if (!a_expr->name || a_expr->name->lst.empty()) {
+                        error_ = core::error_t(core::error_code_t::sql_parse_error,
+                                               std::pmr::string{"Unsupported operator in ORDER BY", resource_});
+                        return nullptr;
+                    }
                     auto op_str = std::string_view(strVal(a_expr->name->lst.front().data));
                     if (!is_arithmetic_operator(op_str)) {
                         error_ = core::error_t(core::error_code_t::sql_parse_error,
                                                std::pmr::string{"Unsupported operator in ORDER BY", resource_});
                         return nullptr;
                     }
-                    std::string sort_alias = "__sort_expr_" + std::to_string(aggregate_counter_++);
-                    auto stype = get_arithmetic_scalar_type(op_str);
+                    // A unary operator carries its operand in rexpr only; after `+`-stripping the
+                    // only arithmetic one left is negation, evaluated as the one-operand
+                    // scalar_type::unary_minus (never as a one-legged binary subtract).
+                    const bool is_unary = a_expr->lexpr == nullptr;
+                    if (!a_expr->rexpr || (is_unary && op_str != "-")) {
+                        error_ = core::error_t(core::error_code_t::sql_parse_error,
+                                               std::pmr::string{"Unsupported operator in ORDER BY", resource_});
+                        return nullptr;
+                    }
+                    auto stype = is_unary ? expressions::scalar_type::unary_minus : get_arithmetic_scalar_type(op_str);
                     expressions::key_t order_key(resource_);
                     order_key.set_path({is_desc ? size_t(1) : size_t(0), static_cast<size_t>(null_ord)});
                     auto computed_sort = make_scalar_expression(resource_, stype, std::move(order_key));
                     // Resolve operands (without appending to any node — purely for sort)
                     logical_plan::node_ptr dummy_node = group; // resolve_select_operand needs a node_ptr
-                    computed_sort->append_param(resolve_select_operand(a_expr->lexpr, names, plan, dummy_node));
-                    if (a_expr->rexpr) {
-                        computed_sort->append_param(resolve_select_operand(a_expr->rexpr, names, plan, dummy_node));
+                    if (!is_unary) {
+                        computed_sort->append_param(resolve_select_operand(a_expr->lexpr, names, plan, dummy_node));
                     }
+                    computed_sort->append_param(resolve_select_operand(a_expr->rexpr, names, plan, dummy_node));
                     sort_exprs.emplace_back(std::move(computed_sort));
-                } else if (nodeTag(sortby->node) == T_A_Const) {
+                } else if (nodeTag(sort_node) == T_A_Const) {
                     // Positional `ORDER BY <n>`: map to the n-th output column of this SELECT.
-                    auto* value = &(pg_ptr_cast<A_Const>(sortby->node)->val);
+                    auto* value = &(pg_ptr_cast<A_Const>(sort_node)->val);
                     if (nodeTag(value) != T_Integer) {
                         error_ = core::error_t(core::error_code_t::sql_parse_error,
                                                std::pmr::string{"non-integer constant in ORDER BY", resource_});
@@ -1615,7 +1645,7 @@ namespace components::sql::transform {
                 } else {
                     error_ = core::error_t(
                         core::error_code_t::sql_parse_error,
-                        std::pmr::string{"Unknown node type in ORDER BY: " + node_tag_to_string(nodeTag(sortby->node)),
+                        std::pmr::string{"Unknown node type in ORDER BY: " + node_tag_to_string(nodeTag(sort_node)),
                                          resource_});
                     return nullptr;
                 }

--- a/integration/cpp/test/CMakeLists.txt
+++ b/integration/cpp/test/CMakeLists.txt
@@ -17,6 +17,7 @@ set( ${PROJECT_NAME}_SOURCES
         test_unique_constraint_operator.cpp
         test_create_index_backfill_batched.cpp
         test_correctness_bugs.cpp
+        test_order_by_expressions.cpp
         test_order_by_nulls.cpp
         test_multi_database_isolation.cpp
         test_index_null_correctness.cpp

--- a/integration/cpp/test/test_order_by_expressions.cpp
+++ b/integration/cpp/test/test_order_by_expressions.cpp
@@ -449,3 +449,82 @@ TEST_CASE("integration::cpp::order_by_expressions::computed_key_over_ungrouped_c
     REQUIRE(cur->is_error());
 }
 
+TEST_CASE("integration::cpp::order_by_expressions::unary_minus_nulls_first") {
+    auto config = test_create_config("/tmp/test_order_by_expressions/unary_nulls_first");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE db;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE db.n (id INT, v BIGINT);")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher
+                    ->execute_sql(session, "INSERT INTO db.n (id, v) VALUES (1, 5), (2, NULL), (3, 7);")
+                    ->is_success());
+    }
+
+    // Explicit NULLS FIRST rides key.path()[1] through the computed-key spec: the NULL row
+    // leads, then -v ascending = v descending (id 3 before id 1).
+    auto session = otterbrix::session_id_t();
+    auto cur = dispatcher->execute_sql(session, "SELECT id FROM db.n ORDER BY -v NULLS FIRST;");
+    REQUIRE(cur->is_success());
+    REQUIRE(cur->size() == 3);
+    REQUIRE(cur->value(0, 0).value<int32_t>() == 2);
+    REQUIRE(cur->value(0, 1).value<int32_t>() == 3);
+    REQUIRE(cur->value(0, 2).value<int32_t>() == 1);
+}
+
+TEST_CASE("integration::cpp::order_by_expressions::computed_desc_nulls_placement") {
+    auto config = test_create_config("/tmp/test_order_by_expressions/computed_desc_nulls");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE db;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE db.n (id INT, v BIGINT);")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher
+                    ->execute_sql(session, "INSERT INTO db.n (id, v) VALUES (1, 5), (2, NULL), (3, 7);")
+                    ->is_success());
+    }
+
+    // v + 0 is NULL for the NULL row (three-valued logic); a descending computed key
+    // defaults to NULLS FIRST, and an explicit NULLS LAST overrides it.
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT id FROM db.n ORDER BY v + 0 DESC;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 3);
+        REQUIRE(cur->value(0, 0).value<int32_t>() == 2);
+        REQUIRE(cur->value(0, 1).value<int32_t>() == 3);
+        REQUIRE(cur->value(0, 2).value<int32_t>() == 1);
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT id FROM db.n ORDER BY v + 0 DESC NULLS LAST;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 3);
+        REQUIRE(cur->value(0, 0).value<int32_t>() == 3);
+        REQUIRE(cur->value(0, 1).value<int32_t>() == 1);
+        REQUIRE(cur->value(0, 2).value<int32_t>() == 2);
+    }
+}
+

--- a/integration/cpp/test/test_order_by_expressions.cpp
+++ b/integration/cpp/test/test_order_by_expressions.cpp
@@ -205,6 +205,109 @@ TEST_CASE("integration::cpp::order_by_expressions::unary_minus_double_column") {
     REQUIRE((cur->value(0, 2).value<double>() > -2.6 && cur->value(0, 2).value<double>() < -2.4));
 }
 
+TEST_CASE("integration::cpp::order_by_expressions::mixed_key_priority") {
+    auto config = test_create_config("/tmp/test_order_by_expressions/mixed_keys");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+    setup(dispatcher);
+
+    {
+        INFO("a leading computed key outranks a plain tie-breaker: ORDER BY g + 0 DESC, v ASC");
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT v FROM db.t ORDER BY g + 0 DESC, v ASC;");
+        // g DESC groups {2,2} before {1,1}; v ASC inside each group.
+        check_order(cur, {20, 30, 10, 40});
+    }
+
+    {
+        INFO("the same ordering with a plain leading key is the reference");
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT v FROM db.t ORDER BY g DESC, v ASC;");
+        check_order(cur, {20, 30, 10, 40});
+    }
+
+    {
+        INFO("a trailing computed key stays the tie-breaker: ORDER BY g ASC, v + 0 DESC");
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT v FROM db.t ORDER BY g ASC, v + 0 DESC;");
+        // g ASC groups {1,1} before {2,2}; v DESC inside each group.
+        check_order(cur, {40, 10, 30, 20});
+    }
+
+    {
+        INFO("a computed key sandwiched between plain keys keeps its rank");
+        auto session = otterbrix::session_id_t();
+        // id % never ties, so use g twice: g ASC, then -v (computed) breaks ties descending v last.
+        auto cur = dispatcher->execute_sql(session, "SELECT v FROM db.t ORDER BY g ASC, -v ASC, id ASC;");
+        // g ASC: {10(g1), 40(g1)} then {30(g2), 20(g2)}; -v ASC = v DESC inside each group.
+        check_order(cur, {40, 10, 30, 20});
+    }
+
+    {
+        INFO("two computed keys keep their relative priority: ORDER BY g + 0 ASC, v + 0 DESC");
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT v FROM db.t ORDER BY g + 0 ASC, v + 0 DESC;");
+        check_order(cur, {40, 10, 30, 20});
+    }
+
+    {
+        INFO("computed temp columns never leak into the result schema");
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT v, g FROM db.t ORDER BY g + 0 DESC, v ASC;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 4);
+        REQUIRE(cur->chunks().front().column_count() == 2);
+    }
+}
+
+TEST_CASE("integration::cpp::order_by_expressions::mixed_key_priority_multichunk") {
+    auto config = test_create_config("/tmp/test_order_by_expressions/mixed_multichunk");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE db;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE db.big (id INT, grp INT);")->is_success());
+    }
+    // > DEFAULT_VECTOR_CAPACITY rows so the k-way merge runs with computed keys at
+    // interleaved priorities across several chunks.
+    {
+        std::string values;
+        for (int i = 0; i < 3000; ++i) {
+            if (i) {
+                values += ", ";
+            }
+            values += "(" + std::to_string(i) + ", " + std::to_string(i % 3) + ")";
+        }
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "INSERT INTO db.big (id, grp) VALUES " + values + ";")->is_success());
+    }
+
+    {
+        INFO("leading computed key over 3000 rows: ORDER BY grp + 0 DESC, id ASC");
+        auto session = otterbrix::session_id_t();
+        auto cur =
+            dispatcher->execute_sql(session, "SELECT id, grp FROM db.big ORDER BY grp + 0 DESC, id ASC LIMIT 4;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 4);
+        // grp DESC puts grp==2 first; within it id ASC: 2, 5, 8, 11.
+        REQUIRE(cur->value(0, 0).value<int32_t>() == 2);
+        REQUIRE(cur->value(0, 1).value<int32_t>() == 5);
+        REQUIRE(cur->value(0, 2).value<int32_t>() == 8);
+        REQUIRE(cur->value(0, 3).value<int32_t>() == 11);
+    }
+}
+
 TEST_CASE("integration::cpp::order_by_expressions::unary_minus_empty_table") {
     auto config = test_create_config("/tmp/test_order_by_expressions/unary_empty");
     test_clear_directory(config);

--- a/integration/cpp/test/test_order_by_expressions.cpp
+++ b/integration/cpp/test/test_order_by_expressions.cpp
@@ -411,3 +411,41 @@ TEST_CASE("integration::cpp::order_by_expressions::null_literal_arithmetic_keys"
         REQUIRE(cur->size() == 2);
     }
 }
+
+TEST_CASE("integration::cpp::order_by_expressions::computed_key_over_group_output") {
+    auto config = test_create_config("/tmp/test_order_by_expressions/group_computed");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+    setup(dispatcher);
+
+    // The grouped validation path used to cast every ORDER BY child to sort_expression_t;
+    // a computed key's direction encoding then reached column-path resolution and the
+    // whole statement crashed before execution. A computed key over a GROUP BY output
+    // column is valid SQL and must sort the aggregated rows.
+    auto session = otterbrix::session_id_t();
+    auto cur = dispatcher->execute_sql(session, "SELECT g, COUNT(*) FROM db.t GROUP BY g ORDER BY g + 0 DESC;");
+    REQUIRE(cur->is_success());
+    REQUIRE(cur->size() == 2);
+    REQUIRE(cur->value(0, 0).value<int32_t>() == 2);
+    REQUIRE(cur->value(0, 1).value<int32_t>() == 1);
+}
+
+TEST_CASE("integration::cpp::order_by_expressions::computed_key_over_ungrouped_column_is_error") {
+    auto config = test_create_config("/tmp/test_order_by_expressions/group_computed_bad");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+    setup(dispatcher);
+
+    // PostgreSQL parity: an ORDER BY expression over a column that is neither grouped nor
+    // aggregated must be rejected cleanly.
+    auto session = otterbrix::session_id_t();
+    auto cur = dispatcher->execute_sql(session, "SELECT g, COUNT(*) FROM db.t GROUP BY g ORDER BY v + 0 DESC;");
+    REQUIRE(cur->is_error());
+}
+

--- a/integration/cpp/test/test_order_by_expressions.cpp
+++ b/integration/cpp/test/test_order_by_expressions.cpp
@@ -263,3 +263,48 @@ TEST_CASE("integration::cpp::order_by_expressions::unary_over_null_rows") {
     REQUIRE(cur->value(0, 1).value<int32_t>() == 1);
     REQUIRE(cur->value(0, 2).value<int32_t>() == 2);
 }
+
+TEST_CASE("integration::cpp::order_by_expressions::null_literal_arithmetic_keys") {
+    auto config = test_create_config("/tmp/test_order_by_expressions/null_literal_keys");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE db;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE db.n (id INT, v BIGINT);")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher
+                    ->execute_sql(session, "INSERT INTO db.n (id, v) VALUES (1, 5), (2, 7);")
+                    ->is_success());
+    }
+
+    // A NULL literal in arithmetic answers NULL (three-valued logic), never an operator
+    // error: every key compares equal and the statement succeeds with all rows.
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT id FROM db.n ORDER BY v + NULL;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 2);
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT id FROM db.n ORDER BY -(v + NULL);");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 2);
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT id FROM db.n ORDER BY -(NULL);");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 2);
+    }
+}

--- a/integration/cpp/test/test_order_by_expressions.cpp
+++ b/integration/cpp/test/test_order_by_expressions.cpp
@@ -1,0 +1,265 @@
+#include "test_config.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <components/types/logical_value.hpp>
+#include <core/operations_helper.hpp>
+
+// ORDER BY over expression keys: unary operators and mixed plain/computed key lists.
+// Issue #558 (A: `ORDER BY -v` crashed; B: a leading arithmetic key was demoted to a
+// tie-breaker so `ORDER BY g + 0 DESC, v ASC` silently sorted by v).
+
+namespace {
+
+    // The shared 4-row fixture: v and g deliberately disagree on order so a dropped or
+    // demoted key is visible in the output, not just in timing.
+    //   id: 1   2   3   4
+    //   v : 30  10  20  40
+    //   g : 2   1   2   1
+    void setup(otterbrix::wrapper_dispatcher_t* dispatcher) {
+        {
+            auto session = otterbrix::session_id_t();
+            REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE db;")->is_success());
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE db.t (id INT, v BIGINT, g INT);")->is_success());
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            REQUIRE(dispatcher
+                        ->execute_sql(session,
+                                      "INSERT INTO db.t (id, v, g) VALUES (1, 30, 2), (2, 10, 1), "
+                                      "(3, 20, 2), (4, 40, 1);")
+                        ->is_success());
+        }
+    }
+
+    // Assert a single-BIGINT-column result equals `expected` top to bottom.
+    void check_order(const components::cursor::cursor_t_ptr& cur, const std::vector<int64_t>& expected) {
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == expected.size());
+        for (size_t i = 0; i < expected.size(); ++i) {
+            REQUIRE(cur->value(0, i).value<int64_t>() == expected[i]);
+        }
+    }
+
+} // namespace
+
+TEST_CASE("integration::cpp::order_by_expressions::unary_minus_evaluation") {
+    auto config = test_create_config("/tmp/test_order_by_expressions/unary_eval");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE db;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE db.m (id INT, v BIGINT, s TEXT);")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher
+                    ->execute_sql(session,
+                                  "INSERT INTO db.m (id, v, s) VALUES (1, 5, 'a'), (2, NULL, 'b'), (3, 7, 'c');")
+                    ->is_success());
+    }
+
+    {
+        INFO("negating a TEXT column is a clean error, not a crash");
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT -s FROM db.m;");
+        REQUIRE(cur->is_error());
+    }
+
+    {
+        INFO("negating a NULL keeps it NULL");
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT -v FROM db.m;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 3);
+        REQUIRE(cur->value(0, 0).value<int64_t>() == -5);
+        REQUIRE(cur->value(0, 1).is_null());
+        REQUIRE(cur->value(0, 2).value<int64_t>() == -7);
+    }
+}
+
+TEST_CASE("integration::cpp::order_by_expressions::unary_minus") {
+    auto config = test_create_config("/tmp/test_order_by_expressions/unary_minus");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+    setup(dispatcher);
+
+    {
+        INFO("ORDER BY -v sorts by the negated value (descending v)");
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT v FROM db.t ORDER BY -v;");
+        check_order(cur, {40, 30, 20, 10});
+    }
+
+    {
+        INFO("ORDER BY -v DESC inverts back to ascending v");
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT v FROM db.t ORDER BY -v DESC;");
+        check_order(cur, {10, 20, 30, 40});
+    }
+
+    {
+        INFO("unary plus is the identity: ORDER BY +v is ascending v");
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT v FROM db.t ORDER BY +v;");
+        check_order(cur, {10, 20, 30, 40});
+    }
+
+    {
+        INFO("nested operand: ORDER BY -(v + 1)");
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT v FROM db.t ORDER BY -(v + 1);");
+        check_order(cur, {40, 30, 20, 10});
+    }
+
+    {
+        INFO("unary minus over an INT key column");
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT id FROM db.t ORDER BY -id;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 4);
+        REQUIRE(cur->value(0, 0).value<int32_t>() == 4);
+        REQUIRE(cur->value(0, 3).value<int32_t>() == 1);
+    }
+
+    {
+        INFO("stacked unary plus strips down to the operand: ORDER BY ++v");
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT v FROM db.t ORDER BY ++v;");
+        check_order(cur, {10, 20, 30, 40});
+    }
+
+    {
+        INFO("unary plus over an expression: ORDER BY +(v + 1)");
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT v FROM db.t ORDER BY +(v + 1);");
+        check_order(cur, {10, 20, 30, 40});
+    }
+
+    {
+        INFO("double negation: ORDER BY -(-v)");
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT v FROM db.t ORDER BY -(-v);");
+        check_order(cur, {10, 20, 30, 40});
+    }
+
+    {
+        INFO("negating a TEXT sort key is a clean error, not a crash");
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE db.txt (s TEXT);")->is_success());
+        auto session2 = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session2, "INSERT INTO db.txt (s) VALUES ('a');")->is_success());
+        auto session3 = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session3, "SELECT s FROM db.txt ORDER BY -s;");
+        REQUIRE(cur->is_error());
+    }
+
+    {
+        INFO("ORDER BY -2 folds to a negative positional constant: clean error, not a crash");
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT v FROM db.t ORDER BY -2;");
+        REQUIRE(cur->is_error());
+    }
+}
+
+TEST_CASE("integration::cpp::order_by_expressions::unary_minus_double_column") {
+    auto config = test_create_config("/tmp/test_order_by_expressions/unary_double");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE db;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE db.d (x DOUBLE);")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "INSERT INTO db.d (x) VALUES (1.5), (-2.5), (0.5);")->is_success());
+    }
+
+    auto session = otterbrix::session_id_t();
+    auto cur = dispatcher->execute_sql(session, "SELECT x FROM db.d ORDER BY -x;");
+    REQUIRE(cur->is_success());
+    REQUIRE(cur->size() == 3);
+    REQUIRE((cur->value(0, 0).value<double>() > 1.4 && cur->value(0, 0).value<double>() < 1.6));
+    REQUIRE((cur->value(0, 1).value<double>() > 0.4 && cur->value(0, 1).value<double>() < 0.6));
+    REQUIRE((cur->value(0, 2).value<double>() > -2.6 && cur->value(0, 2).value<double>() < -2.4));
+}
+
+TEST_CASE("integration::cpp::order_by_expressions::unary_minus_empty_table") {
+    auto config = test_create_config("/tmp/test_order_by_expressions/unary_empty");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE db;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE db.e (v BIGINT);")->is_success());
+    }
+
+    // The #558.A crash fired during SQL->plan transformation, before any row was read,
+    // so the empty table is the minimal reproduction.
+    auto session = otterbrix::session_id_t();
+    auto cur = dispatcher->execute_sql(session, "SELECT v FROM db.e ORDER BY -v;");
+    REQUIRE(cur->is_success());
+    REQUIRE(cur->size() == 0);
+}
+
+TEST_CASE("integration::cpp::order_by_expressions::unary_over_null_rows") {
+    auto config = test_create_config("/tmp/test_order_by_expressions/unary_null");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE db;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE db.n (id INT, v BIGINT);")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher
+                    ->execute_sql(session, "INSERT INTO db.n (id, v) VALUES (1, 5), (2, NULL), (3, 7);")
+                    ->is_success());
+    }
+
+    // A NULL sort key sorts LAST (the sorter's ordering convention): -v over {5, NULL, 7}
+    // is {-5, NULL, -7}, so ascending order is -7 (id 3), -5 (id 1), NULL (id 2).
+    auto session = otterbrix::session_id_t();
+    auto cur = dispatcher->execute_sql(session, "SELECT id FROM db.n ORDER BY -v;");
+    REQUIRE(cur->is_success());
+    REQUIRE(cur->size() == 3);
+    REQUIRE(cur->value(0, 0).value<int32_t>() == 3);
+    REQUIRE(cur->value(0, 1).value<int32_t>() == 1);
+    REQUIRE(cur->value(0, 2).value<int32_t>() == 2);
+}

--- a/services/dispatcher/validate_logical_plan.cpp
+++ b/services/dispatcher/validate_logical_plan.cpp
@@ -2689,6 +2689,12 @@ namespace services::dispatcher {
                 if (node_sort) {
                     // Add hidden columns for sort keys not in the GROUP output
                     for (auto& sort_child : node_sort->expressions()) {
+                        if (sort_child->group() != expression_group::sort) {
+                            // A computed (scalar) sort key has no column of its own — its key
+                            // carries the direction encoding, not a name. Its operands are
+                            // resolved against the GROUP output by validate_schema below.
+                            continue;
+                        }
                         auto* sort_expr = static_cast<sort_expression_t*>(sort_child.get());
                         auto& skey = sort_expr->key();
                         // Try resolving in the GROUP result schema first


### PR DESCRIPTION
Fixes the two ORDER BY expression-key defects from #558 (section A crash + section B silent wrong order), the unary-negation evaluator hazards they exposed, and a grouped-ORDER-BY validation crash in the same family.

### 1. `ORDER BY -v` crashed the process (#558.A)

The parser emits a unary operator as `A_Expr{op, lexpr = NULL, rexpr}`, and the ORDER BY arithmetic arm passed `lexpr` into operand resolution unguarded — a null dereference during SQL→plan transformation, so even an empty table crashed.

```sql
CREATE TABLE db.t (id INT, v BIGINT);
SELECT v FROM db.t ORDER BY -v;   -- before: SIGSEGV; now: descending v
SELECT v FROM db.t ORDER BY +v;   -- before: SIGSEGV; now: ascending v (identity, also ++v, +(v+1))
SELECT v FROM db.t ORDER BY -(v + 1);  -- nested operands work
```

`-expr` is evaluated as the one-operand `unary_minus` scalar; unary `+` strips down to its operand and re-dispatches (column / expression / positional constant). Explicit NULLS placement rides along: `ORDER BY -v NULLS FIRST` and `ORDER BY v + 0 DESC NULLS LAST` honor the request, and a descending computed key defaults to NULLS FIRST like a plain one.

### 2. A leading arithmetic sort key was silently demoted (#558.B)

Plain keys were registered with the comparator at plan time, computed keys appended after the first chunk — so every computed key ranked behind every plain key regardless of the ORDER BY list.

```sql
INSERT INTO db.t (id, v, g) VALUES (1, 30, 2), (2, 10, 1), (3, 20, 2), (4, 40, 1);
SELECT v FROM db.t ORDER BY g + 0 DESC, v ASC;
-- before: 10, 20, 30, 40   (sorted by v ASC; the leading key never applied)
-- now:    20, 30, 10, 40   (matches ORDER BY g DESC, v ASC)
```

Sort keys now live in one position-preserving spec list; the comparator is built once inside the sort operator, walking the specs in ORDER BY position (a computed key's temp-column index is unknowable before the first chunk's width is seen). The materialize-then-strip flow and the k-way merge are unchanged.

### 3. NULL literals in arithmetic answer NULL, not an operator error

The operand type guards from #592 sweep up NA-typed operands — NULL literals and all-NULL nested results — although three-valued logic makes their result NULL. A computed sort key has no bind-time projection check, so the runtime guard was the deciding one:

```sql
SELECT id FROM db.n ORDER BY v + NULL;     -- before: ERROR arithmetic requires numeric...; now: rows, all keys NULL
SELECT id FROM db.n ORDER BY -(v + NULL);  -- same
SELECT id FROM db.n ORDER BY -(NULL);      -- same
SELECT id FROM db.n ORDER BY -v;           -- v = {5, NULL, 7}: NULL-key rows keep three-valued placement
```

NA-typed operands now pass through: unary minus over NA produces an NA-typed all-invalid vector, the kernels' own NA path handles the binary case, and the per-row CASE arms defer to the value ops' NULL early-outs. Concrete non-arithmetic types keep #592's operator errors ("unary minus requires a numeric operand").

### 4. Grouped ORDER BY over a computed key crashed at validation

The grouped-aggregate path cast every ORDER BY child to a plain sort key before synthesizing hidden columns; a computed key's direction encoding reached column-path resolution and the statement crashed before execution.

```sql
SELECT g, COUNT(*) FROM db.t GROUP BY g ORDER BY g + 0 DESC;  -- before: SIGSEGV; now: sorted aggregate
SELECT g, COUNT(*) FROM db.t GROUP BY g ORDER BY v + 0 DESC;  -- ungrouped column: clean validation error (PostgreSQL parity)
```

### Tests

`integration/cpp/test/test_order_by_expressions.cpp` — 12 cases / 175 assertions: the unary matrix (`-v`, `-v DESC`, `+v`, `++v`, `+(v+1)`, `-(-v)`, `-id`, DOUBLE keys, empty table, NULL rows, NULL-literal operands, TEXT as a clean error), the key-priority matrix (leading/trailing/sandwiched/two computed keys against plain-key references, temp columns never leaking, 3000-row multi-chunk merge under LIMIT), NULLS FIRST/LAST through computed keys, and the grouped cases. Every case crashed or returned the wrong order before the fix.

Full integration suite: 1401/1401 on this branch.

### Performance

The repo's TPCH suite (SF 0.01) does not yet run on this engine (identical failure sets on main and this branch). Measured instead: `profile_arithmetic` (16 arithmetic queries × 1000 iterations, every query ending in ORDER BY) — 6.81 ms/query on this branch vs 6.82 on main (3-run averages); and the 100k-row ORDER BY micro-benchmark via the C API showed no regression on plain, computed, and multi-key sorts.
