### PR TITLE
fix(disk): WAL append-insert race

### DIFF
--- a/services/disk/agent_disk.cpp
+++ b/services/disk/agent_disk.cpp
@@ -625,10 +625,26 @@ namespace services::disk {
                                     ? ctx.database_oid
                                     : components::catalog::well_known_oid::main_database;
 
-            // Sent before PHYSICAL_INSERT so replay re-adds the column first, but not awaited here — a second
-            // suspending cross-actor await in one handler is a lost-wakeup.
-            unique_future<core::result_wrapper_t<wal::id_t>> add_column_future;
-            if (!wal_added_columns.empty()) {
+            // CREATE INDEX backfill uses start_row as the row-id base, so it must match the materialized start.
+            components::vector::data_chunk_t wal_chunk(resource(), data->types(), data->size());
+            data->copy(wal_chunk, 0);
+            std::pmr::vector<components::vector::data_chunk_t> wal_chunks(resource());
+            wal_chunks.emplace_back(std::move(wal_chunk));
+
+            // One journal write and one await: a second suspending cross-actor await in a handler is a lost wakeup.
+            unique_future<core::result_wrapper_t<wal::id_t>> wal_future;
+            if (wal_added_columns.empty()) {
+                auto [_w, wf] = actor_zeta::otterbrix::send(manager_wal_addr_,
+                                                            &wal::manager_wal_replicate_t::write_physical_insert,
+                                                            ctx.session,
+                                                            table_oid,
+                                                            std::move(wal_chunks),
+                                                            start_row,
+                                                            actual_count,
+                                                            txn.transaction_id,
+                                                            db_oid);
+                wal_future = std::move(wf);
+            } else {
                 std::pmr::vector<components::types::complex_logical_type> col_types(resource());
                 col_types.reserve(wal_added_columns.size());
                 for (const auto& col : wal_added_columns) {
@@ -638,36 +654,24 @@ namespace services::disk {
                 }
                 auto schema_chunk = std::make_unique<components::vector::data_chunk_t>(resource(), col_types, 0);
                 schema_chunk->set_cardinality(0);
-                auto [_sc, scf] = actor_zeta::otterbrix::send(manager_wal_addr_,
-                                                              &wal::manager_wal_replicate_t::write_physical_add_column,
-                                                              ctx.session,
-                                                              table_oid,
-                                                              std::move(schema_chunk),
-                                                              static_cast<std::uint64_t>(wal_added_columns.size()),
-                                                              txn.transaction_id,
-                                                              db_oid);
-                add_column_future = std::move(scf);
+                auto [_g, gf] = actor_zeta::otterbrix::send(manager_wal_addr_,
+                                                            &wal::manager_wal_replicate_t::write_physical_grow,
+                                                            ctx.session,
+                                                            table_oid,
+                                                            std::move(schema_chunk),
+                                                            static_cast<std::uint64_t>(wal_added_columns.size()),
+                                                            std::move(wal_chunks),
+                                                            start_row,
+                                                            actual_count,
+                                                            txn.transaction_id,
+                                                            db_oid);
+                wal_future = std::move(gf);
             }
-
-            // CREATE INDEX backfill uses start_row as the row-id base, so it must match the materialized start.
-            components::vector::data_chunk_t wal_chunk(resource(), data->types(), data->size());
-            data->copy(wal_chunk, 0);
-            std::pmr::vector<components::vector::data_chunk_t> wal_chunks(resource());
-            wal_chunks.emplace_back(std::move(wal_chunk));
-            auto [_w, wf] = actor_zeta::otterbrix::send(manager_wal_addr_,
-                                                        &wal::manager_wal_replicate_t::write_physical_insert,
-                                                        ctx.session,
-                                                        table_oid,
-                                                        std::move(wal_chunks),
-                                                        start_row,
-                                                        actual_count,
-                                                        txn.transaction_id,
-                                                        db_oid);
-            auto wal_result = co_await std::move(wf);
+            auto wal_result = co_await std::move(wal_future);
             if (wal_result.has_error()) {
                 error(log_,
-                      "agent_disk[{}]::storage_append_inner: the PHYSICAL_INSERT did not reach the journal for "
-                      "oid={}, the rows are NOT appended: {}",
+                      "agent_disk[{}]::storage_append_inner: the rows did not reach the journal for oid={}, they are "
+                      "NOT appended: {}",
                       pool_idx_,
                       static_cast<unsigned>(table_oid),
                       wal_result.error().what);
@@ -675,29 +679,9 @@ namespace services::disk {
             }
             if (wal_result.value() == wal::id_t{}) {
                 trace(log_,
-                      "agent_disk[{}]::storage_append_inner: physical_insert WAL returned zero id for oid={}",
+                      "agent_disk[{}]::storage_append_inner: WAL returned zero id for oid={}",
                       pool_idx_,
                       static_cast<unsigned>(table_oid));
-            }
-
-            if (add_column_future.valid()) {
-                auto add_column_result = co_await std::move(add_column_future);
-                if (add_column_result.has_error()) {
-                    error(log_,
-                          "agent_disk[{}]::storage_append_inner: the PHYSICAL_ADD_COLUMN did not reach the "
-                          "journal for oid={}, the rows are NOT appended: {}",
-                          pool_idx_,
-                          static_cast<unsigned>(table_oid),
-                          add_column_result.error().what);
-                    co_return add_column_result.convert_error<std::pair<uint64_t, uint64_t>>();
-                }
-                if (add_column_result.value() == wal::id_t{}) {
-                    trace(log_,
-                          "agent_disk[{}]::storage_append_inner: physical_add_column WAL returned zero id for "
-                          "oid={}",
-                          pool_idx_,
-                          static_cast<unsigned>(table_oid));
-                }
             }
         }
 

--- a/services/disk/tests/test_wal_catalog.cpp
+++ b/services/disk/tests/test_wal_catalog.cpp
@@ -547,8 +547,7 @@ namespace {
     }
 } // namespace
 
-// The PHYSICAL_ADD_COLUMN write is awaited but drained only after the insert await -- same FIFO
-// WAL worker means it's already complete by then, keeping the handler's single suspension point.
+// write_physical_grow journals the PHYSICAL_ADD_COLUMN and the PHYSICAL_INSERT that needs it in one worker handler.
 TEST_CASE("services::disk::wal_catalog::a_growth_append_journals_the_add_column_ahead_of_the_insert") {
     auto dir = wal_cat_dir() + "/addcol_journaled";
     cleanup_dir(dir);

--- a/services/wal/manager_wal_replicate.cpp
+++ b/services/wal/manager_wal_replicate.cpp
@@ -261,8 +261,8 @@ namespace services::wal {
                 co_await actor_zeta::dispatch(this, &manager_wal_replicate_t::write_physical_update, msg);
                 break;
             }
-            case actor_zeta::msg_id<manager_wal_replicate_t, &manager_wal_replicate_t::write_physical_add_column>: {
-                co_await actor_zeta::dispatch(this, &manager_wal_replicate_t::write_physical_add_column, msg);
+            case actor_zeta::msg_id<manager_wal_replicate_t, &manager_wal_replicate_t::write_physical_grow>: {
+                co_await actor_zeta::dispatch(this, &manager_wal_replicate_t::write_physical_grow, msg);
                 break;
             }
             default:
@@ -657,31 +657,38 @@ namespace services::wal {
     }
 
     manager_wal_replicate_t::unique_future<core::result_wrapper_t<wal::id_t>>
-    manager_wal_replicate_t::write_physical_add_column(session_id_t session,
-                                                       components::catalog::oid_t table_oid,
-                                                       std::unique_ptr<components::vector::data_chunk_t> schema_chunk,
-                                                       uint64_t column_count,
-                                                       uint64_t txn_id,
-                                                       components::catalog::oid_t database_oid) {
+    manager_wal_replicate_t::write_physical_grow(session_id_t session,
+                                                 components::catalog::oid_t table_oid,
+                                                 std::unique_ptr<components::vector::data_chunk_t> schema_chunk,
+                                                 uint64_t column_count,
+                                                 std::pmr::vector<components::vector::data_chunk_t> chunks,
+                                                 uint64_t row_start,
+                                                 uint64_t row_count,
+                                                 uint64_t txn_id,
+                                                 components::catalog::oid_t database_oid) {
         if (recovery_error_.contains_error()) {
             co_return core::result_wrapper_t<wal::id_t>{recovery_error_};
         }
 
         auto* worker = get_or_create_worker(database_oid);
-        auto wal_id = next_wal_id();
+        const auto add_column_id = next_wal_id();
+        const auto insert_id = next_wal_id();
         auto [needs_sched, fut] = actor_zeta::otterbrix::send(worker->address(),
-                                                              &wal_worker_t::write_physical_add_column,
+                                                              &wal_worker_t::write_physical_grow,
                                                               session,
                                                               table_oid,
                                                               std::move(schema_chunk),
                                                               column_count,
+                                                              std::move(chunks),
+                                                              row_start,
+                                                              row_count,
                                                               txn_id,
-                                                              wal_id);
+                                                              add_column_id,
+                                                              insert_id);
         if (needs_sched) {
             scheduler_->enqueue(worker);
         }
         auto result = co_await std::move(fut);
         co_return std::move(result);
     }
-
 } // namespace services::wal

--- a/services/wal/manager_wal_replicate.hpp
+++ b/services/wal/manager_wal_replicate.hpp
@@ -109,12 +109,15 @@ namespace services::wal {
                               components::catalog::oid_t database_oid);
 
         unique_future<core::result_wrapper_t<wal::id_t>>
-        write_physical_add_column(session_id_t session,
-                                  components::catalog::oid_t table_oid,
-                                  std::unique_ptr<components::vector::data_chunk_t> schema_chunk,
-                                  uint64_t column_count,
-                                  uint64_t txn_id,
-                                  components::catalog::oid_t database_oid);
+        write_physical_grow(session_id_t session,
+                            components::catalog::oid_t table_oid,
+                            std::unique_ptr<components::vector::data_chunk_t> schema_chunk,
+                            uint64_t column_count,
+                            std::pmr::vector<components::vector::data_chunk_t> chunks,
+                            uint64_t row_start,
+                            uint64_t row_count,
+                            uint64_t txn_id,
+                            components::catalog::oid_t database_oid);
 
         using dispatch_traits = actor_zeta::implements<wal_contract,
                                                        &manager_wal_replicate_t::load,
@@ -125,7 +128,7 @@ namespace services::wal {
                                                        &manager_wal_replicate_t::write_physical_insert,
                                                        &manager_wal_replicate_t::write_physical_delete,
                                                        &manager_wal_replicate_t::write_physical_update,
-                                                       &manager_wal_replicate_t::write_physical_add_column>;
+                                                       &manager_wal_replicate_t::write_physical_grow>;
 
         wal::id_t next_wal_id();
 

--- a/services/wal/wal.cpp
+++ b/services/wal/wal.cpp
@@ -103,8 +103,8 @@ namespace services::wal {
                 co_await actor_zeta::dispatch(this, &wal_worker_t::write_physical_update, msg);
                 break;
             }
-            case actor_zeta::msg_id<wal_worker_t, &wal_worker_t::write_physical_add_column>: {
-                co_await actor_zeta::dispatch(this, &wal_worker_t::write_physical_add_column, msg);
+            case actor_zeta::msg_id<wal_worker_t, &wal_worker_t::write_physical_grow>: {
+                co_await actor_zeta::dispatch(this, &wal_worker_t::write_physical_grow, msg);
                 break;
             }
             default:
@@ -284,6 +284,35 @@ namespace services::wal {
         last_crc_ = record_crc;
 
         co_return core::result_wrapper_t<wal::id_t>{wal_id};
+    }
+
+    wal_worker_t::unique_future<core::result_wrapper_t<wal::id_t>>
+    wal_worker_t::write_physical_grow(session_id_t session,
+                                      components::catalog::oid_t table_oid,
+                                      std::unique_ptr<components::vector::data_chunk_t> schema_chunk,
+                                      uint64_t column_count,
+                                      std::pmr::vector<components::vector::data_chunk_t> chunks,
+                                      uint64_t row_start,
+                                      uint64_t row_count,
+                                      uint64_t txn_id,
+                                      wal::id_t add_column_id,
+                                      wal::id_t insert_id) {
+        auto added = co_await write_physical_add_column(session,
+                                                        table_oid,
+                                                        std::move(schema_chunk),
+                                                        column_count,
+                                                        txn_id,
+                                                        add_column_id);
+        if (added.has_error()) {
+            co_return std::move(added);
+        }
+        co_return co_await write_physical_insert(session,
+                                                 table_oid,
+                                                 std::move(chunks),
+                                                 row_start,
+                                                 row_count,
+                                                 txn_id,
+                                                 insert_id);
     }
 
     wal_worker_t::unique_future<core::result_wrapper_t<wal::id_t>> wal_worker_t::commit_txn(session_id_t /*session*/,

--- a/services/wal/wal.hpp
+++ b/services/wal/wal.hpp
@@ -132,12 +132,16 @@ namespace services::wal {
                               wal::id_t wal_id);
 
         unique_future<core::result_wrapper_t<wal::id_t>>
-        write_physical_add_column(session_id_t session,
-                                  components::catalog::oid_t table_oid,
-                                  std::unique_ptr<components::vector::data_chunk_t> schema_chunk,
-                                  uint64_t column_count,
-                                  uint64_t txn_id,
-                                  wal::id_t wal_id);
+        write_physical_grow(session_id_t session,
+                            components::catalog::oid_t table_oid,
+                            std::unique_ptr<components::vector::data_chunk_t> schema_chunk,
+                            uint64_t column_count,
+                            std::pmr::vector<components::vector::data_chunk_t> chunks,
+                            uint64_t row_start,
+                            uint64_t row_count,
+                            uint64_t txn_id,
+                            wal::id_t add_column_id,
+                            wal::id_t insert_id);
 
         using dispatch_traits = actor_zeta::dispatch_traits<&wal_worker_t::load,
                                                             &wal_worker_t::commit_txn,
@@ -146,9 +150,17 @@ namespace services::wal {
                                                             &wal_worker_t::write_physical_insert,
                                                             &wal_worker_t::write_physical_delete,
                                                             &wal_worker_t::write_physical_update,
-                                                            &wal_worker_t::write_physical_add_column>;
+                                                            &wal_worker_t::write_physical_grow>;
 
     private:
+        unique_future<core::result_wrapper_t<wal::id_t>>
+        write_physical_add_column(session_id_t session,
+                                  components::catalog::oid_t table_oid,
+                                  std::unique_ptr<components::vector::data_chunk_t> schema_chunk,
+                                  uint64_t column_count,
+                                  uint64_t txn_id,
+                                  wal::id_t wal_id);
+
         /// Refuses when a segment can't be opened -- skipping one breaks the CRC chain and page_lsn ordering.
         [[nodiscard]] core::error_t recover_from_disk();
 

--- a/services/wal/wal_contract.hpp
+++ b/services/wal/wal_contract.hpp
@@ -70,17 +70,19 @@ namespace services::wal {
                               uint64_t txn_id,
                               components::catalog::oid_t database_oid);
 
-        // Schema-growth record (dynamic add_column on computed / relkind='g' tables).
-        // schema_chunk is a 0-row data_chunk whose columns ARE the new columns
-        // (alias-tagged types). Written BEFORE the PHYSICAL_INSERT that depends on
-        // them so WAL-first replay re-applies the schema before the rows.
+        // Schema growth (dynamic add_column on computed / relkind='g' tables): the PHYSICAL_ADD_COLUMN, then the
+        // PHYSICAL_INSERT that needs it, in one write, so WAL-first replay re-applies the schema before the rows.
+        // schema_chunk is a 0-row data_chunk whose columns ARE the new columns (alias-tagged types).
         actor_zeta::unique_future<core::result_wrapper_t<id_t>>
-        write_physical_add_column(session_id_t session,
-                                  components::catalog::oid_t table_oid,
-                                  std::unique_ptr<components::vector::data_chunk_t> schema_chunk,
-                                  uint64_t column_count,
-                                  uint64_t txn_id,
-                                  components::catalog::oid_t database_oid);
+        write_physical_grow(session_id_t session,
+                            components::catalog::oid_t table_oid,
+                            std::unique_ptr<components::vector::data_chunk_t> schema_chunk,
+                            uint64_t column_count,
+                            std::pmr::vector<components::vector::data_chunk_t> chunks,
+                            uint64_t row_start,
+                            uint64_t row_count,
+                            uint64_t txn_id,
+                            components::catalog::oid_t database_oid);
 
         using dispatch_traits = actor_zeta::dispatch_traits<&wal_contract::load,
                                                             &wal_contract::commit_txn,
@@ -90,7 +92,7 @@ namespace services::wal {
                                                             &wal_contract::write_physical_insert,
                                                             &wal_contract::write_physical_delete,
                                                             &wal_contract::write_physical_update,
-                                                            &wal_contract::write_physical_add_column>;
+                                                            &wal_contract::write_physical_grow>;
 
         wal_contract() = delete;
     };


### PR DESCRIPTION
Fixed case where disk would send two consecutive messages to the WAL actor and then be parked without wakeup