### PR TITLE
Removed row kernels for compute functions

### DIFF
--- a/components/compute/compute_kernel.cpp
+++ b/components/compute/compute_kernel.cpp
@@ -82,16 +82,6 @@ namespace components::compute {
         return finalize_(ctx, states, first, count, output);
     }
 
-    row_kernel::row_kernel(kernel_signature_t signature, row_exec_fn exec, kernel_init_fn init)
-        : compute_kernel(std::move(signature), init)
-        , exec_(exec) {}
-
-    core::error_t row_kernel::execute(kernel_context& ctx,
-                                      const std::pmr::vector<types::logical_value_t>& inputs,
-                                      std::pmr::vector<types::logical_value_t>& output) const {
-        return exec_(ctx, inputs, output);
-    }
-
     expand_kernel::expand_kernel(kernel_signature_t signature, expand_exec_fn exec)
         : compute_kernel(std::move(signature))
         , exec_(exec) {}

--- a/components/compute/compute_kernel.hpp
+++ b/components/compute/compute_kernel.hpp
@@ -14,9 +14,7 @@
 namespace components::compute {
     class compute_kernel;
 
-    // originally, arrow-compute's datum is a variant<scalar, vector<T>, data_chunk>.
-    // in our implementation it is a little bit simplified
-    using datum_t = std::variant<std::pmr::vector<types::logical_value_t>, vector::data_chunk_t>;
+    using datum_t = vector::data_chunk_t;
 
     // opaque kernel-specific state, for example, if there is some kind of initialization required
     class kernel_state {
@@ -125,22 +123,6 @@ namespace components::compute {
         aggregate_layout_fn layout_;
         aggregate_update_fn update_;
         aggregate_finalize_fn finalize_;
-    };
-
-    using row_exec_fn = core::error_t (*)(kernel_context& ctx,
-                                          const std::pmr::vector<types::logical_value_t>& inputs,
-                                          std::pmr::vector<types::logical_value_t>& output);
-
-    class row_kernel : public compute_kernel {
-    public:
-        row_kernel(kernel_signature_t signature, row_exec_fn exec, kernel_init_fn init = nullptr);
-
-        core::error_t execute(kernel_context& ctx,
-                              const std::pmr::vector<types::logical_value_t>& inputs,
-                              std::pmr::vector<types::logical_value_t>& output) const;
-
-    private:
-        row_exec_fn exec_;
     };
 
     using expand_exec_fn = core::error_t (*)(kernel_context& ctx,

--- a/components/compute/function.cpp
+++ b/components/compute/function.cpp
@@ -118,13 +118,6 @@ namespace components::compute {
             return executor_->execute(inputs);
         }
 
-        core::result_wrapper_t<datum_t> execute(const std::pmr::vector<logical_value_t>& inputs) override {
-            if (auto st = check_init(); st.contains_error()) {
-                return st;
-            }
-            return executor_->execute(inputs);
-        }
-
         aggregate_state_layout_t state_layout() const override { return executor_->state_layout(); }
 
         core::error_t
@@ -284,31 +277,6 @@ namespace components::compute {
         }
     }
 
-    core::result_wrapper_t<datum_t> function::execute(const std::pmr::vector<logical_value_t>& args,
-                                                      const function_options* options,
-                                                      exec_context_t& ctx) const {
-        std::pmr::vector<complex_logical_type> types(args.get_allocator().resource());
-        types.reserve(args.size());
-        for (const auto& arg : args) {
-            types.emplace_back(arg.type());
-        }
-
-        auto fn_exec = function_executor_impl_t::get_best_function_executor(ctx.resource(), types, *this);
-        if (fn_exec.has_error()) {
-            return fn_exec.convert_error<datum_t>();
-        }
-
-        if (auto st = fn_exec.value().check_args(ctx.resource(), types); st.contains_error()) {
-            return st;
-        }
-
-        if (auto st = fn_exec.value().init(options, ctx); st.contains_error()) {
-            return st;
-        } else {
-            return fn_exec.value().execute(args);
-        }
-    }
-
     const function_options* function::default_options() const { return default_options_; }
 
     vector_function::vector_function(std::string name, arity fn_arity, function_doc doc, size_t available_kernel_slots)
@@ -336,19 +304,6 @@ namespace components::compute {
 
     std::unique_ptr<function> aggregate_function::get_copy(std::pmr::memory_resource* resource) const {
         auto result = std::make_unique<aggregate_function>(name_, arity_, doc_, kernel_slots_, mergeable_);
-        for (const auto& kernel : kernels_) {
-            [[maybe_unused]] auto add_res = result->add_kernel(resource, kernel);
-        }
-        return result;
-    }
-
-    row_function::row_function(std::string name, arity fn_arity, function_doc doc, size_t available_kernel_slots)
-        : function_impl<row_kernel>(std::move(name), fn_arity, std::move(doc), available_kernel_slots) {}
-
-    void row_function::accept_visitor(function_visitor& visitor) const { visitor.visit(*this); }
-
-    std::unique_ptr<function> row_function::get_copy(std::pmr::memory_resource* resource) const {
-        auto result = std::make_unique<row_function>(name_, arity_, doc_, kernel_slots_);
         for (const auto& kernel : kernels_) {
             [[maybe_unused]] auto add_res = result->add_kernel(resource, kernel);
         }
@@ -482,8 +437,6 @@ namespace components::compute {
             result = &func.kernels()[nth_].get();
         }
 
-        void kernel_nth_visitor::visit(const row_function& func) { result = &func.kernels()[nth_].get(); }
-
         void kernel_nth_visitor::visit(const expand_function& func) { result = &func.kernels()[nth_].get(); }
 
         kernel_executor_visitor::kernel_executor_visitor()
@@ -496,8 +449,6 @@ namespace components::compute {
         void kernel_executor_visitor::visit(const compute::aggregate_function&) {
             result = detail::kernel_executor_t::make_aggregate();
         }
-
-        void kernel_executor_visitor::visit(const row_function&) { result = detail::kernel_executor_t::make_row(); }
 
         void kernel_executor_visitor::visit(const expand_function&) {}
 

--- a/components/compute/function.hpp
+++ b/components/compute/function.hpp
@@ -12,7 +12,6 @@
 #include <vector>
 
 namespace components::compute {
-    class row_function;
     class vector_function;
     class aggregate_function;
     class expand_function;
@@ -50,7 +49,6 @@ namespace components::compute {
 
         virtual core::result_wrapper_t<datum_t> execute(const vector::data_chunk_t& args) = 0;
         virtual core::result_wrapper_t<datum_t> execute(const std::vector<vector::data_chunk_t>& inputs) = 0;
-        virtual core::result_wrapper_t<datum_t> execute(const std::pmr::vector<types::logical_value_t>& inputs) = 0;
 
         // Aggregates only: fold a chunk into one accumulator per group, then emit one value per
         // group. The caller owns the accumulators and says how big one is by asking state_layout.
@@ -67,7 +65,6 @@ namespace components::compute {
 
         virtual void visit(const vector_function& func) = 0;
         virtual void visit(const aggregate_function& func) = 0;
-        virtual void visit(const row_function& func) = 0;
         virtual void visit(const expand_function& func) = 0;
     };
 
@@ -100,10 +97,6 @@ namespace components::compute {
                                                         const function_options* options = nullptr,
                                                         exec_context_t& ctx = default_exec_context()) const;
 
-        virtual core::result_wrapper_t<datum_t> execute(const std::pmr::vector<types::logical_value_t>& inputs,
-                                                        const function_options* options = nullptr,
-                                                        exec_context_t& ctx = default_exec_context()) const;
-
         const function_options* default_options() const;
 
         virtual core::result_wrapper_t<std::reference_wrapper<const compute_kernel>>
@@ -126,7 +119,7 @@ namespace components::compute {
 
         // Whether partial results of this function can be combined by a fragment-
         // merge kernel (SUM/COUNT/MIN/MAX/AVG). Resolved as a capability here rather
-        // than by a hardcoded name list; row/expand functions inherit the false
+        // than by a hardcoded name list; vector/expand functions inherit the false
         // default, only algebraically-mergeable aggregates override it.
         [[nodiscard]] virtual bool is_mergeable() const { return false; }
 
@@ -212,7 +205,6 @@ namespace components::compute {
 
             void visit(const vector_function& func) override;
             void visit(const aggregate_function& func) override;
-            void visit(const row_function& func) override;
             void visit(const expand_function& func) override;
 
         private:
@@ -226,7 +218,6 @@ namespace components::compute {
 
             void visit(const vector_function& func) override;
             void visit(const aggregate_function& func) override;
-            void visit(const row_function& func) override;
             void visit(const expand_function& func) override;
         };
 
@@ -257,14 +248,6 @@ namespace components::compute {
 
     private:
         bool mergeable_;
-    };
-
-    class row_function : public detail::function_impl<row_kernel> {
-    public:
-        row_function(std::string name, arity fn_arity, function_doc doc, size_t available_kernel_slots);
-        void accept_visitor(function_visitor& visitor) const override;
-
-        [[nodiscard]] std::unique_ptr<function> get_copy(std::pmr::memory_resource* resource) const override;
     };
 
     class expand_function : public detail::function_impl<expand_kernel> {

--- a/components/compute/kernel_executor.cpp
+++ b/components/compute/kernel_executor.cpp
@@ -96,12 +96,13 @@ namespace components::compute::detail {
                 return st;
             }
 
-            if (auto st = execute_batch(inputs); st.contains_error()) {
-                return st;
+            auto produced = execute_batch(inputs);
+            if (produced.has_error()) {
+                return produced.error();
             }
 
             data_chunk_t out(kernel_ctx().exec_context().resource(), {});
-            out.data.emplace_back(std::move(results_.front()));
+            out.data.emplace_back(std::move(produced.value()));
             out.set_cardinality(inputs.size());
             if (auto st = kernel().finalize(kernel_ctx(), out); st.contains_error()) {
                 return st;
@@ -120,14 +121,11 @@ namespace components::compute::detail {
             }
 
             for (const auto& in : inputs) {
-                if (auto st = execute_batch(in); st.contains_error()) {
-                    return st;
+                auto produced = execute_batch(in);
+                if (produced.has_error()) {
+                    return produced.error();
                 }
-            }
-
-            // fuse all vectors into one
-            for (auto&& res : results_) {
-                merged.data.emplace_back(std::move(res));
+                merged.data.emplace_back(std::move(produced.value()));
             }
 
             if (auto st = kernel().finalize(kernel_ctx(), merged); st.contains_error()) {
@@ -137,51 +135,14 @@ namespace components::compute::detail {
             return merged;
         }
 
-        core::result_wrapper_t<datum_t> execute(const std::pmr::vector<logical_value_t>& inputs) override {
-            if (auto st = check_kernel(); st.contains_error()) {
-                return st;
-            }
-
-            std::pmr::vector<complex_logical_type> types(exec_ctx().resource());
-            types.reserve(inputs.size());
-            for (const auto& v : inputs) {
-                types.emplace_back(v.type());
-            }
-
-            data_chunk_t single_row(exec_ctx().resource(), types, static_cast<uint64_t>(1));
-            for (size_t i = 0; i < inputs.size(); ++i) {
-                single_row.set_value(static_cast<uint64_t>(i), 0, inputs[i]);
-            }
-            single_row.set_cardinality(1);
-
-            if (auto st = execute_batch(single_row); st.contains_error()) {
-                return st;
-            }
-
-            data_chunk_t out(exec_ctx().resource(), {});
-            out.data.emplace_back(std::move(results_.front()));
-            out.set_cardinality(1);
-            if (auto st = kernel().finalize(kernel_ctx(), out); st.contains_error()) {
-                return st;
-            }
-
-            std::pmr::vector<logical_value_t> result(exec_ctx().resource());
-            result.push_back(out.data.front().value(0));
-            return result;
-        }
-
     private:
-        core::error_t execute_batch(const data_chunk_t& inputs) {
+        core::result_wrapper_t<vector_t> execute_batch(const data_chunk_t& inputs) {
             auto output = prepare_vector_output(inputs.size());
             if (auto st = kernel().execute(kernel_ctx(), inputs, output); st.contains_error()) {
                 return st;
             }
-
-            results_.emplace_back(std::move(output));
-            return core::error_t::no_error();
+            return output;
         }
-
-        std::vector<vector_t> results_;
     };
 
     class aggregate_executor final : public kernel_executor_impl<aggregate_kernel> {
@@ -227,10 +188,6 @@ namespace components::compute::detail {
             return not_directly_executable();
         }
 
-        core::result_wrapper_t<datum_t> execute(const std::pmr::vector<logical_value_t>&) override {
-            return not_directly_executable();
-        }
-
     private:
         // An aggregate reduces many rows into per-group accumulators, so it is driven by
         // update()/finalize() and never produces a value straight out of one call.
@@ -244,84 +201,9 @@ namespace components::compute::detail {
         const std::pmr::vector<types::complex_logical_type>* input_types_ = nullptr;
     };
 
-    class row_executor final : public kernel_executor_impl<row_kernel> {
-    public:
-        core::result_wrapper_t<datum_t> execute(const data_chunk_t& inputs) override {
-            if (auto st = check_kernel(); st.contains_error()) {
-                return st;
-            }
-
-            std::pmr::vector<logical_value_t> results(exec_ctx().resource());
-            results.reserve(inputs.size());
-
-            if (auto st = execute_chunk(inputs, results); st.contains_error()) {
-                return st;
-            }
-            return results;
-        }
-
-        core::result_wrapper_t<datum_t> execute(const std::vector<data_chunk_t>& inputs) override {
-            if (auto st = check_kernel(); st.contains_error()) {
-                return st;
-            }
-
-            std::pmr::vector<logical_value_t> results(exec_ctx().resource());
-            size_t total = 0;
-            for (const auto& chunk : inputs) {
-                total += chunk.size();
-            }
-            results.reserve(total);
-
-            for (const auto& chunk : inputs) {
-                if (auto st = execute_chunk(chunk, results); st.contains_error()) {
-                    return st;
-                }
-            }
-            return results;
-        }
-
-        core::result_wrapper_t<datum_t> execute(const std::pmr::vector<logical_value_t>& inputs) override {
-            if (auto st = check_kernel(); st.contains_error()) {
-                return st;
-            }
-
-            std::pmr::vector<logical_value_t> output(inputs.get_allocator().resource());
-            if (auto st = kernel().execute(kernel_ctx(), inputs, output); st.contains_error()) {
-                return st;
-            }
-
-            return output;
-        }
-
-    private:
-        core::error_t execute_chunk(const data_chunk_t& chunk, std::pmr::vector<logical_value_t>& results) {
-            for (size_t i = 0; i < chunk.size(); ++i) {
-                std::pmr::vector<logical_value_t> row_in(exec_ctx().resource());
-                row_in.reserve(chunk.column_count());
-
-                for (size_t j = 0; j < chunk.column_count(); ++j) {
-                    row_in.emplace_back(chunk.value(j, i));
-                }
-
-                std::pmr::vector<logical_value_t> row_out(exec_ctx().resource());
-                if (auto st = kernel().execute(kernel_ctx(), row_in, row_out); st.contains_error()) {
-                    return st;
-                }
-
-                // row_kernel contract: one scalar output per call
-                if (!row_out.empty()) {
-                    results.emplace_back(std::move(row_out.front()));
-                }
-            }
-            return core::error_t::no_error();
-        }
-    };
-
     std::unique_ptr<kernel_executor_t> kernel_executor_t::make_vector() { return std::make_unique<vector_executor>(); }
 
     std::unique_ptr<kernel_executor_t> kernel_executor_t::make_aggregate() {
         return std::make_unique<aggregate_executor>();
     }
-
-    std::unique_ptr<kernel_executor_t> kernel_executor_t::make_row() { return std::make_unique<row_executor>(); }
 } // namespace components::compute::detail

--- a/components/compute/kernel_executor.cpp
+++ b/components/compute/kernel_executor.cpp
@@ -17,13 +17,10 @@ namespace components::compute::detail {
             kernel_ = static_cast<const KernelType*>(&args.kernel);
 
             // TODO: support multiple output types
-            auto out =
-                kernel_->signature().output_types.front().resolve(kernel_ctx_->exec_context().resource(), args.inputs);
-            if (out.has_error()) {
-                return out.error();
-            }
-
-            output_type_ = out.value();
+            VALUE_OR_RETURN(
+                auto out,
+                kernel_->signature().output_types.front().resolve(kernel_ctx_->exec_context().resource(), args.inputs));
+            output_type_ = std::move(out);
             return core::error_t::no_error();
         }
 
@@ -96,13 +93,9 @@ namespace components::compute::detail {
                 return st;
             }
 
-            auto produced = execute_batch(inputs);
-            if (produced.has_error()) {
-                return produced.error();
-            }
-
+            VALUE_OR_RETURN(auto produced, execute_batch(inputs));
             data_chunk_t out(kernel_ctx().exec_context().resource(), {});
-            out.data.emplace_back(std::move(produced.value()));
+            out.data.emplace_back(std::move(produced));
             out.set_cardinality(inputs.size());
             if (auto st = kernel().finalize(kernel_ctx(), out); st.contains_error()) {
                 return st;
@@ -121,11 +114,8 @@ namespace components::compute::detail {
             }
 
             for (const auto& in : inputs) {
-                auto produced = execute_batch(in);
-                if (produced.has_error()) {
-                    return produced.error();
-                }
-                merged.data.emplace_back(std::move(produced.value()));
+                VALUE_OR_RETURN(auto produced, execute_batch(in));
+                merged.data.emplace_back(std::move(produced));
             }
 
             if (auto st = kernel().finalize(kernel_ctx(), merged); st.contains_error()) {

--- a/components/compute/kernel_executor.hpp
+++ b/components/compute/kernel_executor.hpp
@@ -16,8 +16,6 @@ namespace components::compute::detail {
         [[nodiscard]] virtual core::result_wrapper_t<datum_t> execute(const vector::data_chunk_t& inputs) = 0;
         [[nodiscard]] virtual core::result_wrapper_t<datum_t>
         execute(const std::vector<vector::data_chunk_t>& inputs) = 0;
-        [[nodiscard]] virtual core::result_wrapper_t<datum_t>
-        execute(const std::pmr::vector<types::logical_value_t>& inputs) = 0;
 
         // Aggregates only: fold a chunk into one accumulator per group, then emit one value per
         // group. The caller owns the accumulators and says how big one is by asking state_layout.
@@ -29,6 +27,5 @@ namespace components::compute::detail {
 
         static std::unique_ptr<kernel_executor_t> make_vector();
         static std::unique_ptr<kernel_executor_t> make_aggregate();
-        static std::unique_ptr<kernel_executor_t> make_row();
     };
 } // namespace components::compute::detail

--- a/components/compute/kernel_signature.hpp
+++ b/components/compute/kernel_signature.hpp
@@ -14,10 +14,9 @@ namespace components::compute {
     enum class function_type_t : uint8_t
     {
         invalid = 0,
-        row = 1,
-        vector = 2,
-        aggregate = 4,
-        expand = 8
+        vector = 1,
+        aggregate = 2,
+        expand = 4
     };
 
     using function_types_mask = std::underlying_type_t<function_type_t>;

--- a/components/compute/kernel_utils.cpp
+++ b/components/compute/kernel_utils.cpp
@@ -4,21 +4,15 @@
 namespace components::compute {
 
     bool all_inputs_valid(const vector::data_chunk_t& inputs) {
-        for (const auto& column : inputs.data) {
-            if (column.type().type() == types::logical_type::NA || !column.validity().all_valid()) {
-                return false;
-            }
-        }
-        return true;
+        return std::all_of(inputs.data.begin(), inputs.data.end(), [](const auto& column) {
+            return column.type().type() != types::logical_type::NA && column.validity().all_valid();
+        });
     }
 
     bool row_contains_null(const vector::data_chunk_t& inputs, uint64_t row) {
-        for (const auto& column : inputs.data) {
-            if (column.is_null(row)) {
-                return true;
-            }
-        }
-        return false;
+        return std::any_of(inputs.data.begin(), inputs.data.end(), [row](const auto& column) {
+            return column.is_null(row);
+        });
     }
 
     exec_context_t::exec_context_t(std::pmr::memory_resource* resource, function_registry_t* registry)

--- a/components/compute/kernel_utils.cpp
+++ b/components/compute/kernel_utils.cpp
@@ -2,6 +2,25 @@
 #include "function.hpp"
 
 namespace components::compute {
+
+    bool all_inputs_valid(const vector::data_chunk_t& inputs) {
+        for (const auto& column : inputs.data) {
+            if (column.type().type() == types::logical_type::NA || !column.validity().all_valid()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool row_contains_null(const vector::data_chunk_t& inputs, uint64_t row) {
+        for (const auto& column : inputs.data) {
+            if (column.is_null(row)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     exec_context_t::exec_context_t(std::pmr::memory_resource* resource, function_registry_t* registry)
         : resource_(resource)
         , func_registry_(registry ? registry : function_registry_t::get_default()) {

--- a/components/compute/kernel_utils.hpp
+++ b/components/compute/kernel_utils.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <components/types/types.hpp>
+#include <components/vector/data_chunk.hpp>
 #include <memory_resource>
 #include <vector>
 
@@ -8,6 +9,9 @@ namespace components::compute {
     class compute_kernel;
     class function_registry_t;
     class function_options;
+
+    bool all_inputs_valid(const vector::data_chunk_t& inputs);
+    bool row_contains_null(const vector::data_chunk_t& inputs, uint64_t row);
 
     class exec_context_t {
     public:

--- a/components/compute/kernels/math_functions.cpp
+++ b/components/compute/kernels/math_functions.cpp
@@ -1,82 +1,99 @@
 #include "../function.hpp"
-#include <components/types/logical_value.hpp>
+
+#include <components/vector/vector_operations.hpp>
 
 #include <cmath>
 
 using namespace components::compute;
 using namespace components::types;
+using namespace components::vector;
 
 namespace {
 
-    inline bool has_null_input(const std::pmr::vector<logical_value_t>& inputs) {
-        for (const auto& v : inputs) {
-            if (v.type().type() == logical_type::NA) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     template<typename T>
-    logical_value_t absolute(std::pmr::memory_resource* resource, const logical_value_t& value) {
-        auto raw = value.value<T>();
-        return logical_value_t{resource, raw < T{0} ? static_cast<T>(-raw) : raw};
-    }
-
-    logical_value_t absolute_decimal(std::pmr::memory_resource* resource, const logical_value_t& value) {
-        const auto* extension = value.type().extension_as<decimal_logical_type_extension>();
-        if (extension->stored_as() == physical_type::INT128) {
-            auto raw = value.value<int128_t>();
-            return logical_value_t::create_decimal(resource, value.type(), raw < 0 ? -raw : raw);
+    void absolute_into(const vector_t& input, vector_t& output, uint64_t count, bool all_valid) {
+        const auto* src = input.data<T>();
+        auto* dst = output.data<T>();
+        for (uint64_t row = 0; row < count; row++) {
+            if (!all_valid && input.is_null(row)) {
+                output.set_null(row, true);
+                continue;
+            }
+            const auto value = src[row];
+            dst[row] = value < T{0} ? static_cast<T>(-value) : value;
         }
-        auto raw = value.value<int64_t>();
-        return logical_value_t::create_decimal(resource, value.type(), raw < 0 ? -raw : raw);
     }
 
-    core::error_t row_abs(kernel_context& ctx,
-                          const std::pmr::vector<logical_value_t>& inputs,
-                          std::pmr::vector<logical_value_t>& output) {
-        auto* resource = ctx.exec_context().resource();
-        if (has_null_input(inputs)) {
-            output.emplace_back(resource, logical_type::NA);
+    core::error_t absolute_decimal_into(const vector_t& input,
+                                        vector_t& output,
+                                        uint64_t count,
+                                        bool all_valid,
+                                        exec_context_t& ctx) {
+        const auto* extension = input.type().extension_as<decimal_logical_type_extension>();
+        switch (extension->stored_as()) {
+            case physical_type::INT16:
+                absolute_into<int16_t>(input, output, count, all_valid);
+                return core::error_t::no_error();
+            case physical_type::INT32:
+                absolute_into<int32_t>(input, output, count, all_valid);
+                return core::error_t::no_error();
+            case physical_type::INT64:
+                absolute_into<int64_t>(input, output, count, all_valid);
+                return core::error_t::no_error();
+            case physical_type::INT128:
+                absolute_into<int128_t>(input, output, count, all_valid);
+                return core::error_t::no_error();
+            default:
+                return core::error_t(core::error_code_t::kernel_error,
+                                     std::pmr::string{"abs: unsupported decimal storage width", ctx.resource()});
+        }
+    }
+
+    core::error_t vector_abs(kernel_context& ctx, const data_chunk_t& inputs, vector_t& output) {
+        auto& exec_ctx = ctx.exec_context();
+        const auto& input = inputs.data.front();
+        const uint64_t count = inputs.size();
+
+        // For NULL input result will be all NULLs
+        if (input.type().type() == logical_type::NA) {
             return core::error_t::no_error();
         }
-        const auto& value = inputs[0];
-        switch (value.type().type()) {
+        const bool all_valid = all_inputs_valid(inputs);
+
+        switch (input.type().type()) {
             case logical_type::TINYINT:
-                output.emplace_back(absolute<int8_t>(resource, value));
+                absolute_into<int8_t>(input, output, count, all_valid);
                 break;
             case logical_type::SMALLINT:
-                output.emplace_back(absolute<int16_t>(resource, value));
+                absolute_into<int16_t>(input, output, count, all_valid);
                 break;
             case logical_type::INTEGER:
-                output.emplace_back(absolute<int32_t>(resource, value));
+                absolute_into<int32_t>(input, output, count, all_valid);
                 break;
             case logical_type::BIGINT:
-                output.emplace_back(absolute<int64_t>(resource, value));
+                absolute_into<int64_t>(input, output, count, all_valid);
                 break;
             case logical_type::HUGEINT:
-                output.emplace_back(absolute<int128_t>(resource, value));
+                absolute_into<int128_t>(input, output, count, all_valid);
                 break;
             case logical_type::FLOAT:
-                output.emplace_back(absolute<float>(resource, value));
+                absolute_into<float>(input, output, count, all_valid);
                 break;
             case logical_type::DOUBLE:
-                output.emplace_back(absolute<double>(resource, value));
+                absolute_into<double>(input, output, count, all_valid);
                 break;
             case logical_type::DECIMAL:
-                output.emplace_back(absolute_decimal(resource, value));
-                break;
+                return absolute_decimal_into(input, output, count, all_valid, exec_ctx);
             case logical_type::UTINYINT:
             case logical_type::USMALLINT:
             case logical_type::UINTEGER:
             case logical_type::UBIGINT:
             case logical_type::UHUGEINT:
-                output.emplace_back(value);
+                vector_ops::copy(input, output, count, 0, 0);
                 break;
             default:
                 return core::error_t(core::error_code_t::kernel_error,
-                                     std::pmr::string{"abs is not defined for this type", resource});
+                                     std::pmr::string{"abs is not defined for this type", exec_ctx.resource()});
         }
         return core::error_t::no_error();
     }
@@ -102,103 +119,120 @@ namespace {
         return types;
     }
 
-    core::error_t row_pow(kernel_context& ctx,
-                          const std::pmr::vector<logical_value_t>& inputs,
-                          std::pmr::vector<logical_value_t>& output) {
-        auto* resource = ctx.exec_context().resource();
-        if (has_null_input(inputs)) {
-            output.emplace_back(resource, logical_type::NA);
-            return core::error_t::no_error();
+    core::error_t vector_pow(kernel_context&, const data_chunk_t& inputs, vector_t& output) {
+        const auto& base = inputs.data[0];
+        const auto& exponent = inputs.data[1];
+        const auto* base_data = base.data<double>();
+        const auto* exponent_data = exponent.data<double>();
+        auto* dst = output.data<double>();
+        const bool all_valid = all_inputs_valid(inputs);
+        for (uint64_t row = 0; row < inputs.size(); row++) {
+            if (!all_valid && row_contains_null(inputs, row)) {
+                output.set_null(row, true);
+                continue;
+            }
+            dst[row] = std::pow(base_data[row], exponent_data[row]);
         }
-        output.emplace_back(resource, std::pow(inputs[0].value<double>(), inputs[1].value<double>()));
         return core::error_t::no_error();
     }
 
-    core::error_t row_sqrt(kernel_context& ctx,
-                           const std::pmr::vector<logical_value_t>& inputs,
-                           std::pmr::vector<logical_value_t>& output) {
-        auto* resource = ctx.exec_context().resource();
-        if (has_null_input(inputs)) {
-            output.emplace_back(resource, logical_type::NA);
-            return core::error_t::no_error();
+    core::error_t vector_sqrt(kernel_context&, const data_chunk_t& inputs, vector_t& output) {
+        const auto& input = inputs.data.front();
+        const auto* src = input.data<double>();
+        auto* dst = output.data<double>();
+        const bool all_valid = all_inputs_valid(inputs);
+        for (uint64_t row = 0; row < inputs.size(); row++) {
+            if (!all_valid && input.is_null(row)) {
+                output.set_null(row, true);
+                continue;
+            }
+            dst[row] = std::sqrt(src[row]);
         }
-        output.emplace_back(resource, std::sqrt(inputs[0].value<double>()));
         return core::error_t::no_error();
     }
 
-    core::error_t row_cbrt(kernel_context& ctx,
-                           const std::pmr::vector<logical_value_t>& inputs,
-                           std::pmr::vector<logical_value_t>& output) {
-        auto* resource = ctx.exec_context().resource();
-        if (has_null_input(inputs)) {
-            output.emplace_back(resource, logical_type::NA);
-            return core::error_t::no_error();
+    core::error_t vector_cbrt(kernel_context&, const data_chunk_t& inputs, vector_t& output) {
+        const auto& input = inputs.data.front();
+        const auto* src = input.data<double>();
+        auto* dst = output.data<double>();
+        const bool all_valid = all_inputs_valid(inputs);
+        for (uint64_t row = 0; row < inputs.size(); row++) {
+            if (!all_valid && input.is_null(row)) {
+                output.set_null(row, true);
+                continue;
+            }
+            dst[row] = std::cbrt(src[row]);
         }
-        output.emplace_back(resource, std::cbrt(inputs[0].value<double>()));
         return core::error_t::no_error();
     }
 
     // 20! is the largest factorial representable in int64
     constexpr int64_t max_factorial_argument = 20;
-    core::error_t row_factorial(kernel_context& ctx,
-                                const std::pmr::vector<logical_value_t>& inputs,
-                                std::pmr::vector<logical_value_t>& output) {
+
+    core::error_t vector_factorial(kernel_context& ctx, const data_chunk_t& inputs, vector_t& output) {
         auto* resource = ctx.exec_context().resource();
-        if (has_null_input(inputs)) {
-            output.emplace_back(resource, logical_type::NA);
-            return core::error_t::no_error();
+        const auto& input = inputs.data.front();
+        const auto* src = input.data<int64_t>();
+        auto* dst = output.data<int64_t>();
+        const bool all_valid = all_inputs_valid(inputs);
+        for (uint64_t row = 0; row < inputs.size(); row++) {
+            if (!all_valid && input.is_null(row)) {
+                output.set_null(row, true);
+                continue;
+            }
+            const auto argument = src[row];
+            if (argument < 0) {
+                return core::error_t(core::error_code_t::kernel_error,
+                                     std::pmr::string{"factorial of a negative number is undefined", resource});
+            }
+            if (argument > max_factorial_argument) {
+                return core::error_t(core::error_code_t::kernel_error,
+                                     std::pmr::string{"factorial argument is too large for bigint", resource});
+            }
+            int64_t result = 1;
+            for (int64_t factor = 2; factor <= argument; factor++) {
+                result *= factor;
+            }
+            dst[row] = result;
         }
-        const auto argument = inputs[0].value<int64_t>();
-        if (argument < 0) {
-            return core::error_t(core::error_code_t::kernel_error,
-                                 std::pmr::string{"factorial of a negative number is undefined", resource});
-        }
-        if (argument > max_factorial_argument) {
-            return core::error_t(core::error_code_t::kernel_error,
-                                 std::pmr::string{"factorial argument is too large for bigint", resource});
-        }
-        int64_t result = 1;
-        for (int64_t factor = 2; factor <= argument; factor++) {
-            result *= factor;
-        }
-        output.emplace_back(resource, result);
         return core::error_t::no_error();
     }
 
-    std::unique_ptr<row_function> make_fixed_type_func(std::pmr::memory_resource* resource,
-                                                       const std::string& name,
-                                                       const std::string& short_doc,
-                                                       const std::string& full_doc,
-                                                       logical_type type,
-                                                       size_t num_args,
-                                                       row_exec_fn kernel) {
+    std::unique_ptr<vector_function> make_fixed_type_func(std::pmr::memory_resource* resource,
+                                                          const std::string& name,
+                                                          const std::string& short_doc,
+                                                          const std::string& full_doc,
+                                                          logical_type type,
+                                                          size_t num_args,
+                                                          vector_exec_fn kernel) {
         function_doc doc{short_doc, full_doc, {"arg"}, false};
-        auto fn = std::make_unique<row_function>(name, arity::fixed_num(num_args), doc, /*available_kernel_slots=*/1);
+        auto fn =
+            std::make_unique<vector_function>(name, arity::fixed_num(num_args), doc, /*available_kernel_slots=*/1);
 
         std::pmr::vector<parameter_type> parameters(resource);
         for (size_t i = 0; i < num_args; i++) {
             parameters.push_back(parameter_type::exact(complex_logical_type{type}));
         }
-        kernel_signature_t sig(function_type_t::row,
+        kernel_signature_t sig(function_type_t::vector,
                                std::move(parameters),
                                {output_type::fixed(complex_logical_type{type})});
-        (void) fn->add_kernel(resource, row_kernel(std::move(sig), kernel));
+        (void) fn->add_kernel(resource, vector_kernel(std::move(sig), kernel));
 
         return fn;
     }
 
-    std::unique_ptr<row_function> make_abs_func(std::pmr::memory_resource* resource,
-                                                const std::string& name,
-                                                const std::string& short_doc,
-                                                const std::string& full_doc) {
+    std::unique_ptr<vector_function> make_abs_func(std::pmr::memory_resource* resource,
+                                                   const std::string& name,
+                                                   const std::string& short_doc,
+                                                   const std::string& full_doc) {
         function_doc doc{short_doc, full_doc, {"arg"}, false};
 
-        auto fn = std::make_unique<row_function>(name, arity::unary(), doc, /*available_kernel_slots=*/1);
+        auto fn = std::make_unique<vector_function>(name, arity::unary(), doc, /*available_kernel_slots=*/1);
 
-        kernel_signature_t sig(function_type_t::row,
+        kernel_signature_t sig(function_type_t::vector,
                                {parameter_type::variable(0, absolute_parameters(resource))},
                                {output_type::same_type_at(0)});
-        row_kernel k(std::move(sig), row_abs);
+        vector_kernel k(std::move(sig), vector_abs);
         (void) fn->add_kernel(resource, std::move(k));
 
         return fn;
@@ -218,28 +252,28 @@ namespace components::compute {
                                                    "POW(x, y) -> x raised to the power y",
                                                    logical_type::DOUBLE,
                                                    2,
-                                                   row_pow));
+                                                   vector_pow));
         (void) r.add_function(make_fixed_type_func(r.resource(),
                                                    "sqrt",
                                                    "Square root",
                                                    "SQRT(x) -> the square root of x",
                                                    logical_type::DOUBLE,
                                                    1,
-                                                   row_sqrt));
+                                                   vector_sqrt));
         (void) r.add_function(make_fixed_type_func(r.resource(),
                                                    "cbrt",
                                                    "Cube root",
                                                    "CBRT(x) -> the cube root of x",
                                                    logical_type::DOUBLE,
                                                    1,
-                                                   row_cbrt));
+                                                   vector_cbrt));
         (void) r.add_function(make_fixed_type_func(r.resource(),
                                                    "factorial",
                                                    "Factorial",
                                                    "FACTORIAL(x) -> the product of the integers 1..x",
                                                    logical_type::BIGINT,
                                                    1,
-                                                   row_factorial));
+                                                   vector_factorial));
     }
 
 } // namespace components::compute

--- a/components/compute/kernels/string_functions.cpp
+++ b/components/compute/kernels/string_functions.cpp
@@ -13,134 +13,78 @@
 
 using namespace components::compute;
 using namespace components::types;
+using namespace components::vector;
 
 namespace {
 
-    // Returns true if any of the inputs is NULL (logical_type::NA).
-    // Caller is expected to emplace an NA logical_value_t into the output and return.
-    inline bool has_null_input(const std::pmr::vector<logical_value_t>& inputs) {
-        for (const auto& v : inputs) {
-            if (v.type().type() == logical_type::NA) {
-                return true;
-            }
+    // The substring of `s` starting at the 1-based `start_1based`, clipped to the string.
+    // SQL semantics: start <= 0 is clamped to 1 (begin); start > length => empty.
+    inline std::string_view substring_from(std::string_view s, int64_t start_1based) {
+        const int64_t start_idx = start_1based <= 0 ? 0 : start_1based - 1;
+        if (static_cast<size_t>(start_idx) >= s.size()) {
+            return std::string_view{};
         }
-        return false;
-    }
-
-    // Coerce any integer-category value to int64_t. Matcher gate
-    // (make_integer) ensures no non-integer types reach here; the assert
-    // guards the invariant, not user-facing validation.
-    inline int64_t coerce_int(const logical_value_t& v) {
-        switch (v.type().type()) {
-            case logical_type::TINYINT:
-                return v.value<int8_t>();
-            case logical_type::SMALLINT:
-                return v.value<int16_t>();
-            case logical_type::INTEGER:
-                return v.value<int32_t>();
-            case logical_type::BIGINT:
-                return v.value<int64_t>();
-            case logical_type::HUGEINT:
-                return static_cast<int64_t>(v.value<int128_t>());
-            case logical_type::UTINYINT:
-                return v.value<uint8_t>();
-            case logical_type::USMALLINT:
-                return v.value<uint16_t>();
-            case logical_type::UINTEGER:
-                return v.value<uint32_t>();
-            case logical_type::UBIGINT:
-                return static_cast<int64_t>(v.value<uint64_t>());
-            case logical_type::UHUGEINT:
-                return static_cast<int64_t>(v.value<uint128_t>());
-            default:
-                assert(false && "integer matcher invariant: type must be integer category");
-                return 0;
-        }
+        return s.substr(static_cast<size_t>(start_idx));
     }
 
     // ------------------------------------------------------------------
     // SUBSTRING(s, start)       — start is 1-based; out-of-range => empty
     // SUBSTRING(s, start, len)  — both 1-based; len <= 0 => empty; clip to bounds
     // ------------------------------------------------------------------
-    static core::error_t row_substring_2(kernel_context& ctx,
-                                         const std::pmr::vector<logical_value_t>& inputs,
-                                         std::pmr::vector<logical_value_t>& output) {
-        auto* resource = ctx.exec_context().resource();
-        if (has_null_input(inputs)) {
-            output.emplace_back(resource, logical_type::NA);
-            return core::error_t::no_error();
+    core::error_t vector_substring_2(kernel_context&, const data_chunk_t& inputs, vector_t& output) {
+        const auto& strings = inputs.data[0];
+        const auto* source = strings.data<std::string_view>();
+        const auto* starts = inputs.data[1].data<int64_t>();
+        const bool all_valid = all_inputs_valid(inputs);
+        for (uint64_t row = 0; row < inputs.size(); row++) {
+            if (!all_valid && row_contains_null(inputs, row)) {
+                output.set_null(row, true);
+                continue;
+            }
+            output.set_value(row, substring_from(source[row], starts[row]));
         }
-        if (inputs[0].type().type() == logical_type::BLOB) {
-            return core::error_t(core::error_code_t::kernel_error,
-                                 std::pmr::string{"string function on BLOB not yet implemented", resource});
-        }
-
-        const auto s = inputs[0].value<std::string_view>();
-        const auto start_1based = coerce_int(inputs[1]);
-
-        // SQL semantics: start <= 0 is clamped to 1 (begin); start > length => empty.
-        int64_t start_idx = start_1based <= 0 ? 0 : start_1based - 1;
-        if (static_cast<size_t>(start_idx) >= s.size()) {
-            output.emplace_back(resource, std::string{});
-            return core::error_t::no_error();
-        }
-
-        output.emplace_back(resource, std::string(s.substr(static_cast<size_t>(start_idx))));
         return core::error_t::no_error();
     }
 
-    static core::error_t row_substring_3(kernel_context& ctx,
-                                         const std::pmr::vector<logical_value_t>& inputs,
-                                         std::pmr::vector<logical_value_t>& output) {
-        auto* resource = ctx.exec_context().resource();
-        if (has_null_input(inputs)) {
-            output.emplace_back(resource, logical_type::NA);
-            return core::error_t::no_error();
+    core::error_t vector_substring_3(kernel_context&, const data_chunk_t& inputs, vector_t& output) {
+        const auto& strings = inputs.data[0];
+        const auto* source = strings.data<std::string_view>();
+        const auto* starts = inputs.data[1].data<int64_t>();
+        const auto* lengths = inputs.data[2].data<int64_t>();
+        const bool all_valid = all_inputs_valid(inputs);
+        for (uint64_t row = 0; row < inputs.size(); row++) {
+            if (!all_valid && row_contains_null(inputs, row)) {
+                output.set_null(row, true);
+                continue;
+            }
+            const auto requested = lengths[row];
+            if (requested <= 0) {
+                output.set_value(row, std::string_view{});
+                continue;
+            }
+            const auto tail = substring_from(source[row], starts[row]);
+            const auto take =
+                static_cast<size_t>(requested) < tail.size() ? static_cast<size_t>(requested) : tail.size();
+            output.set_value(row, tail.substr(0, take));
         }
-        if (inputs[0].type().type() == logical_type::BLOB) {
-            return core::error_t(core::error_code_t::kernel_error,
-                                 std::pmr::string{"string function on BLOB not yet implemented", resource});
-        }
-
-        const auto s = inputs[0].value<std::string_view>();
-        const auto start_1based = coerce_int(inputs[1]);
-        const auto len_in = coerce_int(inputs[2]);
-
-        if (len_in <= 0) {
-            output.emplace_back(resource, std::string{});
-            return core::error_t::no_error();
-        }
-
-        int64_t start_idx = start_1based <= 0 ? 0 : start_1based - 1;
-        if (static_cast<size_t>(start_idx) >= s.size()) {
-            output.emplace_back(resource, std::string{});
-            return core::error_t::no_error();
-        }
-
-        size_t avail = s.size() - static_cast<size_t>(start_idx);
-        size_t take = static_cast<size_t>(len_in) < avail ? static_cast<size_t>(len_in) : avail;
-        output.emplace_back(resource, std::string(s.substr(static_cast<size_t>(start_idx), take)));
         return core::error_t::no_error();
     }
 
     // ------------------------------------------------------------------
     // LENGTH(s) — byte length (BIGINT). Not codepoint length.
     // ------------------------------------------------------------------
-    static core::error_t row_length(kernel_context& ctx,
-                                    const std::pmr::vector<logical_value_t>& inputs,
-                                    std::pmr::vector<logical_value_t>& output) {
-        auto* resource = ctx.exec_context().resource();
-        if (has_null_input(inputs)) {
-            output.emplace_back(resource, logical_type::NA);
-            return core::error_t::no_error();
+    core::error_t vector_length(kernel_context&, const data_chunk_t& inputs, vector_t& output) {
+        const auto& strings = inputs.data.front();
+        const auto* source = strings.data<std::string_view>();
+        auto* destination = output.data<int64_t>();
+        const bool all_valid = all_inputs_valid(inputs);
+        for (uint64_t row = 0; row < inputs.size(); row++) {
+            if (!all_valid && strings.is_null(row)) {
+                output.set_null(row, true);
+                continue;
+            }
+            destination[row] = static_cast<int64_t>(source[row].size());
         }
-        if (inputs[0].type().type() == logical_type::BLOB) {
-            return core::error_t(core::error_code_t::kernel_error,
-                                 std::pmr::string{"string function on BLOB not yet implemented", resource});
-        }
-
-        const auto s = inputs[0].value<std::string_view>();
-        output.emplace_back(resource, static_cast<int64_t>(s.size()));
         return core::error_t::no_error();
     }
 
@@ -148,31 +92,49 @@ namespace {
     // REGEXP_REPLACE(s, pattern, replacement) — std::regex ECMAScript.
     // Invalid pattern => kernel_error.
     // ------------------------------------------------------------------
-    static core::error_t row_regexp_replace(kernel_context& ctx,
-                                            const std::pmr::vector<logical_value_t>& inputs,
-                                            std::pmr::vector<logical_value_t>& output) {
+
+    // Cached regex, because it is expensive and there is a good chance it would be reused
+    // TODO: cache all encountered putterns, because alternating patterns will cause recompile for each row
+    class regexp_replace_state_t final : public kernel_state {
+    public:
+        std::regex compiled{"", std::regex::ECMAScript};
+        std::string pattern;
+    };
+
+    core::result_wrapper_t<kernel_state_ptr> init_regexp_replace(kernel_context&, kernel_init_args) {
+        return kernel_state_ptr{std::make_unique<regexp_replace_state_t>()};
+    }
+
+    core::error_t vector_regexp_replace(kernel_context& ctx, const data_chunk_t& inputs, vector_t& output) {
         auto* resource = ctx.exec_context().resource();
-        if (has_null_input(inputs)) {
-            output.emplace_back(resource, logical_type::NA);
-            return core::error_t::no_error();
-        }
-        if (inputs[0].type().type() == logical_type::BLOB) {
-            return core::error_t(core::error_code_t::kernel_error,
-                                 std::pmr::string{"string function on BLOB not yet implemented", resource});
-        }
+        const auto* subjects = inputs.data[0].data<std::string_view>();
+        const auto* patterns = inputs.data[1].data<std::string_view>();
+        const auto* replacements = inputs.data[2].data<std::string_view>();
+        const bool all_valid = all_inputs_valid(inputs);
 
-        const auto s = inputs[0].value<std::string_view>();
-        const auto pattern_sv = inputs[1].value<std::string_view>();
-        const auto replacement_sv = inputs[2].value<std::string_view>();
+        auto* state = static_cast<regexp_replace_state_t*>(ctx.state());
+        assert(state && "regexp_replace kernel was not initialized");
 
-        try {
-            std::regex re(pattern_sv.data(), pattern_sv.size(), std::regex::ECMAScript);
-            std::string result = std::regex_replace(std::string(s), re, std::string(replacement_sv));
-            output.emplace_back(resource, std::move(result));
-        } catch (const std::regex_error& e) {
-            return core::error_t(
-                core::error_code_t::kernel_error,
-                std::pmr::string{std::string("regexp_replace: invalid pattern: ") + e.what(), resource});
+        for (uint64_t row = 0; row < inputs.size(); row++) {
+            if (!all_valid && row_contains_null(inputs, row)) {
+                output.set_null(row, true);
+                continue;
+            }
+            const auto pattern = patterns[row];
+            try {
+                // Recompiled only when the pattern actually changes
+                if (state->pattern != pattern) {
+                    state->compiled.assign(pattern.data(), pattern.size(), std::regex::ECMAScript);
+                    state->pattern.assign(pattern.data(), pattern.size());
+                }
+                const std::string replaced =
+                    std::regex_replace(std::string(subjects[row]), state->compiled, std::string(replacements[row]));
+                output.set_value(row, std::string_view{replaced});
+            } catch (const std::regex_error& e) {
+                return core::error_t(
+                    core::error_code_t::kernel_error,
+                    std::pmr::string{std::string("regexp_replace: invalid pattern: ") + e.what(), resource});
+            }
         }
         return core::error_t::no_error();
     }
@@ -184,7 +146,7 @@ namespace {
         bool case_insensitive = false;
     };
 
-    static core::result_wrapper_t<kernel_state_ptr> init_regexp_like(kernel_context&, kernel_init_args) {
+    core::result_wrapper_t<kernel_state_ptr> init_regexp_like(kernel_context&, kernel_init_args) {
         return kernel_state_ptr{std::make_unique<regexp_like_state_t>()};
     }
 
@@ -195,144 +157,147 @@ namespace {
     // Uses core::regex_t (RE2) rather than std::regex: it reports a bad pattern as an error instead
     // of throwing, and takes case-insensitivity as a compile option, which is exactly what ILIKE
     // needs. `flags` follows PostgreSQL: 'i' selects a case-insensitive match.
-    static core::error_t row_regexp_like(kernel_context& ctx,
-                                         const std::pmr::vector<logical_value_t>& inputs,
-                                         std::pmr::vector<logical_value_t>& output) {
+    core::error_t vector_regexp_like(kernel_context& ctx, const data_chunk_t& inputs, vector_t& output) {
         auto* resource = ctx.exec_context().resource();
-        if (has_null_input(inputs)) {
-            output.emplace_back(resource, logical_type::NA);
-            return core::error_t::no_error();
-        }
-        if (inputs[0].type().type() == logical_type::BLOB) {
-            return core::error_t(core::error_code_t::kernel_error,
-                                 std::pmr::string{"string function on BLOB not yet implemented", resource});
-        }
-
-        const auto subject = inputs[0].value<std::string_view>();
-        const auto pattern = inputs[1].value<std::string_view>();
-        bool case_insensitive = false;
-        bool glob = false;
-        bool negate = false;
-        if (inputs.size() > 2) {
-            const auto flags = inputs[2].value<std::string_view>();
-            case_insensitive = flags.find('i') != std::string_view::npos;
-            glob = flags.find('l') != std::string_view::npos;
-            negate = flags.find('n') != std::string_view::npos;
-        }
+        const auto* subjects = inputs.data[0].data<std::string_view>();
+        const auto* patterns = inputs.data[1].data<std::string_view>();
+        const std::string_view* flag_values =
+            inputs.column_count() > 2 ? inputs.data[2].data<std::string_view>() : nullptr;
+        auto* destination = output.data<bool>();
+        const bool all_valid = all_inputs_valid(inputs);
 
         // Compiling per row would dominate the match, so the compiled pattern lives in the kernel
         // state, which belongs to the call site: one regexp_like node sees one pattern, and a LIKE
         // ANY fold gives each of its N patterns a node of its own.
         auto* state = static_cast<regexp_like_state_t*>(ctx.state());
         assert(state && "regexp_like kernel was not initialized");
-        if (!state->compiled.has_value() || state->case_insensitive != case_insensitive || state->pattern != pattern) {
-            // `l` marks the pattern a SQL LIKE glob: LIKE ANY over a sub-query binds its patterns
-            // raw, so nothing upstream of the match can convert them.
-            const std::string source = glob ? core::like_to_regex(std::string{pattern}) : std::string{pattern};
-            auto compiled = core::regex_t::compile(resource, source, case_insensitive);
-            if (compiled.has_error()) {
-                return compiled.error();
+
+        for (uint64_t row = 0; row < inputs.size(); row++) {
+            if (!all_valid && row_contains_null(inputs, row)) {
+                output.set_null(row, true);
+                continue;
             }
-            state->compiled.emplace(std::move(compiled.value()));
-            state->pattern.assign(pattern.data(), pattern.size());
-            state->case_insensitive = case_insensitive;
+            const auto pattern = patterns[row];
+            bool case_insensitive = false;
+            bool glob = false;
+            bool negate = false;
+            if (flag_values != nullptr) {
+                const auto flags = flag_values[row];
+                case_insensitive = flags.find('i') != std::string_view::npos;
+                glob = flags.find('l') != std::string_view::npos;
+                negate = flags.find('n') != std::string_view::npos;
+            }
+
+            if (!state->compiled.has_value() || state->case_insensitive != case_insensitive ||
+                state->pattern != pattern) {
+                // `l` marks the pattern a SQL LIKE glob: LIKE ANY over a sub-query binds its
+                // patterns raw, so nothing upstream of the match can convert them.
+                const std::string source = glob ? core::like_to_regex(std::string{pattern}) : std::string{pattern};
+                auto compiled = core::regex_t::compile(resource, source, case_insensitive);
+                if (compiled.has_error()) {
+                    return compiled.error();
+                }
+                state->compiled.emplace(std::move(compiled.value()));
+                state->pattern.assign(pattern.data(), pattern.size());
+                state->case_insensitive = case_insensitive;
+            }
+            // `n` inverts the match (NOT LIKE) here rather than through a node of its own. A NULL
+            // subject already produced NULL above, so the inversion never turns UNKNOWN into a match.
+            const bool matched = state->compiled->match(subjects[row]);
+            destination[row] = negate ? !matched : matched;
         }
-        // `n` inverts the match (NOT LIKE) here rather than through a node of its own. A NULL
-        // subject already returned NA above, so the inversion never turns UNKNOWN into a match.
-        const bool matched = state->compiled->match(subject);
-        output.emplace_back(resource, negate ? !matched : matched);
         return core::error_t::no_error();
     }
 
     // ------------------------------------------------------------------
     // Makers (mirror make_sum_func style from aggregate.cpp).
     // ------------------------------------------------------------------
-    std::unique_ptr<row_function> make_substring_func(std::pmr::memory_resource* resource,
-                                                      const std::string& name,
-                                                      const std::string& short_doc,
-                                                      const std::string& full_doc) {
+    std::unique_ptr<vector_function> make_substring_func(std::pmr::memory_resource* resource,
+                                                         const std::string& name,
+                                                         const std::string& short_doc,
+                                                         const std::string& full_doc) {
         function_doc doc{short_doc, full_doc, {"string", "start", "length"}, false};
 
         // arity::var_args(2) — accept 2 or 3 args; two kernel slots for the overloads.
-        auto fn = std::make_unique<row_function>(name, arity::var_args(2), doc, /*available_kernel_slots=*/2);
+        auto fn = std::make_unique<vector_function>(name, arity::var_args(2), doc, /*available_kernel_slots=*/2);
 
-        // NA-aware: NA is accepted at signature-match time by the string/integer
-        // matchers (kernel_signature.cpp); kernel body propagates via has_null_input.
+        // NULL-aware: a null argument is accepted at signature-match time by the string/integer
+        // matchers (kernel_signature.cpp); the kernel body propagates it through the validity mask.
         kernel_signature_t sig2(
-            function_type_t::row,
+            function_type_t::vector,
             {parameter_type::exact(logical_type::STRING_LITERAL), parameter_type::exact(logical_type::BIGINT)},
             {output_type::fixed(logical_type::STRING_LITERAL)});
-        row_kernel k2(std::move(sig2), row_substring_2);
+        vector_kernel k2(std::move(sig2), vector_substring_2);
         (void) fn->add_kernel(resource, std::move(k2));
 
-        kernel_signature_t sig3(function_type_t::row,
+        kernel_signature_t sig3(function_type_t::vector,
                                 {parameter_type::exact(logical_type::STRING_LITERAL),
                                  parameter_type::exact(logical_type::BIGINT),
                                  parameter_type::exact(logical_type::BIGINT)},
                                 {output_type::fixed(logical_type::STRING_LITERAL)});
-        row_kernel k3(std::move(sig3), row_substring_3);
+        vector_kernel k3(std::move(sig3), vector_substring_3);
         (void) fn->add_kernel(resource, std::move(k3));
 
         return fn;
     }
 
-    std::unique_ptr<row_function> make_length_func(std::pmr::memory_resource* resource,
-                                                   const std::string& name,
-                                                   const std::string& short_doc,
-                                                   const std::string& full_doc) {
+    std::unique_ptr<vector_function> make_length_func(std::pmr::memory_resource* resource,
+                                                      const std::string& name,
+                                                      const std::string& short_doc,
+                                                      const std::string& full_doc) {
         function_doc doc{short_doc, full_doc, {"string"}, false};
 
-        auto fn = std::make_unique<row_function>(name, arity::unary(), doc, /*available_kernel_slots=*/1);
+        auto fn = std::make_unique<vector_function>(name, arity::unary(), doc, /*available_kernel_slots=*/1);
 
-        kernel_signature_t sig(function_type_t::row,
+        kernel_signature_t sig(function_type_t::vector,
                                {parameter_type::exact(logical_type::STRING_LITERAL)},
                                {output_type::fixed(logical_type::BIGINT)});
-        row_kernel k(std::move(sig), row_length);
+        vector_kernel k(std::move(sig), vector_length);
         (void) fn->add_kernel(resource, std::move(k));
 
         return fn;
     }
 
-    std::unique_ptr<row_function> make_regexp_replace_func(std::pmr::memory_resource* resource,
-                                                           const std::string& name,
-                                                           const std::string& short_doc,
-                                                           const std::string& full_doc) {
+    std::unique_ptr<vector_function> make_regexp_replace_func(std::pmr::memory_resource* resource,
+                                                              const std::string& name,
+                                                              const std::string& short_doc,
+                                                              const std::string& full_doc) {
         function_doc doc{short_doc, full_doc, {"string", "pattern", "replacement"}, false};
 
-        auto fn = std::make_unique<row_function>(name, arity::ternary(), doc, /*available_kernel_slots=*/1);
+        auto fn = std::make_unique<vector_function>(name, arity::ternary(), doc, /*available_kernel_slots=*/1);
 
-        kernel_signature_t sig(function_type_t::row,
+        kernel_signature_t sig(function_type_t::vector,
                                {parameter_type::exact(logical_type::STRING_LITERAL),
                                 parameter_type::exact(logical_type::STRING_LITERAL),
                                 parameter_type::exact(logical_type::STRING_LITERAL)},
                                {output_type::fixed(logical_type::STRING_LITERAL)});
-        row_kernel k(std::move(sig), row_regexp_replace);
+        vector_kernel k(std::move(sig), vector_regexp_replace, init_regexp_replace);
         (void) fn->add_kernel(resource, std::move(k));
 
         return fn;
     }
 
-    std::unique_ptr<row_function> make_regexp_like_func(std::pmr::memory_resource* resource,
-                                                        const std::string& name,
-                                                        const std::string& short_doc,
-                                                        const std::string& full_doc) {
+    std::unique_ptr<vector_function> make_regexp_like_func(std::pmr::memory_resource* resource,
+                                                           const std::string& name,
+                                                           const std::string& short_doc,
+                                                           const std::string& full_doc) {
         function_doc doc{short_doc, full_doc, {"string", "pattern", "flags"}, false};
 
-        auto fn = std::make_unique<row_function>(name, arity::var_args(2), doc, /*available_kernel_slots=*/2);
+        auto fn = std::make_unique<vector_function>(name, arity::var_args(2), doc, /*available_kernel_slots=*/2);
 
         kernel_signature_t sig2(
-            function_type_t::row,
+            function_type_t::vector,
             {parameter_type::exact(logical_type::STRING_LITERAL), parameter_type::exact(logical_type::STRING_LITERAL)},
             {output_type::fixed(logical_type::BOOLEAN)});
-        row_kernel k2(std::move(sig2), row_regexp_like, init_regexp_like);
+        vector_kernel k2(std::move(sig2), vector_regexp_like, init_regexp_like);
         (void) fn->add_kernel(resource, std::move(k2));
 
-        kernel_signature_t sig3(function_type_t::row,
+        kernel_signature_t sig3(function_type_t::vector,
                                 {parameter_type::exact(logical_type::STRING_LITERAL),
                                  parameter_type::exact(logical_type::STRING_LITERAL),
                                  parameter_type::exact(logical_type::STRING_LITERAL)},
                                 {output_type::fixed(logical_type::BOOLEAN)});
-        row_kernel k3(std::move(sig3), row_regexp_like, init_regexp_like);
+        vector_kernel k3(std::move(sig3), vector_regexp_like, init_regexp_like);
         (void) fn->add_kernel(resource, std::move(k3));
 
         return fn;

--- a/components/compute/tests/test_execution.cpp
+++ b/components/compute/tests/test_execution.cpp
@@ -108,16 +108,15 @@ static core::result_wrapper_t<std::pmr::vector<int>> run_aggregate(std::pmr::mem
     return values;
 }
 
-static core::error_t row_double(kernel_context&,
-                                const std::pmr::vector<logical_value_t>& inputs,
-                                std::pmr::vector<logical_value_t>& output) {
-    output.emplace_back(inputs[0].resource(), inputs[0].value<int>() * 2);
+// A plain elementwise kernel: no options, no init, no finalize. The kernels above carry all
+// three, so this one covers the bare vector_kernel shape a scalar function actually uses.
+static core::error_t vec_double(kernel_context&, const data_chunk_t& inputs, vector_t& output) {
+    const auto* source = inputs.data[0].data<int>();
+    auto* destination = output.data<int>();
+    for (uint64_t row = 0; row < inputs.size(); ++row) {
+        destination[row] = source[row] * 2;
+    }
     return core::error_t::no_error();
-}
-
-static core::error_t
-row_exec_fail(kernel_context&, const std::pmr::vector<logical_value_t>&, std::pmr::vector<logical_value_t>&) {
-    return TEST_ERROR;
 }
 
 inline function_doc function_doc_with_options() { return function_doc{"", "", {}, true}; }
@@ -141,7 +140,7 @@ TEST_CASE("components::compute::vector::single") {
 
     auto res = fn->execute(chunk, &opts);
     REQUIRE_FALSE(res.has_error());
-    REQUIRE(std::get<data_chunk_t>(res.value()).data[0].data<int>()[0] == MAGIC_MULTIPLIER * 10);
+    REQUIRE(res.value().data[0].data<int>()[0] == MAGIC_MULTIPLIER * 10);
 }
 
 TEST_CASE("components::compute::vector::batch") {
@@ -171,9 +170,9 @@ TEST_CASE("components::compute::vector::batch") {
 
     auto res = fn->execute(batch, &opts);
     REQUIRE_FALSE(res.has_error());
-    REQUIRE(std::get<data_chunk_t>(res.value()).data.size() == 2);
-    REQUIRE(std::get<data_chunk_t>(res.value()).data[0].data<int>()[0] == MAGIC_MULTIPLIER);
-    REQUIRE(std::get<data_chunk_t>(res.value()).data[1].data<int>()[0] == MAGIC_MULTIPLIER * 10);
+    REQUIRE(res.value().data.size() == 2);
+    REQUIRE(res.value().data[0].data<int>()[0] == MAGIC_MULTIPLIER);
+    REQUIRE(res.value().data[1].data<int>()[0] == MAGIC_MULTIPLIER * 10);
 }
 
 static data_chunk_t two_ints(std::pmr::memory_resource* resource, int first, int second) {
@@ -239,14 +238,14 @@ TEST_CASE("components::compute::aggregate::per_group") {
     REQUIRE(res.value()[1] == 15); // 10 (init) + 2 + 3
 }
 
-TEST_CASE("components::compute::row::single") {
+TEST_CASE("components::compute::vector::plain::chunk") {
     core::pmr::otterbrix_resource resource;
-    auto fn = std::make_unique<row_function>("row_single", arity::unary(), function_doc{}, 1);
+    auto fn = std::make_unique<vector_function>("plain_chunk", arity::unary(), function_doc{}, 1);
 
-    kernel_signature_t sig(function_type_t::row,
+    kernel_signature_t sig(function_type_t::vector,
                            {parameter_type::exact(logical_type::INTEGER)},
                            {output_type::fixed(logical_type::INTEGER)});
-    row_kernel k(std::move(sig), row_double);
+    vector_kernel k(std::move(sig), vec_double);
     REQUIRE_FALSE(fn->add_kernel(&resource, std::move(k)).contains_error());
 
     data_chunk_t chunk(&resource, {logical_type::INTEGER}, 3);
@@ -257,21 +256,21 @@ TEST_CASE("components::compute::row::single") {
 
     auto res = fn->execute(chunk);
     REQUIRE_FALSE(res.has_error());
-    auto& vals = std::get<std::pmr::vector<logical_value_t>>(res.value());
-    REQUIRE(vals.size() == 3);
-    REQUIRE(vals[0].value<int>() == 2);
-    REQUIRE(vals[1].value<int>() == 4);
-    REQUIRE(vals[2].value<int>() == 6);
+    auto& out = res.value();
+    REQUIRE(out.size() == 3);
+    REQUIRE(out.data[0].data<int>()[0] == 2);
+    REQUIRE(out.data[0].data<int>()[1] == 4);
+    REQUIRE(out.data[0].data<int>()[2] == 6);
 }
 
-TEST_CASE("components::compute::row::batch") {
+TEST_CASE("components::compute::vector::plain::batch") {
     core::pmr::otterbrix_resource resource;
-    auto fn = std::make_unique<row_function>("row_batch", arity::unary(), function_doc{}, 1);
+    auto fn = std::make_unique<vector_function>("plain_batch", arity::unary(), function_doc{}, 1);
 
-    kernel_signature_t sig(function_type_t::row,
+    kernel_signature_t sig(function_type_t::vector,
                            {parameter_type::exact(logical_type::INTEGER)},
                            {output_type::fixed(logical_type::INTEGER)});
-    row_kernel k(std::move(sig), row_double);
+    vector_kernel k(std::move(sig), vec_double);
     REQUIRE_FALSE(fn->add_kernel(&resource, std::move(k)).contains_error());
 
     data_chunk_t c1(&resource, {logical_type::INTEGER}, 2);
@@ -287,34 +286,14 @@ TEST_CASE("components::compute::row::batch") {
     batch.emplace_back(std::move(c1));
     batch.emplace_back(std::move(c2));
 
+    // One vector per input chunk, fused into the result chunk's columns.
     auto res = fn->execute(batch);
     REQUIRE_FALSE(res.has_error());
-    auto& vals = std::get<std::pmr::vector<logical_value_t>>(res.value());
-    REQUIRE(vals.size() == 3);
-    REQUIRE(vals[0].value<int>() == 10);
-    REQUIRE(vals[1].value<int>() == 14);
-    REQUIRE(vals[2].value<int>() == 20);
-}
-
-TEST_CASE("components::compute::row::values") {
-    core::pmr::otterbrix_resource resource;
-    // Direct pmr::vector path — single scalar call
-    auto fn = std::make_unique<row_function>("row_vals", arity::unary(), function_doc{}, 1);
-
-    kernel_signature_t sig(function_type_t::row,
-                           {parameter_type::exact(logical_type::INTEGER)},
-                           {output_type::fixed(logical_type::INTEGER)});
-    row_kernel k(std::move(sig), row_double);
-    REQUIRE_FALSE(fn->add_kernel(&resource, std::move(k)).contains_error());
-
-    std::pmr::vector<logical_value_t> inputs(&resource);
-    inputs.emplace_back(&resource, 21);
-
-    auto res = fn->execute(inputs);
-    REQUIRE_FALSE(res.has_error());
-    auto& vals = std::get<std::pmr::vector<logical_value_t>>(res.value());
-    REQUIRE(vals.size() == 1);
-    REQUIRE(vals[0].value<int>() == 42);
+    auto& out = res.value();
+    REQUIRE(out.column_count() == 2);
+    REQUIRE(out.data[0].data<int>()[0] == 10);
+    REQUIRE(out.data[0].data<int>()[1] == 14);
+    REQUIRE(out.data[1].data<int>()[0] == 20);
 }
 
 TEST_CASE("components::compute::expand::generate_series") {
@@ -439,26 +418,10 @@ TEST_CASE("components::compute::errors") {
         auto status = run_aggregate(&resource, *fn, chunks, {{0, 0}}, 1).error().type;
         REQUIRE(status == core::error_code_t::kernel_error);
     }
-
-    SECTION("faulty row exec") {
-        auto fn = std::make_unique<row_function>("row", arity::unary(), function_doc{}, 1);
-
-        kernel_signature_t sig(function_type_t::row,
-                               {parameter_type::exact(logical_type::INTEGER)},
-                               {output_type::fixed(logical_type::INTEGER)});
-        row_kernel k(std::move(sig), row_exec_fail);
-        REQUIRE_FALSE(fn->add_kernel(&resource, std::move(k)).contains_error());
-
-        std::pmr::vector<logical_value_t> inputs(&resource);
-        inputs.emplace_back(&resource, 1);
-
-        auto status = fn->execute(inputs).error().type;
-        REQUIRE(status == core::error_code_t::kernel_error);
-    }
 }
 
 // ---------------------------------------------------------------------------
-// SUBSTRING / LENGTH / REGEXP_REPLACE — string row-kernel execution tests
+// SUBSTRING / LENGTH / REGEXP_REPLACE — string kernel execution tests
 // ---------------------------------------------------------------------------
 
 namespace {
@@ -477,6 +440,60 @@ namespace {
             return nullptr;
         }
     };
+
+    // One scalar argument of a one-row argument chunk. A NULL argument is an NA-typed column —
+    // the shape the engine hands a kernel when a whole input column is null, and the one that
+    // carries no data buffer to read from.
+    struct arg_t {
+        enum class kind_t
+        {
+            text,
+            integer,
+            null
+        };
+
+        kind_t kind;
+        std::string text_value;
+        int64_t integer_value;
+
+        static arg_t text(std::string_view value) { return {kind_t::text, std::string(value), 0}; }
+        static arg_t integer(int64_t value) { return {kind_t::integer, {}, value}; }
+        static arg_t null() { return {kind_t::null, {}, 0}; }
+    };
+
+    data_chunk_t one_row_chunk(std::pmr::memory_resource* resource, const std::vector<arg_t>& args) {
+        std::pmr::vector<complex_logical_type> types(resource);
+        for (const auto& arg : args) {
+            switch (arg.kind) {
+                case arg_t::kind_t::text:
+                    types.emplace_back(logical_type::STRING_LITERAL);
+                    break;
+                case arg_t::kind_t::integer:
+                    types.emplace_back(logical_type::BIGINT);
+                    break;
+                case arg_t::kind_t::null:
+                    types.emplace_back(logical_type::NA);
+                    break;
+            }
+        }
+
+        data_chunk_t chunk(resource, types, uint64_t{1});
+        for (size_t column = 0; column < args.size(); ++column) {
+            switch (args[column].kind) {
+                case arg_t::kind_t::text:
+                    chunk.data[column].set_value(0, std::string_view{args[column].text_value});
+                    break;
+                case arg_t::kind_t::integer:
+                    chunk.data[column].set_value(0, args[column].integer_value);
+                    break;
+                case arg_t::kind_t::null:
+                    // An NA column is null by construction and owns no data.
+                    break;
+            }
+        }
+        chunk.set_cardinality(1);
+        return chunk;
+    }
 } // namespace
 
 TEST_CASE("components::compute::string::substring_basic") {
@@ -484,16 +501,11 @@ TEST_CASE("components::compute::string::substring_basic") {
     auto* fn = fx.get("substring");
     REQUIRE(fn != nullptr);
 
-    std::pmr::vector<logical_value_t> inputs(&fx.resource);
-    inputs.emplace_back(&fx.resource, std::string("hello world"));
-    inputs.emplace_back(&fx.resource, static_cast<int64_t>(7));
-    inputs.emplace_back(&fx.resource, static_cast<int64_t>(5));
+    auto args = one_row_chunk(&fx.resource, {arg_t::text("hello world"), arg_t::integer(7), arg_t::integer(5)});
 
-    auto res = fn->execute(inputs);
+    auto res = fn->execute(args);
     REQUIRE_FALSE(res.has_error());
-    auto& vals = std::get<std::pmr::vector<logical_value_t>>(res.value());
-    REQUIRE(vals.size() == 1);
-    REQUIRE(vals[0].value<std::string_view>() == "world");
+    REQUIRE(res.value().data[0].data<std::string_view>()[0] == "world");
 }
 
 TEST_CASE("components::compute::string::substring_omit_len") {
@@ -501,15 +513,11 @@ TEST_CASE("components::compute::string::substring_omit_len") {
     auto* fn = fx.get("substring");
     REQUIRE(fn != nullptr);
 
-    std::pmr::vector<logical_value_t> inputs(&fx.resource);
-    inputs.emplace_back(&fx.resource, std::string("abcdefgh"));
-    inputs.emplace_back(&fx.resource, static_cast<int64_t>(3));
+    auto args = one_row_chunk(&fx.resource, {arg_t::text("abcdefgh"), arg_t::integer(3)});
 
-    auto res = fn->execute(inputs);
+    auto res = fn->execute(args);
     REQUIRE_FALSE(res.has_error());
-    auto& vals = std::get<std::pmr::vector<logical_value_t>>(res.value());
-    REQUIRE(vals.size() == 1);
-    REQUIRE(vals[0].value<std::string_view>() == "cdefgh");
+    REQUIRE(res.value().data[0].data<std::string_view>()[0] == "cdefgh");
 }
 
 TEST_CASE("components::compute::string::substring_out_of_range") {
@@ -517,16 +525,11 @@ TEST_CASE("components::compute::string::substring_out_of_range") {
     auto* fn = fx.get("substring");
     REQUIRE(fn != nullptr);
 
-    std::pmr::vector<logical_value_t> inputs(&fx.resource);
-    inputs.emplace_back(&fx.resource, std::string("abc"));
-    inputs.emplace_back(&fx.resource, static_cast<int64_t>(99));
-    inputs.emplace_back(&fx.resource, static_cast<int64_t>(5));
+    auto args = one_row_chunk(&fx.resource, {arg_t::text("abc"), arg_t::integer(99), arg_t::integer(5)});
 
-    auto res = fn->execute(inputs);
+    auto res = fn->execute(args);
     REQUIRE_FALSE(res.has_error());
-    auto& vals = std::get<std::pmr::vector<logical_value_t>>(res.value());
-    REQUIRE(vals.size() == 1);
-    REQUIRE(vals[0].value<std::string_view>().empty());
+    REQUIRE(res.value().data[0].data<std::string_view>()[0].empty());
 }
 
 TEST_CASE("components::compute::string::substring_null") {
@@ -534,16 +537,11 @@ TEST_CASE("components::compute::string::substring_null") {
     auto* fn = fx.get("substring");
     REQUIRE(fn != nullptr);
 
-    std::pmr::vector<logical_value_t> inputs(&fx.resource);
-    inputs.emplace_back(&fx.resource, logical_type::NA);
-    inputs.emplace_back(&fx.resource, static_cast<int64_t>(1));
-    inputs.emplace_back(&fx.resource, static_cast<int64_t>(2));
+    auto args = one_row_chunk(&fx.resource, {arg_t::null(), arg_t::integer(1), arg_t::integer(2)});
 
-    auto res = fn->execute(inputs);
+    auto res = fn->execute(args);
     REQUIRE_FALSE(res.has_error());
-    auto& vals = std::get<std::pmr::vector<logical_value_t>>(res.value());
-    REQUIRE(vals.size() == 1);
-    REQUIRE(vals[0].type().type() == logical_type::NA);
+    REQUIRE(res.value().data[0].is_null(0));
 }
 
 TEST_CASE("components::compute::string::length_basic") {
@@ -551,14 +549,11 @@ TEST_CASE("components::compute::string::length_basic") {
     auto* fn = fx.get("length");
     REQUIRE(fn != nullptr);
 
-    std::pmr::vector<logical_value_t> inputs(&fx.resource);
-    inputs.emplace_back(&fx.resource, std::string("hello"));
+    auto args = one_row_chunk(&fx.resource, {arg_t::text("hello")});
 
-    auto res = fn->execute(inputs);
+    auto res = fn->execute(args);
     REQUIRE_FALSE(res.has_error());
-    auto& vals = std::get<std::pmr::vector<logical_value_t>>(res.value());
-    REQUIRE(vals.size() == 1);
-    REQUIRE(vals[0].value<int64_t>() == 5);
+    REQUIRE(res.value().data[0].data<int64_t>()[0] == 5);
 }
 
 TEST_CASE("components::compute::string::length_empty") {
@@ -566,14 +561,11 @@ TEST_CASE("components::compute::string::length_empty") {
     auto* fn = fx.get("length");
     REQUIRE(fn != nullptr);
 
-    std::pmr::vector<logical_value_t> inputs(&fx.resource);
-    inputs.emplace_back(&fx.resource, std::string(""));
+    auto args = one_row_chunk(&fx.resource, {arg_t::text("")});
 
-    auto res = fn->execute(inputs);
+    auto res = fn->execute(args);
     REQUIRE_FALSE(res.has_error());
-    auto& vals = std::get<std::pmr::vector<logical_value_t>>(res.value());
-    REQUIRE(vals.size() == 1);
-    REQUIRE(vals[0].value<int64_t>() == 0);
+    REQUIRE(res.value().data[0].data<int64_t>()[0] == 0);
 }
 
 TEST_CASE("components::compute::string::length_null") {
@@ -581,14 +573,31 @@ TEST_CASE("components::compute::string::length_null") {
     auto* fn = fx.get("length");
     REQUIRE(fn != nullptr);
 
-    std::pmr::vector<logical_value_t> inputs(&fx.resource);
-    inputs.emplace_back(&fx.resource, logical_type::NA);
+    auto args = one_row_chunk(&fx.resource, {arg_t::null()});
 
-    auto res = fn->execute(inputs);
+    auto res = fn->execute(args);
     REQUIRE_FALSE(res.has_error());
-    auto& vals = std::get<std::pmr::vector<logical_value_t>>(res.value());
-    REQUIRE(vals.size() == 1);
-    REQUIRE(vals[0].type().type() == logical_type::NA);
+    REQUIRE(res.value().data[0].is_null(0));
+}
+
+// A whole column of NULLs is typed NA and owns no data buffer, while its validity mask reads
+// as all-valid. The kernel has to notice that by type, or it reads a buffer that was never
+// allocated.
+TEST_CASE("components::compute::string::length_null_column") {
+    string_registry_fixture fx;
+    auto* fn = fx.get("length");
+    REQUIRE(fn != nullptr);
+
+    std::pmr::vector<complex_logical_type> types(&fx.resource);
+    types.emplace_back(logical_type::NA);
+    data_chunk_t args(&fx.resource, types, uint64_t{4});
+    args.set_cardinality(4);
+
+    auto res = fn->execute(args);
+    REQUIRE_FALSE(res.has_error());
+    for (uint64_t row = 0; row < 4; ++row) {
+        REQUIRE(res.value().data[0].is_null(row));
+    }
 }
 
 TEST_CASE("components::compute::string::regexp_replace_basic") {
@@ -596,16 +605,12 @@ TEST_CASE("components::compute::string::regexp_replace_basic") {
     auto* fn = fx.get("regexp_replace");
     REQUIRE(fn != nullptr);
 
-    std::pmr::vector<logical_value_t> inputs(&fx.resource);
-    inputs.emplace_back(&fx.resource, std::string("hello 123 world 456"));
-    inputs.emplace_back(&fx.resource, std::string("[0-9]+"));
-    inputs.emplace_back(&fx.resource, std::string("#"));
+    auto args =
+        one_row_chunk(&fx.resource, {arg_t::text("hello 123 world 456"), arg_t::text("[0-9]+"), arg_t::text("#")});
 
-    auto res = fn->execute(inputs);
+    auto res = fn->execute(args);
     REQUIRE_FALSE(res.has_error());
-    auto& vals = std::get<std::pmr::vector<logical_value_t>>(res.value());
-    REQUIRE(vals.size() == 1);
-    REQUIRE(vals[0].value<std::string_view>() == "hello # world #");
+    REQUIRE(res.value().data[0].data<std::string_view>()[0] == "hello # world #");
 }
 
 TEST_CASE("components::compute::string::regexp_replace_no_match") {
@@ -613,16 +618,11 @@ TEST_CASE("components::compute::string::regexp_replace_no_match") {
     auto* fn = fx.get("regexp_replace");
     REQUIRE(fn != nullptr);
 
-    std::pmr::vector<logical_value_t> inputs(&fx.resource);
-    inputs.emplace_back(&fx.resource, std::string("abcdef"));
-    inputs.emplace_back(&fx.resource, std::string("[0-9]+"));
-    inputs.emplace_back(&fx.resource, std::string("#"));
+    auto args = one_row_chunk(&fx.resource, {arg_t::text("abcdef"), arg_t::text("[0-9]+"), arg_t::text("#")});
 
-    auto res = fn->execute(inputs);
+    auto res = fn->execute(args);
     REQUIRE_FALSE(res.has_error());
-    auto& vals = std::get<std::pmr::vector<logical_value_t>>(res.value());
-    REQUIRE(vals.size() == 1);
-    REQUIRE(vals[0].value<std::string_view>() == "abcdef");
+    REQUIRE(res.value().data[0].data<std::string_view>()[0] == "abcdef");
 }
 
 TEST_CASE("components::compute::string::regexp_replace_null") {
@@ -630,14 +630,84 @@ TEST_CASE("components::compute::string::regexp_replace_null") {
     auto* fn = fx.get("regexp_replace");
     REQUIRE(fn != nullptr);
 
-    std::pmr::vector<logical_value_t> inputs(&fx.resource);
-    inputs.emplace_back(&fx.resource, logical_type::NA);
-    inputs.emplace_back(&fx.resource, std::string("x"));
-    inputs.emplace_back(&fx.resource, std::string("y"));
+    auto args = one_row_chunk(&fx.resource, {arg_t::null(), arg_t::text("x"), arg_t::text("y")});
 
-    auto res = fn->execute(inputs);
+    auto res = fn->execute(args);
     REQUIRE_FALSE(res.has_error());
-    auto& vals = std::get<std::pmr::vector<logical_value_t>>(res.value());
-    REQUIRE(vals.size() == 1);
-    REQUIRE(vals[0].type().type() == logical_type::NA);
+    REQUIRE(res.value().data[0].is_null(0));
+}
+
+// The graph builds one executor per function node and drives every chunk through it, so an
+// executor must not carry a produced vector between calls — the second chunk would come back
+// holding the first chunk's output.
+TEST_CASE("components::compute::string::one_executor_over_several_chunks") {
+    string_registry_fixture fx;
+    auto* fn = fx.get("length");
+    REQUIRE(fn != nullptr);
+
+    std::pmr::vector<complex_logical_type> in_types(&fx.resource);
+    in_types.emplace_back(logical_type::STRING_LITERAL);
+    auto executor = fn->make_executor(&fx.resource, in_types);
+    REQUIRE_FALSE(executor.has_error());
+
+    auto chunk_of = [&](std::string_view first, std::string_view second) {
+        data_chunk_t chunk(&fx.resource, in_types, uint64_t{2});
+        chunk.data[0].set_value(0, first);
+        chunk.data[0].set_value(1, second);
+        chunk.set_cardinality(2);
+        return chunk;
+    };
+
+    auto first = executor.value()->execute(chunk_of("a", "bb"));
+    REQUIRE_FALSE(first.has_error());
+    REQUIRE(first.value().data[0].data<int64_t>()[0] == 1);
+    REQUIRE(first.value().data[0].data<int64_t>()[1] == 2);
+
+    auto second = executor.value()->execute(chunk_of("cccc", "ddddd"));
+    REQUIRE_FALSE(second.has_error());
+    REQUIRE(second.value().data[0].data<int64_t>()[0] == 4);
+    REQUIRE(second.value().data[0].data<int64_t>()[1] == 5);
+}
+
+// Several rows in one call: the whole point of a vector kernel, and the case the row path
+// could not express.
+TEST_CASE("components::compute::string::length_over_a_chunk") {
+    string_registry_fixture fx;
+    auto* fn = fx.get("length");
+    REQUIRE(fn != nullptr);
+
+    std::pmr::vector<complex_logical_type> types(&fx.resource);
+    types.emplace_back(logical_type::STRING_LITERAL);
+    data_chunk_t args(&fx.resource, types, uint64_t{3});
+    args.data[0].set_value(0, std::string_view{"a"});
+    args.data[0].set_value(1, std::string_view{"bb"});
+    args.data[0].set_value(2, std::string_view{"ccc"});
+    args.set_cardinality(3);
+
+    auto res = fn->execute(args);
+    REQUIRE_FALSE(res.has_error());
+    REQUIRE(res.value().data[0].data<int64_t>()[0] == 1);
+    REQUIRE(res.value().data[0].data<int64_t>()[1] == 2);
+    REQUIRE(res.value().data[0].data<int64_t>()[2] == 3);
+}
+
+// One null row among valid ones: the validity mask carries it, the valid rows still compute.
+TEST_CASE("components::compute::string::length_null_row_within_chunk") {
+    string_registry_fixture fx;
+    auto* fn = fx.get("length");
+    REQUIRE(fn != nullptr);
+
+    std::pmr::vector<complex_logical_type> types(&fx.resource);
+    types.emplace_back(logical_type::STRING_LITERAL);
+    data_chunk_t args(&fx.resource, types, uint64_t{3});
+    args.data[0].set_value(0, std::string_view{"ab"});
+    args.data[0].set_null(1, true);
+    args.data[0].set_value(2, std::string_view{"cdef"});
+    args.set_cardinality(3);
+
+    auto res = fn->execute(args);
+    REQUIRE_FALSE(res.has_error());
+    REQUIRE(res.value().data[0].data<int64_t>()[0] == 2);
+    REQUIRE(res.value().data[0].is_null(1));
+    REQUIRE(res.value().data[0].data<int64_t>()[2] == 4);
 }

--- a/components/execution_dag/execution_dag.cpp
+++ b/components/execution_dag/execution_dag.cpp
@@ -500,34 +500,15 @@ namespace components::execution_dag {
         if (result.has_error()) {
             return result.error();
         }
-        auto& produced = result.value();
-        if (std::holds_alternative<vector::data_chunk_t>(produced)) {
-            auto& chunk = std::get<vector::data_chunk_t>(produced);
-            assert(chunk.size() == count);
-            if (chunk.column_count() != output_indices_.size()) {
-                return core::error_t(
-                    core::error_code_t::incorrect_function_return_type,
-                    std::pmr::string{"execution graph: function returned an unexpected column count", resource()});
-            }
-            for (size_t position = 0; position < output_indices_.size(); position++) {
-                output(position).reference(chunk.data[position]);
-            }
-            return core::error_t::no_error();
-        }
-
-        auto& values = std::get<std::pmr::vector<types::logical_value_t>>(produced);
-        assert(values.size() == count);
-        if (output_indices_.size() != 1) {
+        auto& chunk = result.value();
+        assert(chunk.size() == count);
+        if (chunk.column_count() != output_indices_.size()) {
             return core::error_t(
                 core::error_code_t::incorrect_function_return_type,
-                std::pmr::string{"execution graph: function returned one column but the node declares several",
-                                 resource()});
+                std::pmr::string{"execution graph: function returned an unexpected column count", resource()});
         }
-        for (uint64_t row = 0; row < values.size(); row++) {
-            output(0).set_null(row, values[row].is_null());
-            if (!values[row].is_null()) {
-                output(0).set_value(row, values[row]);
-            }
+        for (size_t position = 0; position < output_indices_.size(); position++) {
+            output(position).reference(chunk.data[position]);
         }
         return core::error_t::no_error();
     }
@@ -1062,6 +1043,11 @@ namespace components::execution_dag {
 
     core::error_t execution_dag_t::process_keys(const vector::data_chunk_t& input,
                                                 const graph_execution_context& context) {
+        // strings are allocated on extenal heaps (basically an arena)
+        // and that will allocate new memory for each batch if not reset
+        for (auto& slot : data_storage_) {
+            slot.reset_string_heap();
+        }
         if (auto error = bind_inputs(input); error.contains_error()) {
             return error;
         }

--- a/components/vector/data_chunk.cpp
+++ b/components/vector/data_chunk.cpp
@@ -143,6 +143,9 @@ namespace components::vector {
         }
         capacity_ = DEFAULT_VECTOR_CAPACITY;
         set_cardinality(0);
+        for (auto& column : data) {
+            column.reset_string_heap();
+        }
     }
 
     void data_chunk_t::drop_unprojected_placeholders() {

--- a/components/vector/vector.cpp
+++ b/components/vector/vector.cpp
@@ -176,6 +176,28 @@ namespace components::vector {
         }
     }
 
+    void vector_t::reset_string_heap() {
+        if (!auxiliary_ || auxiliary_.use_count() != 1) {
+            return;
+        }
+        switch (auxiliary_->type()) {
+            case vector_buffer_type::STRING:
+                static_cast<string_vector_buffer_t*>(auxiliary_.get())->reset();
+                break;
+            case vector_buffer_type::STRUCT:
+                for (auto& child : entries()) {
+                    child->reset_string_heap();
+                }
+                break;
+            case vector_buffer_type::LIST:
+            case vector_buffer_type::ARRAY:
+                entry().reset_string_heap();
+                break;
+            default:
+                break;
+        }
+    }
+
     void vector_t::reference(const vector_t& other) {
         assert(other.type_ == type_ && "vector_t reference to incorrect type");
         reinterpret(other);

--- a/components/vector/vector.hpp
+++ b/components/vector/vector.hpp
@@ -146,6 +146,13 @@ namespace components::vector {
 
         void set_auxiliary(std::shared_ptr<vector_buffer_t> new_buffer) { auxiliary_ = std::move(new_buffer); }
 
+        // Release the strings this vector (and anything nested in it) has stored, so a vector
+        // that is refilled per chunk does not accumulate every string of the whole scan. Call it
+        // only when the previous contents are dead: any string_view still pointing into the
+        // arena dangles afterwards. A buffer shared with another vector — reference() hands out
+        // the same one — is left alone, because that vector's cells still read from it.
+        void reset_string_heap();
+
         void copy_buffer(vector_t& other) {
             buffer_ = other.buffer_;
             data_ = other.data_;

--- a/components/vector/vector_buffer.cpp
+++ b/components/vector/vector_buffer.cpp
@@ -39,6 +39,11 @@ namespace components::vector {
         refs_.push_back(std::move(heap));
     }
 
+    void string_vector_buffer_t::reset() {
+        string_buffer_.reset();
+        refs_.clear();
+    }
+
     dictionary_vector_buffer_t::dictionary_vector_buffer_t(const indexing_vector_t& select)
         : vector_buffer_t(select.resource(), vector_buffer_type::DICTIONARY)
         , indexing_vector_(select) {}

--- a/components/vector/vector_buffer.hpp
+++ b/components/vector/vector_buffer.hpp
@@ -115,6 +115,7 @@ namespace components::vector {
         void* insert(T&& str_like);
         void* empty_string(size_t size);
         void add_heap_reference(std::unique_ptr<vector_buffer_t> heap);
+        void reset();
 
     private:
         core::string_buffer_t string_buffer_;

--- a/integration/cpp/test/test_batch_execution.cpp
+++ b/integration/cpp/test/test_batch_execution.cpp
@@ -23,39 +23,44 @@ constexpr auto JOIN_RIGHT_SIZE = 5;
 static auto update_calls = 0;
 static auto finalize_calls = 0;
 
-static core::error_t double_val_exec(kernel_context& ctx,
-                                     const std::pmr::vector<types::logical_value_t>& in,
-                                     std::pmr::vector<types::logical_value_t>& out) {
-    out.emplace_back(ctx.exec_context().resource(), in[0].value<int64_t>() * 2);
+static core::error_t double_val_exec(kernel_context&, const vector::data_chunk_t& in, vector::vector_t& out) {
+    const auto* source = in.data[0].data<int64_t>();
+    auto* destination = out.data<int64_t>();
+    for (uint64_t row = 0; row < in.size(); ++row) {
+        destination[row] = source[row] * 2;
+    }
     return core::error_t::no_error();
 }
 
-std::unique_ptr<row_function> make_double_val_func(std::pmr::memory_resource* resource) {
+std::unique_ptr<vector_function> make_double_val_func(std::pmr::memory_resource* resource) {
     function_doc doc{"double_val", "multiplies by 2", {"arg"}, false};
-    auto fn = std::make_unique<row_function>("double_val", arity::unary(), doc, 1);
-    kernel_signature_t sig(function_type_t::row,
+    auto fn = std::make_unique<vector_function>("double_val", arity::unary(), doc, 1);
+    kernel_signature_t sig(function_type_t::vector,
                            {parameter_type::exact(types::logical_type::BIGINT)},
                            {output_type::fixed(types::logical_type::BIGINT)});
-    row_kernel k{std::move(sig), double_val_exec};
+    vector_kernel k{std::move(sig), double_val_exec};
     fn->add_kernel(resource, std::move(k));
     return fn;
 }
 
-static core::error_t gt_threshold_exec(kernel_context&,
-                                       const std::pmr::vector<types::logical_value_t>& in,
-                                       std::pmr::vector<types::logical_value_t>& out) {
-    out.emplace_back(out.get_allocator().resource(), in[0].value<int64_t>() > in[1].value<int64_t>());
+static core::error_t gt_threshold_exec(kernel_context&, const vector::data_chunk_t& in, vector::vector_t& out) {
+    const auto* left = in.data[0].data<int64_t>();
+    const auto* right = in.data[1].data<int64_t>();
+    auto* destination = out.data<bool>();
+    for (uint64_t row = 0; row < in.size(); ++row) {
+        destination[row] = left[row] > right[row];
+    }
     return core::error_t::no_error();
 }
 
-std::unique_ptr<row_function> make_gt_threshold_func(std::pmr::memory_resource* resource) {
+std::unique_ptr<vector_function> make_gt_threshold_func(std::pmr::memory_resource* resource) {
     function_doc doc{"gt_threshold", "x > y", {"arg1", "arg2"}, false};
-    auto fn = std::make_unique<row_function>("gt_threshold", arity::binary(), doc, 1);
+    auto fn = std::make_unique<vector_function>("gt_threshold", arity::binary(), doc, 1);
     kernel_signature_t sig(
-        function_type_t::row,
+        function_type_t::vector,
         {parameter_type::exact(types::logical_type::BIGINT), parameter_type::exact(types::logical_type::BIGINT)},
         {output_type::fixed(types::logical_type::BOOLEAN)});
-    row_kernel k{std::move(sig), gt_threshold_exec};
+    vector_kernel k{std::move(sig), gt_threshold_exec};
     fn->add_kernel(resource, std::move(k));
     return fn;
 }

--- a/integration/cpp/test/test_udfs.cpp
+++ b/integration/cpp/test/test_udfs.cpp
@@ -110,44 +110,49 @@ std::unique_ptr<aggregate_function> make_mult_func(std::pmr::memory_resource* re
     return fn;
 }
 
-static core::error_t is_even_exec(kernel_context& ctx,
-                                  const std::pmr::vector<types::logical_value_t>& in,
-                                  std::pmr::vector<types::logical_value_t>& out) {
-    out.emplace_back(ctx.exec_context().resource(), in[0].value<int64_t>() % 2 == 0);
+static core::error_t is_even_exec(kernel_context&, const vector::data_chunk_t& in, vector::vector_t& out) {
+    const auto* source = in.data[0].data<int64_t>();
+    auto* destination = out.data<bool>();
+    for (uint64_t row = 0; row < in.size(); ++row) {
+        destination[row] = source[row] % 2 == 0;
+    }
     return core::error_t::no_error();
 }
 
-std::unique_ptr<row_function> make_is_even_func(std::pmr::memory_resource* resource) {
+std::unique_ptr<vector_function> make_is_even_func(std::pmr::memory_resource* resource) {
     function_doc doc{"short_doc", "full_doc", {"arg"}, false};
 
-    auto fn = std::make_unique<row_function>(udf3_name, arity::unary(), doc, 1);
+    auto fn = std::make_unique<vector_function>(udf3_name, arity::unary(), doc, 1);
 
-    kernel_signature_t sig(function_type_t::row,
+    kernel_signature_t sig(function_type_t::vector,
                            {parameter_type::exact(types::logical_type::BIGINT)},
                            {output_type::fixed(types::logical_type::BOOLEAN)});
-    row_kernel k{std::move(sig), is_even_exec};
+    vector_kernel k{std::move(sig), is_even_exec};
 
     fn->add_kernel(resource, std::move(k));
     return fn;
 }
 
-static core::error_t modulo_exec(kernel_context& ctx,
-                                 const std::pmr::vector<types::logical_value_t>& in,
-                                 std::pmr::vector<types::logical_value_t>& out) {
-    out.emplace_back(ctx.exec_context().resource(), in[0].value<int64_t>() % in[1].value<int64_t>());
+static core::error_t modulo_exec(kernel_context&, const vector::data_chunk_t& in, vector::vector_t& out) {
+    const auto* left = in.data[0].data<int64_t>();
+    const auto* right = in.data[1].data<int64_t>();
+    auto* destination = out.data<int64_t>();
+    for (uint64_t row = 0; row < in.size(); ++row) {
+        destination[row] = left[row] % right[row];
+    }
     return core::error_t::no_error();
 }
 
-std::unique_ptr<row_function> make_modulo_func(std::pmr::memory_resource* resource) {
+std::unique_ptr<vector_function> make_modulo_func(std::pmr::memory_resource* resource) {
     function_doc doc{"short_doc", "full_doc", {"arg1", "arg2"}, false};
 
-    auto fn = std::make_unique<row_function>(udf4_name, arity::binary(), doc, 1);
+    auto fn = std::make_unique<vector_function>(udf4_name, arity::binary(), doc, 1);
 
     kernel_signature_t sig(
-        function_type_t::row,
+        function_type_t::vector,
         {parameter_type::exact(types::logical_type::BIGINT), parameter_type::exact(types::logical_type::BIGINT)},
         {output_type::fixed(types::logical_type::BIGINT)});
-    row_kernel k{std::move(sig), modulo_exec};
+    vector_kernel k{std::move(sig), modulo_exec};
 
     fn->add_kernel(resource, std::move(k));
     return fn;

--- a/services/dispatcher/tests/test_resolve_function.cpp
+++ b/services/dispatcher/tests/test_resolve_function.cpp
@@ -34,8 +34,7 @@ namespace {
     }
 
     components::compute::function_types_mask any_kind() {
-        return components::compute::create_mask(components::compute::function_type_t::row,
-                                                components::compute::function_type_t::vector,
+        return components::compute::create_mask(components::compute::function_type_t::vector,
                                                 components::compute::function_type_t::aggregate,
                                                 components::compute::function_type_t::expand);
     }
@@ -188,8 +187,7 @@ TEST_CASE("dispatcher::resolve_function: a family entry keeps the argument's par
 // evaluated before grouping, so WHERE takes only scalar functions; the aggregate slot of a
 // GROUP BY is the mirror image and takes nothing else.
 TEST_CASE("dispatcher::resolve_function: the clause decides which function kinds are allowed") {
-    const auto scalar_only = components::compute::create_mask(components::compute::function_type_t::row,
-                                                              components::compute::function_type_t::vector);
+    const auto scalar_only = components::compute::create_mask(components::compute::function_type_t::vector);
     const auto aggregate_only = components::compute::create_mask(components::compute::function_type_t::aggregate);
 
     auto integer = args({logical_type::BIGINT});

--- a/services/dispatcher/tests/test_stamp_scalar_types.cpp
+++ b/services/dispatcher/tests/test_stamp_scalar_types.cpp
@@ -88,8 +88,7 @@ namespace {
             casts(),
             functions(),
             execution_context,
-            components::compute::create_mask(components::compute::function_type_t::row,
-                                             components::compute::function_type_t::vector)};
+            components::compute::create_mask(components::compute::function_type_t::vector)};
         components::expressions::expression_ptr expression{expr};
         return validation::resolve_expression(expression, context);
     }

--- a/services/dispatcher/validate_logical_plan.cpp
+++ b/services/dispatcher/validate_logical_plan.cpp
@@ -278,8 +278,7 @@ namespace services::dispatcher {
                 context.cast_registry,
                 context.function_registry,
                 context.execution_context,
-                components::compute::create_mask(components::compute::function_type_t::row,
-                                                 components::compute::function_type_t::vector),
+                components::compute::create_mask(components::compute::function_type_t::vector),
                 schema_right};
             expression_ptr expression{expr};
             if (auto error = validation::resolve_expression(expression, expression_context); error.contains_error()) {
@@ -331,8 +330,7 @@ namespace services::dispatcher {
                 } else if (node->expressions()[0]->group() == expression_group::function) {
                     auto* expr = reinterpret_cast<function_expression_t*>(node->expressions()[0].get());
                     auto allowed_function_types =
-                        components::compute::create_mask(components::compute::function_type_t::row,
-                                                         components::compute::function_type_t::vector);
+                        components::compute::create_mask(components::compute::function_type_t::vector);
                     auto expr_res =
                         validate_schema(context, expr, parameters, schema_left, schema_right, allowed_function_types);
                     if (expr_res.has_error()) {
@@ -376,8 +374,7 @@ namespace services::dispatcher {
                         scalar_expr,
                         schema,
                         parameters,
-                        components::compute::create_mask(components::compute::function_type_t::row,
-                                                         components::compute::function_type_t::vector));
+                        components::compute::create_mask(components::compute::function_type_t::vector));
                     if (resolve_error.contains_error()) {
                         return resolve_error;
                     }
@@ -470,8 +467,7 @@ namespace services::dispatcher {
                             scalar_expr,
                             *schema_left,
                             parameters,
-                            components::compute::create_mask(components::compute::function_type_t::row,
-                                                             components::compute::function_type_t::vector),
+                            components::compute::create_mask(components::compute::function_type_t::vector),
                             schema_right,
                             nullptr);
                         if (resolve_error.contains_error()) {
@@ -1008,8 +1004,7 @@ namespace services::dispatcher {
                             context.cast_registry,
                             context.function_registry,
                             context.execution_context,
-                            components::compute::create_mask(components::compute::function_type_t::row,
-                                                             components::compute::function_type_t::vector,
+                            components::compute::create_mask(components::compute::function_type_t::vector,
                                                              components::compute::function_type_t::aggregate)};
                         for (auto& expr : node_group->expressions()) {
                             if (expr->group() == expression_group::aggregate) {
@@ -1422,8 +1417,7 @@ namespace services::dispatcher {
                                     scalar_expr,
                                     incoming_schema,
                                     parameters,
-                                    components::compute::create_mask(components::compute::function_type_t::row,
-                                                                     components::compute::function_type_t::vector,
+                                    components::compute::create_mask(components::compute::function_type_t::vector,
                                                                      components::compute::function_type_t::aggregate));
                                 if (resolve_error.contains_error()) {
                                     return resolve_error;
@@ -1554,8 +1548,7 @@ namespace services::dispatcher {
                             context.cast_registry,
                             context.function_registry,
                             context.execution_context,
-                            components::compute::create_mask(components::compute::function_type_t::row,
-                                                             components::compute::function_type_t::vector),
+                            components::compute::create_mask(components::compute::function_type_t::vector),
                             nullptr,
                             group_keys};
                         expression_ptr expression{scalar_expr};
@@ -1581,8 +1574,7 @@ namespace services::dispatcher {
                             context.cast_registry,
                             context.function_registry,
                             context.execution_context,
-                            components::compute::create_mask(components::compute::function_type_t::row,
-                                                             components::compute::function_type_t::vector,
+                            components::compute::create_mask(components::compute::function_type_t::vector,
                                                              components::compute::function_type_t::aggregate,
                                                              components::compute::function_type_t::expand),
                             nullptr,
@@ -1790,8 +1782,7 @@ namespace services::dispatcher {
                                     scalar_expr,
                                     result,
                                     parameters,
-                                    components::compute::create_mask(components::compute::function_type_t::row,
-                                                                     components::compute::function_type_t::vector));
+                                    components::compute::create_mask(components::compute::function_type_t::vector));
                                 if (resolve_error.contains_error()) {
                                     return resolve_error;
                                 }
@@ -1907,8 +1898,7 @@ namespace services::dispatcher {
                                      context.function_registry,
                                      function_node->name(),
                                      function_input,
-                                     components::compute::create_mask(components::compute::function_type_t::row,
-                                                                      components::compute::function_type_t::vector,
+                                     components::compute::create_mask(components::compute::function_type_t::vector,
                                                                       components::compute::function_type_t::expand));
                 if (fn_resolved.has_error()) {
                     return fn_resolved.convert_error<named_schema>();
@@ -2314,8 +2304,7 @@ namespace services::dispatcher {
                 if (node->type() == node_type::update_t) {
                     auto* node_update = reinterpret_cast<node_update_t*>(node);
                     auto allowed_function_types =
-                        components::compute::create_mask(components::compute::function_type_t::row,
-                                                         components::compute::function_type_t::vector);
+                        components::compute::create_mask(components::compute::function_type_t::vector);
                     for (auto& expr : node_update->updates()) {
                         auto target_res = validation::find_types(resource, expr->key(), table_schema);
                         if (target_res.has_error()) {
@@ -2332,8 +2321,7 @@ namespace services::dispatcher {
                                 scalar,
                                 table_schema,
                                 parameters,
-                                components::compute::create_mask(components::compute::function_type_t::row,
-                                                                 components::compute::function_type_t::vector),
+                                components::compute::create_mask(components::compute::function_type_t::vector),
                                 source_schema);
                             if (resolve_error.contains_error()) {
                                 return resolve_error;


### PR DESCRIPTION
Since we now execute everything in batches, there is no longer need for per-row kernels.
Pre-existing once were converted to vector form and row-kernel removed entirely