### PR TITLE
Reject non-numeric arithmetic and LIKE operands cleanly

### DIFF
--- a/components/expressions/update_expression.cpp
+++ b/components/expressions/update_expression.cpp
@@ -410,6 +410,17 @@ namespace components::expressions {
             owned_output_.emplace(vector_ops::apply_unary_vector_op(resource, *unary_op, *left_vec, vec_count));
         } else if (auto arith_op = to_arith_op(type_)) {
             auto* right_vec = right_->output_vec();
+            // A NULL literal answers NULL through the kernels' NA path; a pair of concrete
+            // types with no operator entry must not silently overwrite the column with the
+            // kernels' all-NULL unresolvable result.
+            if (left_vec->type().type() != types::logical_type::NA &&
+                right_vec->type().type() != types::logical_type::NA &&
+                types::arithmetic_result_type(left_vec->type().type(), right_vec->type().type(), *arith_op) ==
+                    types::logical_type::NA) {
+                return core::error_t{
+                    core::error_code_t::arithmetics_failure,
+                    std::pmr::string{"arithmetic requires numeric or compatible temporal operands", resource}};
+            }
             if (*arith_op == arithmetic_op::divide || *arith_op == arithmetic_op::mod) {
                 types::logical_value_t zero(resource, right_vec->type());
                 for (uint64_t i = 0; i < vec_count; ++i) {

--- a/components/physical_plan/operators/predicates/utils.cpp
+++ b/components/physical_plan/operators/predicates/utils.cpp
@@ -154,6 +154,13 @@ namespace components::operators::predicates::impl {
                 if (inner_val.has_error()) {
                     return inner_val;
                 }
+                // A NULL operand negates to NULL (three-valued logic); anything else must be
+                // numeric before it reaches the value machinery.
+                if (!inner_val.value().is_null() &&
+                    !types::is_arithmetic_numeric(inner_val.value().type().type())) {
+                    return core::error_t(core::error_code_t::arithmetics_failure,
+                                         std::pmr::string{"unary minus requires a numeric operand", resource});
+                }
                 return types::logical_value_t::subtract(types::logical_value_t(resource, int64_t(0)),
                                                         inner_val.value());
             };
@@ -180,6 +187,38 @@ namespace components::operators::predicates::impl {
             // scalar-scalar arithmetic helper exists (only vector::compute_* over vectors/scalars,
             // and logical_value_t::sum/...); using vectors per row would be the L4 anti-pattern.
             // Skipped: a typed path would require a new helper, which is out of scope here.
+            // NULL operands answer NULL through the value ops' own early-outs; a pair of
+            // concrete types with no operator entry must not reach them.
+            if (!left_val.value().is_null() && !right_val.value().is_null()) {
+                vector::arithmetic_op vop;
+                switch (op) {
+                    case expressions::scalar_type::add:
+                        vop = vector::arithmetic_op::add;
+                        break;
+                    case expressions::scalar_type::subtract:
+                        vop = vector::arithmetic_op::subtract;
+                        break;
+                    case expressions::scalar_type::multiply:
+                        vop = vector::arithmetic_op::multiply;
+                        break;
+                    case expressions::scalar_type::divide:
+                        vop = vector::arithmetic_op::divide;
+                        break;
+                    case expressions::scalar_type::mod:
+                        vop = vector::arithmetic_op::mod;
+                        break;
+                    default:
+                        return core::error_t(core::error_code_t::comparison_failure,
+                                             std::pmr::string{"Unsupported arithmetic op in predicate", resource});
+                }
+                if (types::arithmetic_result_type(left_val.value().type().type(),
+                                                  right_val.value().type().type(),
+                                                  vop) == types::logical_type::NA) {
+                    return core::error_t(
+                        core::error_code_t::arithmetics_failure,
+                        std::pmr::string{"arithmetic requires numeric or compatible temporal operands", resource});
+                }
+            }
             switch (op) {
                 case expressions::scalar_type::add:
                     return types::logical_value_t::sum(left_val.value(), right_val.value());

--- a/components/sql/transformer/impl/transform_insert.cpp
+++ b/components/sql/transformer/impl/transform_insert.cpp
@@ -416,7 +416,11 @@ namespace components::sql::transform {
                         } else {
                             auto col_type = it->type().type();
                             auto val_type = value.value().type().type();
-                            if (types::is_numeric(col_type) && types::is_numeric(val_type) && col_type != val_type) {
+                            // BOOLEAN is is_numeric but has no numeric widening: asking the promotion
+                            // oracle for a (numeric, BOOLEAN) common type poisons the column vector.
+                            // An unpromotable mix takes the plain per-value store below.
+                            if (types::is_arithmetic_numeric(col_type) && types::is_arithmetic_numeric(val_type) &&
+                                col_type != val_type) {
                                 auto promoted = types::promote_type(col_type, val_type);
                                 if (promoted != col_type) {
                                     chunk.data[column_index] =
@@ -447,7 +451,11 @@ namespace components::sql::transform {
                         } else {
                             auto col_type = it->type().type();
                             auto val_type = value.value().type().type();
-                            if (types::is_numeric(col_type) && types::is_numeric(val_type) && col_type != val_type) {
+                            // BOOLEAN is is_numeric but has no numeric widening: asking the promotion
+                            // oracle for a (numeric, BOOLEAN) common type poisons the column vector.
+                            // An unpromotable mix takes the plain per-value store below.
+                            if (types::is_arithmetic_numeric(col_type) && types::is_arithmetic_numeric(val_type) &&
+                                col_type != val_type) {
                                 auto promoted = types::promote_type(col_type, val_type);
                                 if (promoted != col_type) {
                                     chunk.data[column_index] =

--- a/components/sql/transformer/impl/transform_select.cpp
+++ b/components/sql/transformer/impl/transform_select.cpp
@@ -811,6 +811,14 @@ namespace components::sql::transform {
         {
             for (auto target : node.targetList->lst) {
                 auto res = pg_ptr_cast<ResTarget>(target.data);
+                // `SELECT +x` projects x itself: peel the identity layers so the stripped
+                // node dispatches to its own arm (column, constant, expression) below.
+                res->val = strip_unary_plus(res->val);
+                if (!res->val) {
+                    error_ = core::error_t(core::error_code_t::sql_parse_error,
+                                           std::pmr::string{"operator is missing its operand", resource_});
+                    return nullptr;
+                }
                 switch (nodeTag(res->val)) {
                     case T_FuncCall: {
                         // Aggregate function in SELECT

--- a/components/sql/transformer/impl/transfrom_common.cpp
+++ b/components/sql/transformer/impl/transfrom_common.cpp
@@ -53,6 +53,13 @@ namespace components::sql::transform {
         if (node->lexpr) {
             expr->append_param(transform_a_expr_operand(node->lexpr, names, params));
             expr->append_param(transform_a_expr_operand(node->rexpr, names, params));
+        } else if (op_str == "+") {
+            // Unary plus in an expression slot: the identity, encoded as 0 + x (an
+            // expression is required here; the pure strip happens in operand position).
+            auto zero_id = params->add_parameter(types::logical_value_t(resource_, int64_t(0)));
+            expr = make_scalar_expression(resource_, scalar_type::add);
+            expr->append_param(zero_id);
+            expr->append_param(transform_a_expr_operand(node->rexpr, names, params));
         } else {
             // Unary minus: proper unary operator with single operand
             expr = make_scalar_expression(resource_, scalar_type::unary_minus);
@@ -64,6 +71,14 @@ namespace components::sql::transform {
     param_storage transformer::transform_a_expr_operand(Node* node,
                                                         const name_collection_t& names,
                                                         logical_plan::parameter_node_t* params) {
+        // `+x` is x in operand position too: peel the identity layers so the stripped node
+        // takes its own arm below.
+        node = strip_unary_plus(node);
+        if (!node) {
+            error_ = core::error_t(core::error_code_t::sql_parse_error,
+                                   std::pmr::string{"operator is missing its operand", resource_});
+            return nullptr;
+        }
         switch (nodeTag(node)) {
             case T_ColumnRef: {
                 // Predicate-arithmetic operand: a correlated outer column is lowered to a
@@ -146,6 +161,15 @@ namespace components::sql::transform {
             }
             expr = make_scalar_expression(resource_, stype, expressions::key_t{resource_, std::move(expr_name)});
             expr->append_param(resolve_select_operand(node->lexpr, names, plan, group));
+            expr->append_param(resolve_select_operand(node->rexpr, names, plan, group));
+        } else if (op_str == "+") {
+            // Unary plus in an expression slot: the identity, encoded as 0 + x (the SELECT
+            // field-clause strip handles the top-level `SELECT +x` form).
+            auto zero_id = plan->parameters->add_parameter(types::logical_value_t(resource_, int64_t(0)));
+            expr = make_scalar_expression(resource_,
+                                          scalar_type::add,
+                                          expressions::key_t{resource_, std::move(expr_name)});
+            expr->append_param(zero_id);
             expr->append_param(resolve_select_operand(node->rexpr, names, plan, group));
         } else {
             // Unary minus: proper unary operator with single operand

--- a/components/sql/transformer/utils.hpp
+++ b/components/sql/transformer/utils.hpp
@@ -207,6 +207,22 @@ namespace components::sql::transform {
         return op == "+" || op == "-" || op == "*" || op == "/" || op == "%";
     }
 
+    // Unary plus is the identity (SQLite semantics: "+X is equivalent to X"): peel every
+    // `+`-layer off an expression and return what remains. A unary operator parses as
+    // A_Expr{op, lexpr = NULL, rexpr = operand}. Returns nullptr for a malformed `+` with
+    // no operand — callers must reject that.
+    inline Node* strip_unary_plus(Node* node) {
+        while (node && nodeTag(node) == T_A_Expr) {
+            auto* plus = pg_ptr_cast<A_Expr>(node);
+            if (plus->lexpr != nullptr || !plus->name || plus->name->lst.empty() ||
+                std::string_view(strVal(plus->name->lst.front().data)) != "+") {
+                break;
+            }
+            node = plus->rexpr;
+        }
+        return node;
+    }
+
     inline expressions::scalar_type get_arithmetic_scalar_type(std::string_view op) {
         if (op == "+")
             return expressions::scalar_type::add;

--- a/integration/cpp/test/CMakeLists.txt
+++ b/integration/cpp/test/CMakeLists.txt
@@ -18,6 +18,7 @@ set( ${PROJECT_NAME}_SOURCES
         test_create_index_backfill_batched.cpp
         test_correctness_bugs.cpp
         test_order_by_nulls.cpp
+        test_unary_plus.cpp
         test_multi_database_isolation.cpp
         test_index_null_correctness.cpp
         test_aggregate_filter.cpp

--- a/integration/cpp/test/CMakeLists.txt
+++ b/integration/cpp/test/CMakeLists.txt
@@ -18,6 +18,7 @@ set( ${PROJECT_NAME}_SOURCES
         test_create_index_backfill_batched.cpp
         test_correctness_bugs.cpp
         test_order_by_nulls.cpp
+        test_arithmetic_type_guards.cpp
         test_unary_plus.cpp
         test_multi_database_isolation.cpp
         test_index_null_correctness.cpp

--- a/integration/cpp/test/CMakeLists.txt
+++ b/integration/cpp/test/CMakeLists.txt
@@ -19,6 +19,7 @@ set( ${PROJECT_NAME}_SOURCES
         test_correctness_bugs.cpp
         test_order_by_nulls.cpp
         test_arithmetic_type_guards.cpp
+        test_like_type_guards.cpp
         test_unary_plus.cpp
         test_multi_database_isolation.cpp
         test_index_null_correctness.cpp

--- a/integration/cpp/test/test_arithmetic_type_guards.cpp
+++ b/integration/cpp/test/test_arithmetic_type_guards.cpp
@@ -1,0 +1,40 @@
+#include "test_config.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <components/types/logical_value.hpp>
+
+// Companion coverage for the operand type guards: paths the bind/runtime checks in the
+// dispatcher and arithmetic evaluator do not reach.
+
+TEST_CASE("integration::cpp::arithmetic_type_guards::mixed_bool_int_insert_survives") {
+    auto config = test_create_config("/tmp/test_arithmetic_type_guards/mixed_insert");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE db;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE db.c ();")->is_success());
+    }
+
+    // The INSERT widening path treated BOOLEAN as numeric and asked the promotion oracle
+    // for a (INTEGER, BOOLEAN) common type; the answer poisoned the column vector and the
+    // statement crashed. An unpromotable pair takes the plain per-value store instead.
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "INSERT INTO db.c (x) VALUES (1), (true);")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT x FROM db.c;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 2);
+        REQUIRE(cur->value(0, 0).value<int64_t>() == 1);
+    }
+}

--- a/integration/cpp/test/test_arithmetic_type_guards.cpp
+++ b/integration/cpp/test/test_arithmetic_type_guards.cpp
@@ -141,3 +141,31 @@ TEST_CASE("integration::cpp::arithmetic_type_guards::where_null_3vl_preserved") 
         REQUIRE(cur->value(0, 0).value<int32_t>() == 3);
     }
 }
+
+TEST_CASE("integration::cpp::arithmetic_type_guards::update_rejects_non_numeric_arithmetic") {
+    auto config = test_create_config("/tmp/test_arithmetic_type_guards/update_guard");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+    setup(dispatcher);
+
+    // The UPDATE expression tree fed b + 1 straight into the binary kernel, whose
+    // unresolvable-pair result is an all-NULL vector: the column was silently overwritten
+    // with NULLs. The operand pair must be rejected and the data left intact.
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "UPDATE db.t SET v = b + 1;");
+        REQUIRE(cur->is_error());
+        REQUIRE(cur->get_error().type == core::error_code_t::arithmetics_failure);
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT v FROM db.t;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 2);
+        REQUIRE(cur->value(0, 0).value<int64_t>() == 7);
+        REQUIRE(cur->value(0, 1).value<int64_t>() == 3);
+    }
+}

--- a/integration/cpp/test/test_arithmetic_type_guards.cpp
+++ b/integration/cpp/test/test_arithmetic_type_guards.cpp
@@ -38,3 +38,106 @@ TEST_CASE("integration::cpp::arithmetic_type_guards::mixed_bool_int_insert_survi
         REQUIRE(cur->value(0, 0).value<int64_t>() == 1);
     }
 }
+
+namespace {
+
+    void setup(otterbrix::wrapper_dispatcher_t* dispatcher) {
+        {
+            auto session = otterbrix::session_id_t();
+            REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE db;")->is_success());
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            REQUIRE(
+                dispatcher->execute_sql(session, "CREATE TABLE db.t (id INT, v BIGINT, b BOOLEAN, s TEXT);")
+                    ->is_success());
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            REQUIRE(dispatcher
+                        ->execute_sql(session,
+                                      "INSERT INTO db.t (id, v, b, s) VALUES (1, 7, true, 'a'), "
+                                      "(2, 3, false, 'b');")
+                        ->is_success());
+        }
+    }
+
+} // namespace
+
+TEST_CASE("integration::cpp::arithmetic_type_guards::where_arithmetic_rejects_non_numeric") {
+    auto config = test_create_config("/tmp/test_arithmetic_type_guards/where_guards");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+    setup(dispatcher);
+
+    // WHERE-clause arithmetic evaluates per row through the predicate value getters, which
+    // had no operand type checking: b + 1 read an indeterminate promotion result (silently
+    // zero rows), s + 1 crashed in the value machinery, -s compared garbage.
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT id FROM db.t WHERE b + 1 > 0;");
+        REQUIRE(cur->is_error());
+        REQUIRE(cur->get_error().type == core::error_code_t::arithmetics_failure);
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT id FROM db.t WHERE s + 1 > 0;");
+        REQUIRE(cur->is_error());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT id FROM db.t WHERE -s < 0;");
+        REQUIRE(cur->is_error());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT id FROM db.t WHERE -v < -5;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        REQUIRE(cur->value(0, 0).value<int32_t>() == 1);
+    }
+}
+
+TEST_CASE("integration::cpp::arithmetic_type_guards::where_null_3vl_preserved") {
+    auto config = test_create_config("/tmp/test_arithmetic_type_guards/where_3vl");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE db;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE db.n (id INT, v BIGINT);")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher
+                    ->execute_sql(session, "INSERT INTO db.n (id, v) VALUES (1, 1), (2, NULL), (3, 20);")
+                    ->is_success());
+    }
+
+    // NULL operands stay three-valued: the NULL row is UNKNOWN and silently excluded,
+    // never an operator error.
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT id FROM db.n WHERE 10 / v > 5;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        REQUIRE(cur->value(0, 0).value<int32_t>() == 1);
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT id FROM db.n WHERE v + 1 > 5;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        REQUIRE(cur->value(0, 0).value<int32_t>() == 3);
+    }
+}

--- a/integration/cpp/test/test_like_type_guards.cpp
+++ b/integration/cpp/test/test_like_type_guards.cpp
@@ -1,0 +1,104 @@
+#include "test_config.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <components/types/logical_value.hpp>
+
+// A non-string LIKE pattern constant is rejected at transform time ("LIKE: right side
+// must be a string"). These cases pin the rejection across every position that lowers
+// LIKE there — WHERE, CASE WHEN, JOIN ON, for LIKE / NOT LIKE / ILIKE, with integer and
+// float patterns, over typed and computing tables — plus string-pattern controls.
+
+namespace {
+
+    void setup(otterbrix::wrapper_dispatcher_t* dispatcher) {
+        {
+            auto session = otterbrix::session_id_t();
+            REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE db;")->is_success());
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE db.t (id INT, s TEXT);")->is_success());
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            REQUIRE(dispatcher
+                        ->execute_sql(session, "INSERT INTO db.t (id, s) VALUES (1, '1a'), (2, '2b');")
+                        ->is_success());
+        }
+    }
+
+    void check_error(otterbrix::wrapper_dispatcher_t* dispatcher, const std::string& sql) {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, sql);
+        INFO(sql);
+        REQUIRE(cur->is_error());
+    }
+
+} // namespace
+
+TEST_CASE("integration::cpp::like_type_guards::non_string_pattern_is_error") {
+    auto config = test_create_config("/tmp/test_like_type_guards/pattern");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+    setup(dispatcher);
+
+    check_error(dispatcher, "SELECT * FROM db.t WHERE s LIKE 1;");
+    check_error(dispatcher, "SELECT * FROM db.t WHERE s NOT LIKE 1;");
+    check_error(dispatcher, "SELECT * FROM db.t WHERE s ILIKE 1;");
+    check_error(dispatcher, "SELECT * FROM db.t WHERE s LIKE 1.5;");
+    check_error(dispatcher, "SELECT * FROM db.t WHERE id LIKE 1;");
+    check_error(dispatcher, "SELECT CASE WHEN s LIKE 1 THEN 1 ELSE 0 END FROM db.t;");
+    check_error(dispatcher, "SELECT t1.id FROM db.t AS t1 JOIN db.t AS t2 ON t1.s LIKE 1;");
+}
+
+TEST_CASE("integration::cpp::like_type_guards::non_string_pattern_computing_table") {
+    auto config = test_create_config("/tmp/test_like_type_guards/computing");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE db;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE db.c ();")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "INSERT INTO db.c (s) VALUES ('x');")->is_success());
+    }
+
+    check_error(dispatcher, "SELECT * FROM db.c WHERE s LIKE 1;");
+}
+
+TEST_CASE("integration::cpp::like_type_guards::string_pattern_still_works") {
+    auto config = test_create_config("/tmp/test_like_type_guards/control");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+    setup(dispatcher);
+
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT id FROM db.t WHERE s LIKE '1%';");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        REQUIRE(cur->value(0, 0).value<int32_t>() == 1);
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT id FROM db.t WHERE s NOT LIKE '1%';");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        REQUIRE(cur->value(0, 0).value<int32_t>() == 2);
+    }
+}

--- a/integration/cpp/test/test_unary_plus.cpp
+++ b/integration/cpp/test/test_unary_plus.cpp
@@ -1,0 +1,162 @@
+#include "test_config.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <components/types/logical_value.hpp>
+
+// Unary plus is the identity (SQLite semantics: "+X is equivalent to X"). The transformer
+// used to lower every no-left-operand arithmetic operator to unary minus, so `SELECT +v`
+// silently returned -v and `SELECT +s` over TEXT crashed in the negation kernel.
+
+namespace {
+
+    void setup(otterbrix::wrapper_dispatcher_t* dispatcher) {
+        {
+            auto session = otterbrix::session_id_t();
+            REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE db;")->is_success());
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE db.t (id INT, v BIGINT, s TEXT);")->is_success());
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            REQUIRE(dispatcher
+                        ->execute_sql(session,
+                                      "INSERT INTO db.t (id, v, s) VALUES (1, 7, 'a'), (2, 3, 'b'), (3, 10, 'c');")
+                        ->is_success());
+        }
+    }
+
+} // namespace
+
+TEST_CASE("integration::cpp::unary_plus::select_column_identity") {
+    auto config = test_create_config("/tmp/test_unary_plus/select_identity");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+    setup(dispatcher);
+
+    auto session = otterbrix::session_id_t();
+    auto cur = dispatcher->execute_sql(session, "SELECT +v FROM db.t;");
+    REQUIRE(cur->is_success());
+    REQUIRE(cur->size() == 3);
+    REQUIRE(cur->value(0, 0).value<int64_t>() == 7);
+    REQUIRE(cur->value(0, 1).value<int64_t>() == 3);
+    REQUIRE(cur->value(0, 2).value<int64_t>() == 10);
+}
+
+TEST_CASE("integration::cpp::unary_plus::select_text_identity") {
+    auto config = test_create_config("/tmp/test_unary_plus/select_text");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+    setup(dispatcher);
+
+    // +s used to reach the numeric negation kernel and kill the process.
+    auto session = otterbrix::session_id_t();
+    auto cur = dispatcher->execute_sql(session, "SELECT +s FROM db.t;");
+    REQUIRE(cur->is_success());
+    REQUIRE(cur->size() == 3);
+    REQUIRE(cur->value(0, 0).value<std::string_view>() == "a");
+    REQUIRE(cur->value(0, 1).value<std::string_view>() == "b");
+    REQUIRE(cur->value(0, 2).value<std::string_view>() == "c");
+}
+
+TEST_CASE("integration::cpp::unary_plus::nested_layers") {
+    auto config = test_create_config("/tmp/test_unary_plus/nested");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+    setup(dispatcher);
+
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT ++v FROM db.t;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 3);
+        REQUIRE(cur->value(0, 0).value<int64_t>() == 7);
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT -(+v) FROM db.t;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 3);
+        REQUIRE(cur->value(0, 0).value<int64_t>() == -7);
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT v + (+v) FROM db.t;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 3);
+        REQUIRE(cur->value(0, 0).value<int64_t>() == 14);
+    }
+}
+
+TEST_CASE("integration::cpp::unary_plus::where_operand_identity") {
+    auto config = test_create_config("/tmp/test_unary_plus/where_operand");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+    setup(dispatcher);
+
+    // With + lowered to negation, WHERE +v > 5 filtered on -v > 5 and matched nothing.
+    auto session = otterbrix::session_id_t();
+    auto cur = dispatcher->execute_sql(session, "SELECT id FROM db.t WHERE +v > 5;");
+    REQUIRE(cur->is_success());
+    REQUIRE(cur->size() == 2);
+    REQUIRE(cur->value(0, 0).value<int32_t>() == 1);
+    REQUIRE(cur->value(0, 1).value<int32_t>() == 3);
+}
+
+TEST_CASE("integration::cpp::unary_plus::aggregate_argument_identity") {
+    auto config = test_create_config("/tmp/test_unary_plus/aggregate_arg");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+    setup(dispatcher);
+
+    auto session = otterbrix::session_id_t();
+    auto cur = dispatcher->execute_sql(session, "SELECT SUM(+v) FROM db.t;");
+    REQUIRE(cur->is_success());
+    REQUIRE(cur->size() == 1);
+    REQUIRE(cur->value(0, 0).value<int64_t>() == 20);
+}
+
+TEST_CASE("integration::cpp::unary_plus::computing_table_identity") {
+    auto config = test_create_config("/tmp/test_unary_plus/computing");
+    test_clear_directory(config);
+    config.disk.on = false;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE db;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE db.c ();")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "INSERT INTO db.c (v) VALUES (7), (3);")->is_success());
+    }
+
+    auto session = otterbrix::session_id_t();
+    auto cur = dispatcher->execute_sql(session, "SELECT +v FROM db.c;");
+    REQUIRE(cur->is_success());
+    REQUIRE(cur->size() == 2);
+    REQUIRE(cur->value(0, 0).value<int64_t>() == 7);
+    REQUIRE(cur->value(0, 1).value<int64_t>() == 3);
+}


### PR DESCRIPTION
Companion to #591/#592: covers the operand-guard gaps those left open, and fixes unary plus, which was silently lowered to negation. No promotion or cast machinery is touched.

### 1. Unary plus negated its operand

The transformer lowered every no-left-operand arithmetic operator to `unary_minus`:

```sql
CREATE TABLE db.t (id INT, v BIGINT, b BOOLEAN, s TEXT);
INSERT INTO db.t (id, v, b, s) VALUES (1, 7, true, 'a'), (2, 3, false, 'b');

SELECT +v FROM db.t;               -- before: -7, -3;  now: 7, 3 (SQLite semantics: +X ≡ X)
SELECT +s FROM db.t;               -- before: "unary minus requires a numeric operand"; now: 'a', 'b'
SELECT id FROM db.t WHERE +v > 5;  -- before: 0 rows (filtered on -v);  now: id 1
SELECT SUM(+v) FROM db.t;          -- before: "single-operand scalar is not supported"; now: 10
```

The SELECT field clause and arithmetic-operand resolution peel `+`-layers and dispatch the stripped node to its own arm; in expression slots that require an expression the identity is encoded as `0 + x`.

### 2. WHERE-clause arithmetic had no operand guards

`WHERE` evaluates per row through the predicate value getters, which #592's evaluator guards do not reach:

```sql
SELECT id FROM db.t WHERE b + 1 > 0;  -- before: silently 0 rows (indeterminate promotion read)
                                      -- now: ERROR arithmetic requires numeric or compatible temporal operands
SELECT id FROM db.t WHERE s + 1 > 0;  -- before: SIGSEGV (swallowed throw, scan-teardown crash)
SELECT id FROM db.t WHERE -s < 0;     -- before: garbage comparison; now: ERROR
```

Guards sit after the NULL early-outs: `WHERE v + 1 > 5` over a NULL row still drops it as UNKNOWN, never errors.

### 3. UPDATE arithmetic silently overwrote data

```sql
UPDATE db.t SET v = b + 1;  -- before: reported success, v became NULL in every row
                            -- now: ERROR, data intact
```

### 4. Mixed boolean/numeric INSERT crashed

The INSERT widening path treated BOOLEAN as numeric and asked the promotion oracle for a `(INTEGER, BOOLEAN)` common type:

```sql
CREATE TABLE db.c ();
INSERT INTO db.c (x) VALUES (1), (true);  -- before: SIGSEGV; now: succeeds, per-value store
```

The widening condition now uses `is_arithmetic_numeric` (from #592); the promotion machinery itself is untouched.

### 5. Tests pinning #591's LIKE rejection

The non-string-pattern rejection is pinned across WHERE / CASE WHEN / JOIN ON, for LIKE / NOT LIKE / ILIKE with integer and float patterns, over typed and computing tables, with string-pattern controls.

Full suite green on this branch; error codes/messages match #592's conventions.
