### PR TITLE
Fix string payload leak from CHECK-rejected INSERT into next row (#551)

### DIFF
--- a/components/table/column_segment.cpp
+++ b/components/table/column_segment.cpp
@@ -1673,9 +1673,30 @@ namespace components::table {
 
     void column_segment_t::revert_append(uint64_t start_row) {
         // A BIT (validity) segment stores appended rows as validity bits, so reverting must reset the
-        // bits in [start_row, end) back to valid before the tail is reused on re-append. Every other
-        // segment (fixed-size / string) only had raw values written into its buffer by the append; a
-        // re-append overwrites them, so reverting just needs to drop the count.
+        // bits in [start_row, end) back to valid before the tail is reused on re-append. A STRING
+        // segment stores per-row offsets as the CUMULATIVE dictionary size (scan derives each length
+        // as offset[row] - offset[row-1]), so the dictionary size must be rolled back to the last
+        // kept row's offset — otherwise a re-appended string lands after the reverted payload and its
+        // offset spans both, concatenating the dead bytes onto the new value. Fixed-size segments
+        // only had raw values written into their buffer; a re-append overwrites them, so reverting
+        // just needs to drop the count.
+        if (type.to_physical_type() == types::physical_type::STRING) {
+            uint64_t new_count = start_row - static_cast<uint64_t>(start);
+            auto& buffer_manager = block->block_manager.buffer_manager;
+            // Resident managed block (already pinned on the append path); pin cannot OOM here.
+            auto pinned = buffer_manager.pin(block);
+            assert(!pinned.has_error() && "revert_append: pin of resident managed block must not OOM");
+            if (!pinned.has_error()) {
+                auto& handle = pinned.value();
+                auto dict = impl::dictionary(*this, handle);
+                auto offsets = reinterpret_cast<int32_t*>(handle.ptr() + block_offset() + impl::DICTIONARY_HEADER_SIZE);
+                // Offsets are cumulative; big-string markers store the negated size, NULL rows copy
+                // the previous offset — |offset[new_count - 1]| is the dictionary usage to keep.
+                int32_t last = new_count == 0 ? 0 : offsets[new_count - 1];
+                dict.size = static_cast<uint32_t>(last < 0 ? -last : last);
+                impl::set_dictionary(*this, handle, dict);
+            }
+        }
         if (type.to_physical_type() == types::physical_type::BIT) {
             uint64_t start_bit = start_row - static_cast<uint64_t>(start);
 

--- a/integration/cpp/test/test_correctness_bugs.cpp
+++ b/integration/cpp/test/test_correctness_bugs.cpp
@@ -699,6 +699,56 @@ TEST_CASE("integration::cpp::correctness_bugs::check_violation_autocommit_revert
     REQUIRE(reverts_after == reverts_before + 1);
 }
 
+// Issue #551: the physical revert of a CHECK-rejected INSERT truncated the segment's
+// row count but left the string dictionary size untouched. String offsets are stored
+// as the CUMULATIVE dictionary size at append time and scan derives each length as
+// offset[row] - offset[row-1], so the next accepted row's offset still included the
+// rejected row's payload — its string came back concatenated with the rejected one
+// ('clean' + 'REJECTED' = 'cleanREJECTED').
+TEST_CASE("integration::cpp::correctness_bugs::check_violation_revert_does_not_leak_string_payload") {
+    auto config = test_create_config("/tmp/test_correctness_bugs/check_violation_string_leak");
+    test_clear_directory(config);
+    config.disk.on = true;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE t;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE t.a (id bigint, name text);")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(
+            dispatcher->execute_sql(session, "ALTER TABLE t.a ADD CONSTRAINT chk_id CHECK (id > 0);")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "INSERT INTO t.a (id, name) VALUES (-1, 'REJECTED');");
+        INFO("CHECK-violating INSERT error: " << (cur->is_error() ? cur->get_error().what : "none"));
+        REQUIRE(cur->is_error());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "INSERT INTO t.a (id, name) VALUES (2, 'clean');")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT * FROM t.a;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        const int name_col = find_column(*cur, "name");
+        REQUIRE(name_col >= 0);
+        auto name = cur->value(static_cast<uint64_t>(name_col), 0);
+        INFO("name value: '" << name.value<std::string_view>() << "'");
+        REQUIRE(name.value<std::string_view>() == "clean");
+    }
+}
+
 TEST_CASE("integration::cpp::correctness_bugs::fk_violation_autocommit_reverts_physical_append") {
     auto config = test_create_config("/tmp/test_correctness_bugs/fk_violation_reverts_physical_append");
     test_clear_directory(config);

--- a/integration/cpp/test/test_correctness_bugs.cpp
+++ b/integration/cpp/test/test_correctness_bugs.cpp
@@ -749,6 +749,85 @@ TEST_CASE("integration::cpp::correctness_bugs::check_violation_revert_does_not_l
     }
 }
 
+// Mid-segment variants of the #551 revert: the segment is NOT empty after the revert,
+// so the dictionary size must be rolled back to the LAST KEPT row's offset (not zero).
+// The kept row being a plain string exercises the positive cumulative offset; the kept
+// row being NULL exercises the offset-copy path (a NULL append copies the previous
+// row's offset, which must still be treated as the dictionary usage to keep).
+TEST_CASE("integration::cpp::correctness_bugs::check_violation_revert_mid_segment_keeps_prior_strings") {
+    auto config = test_create_config("/tmp/test_correctness_bugs/check_violation_string_leak_mid_segment");
+    test_clear_directory(config);
+    config.disk.on = true;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE t;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE t.a (id bigint, name text);")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(
+            dispatcher->execute_sql(session, "ALTER TABLE t.a ADD CONSTRAINT chk_id CHECK (id > 0);")->is_success());
+    }
+
+    SECTION("last kept row is a plain string") {
+        {
+            auto session = otterbrix::session_id_t();
+            REQUIRE(dispatcher->execute_sql(session, "INSERT INTO t.a (id, name) VALUES (1, 'keep');")->is_success());
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            REQUIRE(dispatcher->execute_sql(session, "INSERT INTO t.a (id, name) VALUES (-1, 'REJECTED');")->is_error());
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            REQUIRE(dispatcher->execute_sql(session, "INSERT INTO t.a (id, name) VALUES (2, 'clean');")->is_success());
+        }
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT name FROM t.a ORDER BY id;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 2);
+        INFO("row0: '" << cur->value(0, 0).value<std::string_view>() << "' row1: '"
+                       << cur->value(0, 1).value<std::string_view>() << "'");
+        REQUIRE(cur->value(0, 0).value<std::string_view>() == "keep");
+        REQUIRE(cur->value(0, 1).value<std::string_view>() == "clean");
+    }
+
+    SECTION("last kept row is NULL") {
+        {
+            auto session = otterbrix::session_id_t();
+            REQUIRE(dispatcher->execute_sql(session, "INSERT INTO t.a (id, name) VALUES (1, 'keep');")->is_success());
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            REQUIRE(dispatcher->execute_sql(session, "INSERT INTO t.a (id) VALUES (3);")->is_success());
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            REQUIRE(dispatcher->execute_sql(session, "INSERT INTO t.a (id, name) VALUES (-1, 'REJECTED');")->is_error());
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            REQUIRE(dispatcher->execute_sql(session, "INSERT INTO t.a (id, name) VALUES (2, 'clean');")->is_success());
+        }
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT name FROM t.a ORDER BY id;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 3);
+        INFO("row0: '" << cur->value(0, 0).value<std::string_view>() << "' row1: '"
+                       << cur->value(0, 1).value<std::string_view>() << "'");
+        REQUIRE(cur->value(0, 0).value<std::string_view>() == "keep");
+        REQUIRE(cur->value(0, 1).value<std::string_view>() == "clean");
+        REQUIRE(cur->value(0, 2).is_null());
+    }
+}
+
 TEST_CASE("integration::cpp::correctness_bugs::fk_violation_autocommit_reverts_physical_append") {
     auto config = test_create_config("/tmp/test_correctness_bugs/fk_violation_reverts_physical_append");
     test_clear_directory(config);


### PR DESCRIPTION
Fixes #551.

## Problem

A `CHECK`-rejected INSERT leaks its string payload into the next successful row:

```sql
CREATE TABLE db.a (id bigint, name text);
ALTER TABLE db.a ADD CONSTRAINT chk_id CHECK (id > 0);
INSERT INTO db.a (id, name) VALUES (-1, 'REJECTED');   -- rejected
INSERT INTO db.a (id, name) VALUES (2, 'clean');       -- accepted
SELECT * FROM db.a;  -- row0: 2 'cleanREJECTED'
```

## Root cause

Constraint validation runs after the DML child has physically appended the row, and the failed-statement abort path reverts the append via `column_segment_t::revert_append`. That revert only truncated the segment's row `count`, on the assumption that a re-append overwrites stale buffer bytes.

That assumption is wrong for STRING segments: each row's stored offset is the **cumulative dictionary size** at append time, and `string_scan_partial` derives every value's length as `offset[row] - offset[row-1]`. After the revert, the dictionary size still included the rejected payload, so the next accepted string was placed after the dead bytes and its cumulative offset spanned both — the scan returned `'clean' + 'REJECTED'` as one 13-byte value.

## Fix

`revert_append` now also rolls the dictionary size back to the last kept row's offset, `|offset[new_count - 1]|` (or 0 when the segment reverts to empty). The absolute value handles both NULL rows (which copy the previous offset) and big-string overflow markers (which store the negated size).

## Testing

- New regression test `integration::cpp::correctness_bugs::check_violation_revert_does_not_leak_string_payload` reproduces the issue verbatim (fails with `'cleanREJECTED'` before the fix, passes after).
- Full integration suite: 415/415 cases pass.
- `test_table` component suite: 74/74 cases pass.