### PR TITLE
fix(storage): column types, nested column data survive a restart

### DIFF
--- a/components/catalog/tests/test_type_spec_roundtrip.cpp
+++ b/components/catalog/tests/test_type_spec_roundtrip.cpp
@@ -1,14 +1,43 @@
 #include <catch2/catch_test_macros.hpp>
 #include <components/catalog/system_table_schemas.hpp>
+#include <components/types/type_binary.hpp>
 #include <components/types/types.hpp>
 
 #include <set>
+#include <vector>
 
 using namespace components::catalog;
 using namespace components::types;
 
 namespace {
     auto* g_resource = std::pmr::new_delete_resource();
+
+    // Mirror of the real catalog read-back (operator_resolve_table, bootstrap):
+    // a non-empty spec wins, otherwise the type comes from atttypid alone
+    complex_logical_type through_catalog(const complex_logical_type& t) {
+        auto spec = encode_type_spec(t);
+        if (!spec.empty()) {
+            return decode_type_spec(g_resource, spec);
+        }
+        return complex_logical_type{oid_to_builtin_type(builtin_type_to_oid(t.type()))};
+    }
+
+    complex_logical_type through_storage(const complex_logical_type& t) {
+        std::vector<char> bytes(type_binary_size(t));
+        type_binary_write(bytes.data(), t);
+        const char* scan = bytes.data();
+        auto decoded = type_binary_read(scan, bytes.data() + bytes.size(), g_resource);
+        INFO("storage round-trip: " << (decoded.has_error() ? decoded.error().what.c_str() : ""));
+        REQUIRE_FALSE(decoded.has_error());
+        return std::move(decoded.value());
+    }
+
+    void check_codecs_agree(const complex_logical_type& t) {
+        const auto catalog_side = through_catalog(t);
+        const auto storage_side = through_storage(t);
+        INFO("tag=" << static_cast<int>(t.type()) << " spec='" << encode_type_spec(t) << "'");
+        REQUIRE(catalog_side == storage_side);
+    }
 } // namespace
 
 TEST_CASE("catalog::type_spec::scalars_encode_empty") {
@@ -223,4 +252,40 @@ TEST_CASE("catalog::type_spec::unknown_prefix_no_crash") {
     // accidentally-valid input — we only verify no exception is thrown.
     auto t = decode_type_spec(g_resource, "garbage_that_is_not_valid_type_spec");
     (void) t; // result type is implementation-defined for garbage input
+}
+
+TEST_CASE("catalog::type_spec::codecs_agree_on_scalars") {
+    for (auto lt : {logical_type::BOOLEAN,
+                    logical_type::INTEGER,
+                    logical_type::BIGINT,
+                    logical_type::DOUBLE,
+                    logical_type::STRING_LITERAL,
+                    logical_type::TIMESTAMP,
+                    logical_type::BLOB,
+                    logical_type::UUID}) {
+        check_codecs_agree(complex_logical_type{lt});
+    }
+}
+
+TEST_CASE("catalog::type_spec::codecs_agree_on_decimal") {
+    check_codecs_agree(complex_logical_type::create_decimal(18, 6));
+}
+
+TEST_CASE("catalog::type_spec::codecs_agree_on_array") {
+    check_codecs_agree(complex_logical_type::create_array(complex_logical_type{logical_type::INTEGER}, 3));
+}
+
+TEST_CASE("catalog::type_spec::codecs_agree_on_list") {
+    check_codecs_agree(complex_logical_type::create_list(complex_logical_type{logical_type::INTEGER}));
+}
+
+TEST_CASE("catalog::type_spec::codecs_agree_on_struct") {
+    std::pmr::vector<complex_logical_type> fields(g_resource);
+    fields.emplace_back(logical_type::STRING_LITERAL, "city");
+    fields.emplace_back(logical_type::STRING_LITERAL, "country");
+    check_codecs_agree(complex_logical_type::create_struct("addr_t", fields));
+}
+
+TEST_CASE("catalog::type_spec::codecs_agree_on_unknown") {
+    check_codecs_agree(complex_logical_type::create_unknown("mystery_t"));
 }

--- a/components/table/CMakeLists.txt
+++ b/components/table/CMakeLists.txt
@@ -24,6 +24,7 @@ set(SOURCE_${PROJECT_NAME}
         column_data_checkpointer.cpp
 
         storage/file_buffer.cpp
+        storage/type_record.cpp
         storage/block_handle.cpp
         storage/block_manager.cpp
         storage/buffer_handle.cpp

--- a/components/table/array_column_data.cpp
+++ b/components/table/array_column_data.cpp
@@ -1,10 +1,10 @@
 #include "array_column_data.hpp"
+#include "persistent_column_data.hpp"
 #include "row_group.hpp"
 #include <components/vector/vector.hpp>
 #include <components/vector/vector_operations.hpp>
 
 namespace components::table {
-
     array_column_data_t::array_column_data_t(std::pmr::memory_resource* resource,
                                              storage::block_manager_t& block_manager,
                                              uint64_t column_index,
@@ -130,7 +130,7 @@ namespace components::table {
             return child;
         }
         state.child_appends.push_back(std::move(child_append));
-        return true;
+        return core::error_t::no_error();
     }
 
     core::result_wrapper_t<bool>
@@ -153,7 +153,7 @@ namespace components::table {
         }
 
         count_ += count;
-        return true;
+        return core::error_t::no_error();
     }
 
     void array_column_data_t::revert_append(int64_t start_row) {
@@ -204,7 +204,7 @@ namespace components::table {
                                             remaining_count);
             }
         }
-        return true;
+        return core::error_t::no_error();
     }
 
     core::result_wrapper_t<bool> array_column_data_t::update_column(const std::vector<uint64_t>& column_path,
@@ -291,5 +291,27 @@ namespace components::table {
     size_t array_column_data_t::array_size() const {
         return static_cast<const types::array_logical_type_extension*>(type_.extension())->size();
     }
+
+    core::error_t
+    array_column_data_t::checkpoint_children(storage::partial_block_manager_t& partial_block_manager,
+                               persistent_column_data_t& persistent) {
+        auto child = child_column->checkpoint(partial_block_manager);
+        if (child.has_error()) {
+            return child.error();
+        }
+        persistent.child_columns.push_back(std::make_unique<persistent_column_data_t>(std::move(child.value())));
+        return core::error_t::no_error();
+    }
+
+    core::error_t array_column_data_t::initialize_children(const persistent_column_data_t& persistent_data) {
+        if (persistent_data.child_columns.size() != 1) {
+            return core::error_t(core::error_code_t::data_corruption,
+                                 std::pmr::string{"column metadata: expected exactly one element column",
+                                                  resource()});
+        }
+        return child_column->initialize_column(*persistent_data.child_columns[0]);
+    }
+
+    validity_column_data_t* array_column_data_t::validity_column() { return &validity; }
 
 } // namespace components::table

--- a/components/table/array_column_data.hpp
+++ b/components/table/array_column_data.hpp
@@ -3,7 +3,6 @@
 #include "validity_column_data.hpp"
 
 namespace components::table {
-
     class array_column_data_t : public column_data_t {
     public:
         array_column_data_t(std::pmr::memory_resource* resource,
@@ -17,6 +16,13 @@ namespace components::table {
         validity_column_data_t validity;
 
         void set_start(int64_t new_start) override;
+        validity_column_data_t* validity_column() override;
+        [[nodiscard]] core::error_t
+        checkpoint_children(storage::partial_block_manager_t& partial_block_manager,
+                            persistent_column_data_t& persistent) override;
+        [[nodiscard]] core::error_t
+        initialize_children(const persistent_column_data_t& persistent_data) override;
+
         filter_propagate_result_t check_zonemap(column_scan_state& state, table_filter_t& filter) override;
 
         void initialize_scan(column_scan_state& state) override;
@@ -56,5 +62,4 @@ namespace components::table {
 
         size_t array_size() const;
     };
-
 } // namespace components::table

--- a/components/table/column_data.cpp
+++ b/components/table/column_data.cpp
@@ -23,7 +23,6 @@
 #include "validity_column_data.hpp"
 
 namespace components::table {
-
 #ifdef DEV_MODE
     namespace {
         std::atomic<uint64_t> g_transitions_with_live_pin{0};
@@ -104,19 +103,17 @@ namespace components::table {
 
     bool column_data_t::has_updates() const { return updates_.get(); }
 
-    scan_vector_type
-    column_data_t::get_vector_scan_type(column_scan_state& state, uint64_t scan_count, vector::vector_t& result) {
+    scan_vector_type column_data_t::get_vector_scan_type([[maybe_unused]] column_scan_state& state,
+                                                         [[maybe_unused]] uint64_t scan_count,
+                                                         vector::vector_t& result) {
         if (result.get_vector_type() != vector::vector_type::FLAT) {
             return scan_vector_type::SCAN_ENTIRE_VECTOR;
         }
         if (has_updates()) {
             return scan_vector_type::SCAN_FLAT_VECTOR;
         }
-        uint64_t remaining_in_segment =
-            static_cast<uint64_t>(state.current->start) + state.current->count - static_cast<uint64_t>(state.row_index);
-        if (remaining_in_segment < scan_count) {
-            return scan_vector_type::SCAN_FLAT_VECTOR;
-        }
+        // TODO: a scan that fits entirely inside the current segment could return
+        // SCAN_ENTIRE_VECTOR, which skips fetch_updates below; that branch was never wired up.
         return scan_vector_type::SCAN_FLAT_VECTOR;
     }
 
@@ -838,6 +835,18 @@ namespace components::table {
         if (persistent.has_error()) {
             return persistent;
         }
+
+        if (auto* validity = validity_column()) {
+            auto validity_data = validity->checkpoint(partial_block_manager);
+            if (validity_data.has_error()) {
+                return validity_data;
+            }
+            persistent.value().validity = std::make_unique<persistent_column_data_t>(std::move(validity_data.value()));
+        }
+        if (auto error = checkpoint_children(partial_block_manager, persistent.value()); error.contains_error()) {
+            return error;
+        }
+
         // Re-point the still-managed LIVE segments (the open tail that was not filled during append, and
         // so never went through the on-fill write-through) to disk-backed, evictable blocks so the
         // post-checkpoint live table stays bounded. The on-disk metadata returned above is independent of
@@ -858,82 +867,56 @@ namespace components::table {
         return persistent;
     }
 
-    void column_data_t::initialize_column(const persistent_column_data_t& persistent_data) {
-        auto l = data_.lock();
-        for (uint32_t i = 0; i < persistent_data.data_pointers.size(); i++) {
-            const auto& dp = persistent_data.data_pointers[i];
-            auto block_handle = block_manager_.register_block(dp.block_pointer.block_id);
+    core::error_t column_data_t::initialize_column(const persistent_column_data_t& persistent_data) {
+        {
+            auto l = data_.lock();
+            for (uint32_t i = 0; i < persistent_data.data_pointers.size(); i++) {
+                const auto& dp = persistent_data.data_pointers[i];
+                auto block_handle = block_manager_.register_block(dp.block_pointer.block_id);
 
-            auto segment = std::make_unique<column_segment_t>(block_handle,
-                                                              type_,
-                                                              static_cast<int64_t>(dp.row_start),
-                                                              dp.tuple_count,
-                                                              static_cast<uint32_t>(dp.block_pointer.block_id),
-                                                              dp.block_pointer.offset,
-                                                              dp.segment_size);
-            segment->set_compression(dp.compression);
-            if (i < persistent_data.segment_statistics.size() && persistent_data.segment_statistics[i].has_stats()) {
-                segment->set_segment_statistics(persistent_data.segment_statistics[i]);
+                auto segment = std::make_unique<column_segment_t>(block_handle,
+                                                                  type_,
+                                                                  static_cast<int64_t>(dp.row_start),
+                                                                  dp.tuple_count,
+                                                                  static_cast<uint32_t>(dp.block_pointer.block_id),
+                                                                  dp.block_pointer.offset,
+                                                                  dp.segment_size);
+                segment->set_compression(dp.compression);
+                if (i < persistent_data.segment_statistics.size() &&
+                    persistent_data.segment_statistics[i].has_stats()) {
+                    segment->set_segment_statistics(persistent_data.segment_statistics[i]);
+                }
+                data_.append_segment(l, std::move(segment));
             }
-            data_.append_segment(l, std::move(segment));
-        }
-        if (!persistent_data.data_pointers.empty()) {
-            uint64_t total = 0;
-            for (const auto& dp : persistent_data.data_pointers) {
-                total += dp.tuple_count;
+            if (!persistent_data.data_pointers.empty()) {
+                uint64_t total = 0;
+                for (const auto& dp : persistent_data.data_pointers) {
+                    total += dp.tuple_count;
+                }
+                count_ = total;
             }
-            count_ = total;
+            if (persistent_data.statistics.has_stats()) {
+                statistics_ = persistent_data.statistics;
+            }
         }
-        if (persistent_data.statistics.has_stats()) {
-            statistics_ = persistent_data.statistics;
+
+        auto* validity = validity_column();
+        if (validity != nullptr) {
+            if (!persistent_data.validity) {
+                return core::error_t(core::error_code_t::data_corruption,
+                                     std::pmr::string{"column metadata: validity child is missing", resource_});
+            }
+            if (auto error = validity->initialize_column(*persistent_data.validity); error.contains_error()) {
+                return error;
+            }
+            if (persistent_data.data_pointers.empty()) {
+                count_ = validity->count();
+            }
+        } else if (persistent_data.validity) {
+            return core::error_t(core::error_code_t::data_corruption,
+                                 std::pmr::string{"column metadata: unexpected validity child", resource_});
         }
+
+        return initialize_children(persistent_data);
     }
-
-    void column_data_t::initialize_column_validity(const persistent_column_data_t& persistent_data) {
-        // Validity is not persisted separately (a checkpoint flushes only the main column's
-        // segments); on reopen the bitmap is implicitly all-valid. We materialize one validity
-        // segment per main-column data pointer and, on a DISK-backed table, write each all-valid
-        // bitmap THROUGH to the data file and swap it for a disk-backed (reloadable) segment via
-        // transition_segment_to_disk -- the same mechanism used on the append fill path. Without
-        // this the reopen-rebuilt validity segments stay managed (block_id >= MAXIMUM_BLOCK), so
-        // the eviction guard pins them all resident and reopening a large table under a small pool
-        // exhausts it. The transient segment's column_segment_t ctor 0xFF-fills the bitmap
-        // (all-valid) before the transition copies it to disk, so reloaded validity reads all-valid.
-        //
-        // Own a partial_block_manager so the all-valid validity segments are PACKED into shared blocks
-        // (segment packing) and flush it at the end of the loop -- the flush is the flush-before-evict
-        // guarantee: every re-pointed validity segment's block is durable before the reopened table is
-        // scanned/evicted.
-        storage::partial_block_manager_t pbm(block_manager_);
-        auto l = data_.lock();
-        for (const auto& dp : persistent_data.data_pointers) {
-            // Disk-load path: segments are sized for known on-disk tuple counts. An OOM here
-            // is not threaded to an agent boundary; assert and skip the row on exhaustion.
-            auto created = apend_transient_segment(l, static_cast<int64_t>(dp.row_start));
-            assert(!created.has_error() && "initialize_column_validity: transient segment OOM");
-            if (created.has_error()) {
-                continue;
-            }
-            const uint64_t seg_index = data_.segment_count(l) - 1;
-            auto* seg = data_.last_segment(l);
-            if (seg) {
-                seg->count = dp.tuple_count;
-            }
-            // Write the all-valid bitmap through to disk and re-point the live segment to a
-            // disk-backed, evictable+reloadable block (no-op for in-memory tables). A write/alloc
-            // failure surfaces as io_error/out_of_memory; the disk-load path is not threaded to an
-            // agent boundary, so assert and keep the managed segment on failure.
-            auto transitioned = transition_segment_to_disk(l, seg_index, pbm);
-            assert(!transitioned.has_error() && "initialize_column_validity: write-through failed");
-        }
-        pbm.flush_partial_blocks();
-        if (!persistent_data.data_pointers.empty()) {
-            uint64_t total = 0;
-            for (const auto& dp : persistent_data.data_pointers) {
-                total += dp.tuple_count;
-            }
-            count_ = total;
-        }
-    }
-
 } // namespace components::table

--- a/components/table/column_data.hpp
+++ b/components/table/column_data.hpp
@@ -8,7 +8,6 @@
 #include <components/types/tri_bool.hpp>
 
 namespace components::table {
-
 #ifdef DEV_MODE
     // Test-observable count of segment transitions performed while SOMEONE ELSE still holds a pin on
     // the segment's block. The swap drops that block_handle_t, so an outstanding buffer_handle_t is
@@ -43,6 +42,8 @@ namespace components::table {
     using filter_match_t = types::tri_bool_t;
 
     constexpr uint64_t MAX_ROW_ID = 1ULL << 55; // 2^55
+
+    class validity_column_data_t;
 
     class column_data_t {
         friend class column_segment_t;
@@ -164,8 +165,7 @@ namespace components::table {
         // the persistent data on success.
         [[nodiscard]] core::result_wrapper_t<persistent_column_data_t>
         checkpoint(storage::partial_block_manager_t& partial_block_manager);
-        virtual void initialize_column(const persistent_column_data_t& persistent_data);
-        void initialize_column_validity(const persistent_column_data_t& persistent_data);
+        [[nodiscard]] core::error_t initialize_column(const persistent_column_data_t& persistent_data);
 
         // Write-through: re-point every COMPLETE managed (in-memory, non-reloadable) segment of this column
         // to a disk-backed segment so the pool can evict+reload them (bounded memory). Called when a row
@@ -179,6 +179,15 @@ namespace components::table {
         // call `pbm.flush_partial_blocks()` before any concurrent scan/eviction of a re-pointed segment can
         // occur (else a re-pointed live segment could load() an unflushed block -> data_corruption).
         [[nodiscard]] virtual core::result_wrapper_t<bool> transition_to_disk(storage::partial_block_manager_t& pbm);
+
+        virtual validity_column_data_t* validity_column() { return nullptr; }
+        [[nodiscard]] virtual core::error_t checkpoint_children(storage::partial_block_manager_t&,
+                                                                persistent_column_data_t&) {
+            return core::error_t::no_error();
+        }
+        [[nodiscard]] virtual core::error_t initialize_children(const persistent_column_data_t&) {
+            return core::error_t::no_error();
+        }
 
         // Compact reclaim: append the ids of disk blocks EXCLUSIVELY owned by this column (and its
         // sub-columns) to `out`, so the caller can mark them free once this collection is replaced by a
@@ -242,5 +251,4 @@ namespace components::table {
 
         std::pmr::memory_resource* resource_;
     };
-
 } // namespace components::table

--- a/components/table/data_table.cpp
+++ b/components/table/data_table.cpp
@@ -1,16 +1,18 @@
 #include "data_table.hpp"
 
 #include <algorithm>
+#include <cassert>
 #include <components/table/storage/partial_block_manager.hpp>
+#include <components/table/storage/type_record.hpp>
 #include <components/vector/data_chunk.hpp>
 #include <components/vector/vector_operations.hpp>
 #include <cstdlib>
 #include <unordered_set>
+#include <vector>
 
 #include "row_group.hpp"
 
 namespace components::table {
-
     data_table_t::data_table_t(std::pmr::memory_resource* resource,
                                storage::block_manager_t& block_manager,
                                std::vector<column_definition_t> column_definitions,
@@ -589,7 +591,7 @@ namespace components::table {
         writer.write<uint32_t>(static_cast<uint32_t>(column_definitions_.size()));
         for (const auto& col : column_definitions_) {
             writer.write_string(col.name());
-            writer.write<uint8_t>(static_cast<uint8_t>(col.type().type()));
+            storage::write_type_record(writer, col.type());
             writer.write<uint8_t>(col.is_not_null() ? 1 : 0);
         }
 
@@ -614,11 +616,13 @@ namespace components::table {
         columns.reserve(col_count);
         for (uint32_t i = 0; i < col_count; i++) {
             auto col_name = reader.read_string();
-            auto logical_type = static_cast<types::logical_type>(reader.read<uint8_t>());
+            auto col_type = storage::read_type_record(reader, resource);
+            if (col_type.has_error()) {
+                return col_type.error();
+            }
             auto not_null = reader.read<uint8_t>() != 0;
-            types::complex_logical_type col_type(logical_type);
-            col_type.set_alias(col_name);
-            columns.emplace_back(col_name, std::move(col_type), not_null);
+            col_type.value().set_alias(col_name);
+            columns.emplace_back(col_name, std::move(col_type.value()), not_null);
         }
 
         auto table = std::make_unique<data_table_t>(resource, block_manager, std::move(columns), std::move(name));
@@ -626,12 +630,14 @@ namespace components::table {
         uint64_t total_loaded_rows = 0;
         auto rg_count = reader.read<uint32_t>();
         for (uint32_t i = 0; i < rg_count; i++) {
-            auto pointer = storage::row_group_pointer_t::deserialize(reader);
+            auto pointer = storage::row_group_pointer_t::deserialize(resource, reader);
 
             // create a new row group and populate from disk pointer
             auto* rg = table->row_groups_->append_row_group(static_cast<int64_t>(pointer.row_start));
             if (rg) {
-                rg->create_from_pointer(pointer);
+                if (auto error = rg->create_from_pointer(pointer); error.contains_error()) {
+                    return error;
+                }
                 total_loaded_rows += pointer.tuple_count;
             }
         }
@@ -646,5 +652,4 @@ namespace components::table {
 
         return table;
     }
-
 } // namespace components::table

--- a/components/table/list_column_data.cpp
+++ b/components/table/list_column_data.cpp
@@ -1,7 +1,8 @@
 #include "list_column_data.hpp"
 
-namespace components::table {
+#include "persistent_column_data.hpp"
 
+namespace components::table {
     list_column_data_t::list_column_data_t(std::pmr::memory_resource* resource,
                                            storage::block_manager_t& block_manager,
                                            uint64_t column_index,
@@ -169,7 +170,7 @@ namespace components::table {
             return child;
         }
         state.child_appends.push_back(std::move(child_append_state));
-        return true;
+        return core::error_t::no_error();
     }
 
     core::result_wrapper_t<bool>
@@ -310,7 +311,7 @@ namespace components::table {
             remaining_count -= batch;
             remaining_column_index++;
         }
-        return true;
+        return core::error_t::no_error();
     }
 
     core::result_wrapper_t<bool> list_column_data_t::update_column(const std::vector<uint64_t>& column_path,
@@ -334,7 +335,7 @@ namespace components::table {
             remaining_child_ids += batch;
             remaining_count -= batch;
         }
-        return true;
+        return core::error_t::no_error();
     }
 
     void list_column_data_t::fetch_row(column_fetch_state& state,
@@ -386,4 +387,27 @@ namespace components::table {
         col_path.back() = 1;
         child_column->get_column_segment_info(row_group_index, col_path, result);
     }
+
+    core::error_t
+    list_column_data_t::checkpoint_children(storage::partial_block_manager_t& partial_block_manager,
+                               persistent_column_data_t& persistent) {
+        auto child = child_column->checkpoint(partial_block_manager);
+        if (child.has_error()) {
+            return child.error();
+        }
+        persistent.child_columns.push_back(std::make_unique<persistent_column_data_t>(std::move(child.value())));
+        return core::error_t::no_error();
+    }
+
+    core::error_t list_column_data_t::initialize_children(const persistent_column_data_t& persistent_data) {
+        if (persistent_data.child_columns.size() != 1) {
+            return core::error_t(core::error_code_t::data_corruption,
+                                 std::pmr::string{"column metadata: expected exactly one element column",
+                                                  resource()});
+        }
+        return child_column->initialize_column(*persistent_data.child_columns[0]);
+    }
+
+    validity_column_data_t* list_column_data_t::validity_column() { return &validity; }
+
 } // namespace components::table

--- a/components/table/list_column_data.hpp
+++ b/components/table/list_column_data.hpp
@@ -17,6 +17,13 @@ namespace components::table {
         validity_column_data_t validity;
 
         void set_start(int64_t new_start) override;
+        validity_column_data_t* validity_column() override;
+        [[nodiscard]] core::error_t
+        checkpoint_children(storage::partial_block_manager_t& partial_block_manager,
+                            persistent_column_data_t& persistent) override;
+        [[nodiscard]] core::error_t
+        initialize_children(const persistent_column_data_t& persistent_data) override;
+
         filter_propagate_result_t check_zonemap(column_scan_state& state, table_filter_t& filter) override;
 
         void initialize_scan(column_scan_state& state) override;

--- a/components/table/persistent_column_data.cpp
+++ b/components/table/persistent_column_data.cpp
@@ -4,12 +4,17 @@
 #include <components/table/storage/metadata_writer.hpp>
 
 namespace components::table {
-
     void persistent_column_data_t::serialize(storage::metadata_writer_t& writer) const {
         // data pointers
         writer.write<uint32_t>(static_cast<uint32_t>(data_pointers.size()));
         for (const auto& dp : data_pointers) {
             dp.serialize(writer);
+        }
+
+        // validity (recursive, optional)
+        writer.write<uint8_t>(validity ? 1 : 0);
+        if (validity) {
+            validity->serialize(writer);
         }
 
         // child columns (recursive)
@@ -45,6 +50,11 @@ namespace components::table {
         result.data_pointers.resize(dp_count);
         for (uint32_t i = 0; i < dp_count; i++) {
             result.data_pointers[i] = storage::data_pointer_t::deserialize(reader);
+        }
+
+        if (reader.read<uint8_t>() != 0) {
+            result.validity =
+                std::make_unique<persistent_column_data_t>(persistent_column_data_t::deserialize(resource, reader));
         }
 
         auto child_count = reader.read<uint32_t>();
@@ -83,3 +93,41 @@ namespace components::table {
     }
 
 } // namespace components::table
+
+namespace components::table::storage {
+    void row_group_pointer_t::serialize(metadata_writer_t& writer) const {
+        writer.write<uint64_t>(row_start);
+        writer.write<uint64_t>(tuple_count);
+
+        writer.write<uint32_t>(static_cast<uint32_t>(columns.size()));
+        for (const auto& column : columns) {
+            column.serialize(writer);
+        }
+
+        writer.write<uint32_t>(static_cast<uint32_t>(deletes_pointers.size()));
+        for (const auto& dp : deletes_pointers) {
+            dp.serialize(writer);
+        }
+    }
+
+    row_group_pointer_t row_group_pointer_t::deserialize(std::pmr::memory_resource* resource,
+                                                         metadata_reader_t& reader) {
+        row_group_pointer_t result;
+        result.row_start = reader.read<uint64_t>();
+        result.tuple_count = reader.read<uint64_t>();
+
+        auto column_count = reader.read<uint32_t>();
+        result.columns.reserve(column_count);
+        for (uint32_t i = 0; i < column_count; i++) {
+            result.columns.push_back(persistent_column_data_t::deserialize(resource, reader));
+        }
+
+        auto deletes_count = reader.read<uint32_t>();
+        result.deletes_pointers.resize(deletes_count);
+        for (uint32_t i = 0; i < deletes_count; i++) {
+            result.deletes_pointers[i] = data_pointer_t::deserialize(reader);
+        }
+
+        return result;
+    }
+} // namespace components::table::storage

--- a/components/table/persistent_column_data.hpp
+++ b/components/table/persistent_column_data.hpp
@@ -13,12 +13,12 @@ namespace components::table::storage {
 } // namespace components::table::storage
 
 namespace components::table {
-
     struct persistent_column_data_t {
         explicit persistent_column_data_t(std::pmr::memory_resource* resource)
             : statistics(resource) {}
 
         std::vector<storage::data_pointer_t> data_pointers;
+        std::unique_ptr<persistent_column_data_t> validity;
         std::vector<std::unique_ptr<persistent_column_data_t>> child_columns;
         base_statistics_t statistics;
         std::vector<base_statistics_t> segment_statistics; // per-segment stats (parallel to data_pointers)
@@ -27,5 +27,16 @@ namespace components::table {
         static persistent_column_data_t deserialize(std::pmr::memory_resource* resource,
                                                     storage::metadata_reader_t& reader);
     };
-
 } // namespace components::table
+
+namespace components::table::storage {
+    struct row_group_pointer_t {
+        uint64_t row_start{0};
+        uint64_t tuple_count{0};
+        std::vector<persistent_column_data_t> columns;
+        std::vector<data_pointer_t> deletes_pointers;
+
+        void serialize(metadata_writer_t& writer) const;
+        static row_group_pointer_t deserialize(std::pmr::memory_resource* resource, metadata_reader_t& reader);
+    };
+} // namespace components::table::storage

--- a/components/table/row_group.cpp
+++ b/components/table/row_group.cpp
@@ -18,7 +18,6 @@
 #include <components/vector/vector_operations.hpp>
 
 namespace components::table {
-
 #ifdef DEV_MODE
     namespace {
         std::atomic<uint64_t> g_gathered_borrowed_strings{0};
@@ -898,14 +897,14 @@ namespace components::table {
         pointer.tuple_count = count;
 
         auto col_count = get_column_count();
-        pointer.data_pointers.resize(col_count);
+        pointer.columns.reserve(col_count);
 
         for (uint64_t i = 0; i < col_count; i++) {
             auto persistent = columns_[i]->checkpoint(partial_block_manager);
             if (persistent.has_error()) {
                 return persistent.convert_error<storage::row_group_pointer_t>(); // out_of_memory
             }
-            pointer.data_pointers[i] = std::move(persistent.value().data_pointers);
+            pointer.columns.push_back(std::move(persistent.value()));
         }
 
         return pointer;
@@ -936,17 +935,20 @@ namespace components::table {
         return true;
     }
 
-    void row_group_t::create_from_pointer(const storage::row_group_pointer_t& pointer) {
+    core::error_t row_group_t::create_from_pointer(const storage::row_group_pointer_t& pointer) {
         count = pointer.tuple_count;
-        auto col_count = get_column_count();
-        auto ptrs_count = pointer.data_pointers.size();
-        auto min_count = std::min(col_count, static_cast<uint64_t>(ptrs_count));
-
-        for (uint64_t i = 0; i < min_count; i++) {
-            persistent_column_data_t pcd(columns_[i]->resource());
-            pcd.data_pointers = pointer.data_pointers[i];
-            columns_[i]->initialize_column(pcd);
+        const auto col_count = get_column_count();
+        if (pointer.columns.size() != col_count) {
+            return core::error_t(core::error_code_t::data_corruption,
+                                 std::pmr::string{"row group metadata: column count differs from the schema",
+                                                  columns_.empty() ? std::pmr::get_default_resource()
+                                                                   : columns_[0]->resource()});
         }
+        for (uint64_t i = 0; i < col_count; i++) {
+            if (auto error = columns_[i]->initialize_column(pointer.columns[i]); error.contains_error()) {
+                return error;
+            }
+        }
+        return core::error_t::no_error();
     }
-
 } // namespace components::table

--- a/components/table/row_group.hpp
+++ b/components/table/row_group.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "column_data.hpp"
 #include "row_version_manager.hpp"
+#include "persistent_column_data.hpp"
 #include "storage/data_pointer.hpp"
 #include <optional>
 
@@ -9,7 +10,6 @@ namespace components::vector {
 }
 
 namespace components::table {
-
 #ifdef DEV_MODE
     // Test-observable count of STRING cells the late-materialisation gather would leave BORROWED
     // from a pin that dies with the gather while the result chunk outlives it (see the guard on
@@ -127,7 +127,7 @@ namespace components::table {
         // the row group pointer on success.
         [[nodiscard]] core::result_wrapper_t<storage::row_group_pointer_t>
         write_to_disk(storage::partial_block_manager_t& partial_block_manager);
-        void create_from_pointer(const storage::row_group_pointer_t& pointer);
+        [[nodiscard]] core::error_t create_from_pointer(const storage::row_group_pointer_t& pointer);
 
         // Write-through: re-point every COMPLETE managed column segment of this row group to a
         // disk-backed segment (call once the row group is closed -> its segments are final). No-op for

--- a/components/table/standard_column_data.cpp
+++ b/components/table/standard_column_data.cpp
@@ -3,7 +3,6 @@
 #include "persistent_column_data.hpp"
 
 namespace components::table {
-
     standard_column_data_t::standard_column_data_t(std::pmr::memory_resource* resource,
                                                    storage::block_manager_t& block_manager,
                                                    uint64_t column_index,
@@ -169,11 +168,6 @@ namespace components::table {
         validity.get_column_segment_info(row_group_index, std::move(col_path), result);
     }
 
-    void standard_column_data_t::initialize_column(const persistent_column_data_t& persistent_data) {
-        column_data_t::initialize_column(persistent_data);
-
-        // create matching transient validity segments for each data segment
-        validity.initialize_column_validity(persistent_data);
-    }
+    validity_column_data_t* standard_column_data_t::validity_column() { return &validity; }
 
 } // namespace components::table

--- a/components/table/standard_column_data.hpp
+++ b/components/table/standard_column_data.hpp
@@ -3,7 +3,6 @@
 #include "validity_column_data.hpp"
 
 namespace components::table {
-
     class standard_column_data_t : public column_data_t {
     public:
         standard_column_data_t(std::pmr::memory_resource* resource,
@@ -52,7 +51,7 @@ namespace components::table {
                                      std::vector<uint64_t> col_path,
                                      std::vector<column_segment_info>& result) override;
 
-        void initialize_column(const persistent_column_data_t& persistent_data) override;
+        validity_column_data_t* validity_column() override;
 
         // Transition the main data segments AND the validity child's segments to disk (both packed via `pbm`).
         [[nodiscard]] core::result_wrapper_t<bool> transition_to_disk(storage::partial_block_manager_t& pbm) override;
@@ -60,5 +59,4 @@ namespace components::table {
         // Compact reclaim: collect the main column's blocks AND the validity child's blocks.
         void collect_disk_block_ids(std::pmr::vector<uint64_t>& out) const override;
     };
-
 } // namespace components::table

--- a/components/table/storage/data_pointer.cpp
+++ b/components/table/storage/data_pointer.cpp
@@ -4,7 +4,6 @@
 #include "metadata_writer.hpp"
 
 namespace components::table::storage {
-
     void data_pointer_t::serialize(metadata_writer_t& writer) const {
         writer.write<uint64_t>(row_start);
         writer.write<uint64_t>(tuple_count);
@@ -24,50 +23,4 @@ namespace components::table::storage {
         result.segment_size = reader.read<uint64_t>();
         return result;
     }
-
-    void row_group_pointer_t::serialize(metadata_writer_t& writer) const {
-        writer.write<uint64_t>(row_start);
-        writer.write<uint64_t>(tuple_count);
-
-        // column count
-        writer.write<uint32_t>(static_cast<uint32_t>(data_pointers.size()));
-        for (const auto& column_ptrs : data_pointers) {
-            // segments per column
-            writer.write<uint32_t>(static_cast<uint32_t>(column_ptrs.size()));
-            for (const auto& dp : column_ptrs) {
-                dp.serialize(writer);
-            }
-        }
-
-        // deletes
-        writer.write<uint32_t>(static_cast<uint32_t>(deletes_pointers.size()));
-        for (const auto& dp : deletes_pointers) {
-            dp.serialize(writer);
-        }
-    }
-
-    row_group_pointer_t row_group_pointer_t::deserialize(metadata_reader_t& reader) {
-        row_group_pointer_t result;
-        result.row_start = reader.read<uint64_t>();
-        result.tuple_count = reader.read<uint64_t>();
-
-        auto col_count = reader.read<uint32_t>();
-        result.data_pointers.resize(col_count);
-        for (uint32_t i = 0; i < col_count; i++) {
-            auto seg_count = reader.read<uint32_t>();
-            result.data_pointers[i].resize(seg_count);
-            for (uint32_t j = 0; j < seg_count; j++) {
-                result.data_pointers[i][j] = data_pointer_t::deserialize(reader);
-            }
-        }
-
-        auto del_count = reader.read<uint32_t>();
-        result.deletes_pointers.resize(del_count);
-        for (uint32_t i = 0; i < del_count; i++) {
-            result.deletes_pointers[i] = data_pointer_t::deserialize(reader);
-        }
-
-        return result;
-    }
-
 } // namespace components::table::storage

--- a/components/table/storage/data_pointer.hpp
+++ b/components/table/storage/data_pointer.hpp
@@ -26,15 +26,4 @@ namespace components::table::storage {
         void serialize(metadata_writer_t& writer) const;
         static data_pointer_t deserialize(metadata_reader_t& reader);
     };
-
-    struct row_group_pointer_t {
-        uint64_t row_start{0};
-        uint64_t tuple_count{0};
-        std::vector<std::vector<data_pointer_t>> data_pointers; // per-column data pointers
-        std::vector<data_pointer_t> deletes_pointers;
-
-        void serialize(metadata_writer_t& writer) const;
-        static row_group_pointer_t deserialize(metadata_reader_t& reader);
-    };
-
 } // namespace components::table::storage

--- a/components/table/storage/single_file_block_manager.hpp
+++ b/components/table/storage/single_file_block_manager.hpp
@@ -15,7 +15,6 @@ namespace core::filesystem {
 } // namespace core::filesystem
 
 namespace components::table::storage {
-
     static constexpr uint64_t BLOCK_START = 3 * SECTOR_SIZE; // 12288
 
     struct main_header_t {
@@ -26,7 +25,7 @@ namespace components::table::storage {
         // is 4088, not 4096. The stride is NOT stored in the file (it is recomputed on open), so
         // a file written by an earlier build has its metadata chain read at the wrong offsets.
         // Such files are refused, not migrated.
-        static constexpr uint32_t CURRENT_VERSION = 0;
+        static constexpr uint32_t CURRENT_VERSION = 1;
 
         uint32_t magic;
         uint32_t version;
@@ -128,5 +127,4 @@ namespace components::table::storage {
         uint64_t iteration_{0};
         uint64_t meta_block_{INVALID_INDEX};
     };
-
 } // namespace components::table::storage

--- a/components/table/storage/type_record.cpp
+++ b/components/table/storage/type_record.cpp
@@ -1,0 +1,34 @@
+#include "type_record.hpp"
+
+#include "metadata_reader.hpp"
+#include "metadata_writer.hpp"
+
+#include <cassert>
+#include <vector>
+
+namespace components::table::storage {
+    void write_type_record(metadata_writer_t& writer, const types::complex_logical_type& type) {
+        const uint32_t size = types::type_binary_size(type);
+        std::vector<char> bytes(size);
+        [[maybe_unused]] const char* written_end = types::type_binary_write(bytes.data(), type);
+        assert(static_cast<uint32_t>(written_end - bytes.data()) == size &&
+               "type_binary_write disagrees with type_binary_size");
+        writer.write<uint32_t>(size);
+        writer.write_data(reinterpret_cast<const std::byte*>(bytes.data()), size);
+    }
+
+    core::result_wrapper_t<types::complex_logical_type> read_type_record(metadata_reader_t& reader,
+                                                                        std::pmr::memory_resource* resource) {
+        const auto size = reader.read<uint32_t>();
+        if (reader.has_error()) {
+            return reader.error();
+        }
+        std::vector<char> bytes(size);
+        reader.read_data(reinterpret_cast<std::byte*>(bytes.data()), size);
+        if (reader.has_error()) {
+            return reader.error();
+        }
+        const char* scan = bytes.data();
+        return types::type_binary_read(scan, bytes.data() + size, resource);
+    }
+} // namespace components::table::storage

--- a/components/table/storage/type_record.hpp
+++ b/components/table/storage/type_record.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <components/types/type_binary.hpp>
+#include <core/result_wrapper.hpp>
+
+#include <memory_resource>
+
+namespace components::table::storage {
+    class metadata_reader_t;
+    class metadata_writer_t;
+
+    void write_type_record(metadata_writer_t& writer, const types::complex_logical_type& type);
+
+    core::result_wrapper_t<types::complex_logical_type> read_type_record(metadata_reader_t& reader,
+                                                                        std::pmr::memory_resource* resource);
+} // namespace components::table::storage

--- a/components/table/struct_column_data.cpp
+++ b/components/table/struct_column_data.cpp
@@ -1,9 +1,9 @@
 #include "struct_column_data.hpp"
 
+#include "persistent_column_data.hpp"
 #include "row_group.hpp"
 
 namespace components::table {
-
     struct_column_data_t::struct_column_data_t(std::pmr::memory_resource* resource,
                                                storage::block_manager_t& block_manager,
                                                uint64_t column_index,
@@ -151,7 +151,7 @@ namespace components::table {
             }
             state.child_appends.push_back(std::move(child_append));
         }
-        return true;
+        return core::error_t::no_error();
     }
 
     core::result_wrapper_t<bool>
@@ -175,7 +175,7 @@ namespace components::table {
             }
         }
         count_ += count;
-        return true;
+        return core::error_t::no_error();
     }
 
     void struct_column_data_t::revert_append(int64_t start_row) {
@@ -214,7 +214,7 @@ namespace components::table {
                 return child;
             }
         }
-        return true;
+        return core::error_t::no_error();
     }
 
     core::result_wrapper_t<bool> struct_column_data_t::update_column(const std::vector<uint64_t>& column_path,
@@ -265,5 +265,36 @@ namespace components::table {
             sub_columns[i]->get_column_segment_info(row_group_index, col_path, result);
         }
     }
+
+    core::error_t
+    struct_column_data_t::checkpoint_children(storage::partial_block_manager_t& partial_block_manager,
+                                              persistent_column_data_t& persistent) {
+        for (auto& sub_column : sub_columns) {
+            auto child = sub_column->checkpoint(partial_block_manager);
+            if (child.has_error()) {
+                return child.error();
+            }
+            persistent.child_columns.push_back(std::make_unique<persistent_column_data_t>(std::move(child.value())));
+        }
+        return core::error_t::no_error();
+    }
+
+    core::error_t
+    struct_column_data_t::initialize_children(const persistent_column_data_t& persistent_data) {
+        if (persistent_data.child_columns.size() != sub_columns.size()) {
+            return core::error_t(core::error_code_t::data_corruption,
+                                 std::pmr::string{"column metadata: field count differs from the schema",
+                                                  resource()});
+        }
+        for (size_t i = 0; i < sub_columns.size(); i++) {
+            if (auto error = sub_columns[i]->initialize_column(*persistent_data.child_columns[i]);
+                error.contains_error()) {
+                return error;
+            }
+        }
+        return core::error_t::no_error();
+    }
+
+    validity_column_data_t* struct_column_data_t::validity_column() { return &validity; }
 
 } // namespace components::table

--- a/components/table/struct_column_data.hpp
+++ b/components/table/struct_column_data.hpp
@@ -3,7 +3,6 @@
 #include "validity_column_data.hpp"
 
 namespace components::table {
-
     class struct_column_data_t : public column_data_t {
     public:
         struct_column_data_t(std::pmr::memory_resource* resource,
@@ -17,6 +16,13 @@ namespace components::table {
         validity_column_data_t validity;
 
         void set_start(int64_t new_start) override;
+        validity_column_data_t* validity_column() override;
+        [[nodiscard]] core::error_t
+        checkpoint_children(storage::partial_block_manager_t& partial_block_manager,
+                            persistent_column_data_t& persistent) override;
+        [[nodiscard]] core::error_t
+        initialize_children(const persistent_column_data_t& persistent_data) override;
+
         uint64_t max_entry() override;
 
         void initialize_scan(column_scan_state& state) override;
@@ -54,5 +60,4 @@ namespace components::table {
                                      std::vector<uint64_t> col_path,
                                      std::vector<column_segment_info>& result) override;
     };
-
 } // namespace components::table

--- a/components/table/test/test_block_manager.cpp
+++ b/components/table/test/test_block_manager.cpp
@@ -10,6 +10,7 @@
 #include <components/table/storage/metadata_reader.hpp>
 #include <components/table/storage/metadata_writer.hpp>
 
+#include <cstddef>
 #include <cstdio>
 #include <cstring>
 #include <fstream>
@@ -454,4 +455,31 @@ TEST_CASE("buffer_pool/standard_buffer_manager: set_memory_limit success returns
         REQUIRE_NOTHROW(r = env.buffer_manager.set_memory_limit(uint64_t(1) << 24));
         REQUIRE_FALSE(r.has_error());
     }
+}
+
+TEST_CASE("single_file_block_manager: a file written by another format version is refused") {
+    using namespace components::table::storage;
+    cleanup_test_file();
+
+    test_env_t env;
+    {
+        single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+        REQUIRE(!bm.create_new_database().has_error());
+    }
+
+    // A file this build would accept becomes a file from a foreign format version by
+    // rewriting one word -- everything else about it stays valid, including the magic.
+    {
+        std::fstream file(test_db_path(), std::ios::in | std::ios::out | std::ios::binary);
+        REQUIRE(file.is_open());
+        const uint32_t foreign_version = main_header_t::CURRENT_VERSION + 1;
+        file.seekp(static_cast<std::streamoff>(offsetof(main_header_t, version)));
+        file.write(reinterpret_cast<const char*>(&foreign_version), sizeof(foreign_version));
+        file.flush();
+        REQUIRE(file.good());
+    }
+
+    single_file_block_manager_t bm(env.buffer_manager, env.fs, test_db_path());
+    auto opened = bm.load_existing_database();
+    REQUIRE(opened.has_error());
 }

--- a/components/table/test/test_metadata.cpp
+++ b/components/table/test/test_metadata.cpp
@@ -12,6 +12,7 @@
 
 #include <cstdio>
 #include <cstring>
+#include <limits>
 #include <unistd.h>
 #include <vector>
 
@@ -236,10 +237,9 @@ TEST_CASE("metadata: sub-blocks fit inside the block's usable region") {
 }
 
 // The metadata sub-block stride is NOT stored in the file — metadata_manager_t recomputes it
-// from the block size on open. Pre-reset builds wrote it as 4096 under version 1; the current
-// format (CURRENT_VERSION == 0) uses 4088, so such a chain read by this build walks to wrong
-// offsets and returns garbage rather than failing. The version has to be matched EXACTLY and an
-// older file refused through the error channel — there is no compatibility path.
+// from the block size on open, so a chain written under a different layout is read at wrong
+// offsets and returns garbage rather than failing. The version therefore has to match EXACTLY
+// and a foreign file be refused through the error channel; there is no compatibility path.
 TEST_CASE("metadata: a file from an older format version is refused") {
     using namespace components::table::storage;
     cleanup_test_file();
@@ -250,11 +250,11 @@ TEST_CASE("metadata: a file from an older format version is refused") {
         REQUIRE(!bm.create_new_database().has_error());
     }
 
-    // Rewrite the version field in place to the previous format version.
+    // Rewrite the version field in place to a version this build cannot have written.
     {
         std::FILE* f = std::fopen(test_db_path().c_str(), "r+b");
         REQUIRE(f != nullptr);
-        const uint32_t legacy_version = 1;                       // what pre-reset builds wrote
+        const uint32_t legacy_version = std::numeric_limits<uint32_t>::max();
         REQUIRE(std::fseek(f, sizeof(uint32_t), SEEK_SET) == 0); // past the magic
         REQUIRE(std::fwrite(&legacy_version, sizeof(legacy_version), 1, f) == 1);
         std::fclose(f);
@@ -266,7 +266,7 @@ TEST_CASE("metadata: a file from an older format version is refused") {
         auto result = bm.load_existing_database();
         REQUIRE(result.has_error());
         INFO("error: " << result.error().what);
-        CHECK(result.error().type == core::error_code_t::data_corruption);
+        REQUIRE(result.error().type == core::error_code_t::data_corruption);
     }
 
     cleanup_test_file();

--- a/components/types/CMakeLists.txt
+++ b/components/types/CMakeLists.txt
@@ -2,6 +2,7 @@ project(types CXX)
 
 set(SOURCE_${PROJECT_NAME}
         types.cpp
+        type_binary.cpp
         physical_value.cpp
         logical_value.cpp
         operations_helper.cpp

--- a/components/types/type_binary.cpp
+++ b/components/types/type_binary.cpp
@@ -1,0 +1,506 @@
+#include <components/types/type_binary.hpp>
+
+#include <components/types/logical_value.hpp>
+
+#include <core/result_wrapper.hpp>
+
+#include <cassert>
+#include <cstring>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace components::types {
+    namespace {
+        inline void write_le16(char* destination, uint16_t value) { std::memcpy(destination, &value, 2); }
+        inline void write_le32(char* destination, uint32_t value) { std::memcpy(destination, &value, 4); }
+        inline void write_le64(char* destination, uint64_t value) { std::memcpy(destination, &value, 8); }
+
+        inline uint16_t read_le16(const char* source) {
+            uint16_t value;
+            std::memcpy(&value, source, 2);
+            return value;
+        }
+        inline uint32_t read_le32(const char* source) {
+            uint32_t value;
+            std::memcpy(&value, source, 4);
+            return value;
+        }
+        inline uint64_t read_le64(const char* source) {
+            uint64_t value;
+            std::memcpy(&value, source, 8);
+            return value;
+        }
+
+        // -------------------------------------------------------------------
+        // Type header codec
+        // -------------------------------------------------------------------
+        // Recursive layout:
+        //   type := [logical_type:1][alias:str][extension]
+        //   str  := [length:2 LE][bytes]
+        //   extension:
+        //     0 NONE
+        //     1 ARRAY_FLAT [element logical_type:1][size:4]   (legacy)
+        //     2 DECIMAL    [width:1][scale:1]                 (legacy)
+        //     3 LIST       [field_id:8][required:1][element:type]
+        //     4 STRUCT     [name:str][child_count:2][child:type * N]
+        //     5 ENUM       [name:str][entry_count:4][[entry_type:1][value:8][name:str] * N]
+        //     6 UNKNOWN    [name:str]
+        //     7 MAP        [key_id:8][value_id:8][value_required:1][key:type][value:type]
+        //     8 ARRAY      [size:4][element:type]
+        enum class wire_extension : uint8_t
+        {
+            NONE = 0,
+            ARRAY_FLAT = 1,
+            DECIMAL = 2,
+            LIST = 3,
+            STRUCT = 4,
+            ENUM = 5,
+            UNKNOWN = 6,
+            MAP = 7,
+            ARRAY = 8
+        };
+
+        // An ARRAY element needs no nested header when it carries nothing beyond
+        // its own tag — exactly what the legacy flat encoding can express.
+        bool fits_flat_array_element(const complex_logical_type& type) {
+            return type.extension() == nullptr && !type.has_alias();
+        }
+
+        uint32_t string_field_size(std::string_view value) { return 2 + static_cast<uint32_t>(value.size()); }
+
+        // ENUM entries are integer literals carrying the entry name as their alias
+        // (enum_logical_type_extension::entries_).
+        bool enum_entry_value(const logical_value_t& entry, int64_t& value) {
+            switch (entry.type().type()) {
+                case logical_type::TINYINT:
+                    value = entry.value<int8_t>();
+                    return true;
+                case logical_type::SMALLINT:
+                    value = entry.value<int16_t>();
+                    return true;
+                case logical_type::INTEGER:
+                    value = entry.value<int32_t>();
+                    return true;
+                case logical_type::BIGINT:
+                    value = entry.value<int64_t>();
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        bool append_enum_entry(std::pmr::memory_resource* resource,
+                               logical_type entry_type,
+                               int64_t value,
+                               std::string_view entry_name,
+                               std::vector<logical_value_t>& entries) {
+            switch (entry_type) {
+                case logical_type::TINYINT:
+                    entries.emplace_back(resource, static_cast<int8_t>(value));
+                    break;
+                case logical_type::SMALLINT:
+                    entries.emplace_back(resource, static_cast<int16_t>(value));
+                    break;
+                case logical_type::INTEGER:
+                    entries.emplace_back(resource, static_cast<int32_t>(value));
+                    break;
+                case logical_type::BIGINT:
+                    entries.emplace_back(resource, static_cast<int64_t>(value));
+                    break;
+                default:
+                    return false;
+            }
+            entries.back().set_alias(std::string{entry_name});
+            return true;
+        }
+
+        // Compute the size of the type header for a single column.
+        uint32_t detail_type_binary_size(const complex_logical_type& column_type) {
+            uint32_t header_size = 1 + 2; // logical_type + alias_length
+            if (column_type.has_alias()) {
+                header_size += static_cast<uint32_t>(column_type.alias().size());
+            }
+            header_size += 1; // extension_type byte
+
+            const auto* extension = column_type.extension();
+            if (!extension) {
+                return header_size;
+            }
+
+            using extension_type = logical_type_extension::extension_type;
+            switch (extension->type()) {
+                case extension_type::ARRAY: {
+                    const auto* array = static_cast<const array_logical_type_extension*>(extension);
+                    if (fits_flat_array_element(array->internal_type())) {
+                        return header_size + 1 + 4;
+                    }
+                    return header_size + 4 + detail_type_binary_size(array->internal_type());
+                }
+                case extension_type::DECIMAL:
+                    return header_size + 2;
+                case extension_type::LIST: {
+                    const auto* list = static_cast<const list_logical_type_extension*>(extension);
+                    return header_size + 8 + 1 + detail_type_binary_size(list->node());
+                }
+                case extension_type::STRUCT: {
+                    const auto* record = static_cast<const struct_logical_type_extension*>(extension);
+                    header_size += string_field_size(record->type_name()) + 2;
+                    for (const auto& child : record->child_types()) {
+                        header_size += detail_type_binary_size(child);
+                    }
+                    return header_size;
+                }
+                case extension_type::ENUM: {
+                    const auto* enumeration = static_cast<const enum_logical_type_extension*>(extension);
+                    header_size += string_field_size(enumeration->type_name()) + 4;
+                    for (const auto& entry : enumeration->entries()) {
+                        header_size += 1 + 8 + string_field_size(entry.type().alias());
+                    }
+                    return header_size;
+                }
+                case extension_type::UNKNOWN: {
+                    const auto* unknown = static_cast<const unknown_logical_type_extension*>(extension);
+                    return header_size + string_field_size(unknown->type_name());
+                }
+                case extension_type::MAP: {
+                    const auto* map = static_cast<const map_logical_type_extension*>(extension);
+                    return header_size + 8 + 8 + 1 + detail_type_binary_size(map->key()) +
+                           detail_type_binary_size(map->value());
+                }
+                default:
+                    // GENERIC / USER / FUNCTION are not column types
+                    return header_size;
+            }
+        }
+
+        char* write_string_field(char* output, std::string_view value) {
+            auto length = static_cast<uint16_t>(value.size());
+            write_le16(output, length);
+            output += 2;
+            std::memcpy(output, value.data(), length);
+            return output + length;
+        }
+
+        // Write the type header for a single column. Returns pointer past written data.
+        char* detail_type_binary_write(char* output, const complex_logical_type& column_type) {
+            *reinterpret_cast<uint8_t*>(output) = static_cast<uint8_t>(column_type.type());
+            output += 1;
+
+            if (column_type.has_alias()) {
+                output = write_string_field(output, column_type.alias());
+            } else {
+                write_le16(output, 0);
+                output += 2;
+            }
+
+            const auto* extension = column_type.extension();
+            if (!extension) {
+                *reinterpret_cast<uint8_t*>(output) = static_cast<uint8_t>(wire_extension::NONE);
+                return output + 1;
+            }
+
+            using extension_type = logical_type_extension::extension_type;
+            switch (extension->type()) {
+                case extension_type::ARRAY: {
+                    const auto* array = static_cast<const array_logical_type_extension*>(extension);
+                    if (fits_flat_array_element(array->internal_type())) {
+                        *reinterpret_cast<uint8_t*>(output) = static_cast<uint8_t>(wire_extension::ARRAY_FLAT);
+                        output += 1;
+                        *reinterpret_cast<uint8_t*>(output) = static_cast<uint8_t>(array->internal_type().type());
+                        output += 1;
+                        write_le32(output, static_cast<uint32_t>(array->size()));
+                        return output + 4;
+                    }
+                    *reinterpret_cast<uint8_t*>(output) = static_cast<uint8_t>(wire_extension::ARRAY);
+                    output += 1;
+                    write_le32(output, static_cast<uint32_t>(array->size()));
+                    output += 4;
+                    return detail_type_binary_write(output, array->internal_type());
+                }
+                case extension_type::DECIMAL: {
+                    const auto* decimal = static_cast<const decimal_logical_type_extension*>(extension);
+                    *reinterpret_cast<uint8_t*>(output) = static_cast<uint8_t>(wire_extension::DECIMAL);
+                    output += 1;
+                    *reinterpret_cast<uint8_t*>(output) = decimal->width();
+                    output += 1;
+                    *reinterpret_cast<uint8_t*>(output) = decimal->scale();
+                    return output + 1;
+                }
+                case extension_type::LIST: {
+                    const auto* list = static_cast<const list_logical_type_extension*>(extension);
+                    *reinterpret_cast<uint8_t*>(output) = static_cast<uint8_t>(wire_extension::LIST);
+                    output += 1;
+                    write_le64(output, list->field_id());
+                    output += 8;
+                    *reinterpret_cast<uint8_t*>(output) = list->required() ? 1 : 0;
+                    output += 1;
+                    return detail_type_binary_write(output, list->node());
+                }
+                case extension_type::STRUCT: {
+                    const auto* record = static_cast<const struct_logical_type_extension*>(extension);
+                    *reinterpret_cast<uint8_t*>(output) = static_cast<uint8_t>(wire_extension::STRUCT);
+                    output += 1;
+                    output = write_string_field(output, record->type_name());
+                    const auto& children = record->child_types();
+                    write_le16(output, static_cast<uint16_t>(children.size()));
+                    output += 2;
+                    for (const auto& child : children) {
+                        output = detail_type_binary_write(output, child);
+                    }
+                    return output;
+                }
+                case extension_type::ENUM: {
+                    const auto* enumeration = static_cast<const enum_logical_type_extension*>(extension);
+                    *reinterpret_cast<uint8_t*>(output) = static_cast<uint8_t>(wire_extension::ENUM);
+                    output += 1;
+                    output = write_string_field(output, enumeration->type_name());
+                    const auto& entries = enumeration->entries();
+                    write_le32(output, static_cast<uint32_t>(entries.size()));
+                    output += 4;
+                    for (const auto& entry : entries) {
+                        int64_t value = 0;
+                        if (!enum_entry_value(entry, value)) {
+                            assert(false && "ENUM entry is not an integer literal");
+                        }
+                        *reinterpret_cast<uint8_t*>(output) = static_cast<uint8_t>(entry.type().type());
+                        output += 1;
+                        write_le64(output, static_cast<uint64_t>(value));
+                        output += 8;
+                        output = write_string_field(output, entry.type().alias());
+                    }
+                    return output;
+                }
+                case extension_type::UNKNOWN: {
+                    const auto* unknown = static_cast<const unknown_logical_type_extension*>(extension);
+                    *reinterpret_cast<uint8_t*>(output) = static_cast<uint8_t>(wire_extension::UNKNOWN);
+                    output += 1;
+                    return write_string_field(output, unknown->type_name());
+                }
+                case extension_type::MAP: {
+                    const auto* map = static_cast<const map_logical_type_extension*>(extension);
+                    *reinterpret_cast<uint8_t*>(output) = static_cast<uint8_t>(wire_extension::MAP);
+                    output += 1;
+                    write_le64(output, map->key_id());
+                    output += 8;
+                    write_le64(output, map->value_id());
+                    output += 8;
+                    *reinterpret_cast<uint8_t*>(output) = map->value_required() ? 1 : 0;
+                    output += 1;
+                    output = detail_type_binary_write(output, map->key());
+                    return detail_type_binary_write(output, map->value());
+                }
+                default:
+                    // GENERIC / USER / FUNCTION are not column types, see BUGS.md B-054.
+                    *reinterpret_cast<uint8_t*>(output) = static_cast<uint8_t>(wire_extension::NONE);
+                    return output + 1;
+            }
+        }
+
+        core::error_t truncated(std::pmr::memory_resource* resource) {
+            return core::error_t(core::error_code_t::data_corruption,
+                                 std::pmr::string{"type record: buffer ends inside the record", resource});
+        }
+
+        core::error_t malformed(std::pmr::memory_resource* resource, const char* what) {
+            return core::error_t(core::error_code_t::data_corruption, std::pmr::string{what, resource});
+        }
+
+        bool read_string_field(const char*& scan, const char* end, std::string& value) {
+            if (scan + 2 > end) {
+                return false;
+            }
+            uint16_t length = read_le16(scan);
+            scan += 2;
+            if (scan + length > end) {
+                return false;
+            }
+            value.assign(scan, length);
+            scan += length;
+            return true;
+        }
+
+        // Read the type record for a single column, advancing `scan`. A truncated buffer or a
+        // body that does not match its tag is data_corruption, named rather than signalled by a
+        // bare flag.
+        core::result_wrapper_t<complex_logical_type>
+        detail_type_binary_read(const char*& scan, const char* end, std::pmr::memory_resource* resource) {
+            if (scan + 1 > end) {
+                return truncated(resource);
+            }
+            auto logical_type_value = static_cast<logical_type>(*reinterpret_cast<const uint8_t*>(scan));
+            scan += 1;
+
+            std::string alias;
+            if (!read_string_field(scan, end, alias)) {
+                return truncated(resource);
+            }
+
+            if (scan >= end) {
+                return truncated(resource);
+            }
+            uint8_t extension_tag = *reinterpret_cast<const uint8_t*>(scan);
+            scan += 1;
+
+            switch (static_cast<wire_extension>(extension_tag)) {
+                case wire_extension::ARRAY_FLAT: {
+                    if (scan + 5 > end) {
+                        return truncated(resource);
+                    }
+                    auto element_type = static_cast<logical_type>(*reinterpret_cast<const uint8_t*>(scan));
+                    scan += 1;
+                    uint32_t array_size = read_le32(scan);
+                    scan += 4;
+                    return complex_logical_type::create_array(element_type,
+                                                              static_cast<size_t>(array_size),
+                                                              std::move(alias));
+                }
+                case wire_extension::DECIMAL: {
+                    if (scan + 2 > end) {
+                        return truncated(resource);
+                    }
+                    uint8_t width = *reinterpret_cast<const uint8_t*>(scan);
+                    scan += 1;
+                    uint8_t scale = *reinterpret_cast<const uint8_t*>(scan);
+                    scan += 1;
+                    return complex_logical_type::create_decimal(width, scale, std::move(alias));
+                }
+                case wire_extension::ARRAY: {
+                    if (scan + 4 > end) {
+                        return truncated(resource);
+                    }
+                    uint32_t array_size = read_le32(scan);
+                    scan += 4;
+                    auto element = detail_type_binary_read(scan, end, resource);
+                    if (element.has_error()) {
+                        return element;
+                    }
+                    return complex_logical_type::create_array(element.value(),
+                                                              static_cast<size_t>(array_size),
+                                                              std::move(alias));
+                }
+                case wire_extension::LIST: {
+                    if (scan + 9 > end) {
+                        return truncated(resource);
+                    }
+                    uint64_t field_id = read_le64(scan);
+                    scan += 8;
+                    bool required = *reinterpret_cast<const uint8_t*>(scan) != 0;
+                    scan += 1;
+                    auto element = detail_type_binary_read(scan, end, resource);
+                    if (element.has_error()) {
+                        return element;
+                    }
+                    return complex_logical_type(
+                        logical_type_value,
+                        std::make_unique<list_logical_type_extension>(field_id, std::move(element.value()), required),
+                        std::move(alias));
+                }
+                case wire_extension::STRUCT: {
+                    std::string type_name;
+                    if (!read_string_field(scan, end, type_name)) {
+                        return truncated(resource);
+                    }
+                    if (scan + 2 > end) {
+                        return truncated(resource);
+                    }
+                    uint16_t child_count = read_le16(scan);
+                    scan += 2;
+                    std::pmr::vector<complex_logical_type> children(resource);
+                    children.reserve(child_count);
+                    for (uint16_t child_index = 0; child_index < child_count; ++child_index) {
+                        auto child = detail_type_binary_read(scan, end, resource);
+                        if (child.has_error()) {
+                            return child;
+                        }
+                        children.push_back(std::move(child.value()));
+                    }
+                    return complex_logical_type(
+                        logical_type_value,
+                        std::make_unique<struct_logical_type_extension>(std::move(type_name), children),
+                        std::move(alias));
+                }
+                case wire_extension::ENUM: {
+                    std::string type_name;
+                    if (!read_string_field(scan, end, type_name)) {
+                        return truncated(resource);
+                    }
+                    if (scan + 4 > end) {
+                        return truncated(resource);
+                    }
+                    uint32_t entry_count = read_le32(scan);
+                    scan += 4;
+                    std::vector<logical_value_t> entries;
+                    entries.reserve(entry_count);
+                    for (uint32_t entry_index = 0; entry_index < entry_count; ++entry_index) {
+                        if (scan + 9 > end) {
+                            return truncated(resource);
+                        }
+                        auto entry_type = static_cast<logical_type>(*reinterpret_cast<const uint8_t*>(scan));
+                        scan += 1;
+                        auto value = static_cast<int64_t>(read_le64(scan));
+                        scan += 8;
+                        std::string entry_name;
+                        if (!read_string_field(scan, end, entry_name)) {
+                            return truncated(resource);
+                        }
+                        if (!append_enum_entry(resource, entry_type, value, entry_name, entries)) {
+                            return malformed(resource, "type record: ENUM entry is not an integer literal");
+                        }
+                    }
+                    return complex_logical_type(
+                        logical_type_value,
+                        std::make_unique<enum_logical_type_extension>(std::move(type_name), std::move(entries)),
+                        std::move(alias));
+                }
+                case wire_extension::UNKNOWN: {
+                    std::string type_name;
+                    if (!read_string_field(scan, end, type_name)) {
+                        return truncated(resource);
+                    }
+                    return complex_logical_type::create_unknown(std::move(type_name), std::move(alias));
+                }
+                case wire_extension::MAP: {
+                    if (scan + 17 > end) {
+                        return truncated(resource);
+                    }
+                    uint64_t key_id = read_le64(scan);
+                    scan += 8;
+                    uint64_t value_id = read_le64(scan);
+                    scan += 8;
+                    bool value_required = *reinterpret_cast<const uint8_t*>(scan) != 0;
+                    scan += 1;
+                    auto key = detail_type_binary_read(scan, end, resource);
+                    if (key.has_error()) {
+                        return key;
+                    }
+                    auto value = detail_type_binary_read(scan, end, resource);
+                    if (value.has_error()) {
+                        return value;
+                    }
+                    return complex_logical_type(logical_type_value,
+                                                std::make_unique<map_logical_type_extension>(resource,
+                                                                                             key_id,
+                                                                                             key.value(),
+                                                                                             value_id,
+                                                                                             value.value(),
+                                                                                             value_required),
+                                                std::move(alias));
+                }
+                default: // no extension
+                    return complex_logical_type(logical_type_value, std::move(alias));
+            }
+        }
+    } // namespace
+
+    uint32_t type_binary_size(const complex_logical_type& type) { return detail_type_binary_size(type); }
+
+    char* type_binary_write(char* output, const complex_logical_type& type) {
+        return detail_type_binary_write(output, type);
+    }
+
+    core::result_wrapper_t<complex_logical_type>
+    type_binary_read(const char*& scan, const char* end, std::pmr::memory_resource* resource) {
+        return detail_type_binary_read(scan, end, resource);
+    }
+} // namespace components::types

--- a/components/types/type_binary.hpp
+++ b/components/types/type_binary.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <components/types/types.hpp>
+
+#include <core/result_wrapper.hpp>
+
+#include <cstdint>
+#include <memory_resource>
+
+namespace components::types {
+    uint32_t type_binary_size(const complex_logical_type& type);
+
+    char* type_binary_write(char* output, const complex_logical_type& type);
+
+    core::result_wrapper_t<complex_logical_type>
+    type_binary_read(const char*& scan, const char* end, std::pmr::memory_resource* resource);
+} // namespace components::types

--- a/components/types/types.cpp
+++ b/components/types/types.cpp
@@ -1,10 +1,11 @@
 #include "types.hpp"
 #include "logical_value.hpp"
 
+#include <concepts>
+
 #include <cassert>
 
 namespace components::types {
-
     namespace {
         std::array<physical_type, 256> make_physical_type_table() {
             std::array<physical_type, 256> t{};
@@ -63,6 +64,20 @@ namespace components::types {
                 throw std::runtime_error("can not create decimal with width bigger than: " +
                                          std::to_string(static_cast<int>(max_width_128)));
             }
+        }
+
+        template<typename Extension>
+        concept typed_extension =
+            std::derived_from<Extension, logical_type_extension> && requires {
+                { Extension::kind } -> std::convertible_to<logical_type_extension::extension_type>;
+            };
+
+        template<typed_extension Extension>
+        Extension* extension_cast(logical_type_extension* extension) {
+            if (extension == nullptr || extension->type() != Extension::kind) {
+                return nullptr;
+            }
+            return static_cast<Extension*>(extension);
         }
     } // anonymous namespace
 
@@ -347,7 +362,13 @@ namespace components::types {
 
     const std::string& complex_logical_type::child_name(uint64_t index) const {
         assert(type_ == logical_type::STRUCT);
-        return static_cast<struct_logical_type_extension*>(extension_.get())->child_types()[index].alias();
+        const auto& fields = child_types();
+        assert(index < fields.size());
+        if (index >= fields.size()) {
+            static const std::string no_name;
+            return no_name;
+        }
+        return fields[index].alias();
     }
 
     bool complex_logical_type::is_unnamed() const { return extension_->alias().empty(); }
@@ -395,17 +416,17 @@ namespace components::types {
 
     const complex_logical_type& complex_logical_type::child_type() const {
         assert(type_ == logical_type::ARRAY || type_ == logical_type::LIST || type_ == logical_type::MAP);
-        if (type_ == logical_type::ARRAY) {
-            return static_cast<array_logical_type_extension*>(extension_.get())->internal_type();
+        if (auto* array = extension_cast<array_logical_type_extension>(extension_.get())) {
+            return array->internal_type();
         }
-        if (type_ == logical_type::LIST) {
-            return static_cast<list_logical_type_extension*>(extension_.get())->node();
+        if (auto* list = extension_cast<list_logical_type_extension>(extension_.get())) {
+            return list->node();
         }
-        if (type_ == logical_type::MAP) {
+        if (auto* map = extension_cast<map_logical_type_extension>(extension_.get())) {
             // MAP is physically a LIST of struct<"key", "value">.
-            return static_cast<map_logical_type_extension*>(extension_.get())->node();
+            return map->node();
         }
-
+        assert(false && "complex_logical_type::child_type: tag has no matching extension");
         return INVALID_TYPE;
     }
 
@@ -422,8 +443,15 @@ namespace components::types {
                 complex_logical_type{logical_type::INTEGER}};
             return interval_fields;
         }
-        assert(extension_);
-        return static_cast<struct_logical_type_extension*>(extension_.get())->child_types();
+        auto* fields = extension_cast<struct_logical_type_extension>(extension_.get());
+        assert(fields && "complex_logical_type::child_types: type is not a STRUCT");
+        if (fields == nullptr) {
+            // Shared because nothing in the tree mutates through this overload;
+            // the assert above is what catches misuse in a Debug build.
+            static std::pmr::vector<complex_logical_type> no_children;
+            return no_children;
+        }
+        return fields->child_types();
     }
 
     const std::pmr::vector<complex_logical_type>& complex_logical_type::child_types() const {
@@ -440,8 +468,14 @@ namespace components::types {
                 complex_logical_type{logical_type::INTEGER}};
             return interval_fields;
         }
-        assert(extension_);
-        return static_cast<struct_logical_type_extension*>(extension_.get())->child_types();
+        const auto* fields =
+            extension_cast<struct_logical_type_extension>(extension_.get());
+        assert(fields && "complex_logical_type::child_types: type is not a STRUCT");
+        if (fields == nullptr) {
+            static const std::pmr::vector<complex_logical_type> no_children;
+            return no_children;
+        }
+        return fields->child_types();
     }
 
     logical_type_extension* complex_logical_type::extension() const { return extension_.get(); }
@@ -509,8 +543,13 @@ namespace components::types {
             return true;
         }
         if (type_ == logical_type::STRUCT && other.type_ == logical_type::STRUCT) {
-            const auto* struct_ext = static_cast<const struct_logical_type_extension*>(extension_.get());
-            const auto* other_struct_ext = static_cast<const struct_logical_type_extension*>(other.extension_.get());
+            const auto* struct_ext =
+                extension_cast<struct_logical_type_extension>(extension_.get());
+            const auto* other_struct_ext =
+                extension_cast<struct_logical_type_extension>(other.extension_.get());
+            if (struct_ext == nullptr || other_struct_ext == nullptr) {
+                return false;
+            }
 
             if (struct_ext->child_types().size() != other_struct_ext->child_types().size()) {
                 return false;

--- a/components/types/types.hpp
+++ b/components/types/types.hpp
@@ -541,6 +541,8 @@ namespace components::types {
 
     class array_logical_type_extension : public logical_type_extension {
     public:
+        static constexpr extension_type kind = extension_type::ARRAY;
+
         explicit array_logical_type_extension(const complex_logical_type& type, uint64_t size);
 
         const complex_logical_type& internal_type() const noexcept { return items_type_; }
@@ -555,6 +557,8 @@ namespace components::types {
 
     class map_logical_type_extension : public logical_type_extension {
     public:
+        static constexpr extension_type kind = extension_type::MAP;
+
         map_logical_type_extension(std::pmr::memory_resource* resource,
                                    const complex_logical_type& key,
                                    const complex_logical_type& value);
@@ -588,6 +592,8 @@ namespace components::types {
 
     class list_logical_type_extension : public logical_type_extension {
     public:
+        static constexpr extension_type kind = extension_type::LIST;
+
         explicit list_logical_type_extension(complex_logical_type type);
         list_logical_type_extension(uint64_t field_id, complex_logical_type type, bool required);
 
@@ -605,6 +611,8 @@ namespace components::types {
 
     class struct_logical_type_extension : public logical_type_extension {
     public:
+        static constexpr extension_type kind = extension_type::STRUCT;
+
         explicit struct_logical_type_extension(std::string name, const std::pmr::vector<complex_logical_type>& fields);
 
         // fields must be aliased

--- a/components/vector/data_chunk_binary.cpp
+++ b/components/vector/data_chunk_binary.cpp
@@ -5,12 +5,12 @@
 #include <stdexcept>
 #include <string_view>
 
+#include <components/types/type_binary.hpp>
 #include <components/types/types.hpp>
 #include <components/vector/vector.hpp>
 #include <components/vector/vector_buffer.hpp>
 
 namespace components::vector {
-
     // -----------------------------------------------------------------------
     // Little-endian helpers
     // -----------------------------------------------------------------------
@@ -60,150 +60,6 @@ namespace components::vector {
 
         bool is_variable_type(types::physical_type physical_type) {
             return physical_type == types::physical_type::STRING;
-        }
-
-        // Compute the size of the type header for a single column.
-        // Format: [logical_type:1][alias_length:2][alias:N][extension_type:1][extension_data:0-5]
-        uint32_t compute_type_header_size(const types::complex_logical_type& column_type) {
-            uint32_t header_size = 1 + 2; // logical_type + alias_length
-            if (column_type.has_alias()) {
-                header_size += static_cast<uint32_t>(column_type.alias().size());
-            }
-            header_size += 1; // extension_type byte
-            auto* extension = column_type.extension();
-            if (extension) {
-                switch (extension->type()) {
-                    case types::logical_type_extension::extension_type::ARRAY:
-                        header_size += 5; // inner_logical_type(1) + array_size(4)
-                        break;
-                    case types::logical_type_extension::extension_type::DECIMAL:
-                        header_size += 2; // width(1) + scale(1)
-                        break;
-                    default:
-                        break;
-                }
-            }
-            return header_size;
-        }
-
-        // Write the type header for a single column. Returns pointer past written data.
-        char* write_type_header(char* output, const types::complex_logical_type& column_type) {
-            // Logical type
-            *reinterpret_cast<uint8_t*>(output) = static_cast<uint8_t>(column_type.type());
-            output += 1;
-
-            // Alias
-            if (column_type.has_alias()) {
-                auto alias_length = static_cast<uint16_t>(column_type.alias().size());
-                write_le16(output, alias_length);
-                output += 2;
-                std::memcpy(output, column_type.alias().data(), alias_length);
-                output += alias_length;
-            } else {
-                write_le16(output, 0);
-                output += 2;
-            }
-
-            // Extension
-            auto* extension = column_type.extension();
-            if (!extension) {
-                *reinterpret_cast<uint8_t*>(output) = 0; // no extension
-                output += 1;
-            } else {
-                switch (extension->type()) {
-                    case types::logical_type_extension::extension_type::ARRAY: {
-                        *reinterpret_cast<uint8_t*>(output) = 1;
-                        output += 1;
-                        auto* array_extension = static_cast<const types::array_logical_type_extension*>(extension);
-                        *reinterpret_cast<uint8_t*>(output) =
-                            static_cast<uint8_t>(array_extension->internal_type().type());
-                        output += 1;
-                        write_le32(output, static_cast<uint32_t>(array_extension->size()));
-                        output += 4;
-                        break;
-                    }
-                    case types::logical_type_extension::extension_type::DECIMAL: {
-                        *reinterpret_cast<uint8_t*>(output) = 2;
-                        output += 1;
-                        auto* decimal_extension = static_cast<const types::decimal_logical_type_extension*>(extension);
-                        *reinterpret_cast<uint8_t*>(output) = decimal_extension->width();
-                        output += 1;
-                        *reinterpret_cast<uint8_t*>(output) = decimal_extension->scale();
-                        output += 1;
-                        break;
-                    }
-                    default:
-                        *reinterpret_cast<uint8_t*>(output) = 0; // unknown extension → none
-                        output += 1;
-                        break;
-                }
-            }
-
-            return output;
-        }
-
-        // Read the type header for a single column. Advances scan pointer. On any
-        // buffer-overflow sets ok=false and returns an INVALID-typed placeholder
-        // (caller must check ok before using the result).
-        types::complex_logical_type read_type_header(const char*& scan, const char* end, bool& ok) {
-            if (scan + 4 > end) {
-                ok = false;
-                return types::complex_logical_type{types::logical_type::INVALID};
-            }
-
-            // Logical type
-            auto logical_type_value = static_cast<types::logical_type>(*reinterpret_cast<const uint8_t*>(scan));
-            scan += 1;
-
-            // Alias
-            uint16_t alias_length = read_le16(scan);
-            scan += 2;
-            std::string alias;
-            if (alias_length > 0) {
-                if (scan + alias_length > end) {
-                    ok = false;
-                    return types::complex_logical_type{types::logical_type::INVALID};
-                }
-                alias.assign(scan, alias_length);
-                scan += alias_length;
-            }
-
-            // Extension type
-            if (scan >= end) {
-                ok = false;
-                return types::complex_logical_type{types::logical_type::INVALID};
-            }
-            uint8_t extension_type = *reinterpret_cast<const uint8_t*>(scan);
-            scan += 1;
-
-            switch (extension_type) {
-                case 1: { // ARRAY
-                    if (scan + 5 > end) {
-                        ok = false;
-                        return types::complex_logical_type{types::logical_type::INVALID};
-                    }
-                    auto inner_logical_type = static_cast<types::logical_type>(*reinterpret_cast<const uint8_t*>(scan));
-                    scan += 1;
-                    uint32_t array_size = read_le32(scan);
-                    scan += 4;
-                    return types::complex_logical_type::create_array(inner_logical_type,
-                                                                     static_cast<size_t>(array_size),
-                                                                     std::move(alias));
-                }
-                case 2: { // DECIMAL
-                    if (scan + 2 > end) {
-                        ok = false;
-                        return types::complex_logical_type{types::logical_type::INVALID};
-                    }
-                    uint8_t width = *reinterpret_cast<const uint8_t*>(scan);
-                    scan += 1;
-                    uint8_t scale = *reinterpret_cast<const uint8_t*>(scan);
-                    scan += 1;
-                    return types::complex_logical_type::create_decimal(width, scale, std::move(alias));
-                }
-                default: // no extension
-                    return types::complex_logical_type(logical_type_value, std::move(alias));
-            }
         }
 
         // Empty/sentinel chunk returned on deserialize failure. Caller must check
@@ -262,7 +118,7 @@ namespace components::vector {
                 column_data_sizes[column_index] = static_cast<uint32_t>(element_size * num_rows);
             }
 
-            column_type_header_sizes[column_index] = compute_type_header_size(column.type());
+            column_type_header_sizes[column_index] = types::type_binary_size(column.type());
             total += column_type_header_sizes[column_index] + 4 + column_data_sizes[column_index];
         }
 
@@ -299,7 +155,10 @@ namespace components::vector {
             auto physical_type = column.type().to_physical_type();
 
             // Write type header (logical_type + alias + extension)
-            output = write_type_header(output, column.type());
+            [[maybe_unused]] const char* type_header_begin = output;
+            output = types::type_binary_write(output, column.type());
+            assert(static_cast<uint32_t>(output - type_header_begin) == column_type_header_sizes[column_index] &&
+                   "type header writer disagrees with compute_type_header_size");
 
             // Write data_size
             write_le32(output, column_data_sizes[column_index]);
@@ -367,11 +226,12 @@ namespace components::vector {
             const char* scan = pointer;
             for (uint16_t column_index = 0; column_index < num_columns; ++column_index) {
                 // Read type header
-                auto column_type = read_type_header(scan, end, ok);
-                if (!ok) {
+                auto column_type = types::type_binary_read(scan, end, resource);
+                if (column_type.has_error()) {
+                    ok = false;
                     return make_empty_error_chunk(resource);
                 }
-                column_types.push_back(std::move(column_type));
+                column_types.push_back(std::move(column_type.value()));
 
                 // Skip data_size + data
                 if (scan + 4 > end) {
@@ -394,8 +254,9 @@ namespace components::vector {
         // Second pass: populate column data.
         for (uint16_t column_index = 0; column_index < num_columns; ++column_index) {
             // Skip type header (already parsed in first pass)
-            read_type_header(pointer, end, ok);
-            if (!ok) {
+            auto skipped = types::type_binary_read(pointer, end, resource);
+            if (skipped.has_error()) {
+                ok = false;
                 return make_empty_error_chunk(resource);
             }
 
@@ -451,5 +312,4 @@ namespace components::vector {
 
         return chunk;
     }
-
 } // namespace components::vector

--- a/integration/cpp/test/test_persistence.cpp
+++ b/integration/cpp/test/test_persistence.cpp
@@ -11,6 +11,75 @@ using namespace components::types;
 
 static const database_name_t database_name = "testdatabase";
 
+namespace {
+    components::cursor::cursor_t_ptr run_sql(otterbrix::wrapper_dispatcher_t* dispatcher, const std::string& query) {
+        return dispatcher->execute_sql(otterbrix::session_id_t(), query);
+    }
+
+    void sql_ok(otterbrix::wrapper_dispatcher_t* dispatcher, const std::string& query) {
+        auto cur = run_sql(dispatcher, query);
+        INFO("query: " << query);
+        REQUIRE(cur->is_success());
+    }
+
+    std::string describe_type(const complex_logical_type& type) {
+        std::string out = "tag=" + std::to_string(static_cast<int>(type.type()));
+        const auto* extension = type.extension();
+        if (extension == nullptr) {
+            return out + " ext=<none>";
+        }
+        out += " ext=" + std::to_string(static_cast<int>(extension->type()));
+        using extension_kind = logical_type_extension::extension_type;
+        if (extension->type() == extension_kind::DECIMAL) {
+            const auto* decimal = type.extension_as<decimal_logical_type_extension>();
+            out += " width=" + std::to_string(static_cast<int>(decimal->width())) +
+                   " scale=" + std::to_string(static_cast<int>(decimal->scale()));
+        } else if (extension->type() == extension_kind::ARRAY) {
+            out += " size=" + std::to_string(type.extension_as<array_logical_type_extension>()->size());
+        } else if (extension->type() == extension_kind::STRUCT) {
+            out += " children=" + std::to_string(type.child_types().size());
+        }
+        return out;
+    }
+
+    void check_column_type_survives_reopen(const std::string& directory,
+                                           const std::string& column_definition,
+                                           const std::string& values,
+                                           const std::string& type_prelude = {}) {
+        auto config = test_create_config("/tmp/otterbrix/integration/test_persistence/" + directory);
+        test_clear_directory(config);
+
+        std::string before;
+        {
+            test_spaces space(config);
+            auto* dispatcher = space.dispatcher();
+            sql_ok(dispatcher, "CREATE DATABASE " + database_name + ";");
+            if (!type_prelude.empty()) {
+                sql_ok(dispatcher, type_prelude);
+            }
+            sql_ok(dispatcher,
+                   "CREATE TABLE " + database_name + ".t (id bigint, c " + column_definition +
+                       ") WITH (storage = 'disk');");
+            sql_ok(dispatcher, "INSERT INTO " + database_name + ".t (id, c) VALUES " + values + ";");
+            sql_ok(dispatcher, "CHECKPOINT;");
+
+            auto cur = run_sql(dispatcher, "SELECT * FROM " + database_name + ".t;");
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->type_data().size() == 2);
+            before = describe_type(cur->type_data()[1]);
+        }
+        {
+            test_spaces space(config);
+            auto* dispatcher = space.dispatcher();
+            auto cur = run_sql(dispatcher, "SELECT * FROM " + database_name + ".t;");
+            REQUIRE(cur->is_success());
+            REQUIRE(cur->type_data().size() == 2);
+            INFO("before=" << before << "  after=" << describe_type(cur->type_data()[1]));
+            REQUIRE(describe_type(cur->type_data()[1]) == before);
+        }
+    }
+} // namespace
+
 #define CHECK_FIND_SQL(QUERY, COUNT)                                                                                   \
     do {                                                                                                               \
         auto session = otterbrix::session_id_t();                                                                      \
@@ -2369,5 +2438,141 @@ TEST_CASE("integration::cpp::test_persistence::reopen_in_memory_reinsert_visible
         CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection;", 100);
         CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE count = 0;", 1);
         CHECK_FIND_SQL("SELECT * FROM TestDatabase.TestCollection WHERE count = 99;", 1);
+    }
+}
+
+TEST_CASE("integration::cpp::test_persistence::decimal_type_survives_reopen") {
+    check_column_type_survives_reopen("type_decimal", "decimal(18,2)", "(1, 12.34)");
+}
+
+TEST_CASE("integration::cpp::test_persistence::array_type_survives_reopen") {
+    check_column_type_survives_reopen("type_array", "int[3]", "(1, ARRAY[1,2,3])");
+}
+
+TEST_CASE("integration::cpp::test_persistence::struct_type_survives_reopen") {
+    check_column_type_survives_reopen("type_struct",
+                                      "addr_t",
+                                      "(1, NULL)",
+                                      "CREATE TYPE addr_t AS (city string, country string);");
+}
+
+TEST_CASE("integration::cpp::test_persistence::varlen_array_survives_reopen") {
+    auto config = test_create_config("/tmp/otterbrix/integration/test_persistence/varlen_array");
+    test_clear_directory(config);
+    {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+        sql_ok(dispatcher, "CREATE DATABASE " + database_name + ";");
+        sql_ok(dispatcher, "CREATE TABLE " + database_name + ".a (xs INT[]);");
+        sql_ok(dispatcher, "INSERT INTO " + database_name + ".a (xs) VALUES (ARRAY[1]);");
+    }
+    {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+        auto cur = run_sql(dispatcher, "SELECT * FROM " + database_name + ".a;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+    }
+}
+
+TEST_CASE("integration::cpp::test_persistence::array_values_survive_restart") {
+    auto config = test_create_config("/tmp/otterbrix/integration/test_persistence/array_values");
+    test_clear_directory(config);
+    {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+        sql_ok(dispatcher, "CREATE DATABASE " + database_name + ";");
+        sql_ok(dispatcher, "CREATE TABLE " + database_name + ".t (id bigint, xs int[3]) WITH (storage = 'disk');");
+        sql_ok(dispatcher, "INSERT INTO " + database_name + ".t (id, xs) VALUES (1, ARRAY[10,20,30]);");
+        sql_ok(dispatcher, "CHECKPOINT;");
+    }
+    {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+        auto cur = run_sql(dispatcher, "SELECT xs FROM " + database_name + ".t WHERE id = 1;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        auto xs = cur->value(0, 0);
+        REQUIRE(xs.children().size() == 3);
+        REQUIRE(xs.children()[0].value<int32_t>() == 10);
+        REQUIRE(xs.children()[1].value<int32_t>() == 20);
+        REQUIRE(xs.children()[2].value<int32_t>() == 30);
+    }
+}
+
+TEST_CASE("integration::cpp::test_persistence::nulls_survive_checkpoint_and_restart") {
+    auto config = test_create_config("/tmp/otterbrix/integration/test_persistence/nulls");
+    test_clear_directory(config);
+
+    auto probe = [](otterbrix::wrapper_dispatcher_t* dispatcher, const char* stage) {
+        auto is_null = run_sql(dispatcher, "SELECT id FROM " + database_name + ".t WHERE n IS NULL;");
+        REQUIRE(is_null->is_success());
+        auto counted = run_sql(dispatcher, "SELECT COUNT(n) FROM " + database_name + ".t;");
+        REQUIRE(counted->is_success());
+        REQUIRE(counted->size() == 1);
+        INFO("stage: " << stage);
+        REQUIRE(is_null->size() == 1);
+        REQUIRE(counted->value(0, 0).value<int64_t>() == 2);
+    };
+
+    {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+        sql_ok(dispatcher, "CREATE DATABASE " + database_name + ";");
+        sql_ok(dispatcher,
+               "CREATE TABLE " + database_name + ".t (id bigint, n bigint, s string) WITH (storage = 'disk');");
+        sql_ok(dispatcher,
+               "INSERT INTO " + database_name + ".t (id, n, s) VALUES (1,10,'a'), (2,NULL,NULL), (3,30,'c');");
+        probe(dispatcher, "pre-checkpoint");
+        sql_ok(dispatcher, "CHECKPOINT;");
+        probe(dispatcher, "post-checkpoint, same session");
+    }
+    {
+        test_spaces space(config);
+        probe(space.dispatcher(), "after restart");
+    }
+}
+
+TEST_CASE("integration::cpp::test_persistence::column_default_applies_after_restart") {
+    auto config = test_create_config("/tmp/otterbrix/integration/test_persistence/default_after_restart");
+    test_clear_directory(config);
+    {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+        sql_ok(dispatcher, "CREATE DATABASE " + database_name + ";");
+        sql_ok(dispatcher, "CREATE TABLE " + database_name + ".t (a bigint, b bigint DEFAULT 7);");
+        sql_ok(dispatcher, "INSERT INTO " + database_name + ".t (a) VALUES (1);");
+    }
+    {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+        sql_ok(dispatcher, "INSERT INTO " + database_name + ".t (a) VALUES (2);");
+        auto cur = run_sql(dispatcher, "SELECT b FROM " + database_name + ".t WHERE a = 2;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        REQUIRE_FALSE(cur->value(0, 0).is_null());
+        REQUIRE(cur->value(0, 0).value<int64_t>() == 7);
+    }
+}
+
+TEST_CASE("integration::cpp::test_persistence::not_null_default_applies_after_restart") {
+    auto config = test_create_config("/tmp/otterbrix/integration/test_persistence/not_null_default");
+    test_clear_directory(config);
+    {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+        sql_ok(dispatcher, "CREATE DATABASE " + database_name + ";");
+        sql_ok(dispatcher, "CREATE TABLE " + database_name + ".t (a bigint, b bigint NOT NULL DEFAULT 7);");
+        sql_ok(dispatcher, "INSERT INTO " + database_name + ".t (a) VALUES (1);");
+    }
+    {
+        test_spaces space(config);
+        auto* dispatcher = space.dispatcher();
+        sql_ok(dispatcher, "INSERT INTO " + database_name + ".t (a) VALUES (2);");
+        auto cur = run_sql(dispatcher, "SELECT b FROM " + database_name + ".t WHERE a = 2;");
+        REQUIRE(cur->is_success());
+        REQUIRE(cur->size() == 1);
+        REQUIRE_FALSE(cur->value(0, 0).is_null());
+        REQUIRE(cur->value(0, 0).value<int64_t>() == 7);
     }
 }

--- a/services/disk/manager_disk_bootstrap.cpp
+++ b/services/disk/manager_disk_bootstrap.cpp
@@ -1,9 +1,9 @@
 #include "manager_disk_impl.hpp"
 
 #include <charconv>
+#include <optional>
 
 namespace services::disk {
-
     using namespace core::filesystem;
     namespace catalog = components::catalog;
     using namespace detail;
@@ -606,6 +606,13 @@ namespace services::disk {
             std::int32_t attnum{0};
             std::string name;
             components::types::complex_logical_type type;
+            // Carried because the storage is what answers for them later: the agent fills an
+            // absent column from the STORAGE column's default at storage_append, and enforces
+            // NOT NULL against the STORAGE column. Dropping them here left a rehydrated table
+            // with neither, so a post-restart INSERT wrote NULL into a NOT NULL DEFAULT column
+            // without complaint (BUGS.md B-051 / #566.B1, #566.B2). The catalog holds both.
+            bool not_null{false};
+            std::optional<components::types::logical_value_t> default_value;
         };
         std::unordered_map<catalog::oid_t, std::vector<rehydrate_col_t>> cols_by_relid;
         {
@@ -614,7 +621,7 @@ namespace services::disk {
                 return;
             }
             auto& attr_table = const_cast<collection_storage_entry_t*>(attr_entry)->table_storage.table();
-            if (attr_table.column_count() < 9 || attr_table.calculate_size() == 0) {
+            if (attr_table.column_count() < 10 || attr_table.calculate_size() == 0) {
                 return;
             }
             std::unordered_set<catalog::oid_t> wanted(need_oids.begin(), need_oids.end());
@@ -665,6 +672,14 @@ namespace services::disk {
                                                   : static_cast<catalog::oid_t>(chunk.get_value<std::uint32_t>(3, i));
                         rc.type = components::types::complex_logical_type(catalog::oid_to_builtin_type(atttypid));
                     }
+                    rc.not_null = !chunk.is_null(5, i) && chunk.get_value<bool>(5, i);
+                    if (!chunk.is_null(9, i)) {
+                        auto defspec_v = chunk.get_value<std::string_view>(9, i);
+                        if (!defspec_v.empty()) {
+                            rc.default_value =
+                                catalog::decode_default_spec(resource_, std::string{defspec_v});
+                        }
+                    }
                     if (!rc.name.empty() && !rc.type.has_alias()) {
                         rc.type.set_alias(rc.name);
                     }
@@ -687,7 +702,7 @@ namespace services::disk {
             std::vector<components::table::column_definition_t> defs;
             defs.reserve(cols.size());
             for (auto& c : cols) {
-                defs.emplace_back(c.name, c.type);
+                defs.emplace_back(c.name, c.type, c.not_null, std::move(c.default_value));
             }
             trace(log_,
                   "manager_disk_t::rehydrate_in_memory_user_storages_sync : oid={} cols={}",
@@ -1100,5 +1115,4 @@ namespace services::disk {
         }
         return last_value;
     }
-
 } // namespace services::disk

--- a/services/wal/tests/test_wal_binary.cpp
+++ b/services/wal/tests/test_wal_binary.cpp
@@ -10,32 +10,68 @@ using namespace services::wal;
 using namespace components::types;
 using namespace components::vector;
 
-// encode_insert/encode_update now take a chunk batch; wrap a single chunk (deep copy).
-static std::pmr::vector<components::vector::data_chunk_t>
-to_chunk_batch(const components::vector::data_chunk_t& chunk) {
-    std::pmr::vector<components::vector::data_chunk_t> batch(chunk.resource());
-    components::vector::data_chunk_t copy(chunk.resource(), chunk.types(), chunk.size() == 0 ? 1 : chunk.size());
-    chunk.copy(copy, 0);
-    batch.emplace_back(std::move(copy));
-    return batch;
-}
+namespace {
+    // encode_insert/encode_update now take a chunk batch; wrap a single chunk (deep copy).
+    static std::pmr::vector<components::vector::data_chunk_t>
+    to_chunk_batch(const components::vector::data_chunk_t& chunk) {
+        std::pmr::vector<components::vector::data_chunk_t> batch(chunk.resource());
+        components::vector::data_chunk_t copy(chunk.resource(), chunk.types(), chunk.size() == 0 ? 1 : chunk.size());
+        chunk.copy(copy, 0);
+        batch.emplace_back(std::move(copy));
+        return batch;
+    }
 
-// WAL binary serialization supports fixed-size and STRING types.
-// ARRAY/LIST not yet supported in binary format — use explicit types.
-static std::pmr::vector<components::types::complex_logical_type> wal_test_types(std::pmr::memory_resource* r) {
-    using namespace components::types;
-    std::pmr::vector<complex_logical_type> types(r);
-    types.emplace_back(logical_type::BIGINT, "count");
-    types.emplace_back(logical_type::STRING_LITERAL, "count_str");
-    types.emplace_back(logical_type::DOUBLE, "count_double");
-    types.emplace_back(logical_type::BOOLEAN, "count_bool");
-    return types;
-}
+    // WAL binary serialization supports fixed-size and STRING types.
+    // ARRAY/LIST not yet supported in binary format — use explicit types.
+    static std::pmr::vector<components::types::complex_logical_type> wal_test_types(std::pmr::memory_resource* r) {
+        using namespace components::types;
+        std::pmr::vector<complex_logical_type> types(r);
+        types.emplace_back(logical_type::BIGINT, "count");
+        types.emplace_back(logical_type::STRING_LITERAL, "count_str");
+        types.emplace_back(logical_type::DOUBLE, "count_double");
+        types.emplace_back(logical_type::BOOLEAN, "count_bool");
+        return types;
+    }
 
-// WAL records carry table_oid (4 bytes) instead of (database, collection)
-// strings. Tests pass arbitrary oids to verify the round-trip; production code uses
-// the actual catalog OIDs.
-constexpr components::catalog::oid_t kTestTableOid = 16500;
+    // WAL records carry table_oid (4 bytes) instead of (database, collection)
+    // strings. Tests pass arbitrary oids to verify the round-trip; production code uses
+    // the actual catalog OIDs.
+    constexpr components::catalog::oid_t kTestTableOid = 16500;
+
+    std::string describe(const complex_logical_type& type) {
+        const auto* extension = type.extension();
+        std::string out = "tag=" + std::to_string(static_cast<int>(type.type())) +
+                          " ext=" + (extension ? std::to_string(static_cast<int>(extension->type())) : "<none>");
+        if (extension && extension->type() == logical_type_extension::extension_type::STRUCT) {
+            out += " children=" + std::to_string(type.child_types().size());
+        }
+        return out;
+    }
+
+    void check_type_header_roundtrip(std::pmr::memory_resource* resource, const complex_logical_type& column_type) {
+        std::pmr::vector<complex_logical_type> types(resource);
+        types.emplace_back(column_type);
+
+        data_chunk_t chunk(resource, types, 1);
+        chunk.set_cardinality(0);
+
+        buffer_t buffer(resource);
+        serialize_binary(chunk, buffer);
+        REQUIRE(buffer.size() > 0);
+
+        bool ok = false;
+        auto result = deserialize_binary(buffer.data(), buffer.size(), resource, ok);
+        REQUIRE(ok);
+        REQUIRE(result.column_count() == 1);
+
+        const auto& decoded = result.data[0].type();
+        INFO("in : " << describe(column_type));
+        INFO("out: " << describe(decoded));
+
+        REQUIRE(decoded == column_type);
+        REQUIRE(decoded.alias() == column_type.alias());
+    }
+} // namespace
 
 TEST_CASE("wal_binary::encode_decode_insert") {
     std::pmr::monotonic_buffer_resource resource(1024 * 64);
@@ -279,4 +315,59 @@ TEST_CASE("wal_binary::data_chunk_binary_with_nulls") {
         REQUIRE(result.data[col].validity().row_is_valid(8));
         REQUIRE(result.data[col].validity().row_is_valid(9));
     }
+}
+
+TEST_CASE("wal_binary::type_header_generic") {
+    std::pmr::monotonic_buffer_resource resource(1024 * 64);
+    check_type_header_roundtrip(&resource, complex_logical_type(logical_type::BIGINT, "plain"));
+}
+
+TEST_CASE("wal_binary::type_header_array") {
+    std::pmr::monotonic_buffer_resource resource(1024 * 64);
+    check_type_header_roundtrip(
+        &resource,
+        complex_logical_type::create_array(complex_logical_type(logical_type::INTEGER), 3, "xs"));
+}
+
+TEST_CASE("wal_binary::type_header_decimal") {
+    std::pmr::monotonic_buffer_resource resource(1024 * 64);
+    check_type_header_roundtrip(&resource, complex_logical_type::create_decimal(18, 2, "price"));
+}
+
+TEST_CASE("wal_binary::type_header_struct") {
+    std::pmr::monotonic_buffer_resource resource(1024 * 64);
+    std::pmr::vector<complex_logical_type> fields(&resource);
+    fields.emplace_back(logical_type::STRING_LITERAL, "city");
+    fields.emplace_back(logical_type::STRING_LITERAL, "country");
+    check_type_header_roundtrip(&resource, complex_logical_type::create_struct("addr_t", fields, "a"));
+}
+
+TEST_CASE("wal_binary::type_header_list") {
+    std::pmr::monotonic_buffer_resource resource(1024 * 64);
+    check_type_header_roundtrip(&resource,
+                                complex_logical_type::create_list(complex_logical_type(logical_type::INTEGER), "xs"));
+}
+
+TEST_CASE("wal_binary::type_header_map") {
+    std::pmr::monotonic_buffer_resource resource(1024 * 64);
+    check_type_header_roundtrip(&resource,
+                                complex_logical_type::create_map(&resource,
+                                                                 complex_logical_type(logical_type::STRING_LITERAL),
+                                                                 complex_logical_type(logical_type::BIGINT),
+                                                                 "m"));
+}
+
+TEST_CASE("wal_binary::type_header_enum") {
+    std::pmr::monotonic_buffer_resource resource(1024 * 64);
+    std::vector<logical_value_t> entries;
+    entries.emplace_back(&resource, 0);
+    entries.back().set_alias("red");
+    entries.emplace_back(&resource, 1);
+    entries.back().set_alias("green");
+    check_type_header_roundtrip(&resource, complex_logical_type::create_enum("color_t", std::move(entries), "c"));
+}
+
+TEST_CASE("wal_binary::type_header_unknown") {
+    std::pmr::monotonic_buffer_resource resource(1024 * 64);
+    check_type_header_roundtrip(&resource, complex_logical_type::create_unknown("mystery_t", "u"));
 }


### PR DESCRIPTION
Persists column type extensions, nested column data and column DEFAULT/NOT NULL across restart. Closes #553, #606, assigned items of #566.A3/A4/B1/B2/B3 and #558.E2