### PR TITLE
Enforce CHECK constraints on UPDATE

### DIFF
--- a/components/logical_plan/node_update.hpp
+++ b/components/logical_plan/node_update.hpp
@@ -33,6 +33,11 @@ namespace components::logical_plan {
         void set_outgoing_fks(std::vector<catalog::fk_info_t> v) { outgoing_fks_ = std::move(v); }
         const std::vector<catalog::fk_info_t>& outgoing_fks() const { return outgoing_fks_; }
 
+        // CHECK constraint (name, expression-text) pairs, enforced against the
+        // gathered post-update rows (see node_insert_t::check_exprs).
+        void set_check_exprs(std::vector<std::pair<std::string, std::string>> v) { check_exprs_ = std::move(v); }
+        const std::vector<std::pair<std::string, std::string>>& check_exprs() const { return check_exprs_; }
+
         // UNIQUE / PRIMARY KEY column groups (contype 'u'/'p'), one ordered
         // column-name list per constraint. Stamped by the dispatcher's enrich pass;
         // the planner forwards these onto the node_check_constraint_t wrapper so
@@ -60,6 +65,7 @@ namespace components::logical_plan {
 
         std::vector<std::string> not_null_cols_;
         std::vector<catalog::fk_info_t> outgoing_fks_;
+        std::vector<std::pair<std::string, std::string>> check_exprs_; // (name, expr)
         std::vector<std::vector<std::string>> unique_groups_;                         // UNIQUE / PK column groups
         std::vector<std::pair<std::string, types::logical_value_t>> column_defaults_; // decoded DEFAULTs
     };

--- a/components/planner/planner.cpp
+++ b/components/planner/planner.cpp
@@ -95,12 +95,13 @@ namespace components::planner {
                 cur = fk_node;
             }
 
-            if (!upd->not_null_cols().empty() || !upd->unique_groups().empty()) {
-                auto cc = boost::intrusive_ptr(
-                    new logical_plan::node_check_constraint_t(r,
-                                                              core::dbname_t{},
-                                                              core::relname_t{},
-                                                              std::vector<std::string>(upd->not_null_cols())));
+            if (!upd->not_null_cols().empty() || !upd->check_exprs().empty() || !upd->unique_groups().empty()) {
+                auto cc = boost::intrusive_ptr(new logical_plan::node_check_constraint_t(
+                    r,
+                    core::dbname_t{},
+                    core::relname_t{},
+                    std::vector<std::string>(upd->not_null_cols()),
+                    std::vector<std::pair<std::string, std::string>>(upd->check_exprs())));
                 // UNIQUE / PK enforcement on the UPDATE write-set (see rewrite_insert).
                 cc->set_unique_groups(upd->unique_groups());
                 cc->set_table_oid(upd->table_oid());

--- a/integration/cpp/test/test_sql_features.cpp
+++ b/integration/cpp/test/test_sql_features.cpp
@@ -2320,6 +2320,122 @@ TEST_CASE("integration::cpp::test_sql_features::check_constraint") {
     }
 }
 
+TEST_CASE("integration::cpp::test_sql_features::check_constraint_on_update") {
+    // Issue #558.C: CHECK constraints must be enforced on UPDATE, not only INSERT.
+    auto config = test_create_config("/tmp/test_sql_features/check_constraint_on_update");
+    test_clear_directory(config);
+    config.disk.on = true;
+    config.wal.on = false;
+    test_spaces space(config);
+    auto* dispatcher = space.dispatcher();
+
+    INFO("setup: items with CHECK (age > 0) and one valid row");
+    {
+        {
+            auto session = otterbrix::session_id_t();
+            dispatcher->execute_sql(session, "CREATE DATABASE TestDatabase;");
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            dispatcher->execute_sql(session, "CREATE TABLE TestDatabase.items (id bigint, age bigint, name text);");
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur =
+                dispatcher->execute_sql(session,
+                                        "ALTER TABLE TestDatabase.items ADD CONSTRAINT chk_age CHECK (age > 0);");
+            REQUIRE(cur->is_success());
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur =
+                dispatcher->execute_sql(session,
+                                        "INSERT INTO TestDatabase.items (id, age, name) VALUES (1, 25, 'alice');");
+            REQUIRE(cur->is_success());
+        }
+    }
+
+    INFO("UPDATE violating the CHECK is rejected");
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "UPDATE TestDatabase.items SET age = -5 WHERE id = 1;");
+        REQUIRE(cur->is_error());
+    }
+
+    INFO("the stored value is unchanged after the rejected UPDATE");
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT age FROM TestDatabase.items WHERE id = 1;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        REQUIRE(*(cur->chunks().front().data[0].data<int64_t>()) == 25);
+    }
+
+    INFO("UPDATE of a different column passes an untouched CHECK column through");
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "UPDATE TestDatabase.items SET name = 'bob' WHERE id = 1;");
+        INFO("other-column update error: " << (cur->is_error() ? cur->get_error().what : "none"));
+        REQUIRE(cur->is_success());
+    }
+
+    INFO("UPDATE satisfying the CHECK is accepted");
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "UPDATE TestDatabase.items SET age = 30 WHERE id = 1;");
+        INFO("valid update error: " << (cur->is_error() ? cur->get_error().what : "none"));
+        REQUIRE(cur->is_success());
+    }
+    {
+        auto session = otterbrix::session_id_t();
+        auto cur = dispatcher->execute_sql(session, "SELECT age FROM TestDatabase.items WHERE id = 1;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        REQUIRE(*(cur->chunks().front().data[0].data<int64_t>()) == 30);
+    }
+
+    INFO("compound CHECK is enforced on UPDATE");
+    {
+        auto config2 = test_create_config("/tmp/test_sql_features/check_constraint_on_update_compound");
+        test_clear_directory(config2);
+        config2.disk.on = true;
+        config2.wal.on = false;
+        test_spaces space2(config2);
+        auto* d2 = space2.dispatcher();
+        {
+            auto session = otterbrix::session_id_t();
+            d2->execute_sql(session, "CREATE DATABASE TestDatabase;");
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            d2->execute_sql(session, "CREATE TABLE TestDatabase.scores (id bigint, val bigint);");
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = d2->execute_sql(
+                session,
+                "ALTER TABLE TestDatabase.scores ADD CONSTRAINT chk_val CHECK (val > 0 AND val < 100);");
+            REQUIRE(cur->is_success());
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = d2->execute_sql(session, "INSERT INTO TestDatabase.scores (id, val) VALUES (1, 50);");
+            REQUIRE(cur->is_success());
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = d2->execute_sql(session, "UPDATE TestDatabase.scores SET val = 100 WHERE id = 1;");
+            REQUIRE(cur->is_error());
+        }
+        {
+            auto session = otterbrix::session_id_t();
+            auto cur = d2->execute_sql(session, "UPDATE TestDatabase.scores SET val = 99 WHERE id = 1;");
+            INFO("in-range update error: " << (cur->is_error() ? cur->get_error().what : "none"));
+            REQUIRE(cur->is_success());
+        }
+    }
+}
+
 TEST_CASE("integration::cpp::test_sql_features::check_constraint_invalid_expr") {
     // Verifies that CHECK constraints with unsupported expression node types
     // (T_FuncCall) are rejected at creation time with a clear error, not silently stored
@@ -5931,3 +6047,4 @@ TEST_CASE("integration::cpp::test_sql_features::col_vs_col_disk_promotes_like_in
                 *core::date::parse_timestamp("2024-03-01 08:00:00"));
     }
 }
+

--- a/services/collection/executor.cpp
+++ b/services/collection/executor.cpp
@@ -1718,6 +1718,28 @@ namespace services::collection::executor {
                 co_await std::move(paf);
             }
 
+            // Heap delete-mark un-stamp, parity with operator_abort_transaction's
+            // storage_revert_deletes: an UPDATE/DELETE in this statement stamped
+            // delete marks (deleter == txn_id) on the old row versions before the
+            // failure surfaced. The marks are invisible to readers, but they
+            // PERSIST on the heap and chunk_vector_info::delete_rows skips an
+            // already-marked slot — so without the un-stamp every later UPDATE or
+            // DELETE of the same rows silently leaves the old version alive.
+            if (!exec_result.dml_deletes.empty() && disk_address_ != actor_zeta::address_t::empty_address()) {
+                std::set<components::catalog::oid_t> revert_delete_tables;
+                for (const auto& del : exec_result.dml_deletes) {
+                    revert_delete_tables.insert(del.table_oid);
+                }
+                components::execution_context_t rd_ctx{session, resolve_txn, session_ctx.session_tz};
+                auto [_rd, rdf] = actor_zeta::send(
+                    disk_address_,
+                    &services::disk::manager_disk_t::storage_revert_deletes,
+                    rd_ctx,
+                    std::vector<components::catalog::oid_t>{revert_delete_tables.begin(),
+                                                            revert_delete_tables.end()});
+                co_await std::move(rdf);
+            }
+
             // Index revert, two-phase (send-all then await-all), deduped per
             // table_oid. revert_insert ← pending index INSERT bucket (dml_appends);
             // revert_delete ← pending index DELETE bucket (dml_deletes). Both are

--- a/services/dispatcher/enrich_logical_plan.cpp
+++ b/services/dispatcher/enrich_logical_plan.cpp
@@ -4,7 +4,7 @@
 // plan-tree resolve idx (populated by operator_resolve_*_t) to annotate DML
 // nodes with the data they need at execution time:
 //   INSERT  — not_null_cols, outgoing FK references, CHECK expressions
-//   UPDATE  — not_null_cols, outgoing FK references
+//   UPDATE  — not_null_cols, outgoing FK references, CHECK expressions
 //   DELETE  — referencing FKs (for CASCADE / SET NULL / SET DEFAULT)
 //   CREATE  — namespace_oid (for catalog registration)
 //
@@ -869,6 +869,9 @@ namespace services::dispatcher { namespace {
                 if (tbl_oid != components::catalog::INVALID_OID && idx) {
                     if (auto it = idx->outgoing_fks_by_oid.find(tbl_oid); it != idx->outgoing_fks_by_oid.end()) {
                         node->set_outgoing_fks(it->second);
+                    }
+                    if (auto it = idx->check_exprs_by_oid.find(tbl_oid); it != idx->check_exprs_by_oid.end()) {
+                        node->set_check_exprs(it->second);
                     }
                     if (auto it = idx->unique_constraints_by_oid.find(tbl_oid);
                         it != idx->unique_constraints_by_oid.end()) {


### PR DESCRIPTION
## Summary

Fixes item **C** of #558: `CHECK` constraints were not enforced on `UPDATE` — `UPDATE t SET a = -5` succeeded against `CHECK (a > 0)`.

Two bugs, one commit each:

### 1. CHECK expressions were never plumbed into the UPDATE plan (`75b83cd`)

The resolve pipeline already collects CHECK expressions for every DML statement (`plan_resolve_index` even documents `check_exprs_by_oid` as "for INSERT/UPDATE"), but only the INSERT path consumed them:

- `node_update_t` had no `check_exprs` field,
- the dispatcher enrich pass never stamped them onto the UPDATE node,
- `rewrite_update()` built the `node_check_constraint_t` wrapper without them.

The fix mirrors the INSERT path through those three spots. The enforcement operator itself (`operator_check_constraint_t`) is DML-agnostic and already validates the gathered post-update row snapshot — the same one UNIQUE-on-UPDATE enforcement uses — so it needed no changes. Columns absent from the SET list are checked against their stored values, not defaults.

### 2. A rejected UPDATE poisoned all later writes to the same rows (`d6a34e1`)

Exposed immediately by bug 1's fix: an UPDATE stamps delete marks (`deleter == txn_id`) on the old row versions before the CHECK failure surfaces. The failed-statement tail (`revert_failed_txn`) reverted the physical appends and pending index markers but never un-stamped those heap delete marks — unlike the explicit-ROLLBACK path (`operator_abort_transaction_t`), which calls `storage_revert_deletes` for exactly this reason (its comment describes the hazard). Since `chunk_vector_info::delete_rows` skips an already-marked slot, every subsequent UPDATE/DELETE of those rows silently left the old version alive — one duplicate row per write, growing without bound. Added the missing `storage_revert_deletes` parity call.

## Test

`integration::cpp::test_sql_features::check_constraint_on_update` covers:
- violating UPDATE rejected, stored value intact afterwards (rollback verified);
- UPDATE of an unrelated column passes an untouched CHECK column through;
- satisfying UPDATE accepted with exactly **one** surviving row version (regresses bug 2);
- compound `AND` CHECK boundary values on UPDATE.

## Validation

Full ctest suite: **1414/1414 passed** (Release, run in tmpfs-safe batches).