### PR TITLE
Fix row duplication after FK-rejected DELETE (#552)

### DIFF
--- a/components/physical_plan/operators/operator_delete.cpp
+++ b/components/physical_plan/operators/operator_delete.cpp
@@ -457,17 +457,19 @@ namespace components::operators {
                                                 ctx->dml_has_parent_constraint,
                                                 constraint_input_,
                                                 index_old_chunks_);
+            // Record the delete marker ONCE across all flushes: COMMIT/ABORT key the
+            // MVCC swap/revert on the txn id, not on per-flush ranges. Recorded BEFORE
+            // the flush-error check so a late flush failure still leaves the marker for
+            // the failed-statement abort tail to un-stamp the already-stamped marks.
+            if (!delete_marker_recorded_) {
+                ctx->dml_deletes.push_back(components::table::dml_delete_range_t{table_oid_, ctx->txn.transaction_id});
+                delete_marker_recorded_ = true;
+            }
+
             if (err.contains_error()) {
                 set_error(err);
                 mark_failed();
                 co_return;
-            }
-
-            // Record the delete marker ONCE across all flushes: COMMIT/ABORT key the
-            // MVCC swap/revert on the txn id, not on per-flush ranges.
-            if (!delete_marker_recorded_) {
-                ctx->dml_deletes.push_back(components::table::dml_delete_range_t{table_oid_, ctx->txn.transaction_id});
-                delete_marker_recorded_ = true;
             }
 
             // Clear the flushed slice (bounded memory). Keep returning_staged_ — it is

--- a/components/physical_plan/operators/operator_update.cpp
+++ b/components/physical_plan/operators/operator_update.cpp
@@ -481,18 +481,22 @@ namespace components::operators {
                                                 ctx->dml_has_parent_constraint,
                                                 constraint_input_,
                                                 output_->chunks());
+            // UPDATE = delete-old + append-new: record the MVCC delete tombstone ONCE
+            // across all flushes (append ranges are per-flush via record_flush; the
+            // delete marker is a single per-txn/table tombstone). Recorded BEFORE the
+            // flush-error check for the same reason record_flush records the append
+            // range first: the storage op stamps the delete marks before its append
+            // half can fail, and only a recorded marker lets the failed-statement
+            // abort tail (storage_revert_deletes) un-stamp them.
+            if (!delete_marker_recorded_) {
+                ctx->dml_deletes.push_back(components::table::dml_delete_range_t{table_oid_, ctx->txn.transaction_id});
+                delete_marker_recorded_ = true;
+            }
+
             if (err.contains_error()) {
                 set_error(err);
                 mark_failed();
                 co_return;
-            }
-
-            // UPDATE = delete-old + append-new: record the MVCC delete tombstone ONCE
-            // across all flushes (append ranges are per-flush via record_flush; the
-            // delete marker is a single per-txn/table tombstone).
-            if (!delete_marker_recorded_) {
-                ctx->dml_deletes.push_back(components::table::dml_delete_range_t{table_oid_, ctx->txn.transaction_id});
-                delete_marker_recorded_ = true;
             }
 
             // Release the flushed batch: the accumulated updated rows and the lockstep

--- a/components/table/test/test_mvcc_operations.cpp
+++ b/components/table/test/test_mvcc_operations.cpp
@@ -767,3 +767,117 @@ TEST_CASE("components::table::mvcc::revert_append_truncates_columns_direct") {
         }
     }
 }
+
+// Issue #552 family: an aborted MVCC update (delete-stamp + append) followed by the
+// failed-statement revert (physical append revert + delete un-stamp) must restore the
+// original row intact, and a subsequent COMMITTED update of that row must yield exactly
+// the new version. The second phase also pins validity_mask_t::set_valid bit semantics:
+// the revert's BIT reset used to clobber a whole 64-bit entry per "bit", leaving the
+// failed append's NULL bit set — the re-appended row then read as NULL forever.
+TEST_CASE("components::table::mvcc::aborted_update_revert_restores_row") {
+    test_env env;
+    std::vector<column_definition_t> columns;
+    columns.emplace_back("id", complex_logical_type(logical_type::BIGINT));
+    columns.emplace_back("val", complex_logical_type(logical_type::STRING_LITERAL));
+    auto table = std::make_unique<data_table_t>(&env.resource, env.block_manager, std::move(columns), "t");
+
+    auto types = table->copy_types();
+    // Row 0: (1, 'p1'), committed immediately.
+    {
+        auto chunk = data_chunk_t(&env.resource, types, 1);
+        chunk.data[0].set_value(0, logical_value_t(&env.resource, int64_t(1)));
+        chunk.data[1].set_value(0, logical_value_t(&env.resource, std::string("p1")));
+        chunk.set_cardinality(1);
+        table_append_state state(&env.resource);
+        REQUIRE_FALSE(table->append_lock(state).has_error());
+        REQUIRE_FALSE(table->initialize_append(state).has_error());
+        REQUIRE_FALSE(table->append(chunk, state).has_error());
+        table->finalize_append(state, transaction_data{0, 0});
+    }
+
+    // Failed-statement txn: stamp delete on row 0, append (77, NULL).
+    const uint64_t txn_id = TRANSACTION_ID_START + 5;
+    const transaction_data txn{txn_id, 100};
+    {
+        auto del_state = table->initialize_delete({});
+        auto row_ids = vector_t(&env.resource, complex_logical_type(logical_type::BIGINT), 1);
+        row_ids.set_value(0, logical_value_t(&env.resource, int64_t(0)));
+        REQUIRE(table->delete_rows(*del_state, row_ids, 1, txn_id) == 1);
+    }
+    int64_t appended_start = 0;
+    {
+        auto chunk = data_chunk_t(&env.resource, types, 1);
+        chunk.data[0].set_value(0, logical_value_t(&env.resource, int64_t(77)));
+        chunk.data[1].set_null(0, true);
+        chunk.set_cardinality(1);
+        table_append_state state(&env.resource);
+        REQUIRE_FALSE(table->append_lock(state).has_error());
+        REQUIRE_FALSE(table->initialize_append(state).has_error());
+        appended_start = state.current_row;
+        REQUIRE_FALSE(table->append(chunk, state).has_error());
+        table->finalize_append(state, txn);
+    }
+    REQUIRE(appended_start == 1);
+
+    // Failed-statement revert: physical append revert + delete un-stamp.
+    table->revert_append(appended_start, 1);
+    table->revert_all_deletes(txn_id);
+
+    // Reader: later txn.
+    auto scan_once = [&](uint64_t reader_txn, uint64_t reader_start) {
+        std::vector<storage_index_t> column_ids;
+        column_ids.emplace_back(0);
+        column_ids.emplace_back(1);
+        table_scan_state scan_state(&env.resource);
+        table->initialize_scan(scan_state, column_ids);
+        scan_state.table_state.txn = transaction_data{reader_txn, reader_start};
+        auto result = data_chunk_t(&env.resource, types, DEFAULT_VECTOR_CAPACITY);
+        table->scan(result, scan_state);
+        return result;
+    };
+    {
+        auto result = scan_once(TRANSACTION_ID_START + 6, 101);
+        REQUIRE(result.size() == 1);
+        INFO("id=" << result.data[0].value(0).value<int64_t>());
+        REQUIRE(result.data[0].value(0).value<int64_t>() == 1);
+        REQUIRE(result.data[1].validity().row_is_valid(0));
+        REQUIRE_FALSE(result.data[1].value(0).is_null());
+    }
+
+    // Second, SUCCESSFUL update: (1, 'renamed') — delete-stamp row0 + append, then commit.
+    const uint64_t txn2 = TRANSACTION_ID_START + 7;
+    {
+        auto del_state = table->initialize_delete({});
+        auto row_ids = vector_t(&env.resource, complex_logical_type(logical_type::BIGINT), 1);
+        row_ids.set_value(0, logical_value_t(&env.resource, int64_t(0)));
+        REQUIRE(table->delete_rows(*del_state, row_ids, 1, txn2) == 1);
+    }
+    int64_t start2 = 0;
+    {
+        auto chunk = data_chunk_t(&env.resource, types, 1);
+        chunk.data[0].set_value(0, logical_value_t(&env.resource, int64_t(1)));
+        chunk.data[1].set_value(0, logical_value_t(&env.resource, std::string("renamed")));
+        chunk.set_cardinality(1);
+        table_append_state state(&env.resource);
+        REQUIRE_FALSE(table->append_lock(state).has_error());
+        REQUIRE_FALSE(table->initialize_append(state).has_error());
+        start2 = state.current_row;
+        REQUIRE_FALSE(table->append(chunk, state).has_error());
+        table->finalize_append(state, transaction_data{txn2, 102});
+    }
+    REQUIRE(start2 == 1);
+    table->commit_append(103, start2, 1);
+    table->commit_all_deletes(txn2, 103);
+
+    {
+        auto result = scan_once(TRANSACTION_ID_START + 8, 104);
+        REQUIRE(result.size() == 1);
+        INFO("id=" << result.data[0].value(0).value<int64_t>());
+        REQUIRE(result.data[0].value(0).value<int64_t>() == 1);
+        INFO("val validity=" << result.data[1].validity().row_is_valid(0));
+        REQUIRE(result.data[1].validity().row_is_valid(0));
+        auto v = result.data[1].value(0);
+        REQUIRE_FALSE(v.is_null());
+        REQUIRE(v.value<std::string_view>() == "renamed");
+    }
+}

--- a/components/vector/validation.cpp
+++ b/components/vector/validation.cpp
@@ -92,9 +92,12 @@ namespace components::vector {
 
     void validity_mask_t::set_valid(uint64_t row_idx) {
         if (!validity_mask_) {
-            resize(resource_, count_);
+            // No mask allocated means every row is already valid.
+            return;
         }
-        validity_mask_[row_idx] = true;
+        uint64_t entry_idx, idx_in_entry;
+        entry_index(row_idx, entry_idx, idx_in_entry);
+        validity_mask_[entry_idx] |= (uint64_t(1) << uint64_t(idx_in_entry));
     }
 
     void validity_mask_t::set_all_invalid(uint64_t count) {

--- a/integration/cpp/test/test_correctness_bugs.cpp
+++ b/integration/cpp/test/test_correctness_bugs.cpp
@@ -745,6 +745,85 @@ TEST_CASE("integration::cpp::correctness_bugs::fk_violation_autocommit_reverts_p
     REQUIRE(reverts_after == reverts_before + 1);
 }
 
+// Issue #552: an FK-rejected DELETE stamps MVCC delete marks (deleter = the failed
+// statement's txn id) before the constraint check runs, and the autocommit failed-
+// statement path never un-stamped them (only explicit ROLLBACK did). The aborted txn
+// never commits so the row stays VISIBLE, but chunk_vector_info::delete_rows skips any
+// already-stamped slot — the next UPDATE's delete-half silently no-ops while its
+// append-half succeeds (duplicate row), and the row can never be deleted again.
+TEST_CASE("integration::cpp::correctness_bugs::fk_rejected_delete_leaves_row_updatable_and_deletable") {
+    auto config = test_create_config("/tmp/test_correctness_bugs/fk_rejected_delete_row_identity");
+    test_clear_directory(config);
+    config.disk.on = true;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE db;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE db.p (id bigint, val text);")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE db.ch (id bigint, pid bigint);")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher
+                    ->execute_sql(session,
+                                  "ALTER TABLE db.ch ADD CONSTRAINT fk_c "
+                                  "FOREIGN KEY (pid) REFERENCES db.p (id);")
+                    ->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "INSERT INTO db.p (id, val) VALUES (1, 'p1');")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "INSERT INTO db.ch (id, pid) VALUES (10, 1);")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "DELETE FROM db.p WHERE id = 1;");
+        INFO("FK-violating DELETE error: " << (cur->is_error() ? cur->get_error().what : "none"));
+        REQUIRE(cur->is_error());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "UPDATE db.p SET val = 'renamed' WHERE id = 1;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT * FROM db.p;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        const int val_col = find_column(*cur, "val");
+        REQUIRE(val_col >= 0);
+        INFO("val: '" << cur->value(static_cast<uint64_t>(val_col), 0).value<std::string_view>() << "'");
+        REQUIRE(cur->value(static_cast<uint64_t>(val_col), 0).value<std::string_view>() == "renamed");
+    }
+    // The row must also still be deletable once the FK obstacle is removed.
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "DELETE FROM db.ch WHERE id = 10;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "DELETE FROM db.p WHERE id = 1;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT * FROM db.p;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 0);
+    }
+}
+
 // A scalar aggregate over a COLUMN argument (not count(*)) over an EMPTY table must
 // emit COUNT=0 (SUM/MIN/MAX/AVG=NULL), not crash. The global-aggregate empty path
 // (operator_group_t::empty_aggregate_result) drives the aggregator over a batch with

--- a/integration/cpp/test/test_correctness_bugs.cpp
+++ b/integration/cpp/test/test_correctness_bugs.cpp
@@ -824,6 +824,83 @@ TEST_CASE("integration::cpp::correctness_bugs::fk_rejected_delete_leaves_row_upd
     }
 }
 
+// UPDATE variant of #552: a constraint-rejected UPDATE's delete-half stamps the same
+// MVCC delete marks (operator_update pushes the same dml_deletes tombstone), so the
+// failed-statement un-stamp must fire for it too — otherwise the next UPDATE
+// duplicates the row exactly as in the DELETE case. NOT NULL is the rejecting
+// constraint here: rewrite_update wires not_null_cols into the UPDATE plan (CHECK
+// expressions are a known gap on the UPDATE path and never reject).
+TEST_CASE("integration::cpp::correctness_bugs::constraint_rejected_update_leaves_row_updatable") {
+    auto config = test_create_config("/tmp/test_correctness_bugs/rejected_update_row_identity");
+    test_clear_directory(config);
+    config.disk.on = true;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE DATABASE db;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "CREATE TABLE db.p (id bigint, val text NOT NULL);")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "INSERT INTO db.p (id, val) VALUES (1, 'p1');")->is_success());
+    }
+    const auto reverts_before = services::collection::executor::dml_appends_reverted();
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "UPDATE db.p SET val = NULL, id = 77 WHERE id = 1;");
+        INFO("NOT-NULL-violating UPDATE error: " << (cur->is_error() ? cur->get_error().what : "none"));
+        REQUIRE(cur->is_error());
+    }
+    const auto reverts_after = services::collection::executor::dml_appends_reverted();
+    INFO("dml_appends_reverted before=" << reverts_before << " after=" << reverts_after);
+    REQUIRE(reverts_after == reverts_before + 1);
+    // The failed UPDATE must leave the table exactly as it was: one row (1, 'p1').
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT * FROM db.p;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        const int id_col = find_column(*cur, "id");
+        REQUIRE(id_col >= 0);
+        REQUIRE(cur->value(static_cast<uint64_t>(id_col), 0).value<int64_t>() == 1);
+        const int val_col = find_column(*cur, "val");
+        REQUIRE(val_col >= 0);
+        REQUIRE(!cur->value(static_cast<uint64_t>(val_col), 0).is_null());
+        REQUIRE(cur->value(static_cast<uint64_t>(val_col), 0).value<std::string_view>() == "p1");
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "UPDATE db.p SET val = 'renamed' WHERE id = 1;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT * FROM db.p;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        const int val_col = find_column(*cur, "val");
+        REQUIRE(val_col >= 0);
+        REQUIRE(!cur->value(static_cast<uint64_t>(val_col), 0).is_null());
+        INFO("val: '" << cur->value(static_cast<uint64_t>(val_col), 0).value<std::string_view>() << "'");
+        REQUIRE(cur->value(static_cast<uint64_t>(val_col), 0).value<std::string_view>() == "renamed");
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        REQUIRE(dispatcher->execute_sql(session, "DELETE FROM db.p WHERE id = 1;")->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT * FROM db.p;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 0);
+    }
+}
+
 // A scalar aggregate over a COLUMN argument (not count(*)) over an EMPTY table must
 // emit COUNT=0 (SUM/MIN/MAX/AVG=NULL), not crash. The global-aggregate empty path
 // (operator_group_t::empty_aggregate_result) drives the aggregator over a batch with

--- a/services/collection/executor.cpp
+++ b/services/collection/executor.cpp
@@ -1778,8 +1778,8 @@ namespace services::collection::executor {
                                                    rd_ctx,
                                                    std::move(revert_delete_tables));
                 co_await std::move(rdf);
-                exec_result.pg_catalog_delete_tables.clear();
             }
+            exec_result.pg_catalog_delete_tables.clear();
 
             auto [_ab, abf] =
                 actor_zeta::send(parent_address_, &services::dispatcher::manager_dispatcher_t::txn_abort_msg, session);

--- a/services/collection/executor.cpp
+++ b/services/collection/executor.cpp
@@ -1754,6 +1754,33 @@ namespace services::collection::executor {
                 }
             }
 
+            // Heap delete-mark un-stamp, mirroring operator_abort_transaction (1).
+            // A DELETE/UPDATE stamped MVCC delete marks (deleter == this txn) BEFORE
+            // the constraint check failed. The aborted txn never commits, so readers
+            // still see the rows — but chunk_vector_info::delete_rows skips an
+            // already-stamped slot, so without the un-stamp the next UPDATE's
+            // delete-half silently no-ops (duplicating the row via its append-half)
+            // and the row can never be deleted again. Union base + catalog heaps:
+            // pg_catalog tables have no index engines but their marks must be
+            // un-stamped all the same.
+            if (resolve_txn.transaction_id != 0 &&
+                (!exec_result.dml_deletes.empty() || !exec_result.pg_catalog_delete_tables.empty()) &&
+                disk_address_ != actor_zeta::address_t::empty_address()) {
+                std::set<components::catalog::oid_t> revert_set{exec_result.pg_catalog_delete_tables.begin(),
+                                                                exec_result.pg_catalog_delete_tables.end()};
+                for (const auto& del : exec_result.dml_deletes) {
+                    revert_set.insert(del.table_oid);
+                }
+                std::vector<components::catalog::oid_t> revert_delete_tables{revert_set.begin(), revert_set.end()};
+                components::execution_context_t rd_ctx{session, resolve_txn, session_ctx.session_tz};
+                auto [_rd, rdf] = actor_zeta::send(disk_address_,
+                                                   &services::disk::manager_disk_t::storage_revert_deletes,
+                                                   rd_ctx,
+                                                   std::move(revert_delete_tables));
+                co_await std::move(rdf);
+                exec_result.pg_catalog_delete_tables.clear();
+            }
+
             auto [_ab, abf] =
                 actor_zeta::send(parent_address_, &services::dispatcher::manager_dispatcher_t::txn_abort_msg, session);
             co_await std::move(abf);


### PR DESCRIPTION
Fixes #552.

## Problem

An FK-rejected DELETE corrupts row identity: the next UPDATE reports 1 row but duplicates it, and the original row becomes undeletable:

```sql
DELETE FROM db.p WHERE id = 1;                 -- correctly rejected (FK)
UPDATE db.p SET val = 'renamed' WHERE id = 1;  -- OK rows=1
SELECT * FROM db.p;                            -- 2 rows: (1,'p1') and (1,'renamed')
```

## Root causes (three commits, found while extending coverage to the UPDATE variant)

**1. Missing heap un-stamp on the autocommit failure path** (`46f8736e`). A DELETE (or an UPDATE's delete-half) stamps its rows' MVCC delete marks (`deleted[row] = txn_id`) **before** constraint validation runs. On explicit ROLLBACK, `operator_abort_transaction` un-stamps them via `storage_revert_deletes` → `revert_all_deletes`; the autocommit failed-statement path (`revert_failed_txn`) never called it — `dml_deletes` only drove the index-bucket revert. The aborted txn never commits, so readers still see the row — but `chunk_vector_info::delete_rows` skips any already-stamped slot: the next UPDATE's delete-half silently no-ops while its append-half succeeds → duplicate row; every later DELETE is skipped the same way → undeletable. Fix mirrors the abort operator's heap un-stamp (base delete tables ∪ `pg_catalog_delete_tables`, keyed by the failed txn's id) into `revert_failed_txn`.

**2. `validity_mask_t::set_valid` wrote a whole 64-bit entry, not a bit** (`558db364`). `validity_mask_[row_idx] = true` indexed **entries** by row index (`set_invalid` has always been bit-precise). Its production caller is `revert_append`'s BIT reset, so the sub-byte head of the reset landed in the wrong entries entirely: a constraint-rejected statement that appended a NULL left that NULL bit behind, and the next row appended into the reused slot — e.g. a successful UPDATE's new version — read as NULL forever. Surfaced by the UPDATE-variant regression test; confirmed with a component-level `data_table_t` replay.

**3. Delete marker recorded after the flush-error check** (`c15269cb`). The MVCC update stamps delete marks before its append half can fail; the marker that lets the abort tail un-stamp them was pushed after the flush-error return in `operator_update`/`operator_delete`, so a mid-flush failure (write_conflict / OOM / RETURNING read-back error) would leak the stamps past fix 1. Reordered per `record_flush`'s record-first principle.

## Testing

- `fk_rejected_delete_leaves_row_updatable_and_deletable` (integration): the issue's exact SQL — fails with `2 == 1` before the fix; also verifies the row is deletable once the child row is removed.
- `constraint_rejected_update_leaves_row_updatable` (integration): NOT-NULL-rejected UPDATE variant — asserts the table state right after the failed statement, the physical append revert firing, and the follow-up update/delete. Fails without fix 1 (duplicate row) and without fix 2 (surviving row reads NULL).
- `components::table::mvcc::aborted_update_revert_restores_row` (component): storage-level replay of abort + revert + committed re-update; pins the `set_valid` bit semantics.
- Full integration suite: 417/417. Component suites: test_table 75/75, test_disk 130/130, test_vector (960k assertions), test_compute, test_index all green.

Note: CHECK expressions are currently not enforced on the UPDATE path at all (`rewrite_update` wires NOT NULL / UNIQUE / FKs but drops `check_exprs`) — pre-existing gap, out of scope here; the UPDATE-variant test uses NOT NULL for that reason.