### PR TITLE
Reject unsupported boolean and text arithmetic

### DIFF
--- a/components/physical_plan/operators/arithmetic_eval.cpp
+++ b/components/physical_plan/operators/arithmetic_eval.cpp
@@ -32,6 +32,21 @@ namespace components::operators {
             }
         }
 
+        types::logical_type operand_type(const resolved_operand& operand) {
+            return operand.vec ? operand.vec->type().type() : operand.scalar->type().type();
+        }
+
+        core::error_t unsupported_arithmetic_error(std::pmr::memory_resource* resource) {
+            return core::error_t(core::error_code_t::arithmetics_failure,
+                                 std::pmr::string{"arithmetic requires numeric or compatible temporal operands",
+                                                  resource});
+        }
+
+        core::error_t unsupported_unary_minus_error(std::pmr::memory_resource* resource) {
+            return core::error_t(core::error_code_t::arithmetics_failure,
+                                 std::pmr::string{"unary minus requires a numeric operand", resource});
+        }
+
         core::result_wrapper_t<resolved_operand> resolve_operand(const expressions::param_storage& param,
                                                                  vector::data_chunk_t& chunk,
                                                                  const logical_plan::storage_parameters& params,
@@ -80,6 +95,9 @@ namespace components::operators {
                         if (inner_op.has_error()) {
                             return inner_op;
                         }
+                        if (!types::is_arithmetic_numeric(operand_type(inner_op.value()))) {
+                            return unsupported_unary_minus_error(resource);
+                        }
 
                         uint64_t count = chunk.size();
                         vector::vector_t computed(resource,
@@ -121,6 +139,10 @@ namespace components::operators {
                     auto right_op = resolve_operand(operands[1], chunk, params, resource, sub_temps, session_tz);
                     if (right_op.has_error()) {
                         return right_op;
+                    }
+                    if (types::arithmetic_result_type(operand_type(left_op.value()), operand_type(right_op.value()), op) ==
+                        types::logical_type::NA) {
+                        return unsupported_arithmetic_error(resource);
                     }
                     uint64_t count = chunk.size();
 
@@ -229,6 +251,9 @@ namespace components::operators {
                         if (inner.has_error()) {
                             return inner;
                         }
+                        if (!types::is_arithmetic_numeric(inner.value().type().type())) {
+                            return unsupported_unary_minus_error(resource);
+                        }
                         return types::logical_value_t::subtract(types::logical_value_t(resource, int64_t(0)),
                                                                 inner.value());
                     }
@@ -245,6 +270,13 @@ namespace components::operators {
                     auto r = resolve_row_value(resource, scalar->params()[1], chunk, params, row_idx, session_tz);
                     if (r.has_error()) {
                         return r;
+                    }
+                    vector::arithmetic_op arithmetic_op;
+                    if (!scalar_to_arithmetic_op(scalar->type(), arithmetic_op) ||
+                        types::arithmetic_result_type(l.value().type().type(),
+                                                      r.value().type().type(),
+                                                      arithmetic_op) == types::logical_type::NA) {
+                        return unsupported_arithmetic_error(resource);
                     }
                     switch (scalar->type()) {
                         case expressions::scalar_type::add:
@@ -620,6 +652,9 @@ namespace components::operators {
             if (operand_res.has_error()) {
                 return operand_res.convert_error<vector::vector_t>();
             }
+            if (!types::is_arithmetic_numeric(detail::operand_type(operand_res.value()))) {
+                return detail::unsupported_unary_minus_error(resource);
+            }
             uint64_t count = chunk.size();
             if (operand_res.value().vec) {
                 return vector::compute_unary_neg(resource, *operand_res.value().vec, count);
@@ -653,6 +688,11 @@ namespace components::operators {
         if (!detail::scalar_to_arithmetic_op(op, arith_op)) {
             return core::error_t(core::error_code_t::arithmetics_failure,
                                  std::pmr::string{"Not an arithmetic scalar_type", resource});
+        }
+        if (types::arithmetic_result_type(detail::operand_type(left_op.value()),
+                                          detail::operand_type(right_op.value()),
+                                          arith_op) == types::logical_type::NA) {
+            return detail::unsupported_arithmetic_error(resource);
         }
 
         if (left_op.value().vec && right_op.value().vec) {

--- a/components/types/types.hpp
+++ b/components/types/types.hpp
@@ -204,6 +204,13 @@ namespace components::types {
         }
     }
 
+    // BOOLEAN has a numeric physical representation, but SQL arithmetic does not
+    // accept it as a number. Keep is_numeric() broad for existing comparison and
+    // storage code while giving arithmetic type resolution a SQL-level predicate.
+    constexpr bool is_arithmetic_numeric(logical_type type) {
+        return type != logical_type::BOOLEAN && is_numeric(type);
+    }
+
     constexpr bool is_string(logical_type type) {
         switch (type) {
             case logical_type::STRING_LITERAL:
@@ -349,7 +356,7 @@ namespace components::types {
     // Handles numeric promotion and temporal arithmetic rules (date/time ± interval, etc.).
     // Returns logical_type::NA for unsupported combinations.
     constexpr logical_type arithmetic_result_type(logical_type lhs, logical_type rhs, vector::arithmetic_op op) {
-        if (is_numeric(lhs) && is_numeric(rhs)) {
+        if (is_arithmetic_numeric(lhs) && is_arithmetic_numeric(rhs)) {
             return promote_type(lhs, rhs);
         }
         auto is_temporal = [](logical_type t) constexpr {
@@ -371,10 +378,11 @@ namespace components::types {
             }
         }
         if (op == vector::arithmetic_op::multiply || op == vector::arithmetic_op::divide) {
-            if (lhs == logical_type::INTERVAL && is_numeric(rhs)) {
+            if (lhs == logical_type::INTERVAL && is_arithmetic_numeric(rhs)) {
                 return logical_type::INTERVAL;
             }
-            if (op == vector::arithmetic_op::multiply && is_numeric(lhs) && rhs == logical_type::INTERVAL) {
+            if (op == vector::arithmetic_op::multiply && is_arithmetic_numeric(lhs) &&
+                rhs == logical_type::INTERVAL) {
                 return logical_type::INTERVAL;
             }
         }

--- a/integration/cpp/test/test_correctness_bugs.cpp
+++ b/integration/cpp/test/test_correctness_bugs.cpp
@@ -87,6 +87,54 @@ TEST_CASE("integration::cpp::correctness_bugs::array_int_slot_width") {
     }
 }
 
+TEST_CASE("integration::cpp::correctness_bugs::unsupported_boolean_text_arithmetic") {
+    auto config = test_create_config("/tmp/test_correctness_bugs/unsupported_boolean_text_arithmetic");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE t;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE t.bad_arith (b BOOLEAN, s TEXT);")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(
+            dispatcher->execute_sql(session, "INSERT INTO t.bad_arith (b, s) VALUES (true, 'hello');")->is_success());
+    }
+
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT b + 1 FROM t.bad_arith;");
+        INFO("BOOLEAN arithmetic error: " << (cur->is_error() ? cur->get_error().what : "none"));
+        REQUIRE(cur->is_error());
+        REQUIRE(cur->get_error().type == core::error_code_t::schema_error);
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT -s FROM t.bad_arith;");
+        INFO("TEXT unary-minus error: " << (cur->is_error() ? cur->get_error().what : "none"));
+        REQUIRE(cur->is_error());
+        REQUIRE(cur->get_error().type == core::error_code_t::schema_error);
+    }
+
+    // Invalid expressions must not corrupt the engine process or session state.
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT b, s FROM t.bad_arith;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        REQUIRE(cur->value(0, 0).value<bool>());
+        REQUIRE(cur->value(1, 0).value<std::string_view>() == "hello");
+    }
+}
+
 TEST_CASE("integration::cpp::correctness_bugs::alias_collision") {
     auto config = test_create_config("/tmp/test_correctness_bugs/alias_collision");
     test_clear_directory(config);

--- a/services/dispatcher/validate_logical_plan.cpp
+++ b/services/dispatcher/validate_logical_plan.cpp
@@ -818,13 +818,32 @@ namespace services::dispatcher {
                                                       std::pmr::string{"unary minus with no operand", resource});
                                     return components::types::complex_logical_type(logical_type::INVALID);
                                 }
-                                return (*this)(s->params()[0]);
+                                auto operand_type = (*this)(s->params()[0]);
+                                if (!resolve_error.contains_error() &&
+                                    !is_arithmetic_numeric(operand_type.type())) {
+                                    resolve_error =
+                                        core::error_t(core::error_code_t::schema_error,
+                                                      std::pmr::string{
+                                                          "unary minus requires a numeric operand",
+                                                          resource});
+                                    return components::types::complex_logical_type(logical_type::INVALID);
+                                }
+                                return operand_type;
                             }
                             if (!s->params().empty()) {
                                 auto lt = (*this)(s->params()[0]);
                                 auto rt = s->params().size() > 1 ? (*this)(s->params()[1]) : lt;
-                                return components::types::complex_logical_type(
-                                    arithmetic_result_type(lt.type(), rt.type(), scalar_to_arith_op(s->type())));
+                                auto result =
+                                    arithmetic_result_type(lt.type(), rt.type(), scalar_to_arith_op(s->type()));
+                                if (!resolve_error.contains_error() && result == logical_type::NA) {
+                                    resolve_error =
+                                        core::error_t(core::error_code_t::schema_error,
+                                                      std::pmr::string{
+                                                          "arithmetic requires numeric or compatible temporal operands",
+                                                          resource});
+                                    return components::types::complex_logical_type(logical_type::INVALID);
+                                }
+                                return components::types::complex_logical_type(result);
                             }
                         }
                         resolve_error =
@@ -925,6 +944,10 @@ namespace services::dispatcher {
                                              std::pmr::string{"unary minus with no operand", resource});
                     }
                     result_type = resolve(scalar_expr->params()[0]);
+                    if (!resolve_error.contains_error() && !is_arithmetic_numeric(result_type.type())) {
+                        return core::error_t(core::error_code_t::schema_error,
+                                             std::pmr::string{"unary minus requires a numeric operand", resource});
+                    }
                     break;
                 }
                 case scalar_type::add:


### PR DESCRIPTION
Addresses the Boolean/text arithmetic portion of #558.

Apologies for the slop. Blame the other guy.

## What changed

- exclude `BOOLEAN` from SQL arithmetic numeric type resolution without changing the broader physical `is_numeric()` classification
- reject unsupported binary arithmetic and unary minus during logical-plan validation with `schema_error`
- add defensive guards in physical/scalar arithmetic evaluation so invalid operand combinations cannot reach unsafe vector/value operations
- add a regression covering `SELECT b + 1`, `SELECT -s`, and a subsequent valid query to verify the engine remains usable

## Root cause

The arithmetic resolver reused the broad numeric classification, which includes `BOOLEAN` for physical representation purposes, and unsupported operands could proceed into arithmetic evaluation. Unary minus over `TEXT` likewise reached evaluation without a SQL-level numeric operand check. Those invalid combinations crashed the process instead of producing an error.

## Impact

Unsupported Boolean/text arithmetic now returns a schema error rather than terminating the process. Valid numeric and temporal arithmetic behavior is preserved.

## Validation

- **RED:** applied only the new regression test to pre-fix commit `f5d71008`; `SELECT b + 1` exited with `SIGSEGV`/139. Reversing the two invalid-query checks in that disposable worktree showed `SELECT -s` independently exited with `SIGSEGV`/139 on this machine.
- **GREEN:** the unchanged regression on this branch passed all 11 assertions.
- full CTest suite: 1,374/1,374 passed
- arithmetic integration suite: 3,883 assertions across 8 test cases passed
- Python suite: 62/62 passed via `uv`
- full Release build completed successfully (536 targets)

The issue report observed `bad_alloc` for unary TEXT negation; this checkout reproduced that path as a segmentation fault, but both are eliminated by rejecting the invalid expression before evaluation.
