### PR TITLE
Reject non-string LIKE patterns without crashing

### DIFF
--- a/components/sql/transformer/impl/transfrom_common.cpp
+++ b/components/sql/transformer/impl/transfrom_common.cpp
@@ -541,6 +541,15 @@ namespace components::sql::transform {
                         // that would turn match-nothing into match-everything.
                         return make_compare_expression(resource_, compare_type::all_false);
                     }
+                    // LIKE patterns are text-only. Reading a numeric/bool payload through
+                    // value<std::string_view>() below treats it as a std::string pointer and
+                    // crashes before the executor's regex operand guards can report an error.
+                    if (!types::is_string(raw_val.value().type().type())) {
+                        error_ =
+                            core::error_t(core::error_code_t::sql_parse_error,
+                                          std::pmr::string{"LIKE: right side must be a string", resource_});
+                        return nullptr;
+                    }
                     auto pattern = expressions::like_to_regex(std::string(raw_val.value().value<std::string_view>()));
                     auto param_id = plan->parameters->add_parameter(types::logical_value_t(resource_, pattern));
                     const bool icase = (op_str == "~~*" || op_str == "!~~*");  // ILIKE / NOT ILIKE

--- a/integration/cpp/test/test_sql_features.cpp
+++ b/integration/cpp/test/test_sql_features.cpp
@@ -508,7 +508,7 @@ TEST_CASE("integration::cpp::test_sql_features::like_disk_pushdown") {
     }
 }
 
-TEST_CASE("integration::cpp::test_sql_features::like_non_string_subject_errors") {
+TEST_CASE("integration::cpp::test_sql_features::like_non_string_operand_errors") {
     // The RE2 migration dropped the old std::regex dispatcher's operand type guard: a non-string
     // LIKE subject reached value<std::string_view>() — *reinterpret_cast<std::string*> over an
     // integer payload — and SEGFAULTED (in-memory regex_predicate::check_impl) or reinterpreted the
@@ -560,6 +560,13 @@ TEST_CASE("integration::cpp::test_sql_features::like_non_string_subject_errors")
         auto cur = dispatcher->execute_sql(session,
                                            "SELECT t.id FROM regexdb.t t JOIN regexdb.d d ON t.id = d.id "
                                            "WHERE t.id LIKE '1%' OR d.k = 999;");
+        REQUIRE(cur->is_error());
+    }
+
+    INFO("non-string LIKE pattern must error before regex conversion, not crash");
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT * FROM regexdb.t WHERE s LIKE 1;");
         REQUIRE(cur->is_error());
     }
 


### PR DESCRIPTION
## Summary

- reject scalar `LIKE`/`ILIKE` patterns whose literal value is not a string
- return a SQL type error before attempting regex conversion
- extend the existing non-string operand regression test to cover `s LIKE 1`

## Root cause

The scalar `LIKE` transformer converted every non-null pattern through
`logical_value_t::value<std::string_view>()`. For a numeric literal, that
reinterpreted the integer payload as a string pointer and caused a `SIGSEGV`
before the executor's operand guards could report an error.

## Impact

Queries such as `WHERE s LIKE 1` now fail cleanly instead of crashing. Existing
coverage continues to verify that a non-string subject such as
`WHERE id LIKE '1%'` also returns an error, while valid string `LIKE` queries
still work.

## Validation

- Red: removed only the new guard, rebuilt, and ran the regression; it exited
  `139` with `SIGSEGV` (`7` assertions passed, `1` failed).
- Green: restored the guard, rebuilt, and reran the identical regression; all
  `10` assertions passed.
- Existing scalar `LIKE` test: all `22` assertions passed.
- Existing NULL-pattern test: all `11` assertions passed.

This addresses the non-string `LIKE` operand portion of #558.

I'm sorry for the slop, blame the other guy.
