### PR TITLE
Navigate absent computing-table keys to NULL instead of erroring

### DIFF
--- a/components/physical_plan_generator/impl/create_plan_select.cpp
+++ b/components/physical_plan_generator/impl/create_plan_select.cpp
@@ -39,6 +39,18 @@ namespace services::planner::impl {
                     auto field = expr->params().empty()
                                      ? expr->key()
                                      : std::get<components::expressions::key_t>(expr->params().front());
+                    if (field.path().empty()) {
+                        // A jsonb navigation over an absent key: validation resolved it to
+                        // a typed NULL leaf (no source column to read), so project it as a
+                        // NULL constant — constant_value is the null it was constructed
+                        // with, and the column type arrives via set_output_types.
+                        col.type = components::operators::select_column_t::kind::constant;
+                        col.key.type = components::operators::group_key_t::kind::column;
+                        if (col.key.name.empty() && !field.storage().empty()) {
+                            col.key.name = std::pmr::string(field.storage().back(), resource);
+                        }
+                        break;
+                    }
                     col.key.type = components::operators::group_key_t::kind::column;
                     col.key.full_path = field.path();
                     // Validation always resolves a concrete side; carry it so a

--- a/components/sql/transformer/impl/transfrom_common.cpp
+++ b/components/sql/transformer/impl/transfrom_common.cpp
@@ -627,6 +627,31 @@ namespace components::sql::transform {
                     return transform_jsonb_exists(node, names, plan->parameters.get(), op_str);
                 }
 
+                // `<nav> IS [NOT] NULL`: the grammar binds IS [NOT] NULL tighter than a
+                // user operator, so the navigation operator arrives on top with the
+                // NullTest wrapped around its key operand. Unwrap the NullTest, resolve
+                // the navigation key from the remaining chain, and emit the null check
+                // over it — the parenthesized spelling `(<nav>) IS NULL` reaches the
+                // same shape through transform_null_test's computed-operand branch.
+                if (is_jsonb_nav_operator(op_str) && node->rexpr && nodeTag(node->rexpr) == T_NullTest) {
+                    auto* null_test = pg_ptr_cast<NullTest>(node->rexpr);
+                    Node* saved_rexpr = node->rexpr;
+                    node->rexpr = pg_ptr_cast<Node>(null_test->arg);
+                    expressions::key_t nav_key{resource_};
+                    const bool resolved = resolve_jsonb_scalar_key(node, names, nav_key);
+                    node->rexpr = saved_rexpr;
+                    if (!resolved) {
+                        return nullptr;
+                    }
+                    auto dummy = plan->parameters->add_parameter(
+                        types::logical_value_t(resource_, types::complex_logical_type{types::logical_type::NA}));
+                    return make_compare_expression(resource_,
+                                                   null_test->nulltesttype == IS_NULL ? compare_type::is_null
+                                                                                      : compare_type::is_not_null,
+                                                   nav_key,
+                                                   dummy);
+                }
+
                 auto comp_type = get_compare_type(op_str);
                 if (comp_type == compare_type::invalid) {
                     error_ = core::error_t(core::error_code_t::sql_parse_error,
@@ -1247,6 +1272,14 @@ namespace components::sql::transform {
         }
 
         // Right operand: the key(s) this step navigates into.
+        // A ParamRef ($1) would stringify to the literal key "$1" — with absent-key
+        // navigation yielding NULL that would silently answer NULL for every row
+        // instead of telling the caller that parameter-supplied keys don't exist.
+        if (node->rexpr && nodeTag(node->rexpr) == T_ParamRef) {
+            error_ = core::error_t(core::error_code_t::sql_parse_error,
+                                   std::pmr::string{"jsonb operator key cannot be a parameter", resource_});
+            return false;
+        }
         std::string key_str = get_str_value(node->rexpr);
         if (has_error()) {
             return false;
@@ -1309,7 +1342,15 @@ namespace components::sql::transform {
         }
         // The only difference from a prefix key is the scalar-vs-table guard above;
         // the flattening itself is identical, so share it.
-        return resolve_jsonb_prefix_key(node, names, out_key);
+        if (!resolve_jsonb_prefix_key(node, names, out_key)) {
+            return false;
+        }
+        // Scalar navigation over a key no column matches is a legal ABSENT leaf
+        // (postgres 3VL — it navigates to SQL NULL), not the hard "path not found"
+        // error a mistyped regular column deserves. Table-valued prefixes (expand /
+        // delete) stay strict — they cannot synthesize columns out of nothing.
+        out_key.set_absent_ok(true);
+        return true;
     }
 
     expression_ptr transformer::transform_jsonb_exists(A_Expr* node,

--- a/integration/cpp/test/test_jsonb_support.cpp
+++ b/integration/cpp/test/test_jsonb_support.cpp
@@ -17,7 +17,9 @@
 //   delete  (projection) : -    #-           .. project every column except the named subtree
 //
 // Paths are spelled either dotted ('a.b') or as a postgres text array ('{a,b}').
-// Keys are case-sensitive; a path that no column matches is a hard ERROR, not NULL.
+// Keys are case-sensitive and matched verbatim (segments are NOT dequoted). A
+// scalar navigation whose path matches no column yields SQL NULL (see
+// navigation_over_missing_key_yields_null); table-valued expansion still errors.
 //
 // The cases below are split in two:
 //   * SUPPORTED  — value-exact pins of behavior that is correct and worth keeping.
@@ -220,7 +222,13 @@ TEST_CASE("integration::cpp::test_jsonb_support::extract_scalar") {
         CHECK(i64(exec(d, "SELECT t #>> 'a.b' AS v FROM jp.t AS tt ORDER BY id;"), "v", 0) == 10);
     }
 
-    SECTION("keys are case-sensitive") { CHECK_FALSE(exec(d, "SELECT t ->> 'X' AS v FROM jp.t;")->is_success()); }
+    SECTION("keys are case-sensitive: the wrong-case key is absent (NULL), not 'x'") {
+        auto cur = exec(d, "SELECT id, t ->> 'X' AS v FROM jp.t ORDER BY id;");
+        REQUIRE(cur->is_success());
+        for (size_t r = 0; r < 4; ++r) {
+            CHECK(is_null(cur, "v", r));
+        }
+    }
 }
 
 // -> and #> : object expansion. These are table-valued — they widen the projection
@@ -598,8 +606,10 @@ TEST_CASE("integration::cpp::test_jsonb_support::compare_two_navigations") {
         CHECK(ids(cur) == std::set<int64_t>{2, 3});
     }
 
-    SECTION("a navigation naming no column is still a clean error, not a wrong answer") {
-        CHECK_FALSE(exec(d, "SELECT id FROM jp.t WHERE t #>> 'a.b' = t #>> 'nokey';")->is_success());
+    SECTION("a navigation naming no column is NULL: the compare is UNKNOWN, no rows") {
+        auto cur = exec(d, "SELECT id FROM jp.t WHERE t #>> 'a.b' = t #>> 'nokey';");
+        REQUIRE(cur->is_success());
+        CHECK(cur->size() == 0);
     }
 }
 
@@ -640,8 +650,6 @@ TEST_CASE("integration::cpp::test_jsonb_support::clean_rejections") {
         "SELECT t #>> ARRAY['a','b'] AS v FROM jp.t;",
         // navigation in the SELECT list of a GROUP BY query
         "SELECT t #>> 'a.b' AS v FROM jp.t GROUP BY id;",
-        // path segments are not dequoted
-        "SELECT t #>> '{\"a\",\"b\"}' AS v FROM jp.t;",
         // an intermediate (non-leaf) key is not a scalar
         "SELECT t #>> 'a' AS v FROM jp.t;",
         // postgres jsonpath / containment / concatenation operators do not exist
@@ -798,8 +806,13 @@ TEST_CASE("integration::cpp::test_jsonb_support::deep_path_insert_keeps_all_segm
     CHECK(i64(exec(d, "SELECT d #>> 'a.b.c' AS v FROM jp.d WHERE id = 1;"), "v", 0) == 111);
     CHECK(i64(exec(d, "SELECT d #>> '{a,b,c}' AS v FROM jp.d WHERE id = 1;"), "v", 0) == 111);
     CHECK(i64(exec(d, "SELECT d #>> 'p.q.r.s.t' AS v FROM jp.d WHERE id = 2;"), "v", 0) == 222);
-    // the truncated path nobody wrote is (correctly) absent now
-    CHECK_FALSE(exec(d, "SELECT d #>> 'a.c' AS v FROM jp.d;")->is_success());
+    // the truncated path nobody wrote is absent: it navigates to NULL
+    {
+        auto miss = exec(d, "SELECT d #>> 'a.c' AS v FROM jp.d ORDER BY id;");
+        REQUIRE(miss->is_success());
+        CHECK(is_null(miss, "v", 0));
+        CHECK(is_null(miss, "v", 1));
+    }
 
     // partial expansion through the deep path
     auto expand = exec(d, "SELECT d -> 'a' -> 'b' FROM jp.d WHERE id = 1;");
@@ -915,8 +928,12 @@ TEST_CASE("integration::cpp::test_jsonb_support::zero_match_expand_is_an_error")
     auto* d = space.dispatcher();
     seed(d);
 
-    // the scalar operator errors, as it always has
-    CHECK_FALSE(exec(d, "SELECT t ->> 'nokey' AS v FROM jp.t;")->is_success());
+    // the scalar operator navigates to NULL for an absent key (postgres 3VL)
+    {
+        auto scalar = exec(d, "SELECT t ->> 'nokey' AS v FROM jp.t;");
+        REQUIRE(scalar->is_success());
+        CHECK(is_null(scalar, "v", 0));
+    }
 
     // the table-valued one now errors too, instead of producing zero columns
     CHECK_FALSE(exec(d, "SELECT t -> 'nokey' FROM jp.t;")->is_success());
@@ -997,19 +1014,78 @@ TEST_CASE("integration::cpp::test_jsonb_support::existence_over_missing_key") {
     CHECK_FALSE(exec(d, "SELECT id FROM jp.r WHERE nosuchcol IS NULL;")->is_success());
 }
 
-// STILL a hard error, deferred (documented): scalar navigation over an absent key
-// should yield SQL NULL, and `<nav> IS NULL` should be a boolean. Both need the
-// select-list / compare paths to synthesize a typed NULL leaf for a flagged key,
-// a larger change than the existence rewrite; pinned so the deferral is visible.
-TEST_CASE("integration::cpp::test_jsonb_support::navigation_over_missing_key_still_errors") {
+// Scalar navigation over an absent key is the NULL-valued analogue of existence
+// (postgres 3VL): a path no column matches navigates to SQL NULL for every row,
+// and `<nav> IS NULL` is an ordinary boolean predicate. Only navigation keys get
+// the lenient handling — a mistyped regular column reference still hard-errors.
+TEST_CASE("integration::cpp::test_jsonb_support::navigation_over_missing_key_yields_null") {
     auto config = make_test_config("/tmp/test_jsonb_matrix/missing_nav");
     test_spaces space(config);
     auto* d = space.dispatcher();
     seed(d);
 
-    CHECK_FALSE(exec(d, "SELECT t ->> 'nokey' AS v FROM jp.t;")->is_success());           // deferred: NULL every row
-    CHECK_FALSE(exec(d, "SELECT t #>> 'no.key' AS v FROM jp.t;")->is_success());          // deferred: NULL every row
-    CHECK_FALSE(exec(d, "SELECT id FROM jp.t WHERE t #>> 'a.b' IS NULL;")->is_success()); // deferred: row 4
+    SECTION("projection: a key no row has is NULL for every row") {
+        // the third spelling: segments are matched verbatim (not dequoted), so a
+        // quoted pg-array path names a key nobody wrote — absent, hence NULL
+        for (const auto* sql : {"SELECT id, t ->> 'nokey' AS v FROM jp.t ORDER BY id;",
+                                "SELECT id, t #>> 'no.key' AS v FROM jp.t ORDER BY id;",
+                                "SELECT id, t #>> '{\"a\",\"b\"}' AS v FROM jp.t ORDER BY id;"}) {
+            INFO(sql);
+            auto cur = exec(d, sql);
+            if (!cur->is_success()) {
+                UNSCOPED_INFO(cur->get_error().what);
+            }
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->size() == 4);
+            for (size_t r = 0; r < 4; ++r) {
+                CHECK(is_null(cur, "v", r));
+            }
+        }
+    }
+
+    SECTION("IS NULL over a navigation is a boolean predicate") {
+        // the parenthesized spelling routes through the NullTest computed-operand path
+        auto paren = exec(d, "SELECT id FROM jp.t WHERE (t #>> 'a.b') IS NULL;");
+        if (!paren->is_success()) {
+            UNSCOPED_INFO(paren->get_error().what);
+        }
+        REQUIRE(paren->is_success());
+        CHECK(ids(paren) == std::set<int64_t>{4});
+        // the bare spelling must agree
+        auto cur = exec(d, "SELECT id FROM jp.t WHERE t #>> 'a.b' IS NULL;");
+        if (!cur->is_success()) {
+            UNSCOPED_INFO(cur->get_error().what);
+        }
+        REQUIRE(cur->is_success());
+        CHECK(ids(cur) == std::set<int64_t>{4});
+        CHECK(ids(exec(d, "SELECT id FROM jp.t WHERE t #>> 'a.b' IS NOT NULL;")) == std::set<int64_t>{1, 2, 3});
+    }
+
+    SECTION("IS [NOT] NULL over a missing key: NULL for every row") {
+        auto cur = exec(d, "SELECT id FROM jp.t WHERE t ->> 'nokey' IS NULL;");
+        if (!cur->is_success()) {
+            UNSCOPED_INFO(cur->get_error().what);
+        }
+        REQUIRE(cur->is_success());
+        CHECK(ids(cur) == std::set<int64_t>{1, 2, 3, 4});
+        auto none = exec(d, "SELECT id FROM jp.t WHERE t ->> 'nokey' IS NOT NULL;");
+        REQUIRE(none->is_success());
+        CHECK(none->size() == 0);
+    }
+
+    SECTION("a compare against a missing key is UNKNOWN: no rows, not an error") {
+        auto cur = exec(d, "SELECT id FROM jp.t WHERE t ->> 'nokey' = 10;");
+        if (!cur->is_success()) {
+            UNSCOPED_INFO(cur->get_error().what);
+        }
+        REQUIRE(cur->is_success());
+        CHECK(cur->size() == 0);
+    }
+
+    SECTION("a mistyped regular column still hard-errors") {
+        CHECK_FALSE(exec(d, "SELECT nosuchcol FROM jp.t;")->is_success());
+        CHECK_FALSE(exec(d, "SELECT id FROM jp.t WHERE nosuchcol = 1;")->is_success());
+    }
 }
 
 // [A] The key operand of a jsonb operator is a literal: a bare string/number, a
@@ -1041,8 +1117,11 @@ TEST_CASE("integration::cpp::test_jsonb_support::key_operand_literals") {
         REQUIRE(cast->is_success());
         CHECK(i64(cast, "v", 0) == 10);
         CHECK(i64(cast, "v", 1) == 30);
-        // ->> is single-key, so ('a.b'::text) is the literal key "a.b" (no such column)
-        CHECK_FALSE(exec(d, "SELECT t ->> ('a.b'::text) AS v FROM jp.t;")->is_success());
+        // ->> is single-key, so ('a.b'::text) is the literal key "a.b" — no such
+        // column, and an absent key navigates to NULL
+        auto miss = exec(d, "SELECT t ->> ('a.b'::text) AS v FROM jp.t;");
+        REQUIRE(miss->is_success());
+        CHECK(is_null(miss, "v", 0));
     }
 
     SECTION("a cast key composes in every clause the bare key does") {
@@ -1060,8 +1139,11 @@ TEST_CASE("integration::cpp::test_jsonb_support::key_operand_literals") {
 
     SECTION("a non-string cast key resolves to its value and never crashes") {
         // (1::bool) used to segfault; now the key is the text "1" (no such column).
-        // Both the scalar and the table-valued form error cleanly on the miss.
-        CHECK_FALSE(exec(d, "SELECT t ->> (1::bool) AS v FROM jp.t;")->is_success());
+        // The scalar form navigates the absent key to NULL; the table-valued form
+        // still errors cleanly (it cannot expand columns that do not exist).
+        auto scalar = exec(d, "SELECT t ->> (1::bool) AS v FROM jp.t;");
+        REQUIRE(scalar->is_success());
+        CHECK(is_null(scalar, "v", 0));
         CHECK_FALSE(exec(d, "SELECT t -> (1::bool) FROM jp.t;")->is_success());
     }
 }

--- a/services/dispatcher/validate_logical_plan.cpp
+++ b/services/dispatcher/validate_logical_plan.cpp
@@ -410,6 +410,35 @@ namespace services::dispatcher {
             }
         }
 
+        // True when `name` is an INTERMEDIATE object key of the flattened
+        // representation: no column is named `name` itself, but columns exist under
+        // "name/". Scalar navigation must NOT treat such a key as an absent (NULL)
+        // leaf — the object exists; reading it as a scalar stays an error.
+        [[nodiscard]] bool has_child_columns(const named_schema& schema, const std::string& name) {
+            const std::string prefix = name + "/";
+            for (const auto& c : schema) {
+                if (c.type.has_alias() && std::string(c.type.alias()).rfind(prefix, 0) == 0) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        // The output column type of a scalar jsonb navigation whose key matches no
+        // column: a typed NULL leaf. STRING_LITERAL matches how a bare NULL literal
+        // is projected; the alias is the projection's output name (the AS alias when
+        // one was given, else the flattened path itself).
+        [[nodiscard]] components::types::complex_logical_type
+        absent_nav_null_type(const components::expressions::scalar_expression_t* scalar_expr,
+                             const components::expressions::key_t& key) {
+            components::types::complex_logical_type null_type(logical_type::STRING_LITERAL);
+            const auto& name_key = scalar_expr->key().storage().empty() ? key : scalar_expr->key();
+            if (!name_key.storage().empty()) {
+                null_type.set_alias(std::string(name_key.storage().back()));
+            }
+            return null_type;
+        }
+
         // Rewrite an is_not_null / is_null predicate on a multi-type field into
         // an OR / AND over its per-type-variant columns: the key "exists" iff ANY
         // variant is non-null, and is null only if ALL variants are null. This is
@@ -487,6 +516,56 @@ namespace services::dispatcher {
                 combined->append_child(make_compare_expression(resource, cmp->type(), vkey, cmp->right()));
             }
             return combined;
+        }
+
+        // A value compare over a jsonb navigation whose key matches no column is
+        // UNKNOWN for every row (the absent leaf is SQL NULL), so it selects
+        // nothing: fold it to the canonical no-rows predicate instead of letting
+        // validate_key hard-error on the flagged key. is_null / is_not_null over
+        // such keys are already folded by rewrite_multitype_null_checks, so what
+        // reaches here is a value compare. union_not is deliberately NOT descended
+        // into: NOT UNKNOWN is still UNKNOWN, but an all_false folded under NOT
+        // would flip into match-everything — the strict "path not found" error is
+        // the safe behavior there.
+        components::expressions::expression_ptr
+        fold_absent_nav_compares(std::pmr::memory_resource* resource,
+                                 const components::expressions::expression_ptr& expr,
+                                 const named_schema& schema) {
+            using namespace components::expressions;
+            if (!expr || expr->group() != expression_group::compare) {
+                return expr;
+            }
+            auto* cmp = static_cast<compare_expression_t*>(expr.get());
+            if (cmp->is_union()) {
+                if (cmp->type() == compare_type::union_not) {
+                    return expr;
+                }
+                auto rebuilt = make_compare_union_expression(resource, cmp->type());
+                for (const auto& ch : cmp->children()) {
+                    rebuilt->append_child(fold_absent_nav_compares(resource, ch, schema));
+                }
+                return rebuilt;
+            }
+            if (cmp->type() == compare_type::is_null || cmp->type() == compare_type::is_not_null) {
+                return expr;
+            }
+            auto operand_is_absent = [&](const param_storage& p) -> bool {
+                if (!std::holds_alternative<components::expressions::key_t>(p)) {
+                    return false;
+                }
+                const auto& key = std::get<components::expressions::key_t>(p);
+                if (!key.absent_ok() || key.storage().empty() || !key.path().empty()) {
+                    return false;
+                }
+                components::expressions::key_t probe = key;
+                auto found = find_types(resource, probe, schema);
+                return found.has_error() && found.error().type != core::error_code_t::ambiguous_name &&
+                       !has_child_columns(schema, key.as_string());
+            };
+            if (operand_is_absent(cmp->left()) || operand_is_absent(cmp->right())) {
+                return make_compare_expression(resource, compare_type::all_false);
+            }
+            return expr;
         }
 
         [[nodiscard]] core::result_wrapper_t<named_schema>
@@ -1831,6 +1910,7 @@ namespace services::dispatcher {
                     // over their variants (jsonb '?'/'?|'/'?&' over multi-type).
                     for (auto& e : node_match->expressions()) {
                         e = impl::rewrite_multitype_null_checks(resource, e, incoming_schema);
+                        e = impl::fold_absent_nav_compares(resource, e, incoming_schema);
                     }
                     auto res = impl::validate_schema(resource,
                                                      idx,
@@ -2074,6 +2154,19 @@ namespace services::dispatcher {
                                     auto res =
                                         impl::validate_key(resource, key, incoming_schema, incoming_schema, true);
                                     if (res.has_error()) {
+                                        // A jsonb navigation key that matches no column is a legal
+                                        // ABSENT leaf (postgres 3VL): project a typed NULL column
+                                        // instead of erroring. Ambiguity still errors, and so does
+                                        // an intermediate object key (its children exist — it is
+                                        // not a scalar, not an absent leaf).
+                                        if (key.absent_ok() &&
+                                            res.error().type != core::error_code_t::ambiguous_name &&
+                                            !impl::has_child_columns(incoming_schema, key.as_string())) {
+                                            result.emplace_back(
+                                                type_from_t{node->result_alias(),
+                                                            impl::absent_nav_null_type(scalar_expr, key)});
+                                            continue;
+                                        }
                                         return res.convert_error<named_schema>();
                                     }
                                 }
@@ -2161,6 +2254,11 @@ namespace services::dispatcher {
                                         : std::get<components::expressions::key_t>(scalar_expr->params().front());
                                 if (!key.path().empty() && key.path().front() < incoming_schema.size()) {
                                     result_schema.push_back(incoming_schema[key.path().front()]);
+                                } else if (key.path().empty() && key.absent_ok()) {
+                                    // An absent jsonb-navigation leaf (validated above as a
+                                    // typed NULL projection) still occupies its output slot.
+                                    result_schema.push_back(type_from_t{node->result_alias(),
+                                                                        impl::absent_nav_null_type(scalar_expr, key)});
                                 }
                             } else if (scalar_expr->type() == scalar_type::star_expand) {
                                 for (const auto& col : incoming_schema) {


### PR DESCRIPTION
Fixes the first bug of #569.

On a computing (schemaless) table, scalar jsonb navigation over a key that no column matches raised a hard error, and `<nav> IS NULL` failed with `invalid compare operand`:

```sql
CREATE TABLE db.t ();
INSERT INTO db.t (id, a.b) VALUES (1, 10), (2, 30);

SELECT t ->> 'nokey' FROM db.t;                 -- ERROR: path 'nokey' not found
SELECT id FROM db.t WHERE t #>> 'a.b' IS NULL;  -- ERROR: invalid compare operand
```

Per postgres 3VL an absent key navigates to SQL NULL for every row, and the null test is an ordinary boolean predicate. Existence (`?` / `?|` / `?&`) already returned false for a missing key; navigation is now its NULL-valued analogue.

### What changed

**Transformer**
- Scalar navigation keys (`->>` / `#>>`) are flagged `absent_ok`, exactly like existence keys.
- `<nav> IS [NOT] NULL`: the grammar binds `IS [NOT] NULL` tighter than a user operator, so the predicate arrives as the navigation `A_Expr` with a `NullTest` as its right operand — that shape is now unwrapped into `is_null`/`is_not_null` over the navigation key (the parenthesized spelling already worked through the NullTest computed-operand path).
- A `ParamRef` key (`t ->> $1`) is rejected loudly: it would otherwise become the literal key `$1` and silently navigate to NULL.

**Validator**
- A flagged key matching no column validates as a typed NULL projection (STRING_LITERAL, same as a bare NULL literal) instead of "path not found".
- Value compares over such keys fold to the canonical no-rows predicate (comparing with NULL is UNKNOWN; `IS [NOT] NULL` folds were already handled by the existence rewrite).
- Deliberately still strict, so no silently-wrong answers appear: ambiguous names, intermediate object keys (`t #>> 'a'` when `a/b`, `a/c` exist), and anything under `NOT (...)` (`NOT UNKNOWN` is still UNKNOWN — folding all_false there would flip into match-everything).

**Planner**
- A `get_field` whose key resolved to the absent leaf (empty path) projects a NULL constant; its type arrives via `set_output_types` like any constant.

Table-valued expansion/deletion (`->` / `#>` / `-` / `#-`) stays strict — it cannot synthesize columns out of nothing.

### Tests
- `navigation_over_missing_key_still_errors` (the deferral pin) is replaced by `navigation_over_missing_key_yields_null`: NULL projection for all three path spellings, `IS [NOT] NULL` both bare and parenthesized, value compares over missing keys returning zero rows, and mistyped regular columns still hard-erroring.
- Pins that asserted the old hard errors are flipped to value-exact NULL assertions (case-sensitivity miss, truncated deep path, cast keys, nav-vs-missing-nav compare).
- Full suite: 1413/1413 pass.